### PR TITLE
RSDK-11340: Combine Resource.FromRobot and Resource.FromDependencies

### DIFF
--- a/cli/mock_resource_arm.txt
+++ b/cli/mock_resource_arm.txt
@@ -57,7 +57,7 @@ func Named(name string) resource.Name {
 //
 // EndPosition example:
 //
-//	myArm, err := arm.FromRobot(machine, "my_arm")
+//	myArm, err := arm.GetResource(machine, "my_arm")
 //	// Get the end position of the arm as a Pose.
 //	pos, err := myArm.EndPosition(context.Background(), nil)
 //
@@ -65,7 +65,7 @@ func Named(name string) resource.Name {
 //
 // MoveToPosition example:
 //
-//	myArm, err := arm.FromRobot(machine, "my_arm")
+//	myArm, err := arm.GetResource(machine, "my_arm")
 //	// Create a Pose for the arm.
 //	examplePose := spatialmath.NewPose(
 //	        r3.Vector{X: 5, Y: 5, Z: 5},
@@ -79,7 +79,7 @@ func Named(name string) resource.Name {
 //
 // MoveToJointPositions example:
 //
-//	myArm, err := arm.FromRobot(machine, "my_arm")
+//	myArm, err := arm.GetResource(machine, "my_arm")
 //
 //	// Declare an array of values with your desired rotational value (in radians) for each joint on the arm.
 //	inputs := referenceframe.FloatsToInputs([]float64{0, math.Pi/2, math.Pi})
@@ -91,7 +91,7 @@ func Named(name string) resource.Name {
 //
 // MoveThroughJointPositions example:
 //
-//	myArm, err := arm.FromRobot(machine, "my_arm")
+//	myArm, err := arm.GetResource(machine, "my_arm")
 //
 //	// Declare a 2D array of values with your desired rotational value (in radians) for each joint on the arm.
 //	inputs := [][]referenceframe.Input{
@@ -106,7 +106,7 @@ func Named(name string) resource.Name {
 //
 // JointPositions example:
 //
-//	myArm , err := arm.FromRobot(machine, "my_arm")
+//	myArm , err := arm.GetResource(machine, "my_arm")
 //
 //	// Get the current position of each joint on the arm as JointPositions.
 //	pos, err := myArm.JointPositions(context.Background(), nil)
@@ -144,15 +144,17 @@ type Arm interface {
 	JointPositions(ctx context.Context, extra map[string]interface{}) ([]referenceframe.Input, error)
 }
 
-// FromDependencies is a helper for getting the named arm from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Arm, error) {
-	return resource.FromDependencies[Arm](deps, Named(name))
-}
-
-// FromRobot is a helper for getting the named Arm from the given Robot.
-func FromRobot(r robot.Robot, name string) (Arm, error) {
-	return robot.ResourceFromRobot[Arm](r, Named(name))
+// GetResource is a helper for getting the named Arm from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Arm, error) {
+	switch v := src.(type) {
+    case resource.Dependencies:
+        return resource.FromDependencies[Arm](v, Named(name))
+    case robot.Robot:
+		return robot.ResourceFromRobot[Arm](v, Named(name))
+    default:
+        return nil, fmt.Errorf("unsupported source type %T", src)
+    }
 }
 
 // NamesFromRobot is a helper for getting all arm names from the given Robot.

--- a/cli/motion.go
+++ b/cli/motion.go
@@ -94,7 +94,7 @@ func motionPrintStatusAction(c *cli.Context, args motionPrintArgs) error {
 		return err
 	}
 
-	myMotion, err := motion.FromRobot(robotClient, "builtin")
+	myMotion, err := motion.GetResource(robotClient, "builtin")
 	if err != nil || myMotion == nil {
 		return fmt.Errorf("no motion: %w", err)
 	}
@@ -148,7 +148,7 @@ func motionGetPoseAction(c *cli.Context, args motionGetPoseArgs) error {
 		utils.UncheckedError(robotClient.Close(ctx))
 	}()
 
-	myMotion, err := motion.FromRobot(robotClient, "builtin")
+	myMotion, err := motion.GetResource(robotClient, "builtin")
 	if err != nil || myMotion == nil {
 		return fmt.Errorf("no motion: %w", err)
 	}
@@ -200,7 +200,7 @@ func motionSetPoseAction(c *cli.Context, args motionSetPoseArgs) error {
 		utils.UncheckedError(robotClient.Close(ctx))
 	}()
 
-	myMotion, err := motion.FromRobot(robotClient, "builtin")
+	myMotion, err := motion.GetResource(robotClient, "builtin")
 	if err != nil || myMotion == nil {
 		return fmt.Errorf("no motion: %w", err)
 	}

--- a/components/arm/arm.go
+++ b/components/arm/arm.go
@@ -57,7 +57,7 @@ func Named(name string) resource.Name {
 //
 // EndPosition example:
 //
-//	myArm, err := arm.FromRobot(machine, "my_arm")
+//	myArm, err := arm.GetResource(machine, "my_arm")
 //	// Get the end position of the arm as a Pose.
 //	pos, err := myArm.EndPosition(context.Background(), nil)
 //
@@ -65,7 +65,7 @@ func Named(name string) resource.Name {
 //
 // MoveToPosition example:
 //
-//	myArm, err := arm.FromRobot(machine, "my_arm")
+//	myArm, err := arm.GetResource(machine, "my_arm")
 //	// Create a Pose for the arm.
 //	examplePose := spatialmath.NewPose(
 //	        r3.Vector{X: 5, Y: 5, Z: 5},
@@ -79,7 +79,7 @@ func Named(name string) resource.Name {
 //
 // MoveToJointPositions example:
 //
-//	myArm, err := arm.FromRobot(machine, "my_arm")
+//	myArm, err := arm.GetResource(machine, "my_arm")
 //
 //	// Declare an array of values with your desired rotational value (in radians) for each joint on the arm.
 //	inputs := referenceframe.FloatsToInputs([]float64{0, math.Pi/2, math.Pi})
@@ -91,7 +91,7 @@ func Named(name string) resource.Name {
 //
 // MoveThroughJointPositions example:
 //
-//	myArm, err := arm.FromRobot(machine, "my_arm")
+//	myArm, err := arm.GetResource(machine, "my_arm")
 //
 //	// Declare a 2D array of values with your desired rotational value (in radians) for each joint on the arm.
 //	inputs := [][]referenceframe.Input{
@@ -106,7 +106,7 @@ func Named(name string) resource.Name {
 //
 // JointPositions example:
 //
-//	myArm , err := arm.FromRobot(machine, "my_arm")
+//	myArm , err := arm.GetResource(machine, "my_arm")
 //
 //	// Get the current position of each joint on the arm as JointPositions.
 //	pos, err := myArm.JointPositions(context.Background(), nil)
@@ -144,15 +144,17 @@ type Arm interface {
 	JointPositions(ctx context.Context, extra map[string]interface{}) ([]referenceframe.Input, error)
 }
 
-// FromDependencies is a helper for getting the named arm from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Arm, error) {
-	return resource.FromDependencies[Arm](deps, Named(name))
-}
-
-// FromRobot is a helper for getting the named Arm from the given Robot.
-func FromRobot(r robot.Robot, name string) (Arm, error) {
-	return robot.ResourceFromRobot[Arm](r, Named(name))
+// GetResource is a helper for getting the named Arm from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Arm, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Arm](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Arm](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all arm names from the given Robot.

--- a/components/arm/wrapper/wrapper.go
+++ b/components/arm/wrapper/wrapper.go
@@ -79,7 +79,7 @@ func (wrapper *Arm) Reconfigure(ctx context.Context, deps resource.Dependencies,
 		return err
 	}
 
-	newArm, err := arm.FromDependencies(deps, newConf.ArmName)
+	newArm, err := arm.GetResource(deps, newConf.ArmName)
 	if err != nil {
 		return err
 	}

--- a/components/audioinput/audio_input.go
+++ b/components/audioinput/audio_input.go
@@ -4,6 +4,7 @@ package audioinput
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/pion/mediadevices/pkg/prop"
 	pb "go.viam.com/api/component/audioinput/v1"
@@ -61,15 +62,17 @@ type LivenessMonitor interface {
 	Monitor(notifyReset func())
 }
 
-// FromDependencies is a helper for getting the named audio input from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (AudioInput, error) {
-	return resource.FromDependencies[AudioInput](deps, Named(name))
-}
-
-// FromRobot is a helper for getting the named audio input from the given Robot.
-func FromRobot(r robot.Robot, name string) (AudioInput, error) {
-	return robot.ResourceFromRobot[AudioInput](r, Named(name))
+// GetResource is a helper for getting the named Audio Input from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (AudioInput, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[AudioInput](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[AudioInput](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all audio input names from the given Robot.

--- a/components/base/base_test.go
+++ b/components/base/base_test.go
@@ -29,15 +29,15 @@ func TestFromRobot(t *testing.T) {
 	expected := []string{"base1", "base2"}
 	testutils.VerifySameElements(t, base.NamesFromRobot(r), expected)
 
-	_, err := base.FromRobot(r, "base1")
+	_, err := base.GetResource(r, "base1")
 	test.That(t, err, test.ShouldBeNil)
 
-	_, err = base.FromRobot(r, "base2")
+	_, err = base.GetResource(r, "base2")
 	test.That(t, err, test.ShouldBeNil)
 
-	_, err = base.FromRobot(r, "base0")
+	_, err = base.GetResource(r, "base0")
 	test.That(t, err, test.ShouldNotBeNil)
 
-	_, err = base.FromRobot(r, "g")
+	_, err = base.GetResource(r, "g")
 	test.That(t, err, test.ShouldNotBeNil)
 }

--- a/components/base/sensorcontrolled/sensorcontrolled.go
+++ b/components/base/sensorcontrolled/sensorcontrolled.go
@@ -149,7 +149,7 @@ func (sb *sensorBase) Reconfigure(ctx context.Context, deps resource.Dependencie
 	sb.controlledBase = nil
 
 	for _, name := range newConf.MovementSensor {
-		ms, err := movementsensor.FromDependencies(deps, name)
+		ms, err := movementsensor.GetResource(deps, name)
 		if err != nil {
 			return errors.Wrapf(err, "no movement sensor named (%s)", name)
 		}
@@ -201,7 +201,7 @@ func (sb *sensorBase) Reconfigure(ctx context.Context, deps resource.Dependencie
 		return errNoGoodSensor
 	}
 
-	sb.controlledBase, err = base.FromDependencies(deps, newConf.Base)
+	sb.controlledBase, err = base.GetResource(deps, newConf.Base)
 	if err != nil {
 		return errors.Wrapf(err, "no base named (%s)", newConf.Base)
 	}

--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -151,7 +151,7 @@ func (wb *wheeledBase) Reconfigure(ctx context.Context, deps resource.Dependenci
 					return newMotors, rdkutils.NewBuildTimeoutError(wb.Name().String(), wb.logger)
 				default:
 				}
-				m, err := motor.FromDependencies(deps, name)
+				m, err := motor.GetResource(deps, name)
 				if err != nil {
 					return newMotors, errors.Wrapf(err, "no %s motor named (%s)", whichMotor, name)
 				}
@@ -167,7 +167,7 @@ func (wb *wheeledBase) Reconfigure(ctx context.Context, deps resource.Dependenci
 				}
 				if (curr)[i].Name().String() != (fromConfig)[i] {
 					for _, name := range fromConfig {
-						m, err := motor.FromDependencies(deps, name)
+						m, err := motor.GetResource(deps, name)
 						if err != nil {
 							return newMotors, errors.Wrapf(err, "no %s motor named (%s)", whichMotor, name)
 						}

--- a/components/board/board.go
+++ b/components/board/board.go
@@ -9,6 +9,7 @@ package board
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	pb "go.viam.com/api/component/board/v1"
@@ -56,7 +57,7 @@ func Named(name string) resource.Name {
 //
 // AnalogByName example:
 //
-//	myBoard, err := board.FromRobot(robot, "my_board")
+//	myBoard, err := board.GetResource(robot, "my_board")
 //
 //	// Get the Analog pin "my_example_analog".
 //	analog, err := myBoard.AnalogByName("my_example_analog")
@@ -65,7 +66,7 @@ func Named(name string) resource.Name {
 //
 // DigitalInterruptByName example:
 //
-//	myBoard, err := board.FromRobot(robot, "my_board")
+//	myBoard, err := board.GetResource(robot, "my_board")
 //
 //	// Get the DigitalInterrupt "my_example_digital_interrupt".
 //	interrupt, err := myBoard.DigitalInterruptByName("my_example_digital_interrupt")
@@ -74,7 +75,7 @@ func Named(name string) resource.Name {
 //
 // GPIOPinByName example:
 //
-//	myBoard, err := board.FromRobot(robot, "my_board")
+//	myBoard, err := board.GetResource(robot, "my_board")
 //
 //	// Get the GPIOPin with pin number 15.
 //	pin, err := myBoard.GPIOPinByName("15")
@@ -83,7 +84,7 @@ func Named(name string) resource.Name {
 //
 // SetPowerMode example:
 //
-//	myBoard, err := board.FromRobot(robot, "my_board")
+//	myBoard, err := board.GetResource(robot, "my_board")
 //
 //	Set the power mode of the board to OFFLINE_DEEP.
 //	myBoard.SetPowerMode(context.Background(), boardpb.PowerMode_POWER_MODE_OFFLINE_DEEP, nil)
@@ -92,7 +93,7 @@ func Named(name string) resource.Name {
 //
 // StreamTicks example:
 //
-//	myBoard, err := board.FromRobot(robot, "my_board")
+//	myBoard, err := board.GetResource(robot, "my_board")
 //
 //	// Make a channel to stream ticks
 //	ticksChan := make(chan board.Tick)
@@ -143,7 +144,7 @@ type Board interface {
 //
 // Read example:
 //
-//	myBoard, err := board.FromRobot(robot, "my_board")
+//	myBoard, err := board.GetResource(robot, "my_board")
 //
 //	// Get the analog pin "my_example_analog".
 //	analog, err := myBoard.AnalogByName("my_example_analog")
@@ -157,7 +158,7 @@ type Board interface {
 //
 // Write example:
 //
-//	myBoard, err := board.FromRobot(robot, "my_board")
+//	myBoard, err := board.GetResource(robot, "my_board")
 //
 //	// Get the Analog pin "my_example_analog".
 //	analog, err := myBoard.AnalogByName("my_example_analog")
@@ -188,15 +189,17 @@ type AnalogValue struct {
 	StepSize float32
 }
 
-// FromDependencies is a helper for getting the named board from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Board, error) {
-	return resource.FromDependencies[Board](deps, Named(name))
-}
-
-// FromRobot is a helper for getting the named board from the given Robot.
-func FromRobot(r robot.Robot, name string) (Board, error) {
-	return robot.ResourceFromRobot[Board](r, Named(name))
+// GetResource is a helper for getting the named Board from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Board, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Board](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Board](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all board names from the given Robot.

--- a/components/board/board_test.go
+++ b/components/board/board_test.go
@@ -23,12 +23,12 @@ func TestFromRobot(t *testing.T) {
 	expected := []string{"board1"}
 	testutils.VerifySameElements(t, board.NamesFromRobot(r), expected)
 
-	_, err := board.FromRobot(r, "board1")
+	_, err := board.GetResource(r, "board1")
 	test.That(t, err, test.ShouldBeNil)
 
-	_, err = board.FromRobot(r, "board0")
+	_, err = board.GetResource(r, "board0")
 	test.That(t, err, test.ShouldNotBeNil)
 
-	_, err = board.FromRobot(r, "g")
+	_, err = board.GetResource(r, "g")
 	test.That(t, err, test.ShouldNotBeNil)
 }

--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -21,7 +21,7 @@ type Tick struct {
 //
 // Value example:
 //
-//	myBoard, err := board.FromRobot(robot, "my_board")
+//	myBoard, err := board.GetResource(robot, "my_board")
 //
 //	// Get the DigitalInterrupt "my_example_digital_interrupt".
 //	interrupt, err := myBoard.DigitalInterruptByName("my_example_digital_interrupt")

--- a/components/board/gpio_pin.go
+++ b/components/board/gpio_pin.go
@@ -11,7 +11,7 @@ import (
 //
 // Set example:
 //
-//	myBoard, err := board.FromRobot(robot, "my_board")
+//	myBoard, err := board.GetResource(robot, "my_board")
 //
 //	// Get the GPIOPin with pin number 15.
 //	pin, err := myBoard.GPIOPinByName("15")
@@ -23,7 +23,7 @@ import (
 //
 // Get example:
 //
-//	myBoard, err := board.FromRobot(robot, "my_board")
+//	myBoard, err := board.GetResource(robot, "my_board")
 //
 //	// Get the GPIOPin with pin number 15.
 //	pin, err := myBoard.GPIOPinByName("15")
@@ -35,7 +35,7 @@ import (
 //
 // PWM example:
 //
-//	myBoard, err := board.FromRobot(robot, "my_board")
+//	myBoard, err := board.GetResource(robot, "my_board")
 //
 //	// Get the GPIOPin with pin number 15.
 //	pin, err := myBoard.GPIOPinByName("15")
@@ -47,7 +47,7 @@ import (
 //
 // SetPWM example:
 //
-//	myBoard, err := board.FromRobot(robot, "my_board")
+//	myBoard, err := board.GetResource(robot, "my_board")
 //
 //	// Get the GPIOPin with pin number 15.
 //	pin, err := myBoard.GPIOPinByName("15")
@@ -59,7 +59,7 @@ import (
 //
 // PWMFreq example:
 //
-//	myBoard, err := board.FromRobot(robot, "my_board")
+//	myBoard, err := board.GetResource(robot, "my_board")
 //
 //	// Get the GPIOPin with pin number 15.
 //	pin, err := myBoard.GPIOPinByName("15")
@@ -71,7 +71,7 @@ import (
 //
 // SetPWMFreq example:
 //
-//	myBoard, err := board.FromRobot(robot, "my_board")
+//	myBoard, err := board.GetResource(robot, "my_board")
 //
 //	// Get the GPIOPin with pin number 15.
 //	pin, err := myBoard.GPIOPinByName("15")

--- a/components/button/button.go
+++ b/components/button/button.go
@@ -3,6 +3,7 @@ package button
 
 import (
 	"context"
+	"fmt"
 
 	pb "go.viam.com/api/component/button/v1"
 
@@ -43,14 +44,17 @@ type Button interface {
 	Push(ctx context.Context, extra map[string]interface{}) error
 }
 
-// FromRobot is a helper for getting the named Button from the given Robot.
-func FromRobot(r robot.Robot, name string) (Button, error) {
-	return robot.ResourceFromRobot[Button](r, Named(name))
-}
-
-// FromDependencies is a helper for getting the named button component from a collection of dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Button, error) {
-	return resource.FromDependencies[Button](deps, Named(name))
+// GetResource is a helper for getting the named Button from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Button, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Button](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Button](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all gripper names from the given Robot.

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -174,19 +174,19 @@ type ImageMetadata struct {
 //
 // Image example:
 //
-//	myCamera, err := camera.FromRobot(machine, "my_camera")
+//	myCamera, err := camera.GetResource(machine, "my_camera")
 //	imageBytes, mimeType, err := myCamera.Image(context.Background(), utils.MimeTypeJPEG, nil)
 //
 // Or try to directly decode as an image.Image:
 //
-//	myCamera, err := camera.FromRobot(machine, "my_camera")
+//	myCamera, err := camera.GetResource(machine, "my_camera")
 //	img, err = camera.DecodeImageFromCamera(context.Background(), utils.MimeTypeJPEG, nil, myCamera)
 //
 // For more information, see the [Image method docs].
 //
 // Images example:
 //
-//	myCamera, err := camera.FromRobot(machine, "my_camera")
+//	myCamera, err := camera.GetResource(machine, "my_camera")
 //
 //	images, metadata, err := myCamera.Images(context.Background(), nil)
 //
@@ -194,7 +194,7 @@ type ImageMetadata struct {
 //
 // NextPointCloud example:
 //
-//	myCamera, err := camera.FromRobot(machine, "my_camera")
+//	myCamera, err := camera.GetResource(machine, "my_camera")
 //
 //	// gets the next point cloud from a camera
 //	pointCloud, err := myCamera.NextPointCloud(context.Background())
@@ -203,7 +203,7 @@ type ImageMetadata struct {
 //
 // Close example:
 //
-//	myCamera, err := camera.FromRobot(machine, "my_camera")
+//	myCamera, err := camera.GetResource(machine, "my_camera")
 //
 //	err = myCamera.Close(context.Background())
 //
@@ -380,15 +380,17 @@ func NewPropertiesError(cameraIdentifier string) error {
 	return errors.Errorf("failed to get properties from %s", cameraIdentifier)
 }
 
-// FromDependencies is a helper for getting the named camera from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Camera, error) {
-	return resource.FromDependencies[Camera](deps, Named(name))
-}
-
-// FromRobot is a helper for getting the named Camera from the given Robot.
-func FromRobot(r robot.Robot, name string) (Camera, error) {
-	return robot.ResourceFromRobot[Camera](r, Named(name))
+// GetResource is a helper for getting the named Camera from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Camera, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Camera](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Camera](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all camera names from the given Robot.

--- a/components/camera/client_test.go
+++ b/components/camera/client_test.go
@@ -924,7 +924,7 @@ func TestMultiplexOverRemoteConnection(t *testing.T) {
 	defer mainRobot.Close(mainCtx)
 	defer mainWebSvc.Close(mainCtx)
 
-	cameraClient, err := camera.FromRobot(mainRobot, "remote:rtpPassthroughCamera")
+	cameraClient, err := camera.GetResource(mainRobot, "remote:rtpPassthroughCamera")
 	test.That(t, err, test.ShouldBeNil)
 
 	image, _, err := cameraClient.Images(mainCtx, nil, nil)
@@ -997,7 +997,7 @@ func TestMultiplexOverMultiHopRemoteConnection(t *testing.T) {
 	defer mainRobot.Close(mainCtx)
 	defer mainWebSvc.Close(mainCtx)
 
-	cameraClient, err := camera.FromRobot(mainRobot, "rtpPassthroughCamera")
+	cameraClient, err := camera.GetResource(mainRobot, "rtpPassthroughCamera")
 	test.That(t, err, test.ShouldBeNil)
 
 	image, _, err := cameraClient.Images(mainCtx, nil, nil)
@@ -1081,7 +1081,7 @@ func TestWhyMustTimeoutOnReadRTP(t *testing.T) {
 	defer mainRobot.Close(mainCtx)
 	defer mainWebSvc.Close(mainCtx)
 
-	cameraClient, err := camera.FromRobot(mainRobot, "rtpPassthroughCamera")
+	cameraClient, err := camera.GetResource(mainRobot, "rtpPassthroughCamera")
 	test.That(t, err, test.ShouldBeNil)
 
 	image, _, err := cameraClient.Images(mainCtx, nil, nil)
@@ -1217,7 +1217,7 @@ func TestGrandRemoteRebooting(t *testing.T) {
 	defer mainRobot.Close(mainCtx)
 	defer mainWebSvc.Close(mainCtx)
 
-	mainCameraClient, err := camera.FromRobot(mainRobot, "rtpPassthroughCamera")
+	mainCameraClient, err := camera.GetResource(mainRobot, "rtpPassthroughCamera")
 	test.That(t, err, test.ShouldBeNil)
 
 	image, _, err := mainCameraClient.Images(mainCtx, nil, nil)

--- a/components/camera/transformpipeline/classifier.go
+++ b/components/camera/transformpipeline/classifier.go
@@ -86,7 +86,7 @@ func (cs *classifierSource) Read(ctx context.Context) (image.Image, func(), erro
 	ctx, span := trace.StartSpan(ctx, "camera::transformpipeline::classifier::Read")
 	defer span.End()
 
-	srv, err := vision.FromRobot(cs.r, cs.classifierName)
+	srv, err := vision.GetResource(cs.r, cs.classifierName)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "source_classifier can't find vision service")
 	}

--- a/components/camera/transformpipeline/classifier_test.go
+++ b/components/camera/transformpipeline/classifier_test.go
@@ -94,7 +94,7 @@ func TestClassifierSource(t *testing.T) {
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 	}()
 
-	classifier, err := camera.FromRobot(r, "classification_transform_camera")
+	classifier, err := camera.GetResource(r, "classification_transform_camera")
 	test.That(t, err, test.ShouldBeNil)
 	defer classifier.Close(ctx)
 

--- a/components/camera/transformpipeline/detector.go
+++ b/components/camera/transformpipeline/detector.go
@@ -79,7 +79,7 @@ func (ds *detectorSource) Read(ctx context.Context) (image.Image, func(), error)
 	ctx, span := trace.StartSpan(ctx, "camera::transformpipeline::detector::Read")
 	defer span.End()
 	// get the bounding boxes from the service
-	srv, err := vision.FromRobot(ds.r, ds.detectorName)
+	srv, err := vision.GetResource(ds.r, ds.detectorName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("source_detector cant find vision service: %w", err)
 	}

--- a/components/camera/transformpipeline/detector_test.go
+++ b/components/camera/transformpipeline/detector_test.go
@@ -116,7 +116,7 @@ func TestColorDetectionSource(t *testing.T) {
 		test.That(t, r.Close(context.Background()), test.ShouldBeNil)
 	}()
 
-	detector, err := camera.FromRobot(r, "color_detect")
+	detector, err := camera.GetResource(r, "color_detect")
 	test.That(t, err, test.ShouldBeNil)
 	defer detector.Close(ctx)
 
@@ -138,7 +138,7 @@ func BenchmarkColorDetectionSource(b *testing.B) {
 		test.That(b, r.Close(context.Background()), test.ShouldBeNil)
 	}()
 	test.That(b, err, test.ShouldBeNil)
-	detector, err := camera.FromRobot(r, "color_detect")
+	detector, err := camera.GetResource(r, "color_detect")
 	test.That(b, err, test.ShouldBeNil)
 	defer detector.Close(ctx)
 

--- a/components/camera/transformpipeline/pipeline.go
+++ b/components/camera/transformpipeline/pipeline.go
@@ -48,7 +48,7 @@ func init() {
 					return nil, err
 				}
 				sourceName := newConf.Source
-				source, err := camera.FromRobot(actualR, sourceName)
+				source, err := camera.GetResource(actualR, sourceName)
 				if err != nil {
 					return nil, fmt.Errorf("no source camera for transform pipeline (%s): %w", sourceName, err)
 				}

--- a/components/encoder/encoder.go
+++ b/components/encoder/encoder.go
@@ -6,6 +6,7 @@ package encoder
 
 import (
 	"context"
+	"fmt"
 
 	pb "go.viam.com/api/component/encoder/v1"
 
@@ -69,7 +70,7 @@ func (t PositionType) String() string {
 //
 // Position example:
 //
-//	myEncoder, err := encoder.FromRobot(machine, "my_encoder")
+//	myEncoder, err := encoder.GetResource(machine, "my_encoder")
 //	if err != nil {
 //	  logger.Fatalf("cannot get encoder: %v", err)
 //	}
@@ -81,7 +82,7 @@ func (t PositionType) String() string {
 //
 // ResetPosition example:
 //
-//	myEncoder, err := encoder.FromRobot(machine, "my_encoder")
+//	myEncoder, err := encoder.GetResource(machine, "my_encoder")
 //	if err != nil {
 //	  logger.Fatalf("cannot get encoder: %v", err)
 //	}
@@ -92,7 +93,7 @@ func (t PositionType) String() string {
 //
 // Properties example:
 //
-//	myEncoder, err := encoder.FromRobot(machine, "my_encoder")
+//	myEncoder, err := encoder.GetResource(machine, "my_encoder")
 //
 //	// Get whether the encoder returns position in ticks or degrees.
 //	properties, err := myEncoder.Properties(context.Background(), nil)
@@ -121,15 +122,17 @@ func Named(name string) resource.Name {
 	return resource.NewName(API, name)
 }
 
-// FromDependencies is a helper for getting the named encoder from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Encoder, error) {
-	return resource.FromDependencies[Encoder](deps, Named(name))
-}
-
-// FromRobot is a helper for getting the named encoder from the given Robot.
-func FromRobot(r robot.Robot, name string) (Encoder, error) {
-	return robot.ResourceFromRobot[Encoder](r, Named(name))
+// GetResource is a helper for getting the named Encoder from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Encoder, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Encoder](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Encoder](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all encoder names from the given Robot.

--- a/components/encoder/encoder_test.go
+++ b/components/encoder/encoder_test.go
@@ -23,12 +23,12 @@ func TestFromRobot(t *testing.T) {
 	expected := []string{"e1"}
 	testutils.VerifySameElements(t, encoder.NamesFromRobot(r), expected)
 
-	_, err := encoder.FromRobot(r, "e1")
+	_, err := encoder.GetResource(r, "e1")
 	test.That(t, err, test.ShouldBeNil)
 
-	_, err = encoder.FromRobot(r, "e0")
+	_, err = encoder.GetResource(r, "e0")
 	test.That(t, err, test.ShouldNotBeNil)
 
-	_, err = encoder.FromRobot(r, "g")
+	_, err = encoder.GetResource(r, "g")
 	test.That(t, err, test.ShouldNotBeNil)
 }

--- a/components/encoder/incremental/incremental_encoder.go
+++ b/components/encoder/incremental/incremental_encoder.go
@@ -130,7 +130,7 @@ func (e *Encoder) Reconfigure(
 		existingEncAName != newConf.Pins.A ||
 		existingEncBName != newConf.Pins.B
 
-	board, err := board.FromDependencies(deps, newConf.BoardName)
+	board, err := board.GetResource(deps, newConf.BoardName)
 	if err != nil {
 		return err
 	}

--- a/components/encoder/single/single_encoder.go
+++ b/components/encoder/single/single_encoder.go
@@ -151,7 +151,7 @@ func (e *Encoder) Reconfigure(
 	needRestart := existingBoardName != newConf.BoardName ||
 		existingDIPinName != newConf.Pins.I
 
-	board, err := board.FromDependencies(deps, newConf.BoardName)
+	board, err := board.GetResource(deps, newConf.BoardName)
 	if err != nil {
 		return err
 	}

--- a/components/gantry/gantry.go
+++ b/components/gantry/gantry.go
@@ -6,6 +6,7 @@ package gantry
 
 import (
 	"context"
+	"fmt"
 
 	pb "go.viam.com/api/component/gantry/v1"
 
@@ -52,7 +53,7 @@ func Named(name string) resource.Name {
 //
 // Position example:
 //
-//	myGantry, err := gantry.FromRobot(machine, "my_gantry")
+//	myGantry, err := gantry.GetResource(machine, "my_gantry")
 //
 //	// Get the current positions of the axes of the gantry in millimeters.
 //	position, err := myGantry.Position(context.Background(), nil)
@@ -61,7 +62,7 @@ func Named(name string) resource.Name {
 //
 // MoveToPosition example:
 //
-//	myGantry, err := gantry.FromRobot(machine, "my_gantry")
+//	myGantry, err := gantry.GetResource(machine, "my_gantry")
 //
 //	// Create a list of positions for the axes of the gantry to move to.
 //	// Assume in this example that the gantry is multi-axis, with 3 axes.
@@ -76,7 +77,7 @@ func Named(name string) resource.Name {
 //
 // Lengths example:
 //
-//	myGantry, err := gantry.FromRobot(machine, "my_gantry")
+//	myGantry, err := gantry.GetResource(machine, "my_gantry")
 //
 //	// Get the lengths of the axes of the gantry in millimeters.
 //	lengths_mm, err := myGantry.Lengths(context.Background(), nil)
@@ -85,7 +86,7 @@ func Named(name string) resource.Name {
 //
 // Home example:
 //
-//	myGantry, err := gantry.FromRobot(machine, "my_gantry")
+//	myGantry, err := gantry.GetResource(machine, "my_gantry")
 //
 //	myGantry.Home(context.Background(), nil)
 //
@@ -115,15 +116,17 @@ type Gantry interface {
 	Home(ctx context.Context, extra map[string]interface{}) (bool, error)
 }
 
-// FromDependencies is a helper for getting the named gantry from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Gantry, error) {
-	return resource.FromDependencies[Gantry](deps, Named(name))
-}
-
-// FromRobot is a helper for getting the named gantry from the given Robot.
-func FromRobot(r robot.Robot, name string) (Gantry, error) {
-	return robot.ResourceFromRobot[Gantry](r, Named(name))
+// GetResource is a helper for getting the named Gantry from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Gantry, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Gantry](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Gantry](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all gantry names from the given Robot.

--- a/components/gantry/multiaxis/multiaxis.go
+++ b/components/gantry/multiaxis/multiaxis.go
@@ -74,7 +74,7 @@ func newMultiAxis(
 	}
 
 	for _, s := range newConf.SubAxes {
-		subAx, err := gantry.FromDependencies(deps, s)
+		subAx, err := gantry.GetResource(deps, s)
 		if err != nil {
 			return nil, errors.Wrapf(err, "no axes named [%s]", s)
 		}

--- a/components/gantry/singleaxis/singleaxis.go
+++ b/components/gantry/singleaxis/singleaxis.go
@@ -169,7 +169,7 @@ func (g *singleAxis) Reconfigure(ctx context.Context, deps resource.Dependencies
 	// Rerun homing if the board has changed
 	if newConf.Board != "" {
 		if g.board == nil || g.board.Name().ShortName() != newConf.Board {
-			board, err := board.FromDependencies(deps, newConf.Board)
+			board, err := board.GetResource(deps, newConf.Board)
 			if err != nil {
 				return err
 			}
@@ -181,7 +181,7 @@ func (g *singleAxis) Reconfigure(ctx context.Context, deps resource.Dependencies
 	// Rerun homing if the motor changes
 	if g.motor == nil || g.motor.Name().ShortName() != newConf.Motor {
 		needsToReHome = true
-		motorDep, err := motor.FromDependencies(deps, newConf.Motor)
+		motorDep, err := motor.GetResource(deps, newConf.Motor)
 		if err != nil {
 			return err
 		}

--- a/components/generic/generic.go
+++ b/components/generic/generic.go
@@ -5,6 +5,8 @@
 package generic
 
 import (
+	"fmt"
+	
 	pb "go.viam.com/api/component/generic/v1"
 
 	"go.viam.com/rdk/data"
@@ -36,15 +38,17 @@ func Named(name string) resource.Name {
 	return resource.NewName(API, name)
 }
 
-// FromDependencies is a helper for getting the named generic from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (resource.Resource, error) {
-	return resource.FromDependencies[resource.Resource](deps, Named(name))
-}
-
-// FromRobot is a helper for getting the named Generic from the given Robot.
-func FromRobot(r robot.Robot, name string) (resource.Resource, error) {
-	return robot.ResourceFromRobot[resource.Resource](r, Named(name))
+// GetResource is a helper for getting the named Generic from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (resource.Resource, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[resource.Resource](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[resource.Resource](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all generic names from the given Robot.

--- a/components/input/gpio/gpio.go
+++ b/components/input/gpio/gpio.go
@@ -111,7 +111,7 @@ func NewGPIOController(
 		return nil, err
 	}
 
-	brd, err := board.FromDependencies(deps, newConf.Board)
+	brd, err := board.GetResource(deps, newConf.Board)
 	if err != nil {
 		return nil, err
 	}

--- a/components/input/input.go
+++ b/components/input/input.go
@@ -6,6 +6,7 @@ package input
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	pb "go.viam.com/api/component/inputcontroller/v1"
@@ -45,7 +46,7 @@ func Named(name string) resource.Name {
 //
 // Controls example:
 //
-//	myController, err := input.FromRobot(machine, "my_input_controller")
+//	myController, err := input.GetResource(machine, "my_input_controller")
 //
 //	// Get the list of Controls provided by the controller.
 //	controls, err := myController.Controls(context.Background(), nil)
@@ -54,7 +55,7 @@ func Named(name string) resource.Name {
 //
 // Events example:
 //
-//	myController, err := input.FromRobot(machine, "my_input_controller")
+//	myController, err := input.GetResource(machine, "my_input_controller")
 //
 //	// Get the most recent Event for each Control.
 //	recent_events, err := myController.Events(context.Background(), nil)
@@ -68,7 +69,7 @@ func Named(name string) resource.Name {
 //	    logger.Info("Start Menu Button was pressed at this time: %v", event.Time)
 //	}
 //
-//	myController, err := input.FromRobot(machine, "my_input_controller")
+//	myController, err := input.GetResource(machine, "my_input_controller")
 //
 //	// Define the EventType "ButtonPress" to serve as the trigger for printStartTime.
 //	triggers := []input.EventType{input.ButtonPress}
@@ -191,15 +192,17 @@ type Triggerable interface {
 	TriggerEvent(ctx context.Context, event Event, extra map[string]interface{}) error
 }
 
-// FromDependencies is a helper for getting the named input controller from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Controller, error) {
-	return resource.FromDependencies[Controller](deps, Named(name))
-}
-
-// FromRobot is a helper for getting the named input controller from the given Robot.
-func FromRobot(r robot.Robot, name string) (Controller, error) {
-	return robot.ResourceFromRobot[Controller](r, Named(name))
+// GetResource is a helper for getting the named Input Controller from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Controller, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Controller](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Controller](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all input controller names from the given Robot.

--- a/components/input/mux/mux.go
+++ b/components/input/mux/mux.go
@@ -50,7 +50,7 @@ func NewController(
 	}
 
 	for _, s := range newConf.Sources {
-		c, err := input.FromDependencies(deps, s)
+		c, err := input.GetResource(deps, s)
 		if err != nil {
 			return nil, err
 		}

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -121,7 +121,7 @@ func (m *Motor) Reconfigure(ctx context.Context, deps resource.Dependencies, con
 	var b board.Board
 	if newConf.BoardName != "" {
 		m.Board = newConf.BoardName
-		b, err = board.FromDependencies(deps, m.Board)
+		b, err = board.GetResource(deps, m.Board)
 		if err != nil {
 			return err
 		}
@@ -156,7 +156,7 @@ func (m *Motor) Reconfigure(ctx context.Context, deps resource.Dependencies, con
 	if newConf.Encoder != "" {
 		m.TicksPerRotation = newConf.TicksPerRotation
 
-		e, err := encoder.FromDependencies(deps, newConf.Encoder)
+		e, err := encoder.GetResource(deps, newConf.Encoder)
 		if err != nil {
 			return err
 		}

--- a/components/motor/gpio/setup.go
+++ b/components/motor/gpio/setup.go
@@ -168,7 +168,7 @@ func getBoardFromRobotConfig(deps resource.Dependencies, conf resource.Config) (
 	if motorConfig.BoardName == "" {
 		return nil, nil, errors.New("expected board name in config for motor")
 	}
-	b, err := board.FromDependencies(deps, motorConfig.BoardName)
+	b, err := board.GetResource(deps, motorConfig.BoardName)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -189,7 +189,7 @@ func createNewMotor(
 	}
 
 	if motorConfig.Encoder != "" {
-		e, err := encoder.FromDependencies(deps, motorConfig.Encoder)
+		e, err := encoder.GetResource(deps, motorConfig.Encoder)
 		if err != nil {
 			return nil, err
 		}

--- a/components/motor/gpiostepper/gpiostepper.go
+++ b/components/motor/gpiostepper/gpiostepper.go
@@ -118,7 +118,7 @@ func newGPIOStepper(
 		return nil, err
 	}
 
-	b, err := board.FromDependencies(deps, mc.BoardName)
+	b, err := board.GetResource(deps, mc.BoardName)
 	if err != nil {
 		return nil, err
 	}

--- a/components/motor/motor.go
+++ b/components/motor/motor.go
@@ -48,7 +48,7 @@ var API = resource.APINamespaceRDK.WithComponentType(SubtypeName)
 //
 // SetPower example:
 //
-//	myMotorComponent, err := motor.FromRobot(machine, "my_motor")
+//	myMotorComponent, err := motor.GetResource(machine, "my_motor")
 //	// Set the motor power to 40% forwards.
 //	myMotorComponent.SetPower(context.Background(), 0.4, nil)
 //
@@ -56,7 +56,7 @@ var API = resource.APINamespaceRDK.WithComponentType(SubtypeName)
 //
 // GoFor example:
 //
-//	myMotorComponent, err := motor.FromRobot(machine, "my_motor")
+//	myMotorComponent, err := motor.GetResource(machine, "my_motor")
 //	// Turn the motor 7.2 revolutions at 60 RPM.
 //	myMotorComponent.GoFor(context.Background(), 60, 7.2, nil)
 //
@@ -171,15 +171,17 @@ func Named(name string) resource.Name {
 	return resource.NewName(API, name)
 }
 
-// FromDependencies is a helper for getting the named motor from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Motor, error) {
-	return resource.FromDependencies[Motor](deps, Named(name))
-}
-
-// FromRobot is a helper for getting the named motor from the given Robot.
-func FromRobot(r robot.Robot, name string) (Motor, error) {
-	return robot.ResourceFromRobot[Motor](r, Named(name))
+// GetResource is a helper for getting the named Motor from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Motor, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Motor](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Motor](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all motor names from the given Robot.

--- a/components/motor/motor_test.go
+++ b/components/motor/motor_test.go
@@ -30,15 +30,15 @@ func TestFromRobot(t *testing.T) {
 	expected := []string{"m1", "m2"}
 	testutils.VerifySameElements(t, motor.NamesFromRobot(r), expected)
 
-	_, err := motor.FromRobot(r, "m1")
+	_, err := motor.GetResource(r, "m1")
 	test.That(t, err, test.ShouldBeNil)
 
-	_, err = motor.FromRobot(r, "m2")
+	_, err = motor.GetResource(r, "m2")
 	test.That(t, err, test.ShouldBeNil)
 
-	_, err = motor.FromRobot(r, "m0")
+	_, err = motor.GetResource(r, "m0")
 	test.That(t, err, test.ShouldNotBeNil)
 
-	_, err = motor.FromRobot(r, "g")
+	_, err = motor.GetResource(r, "g")
 	test.That(t, err, test.ShouldNotBeNil)
 }

--- a/components/movementsensor/merged/merged.go
+++ b/components/movementsensor/merged/merged.go
@@ -100,7 +100,7 @@ func (m *merged) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 		}
 
 		for _, name := range names {
-			ms, err := movementsensor.FromDependencies(deps, name)
+			ms, err := movementsensor.GetResource(deps, name)
 			msName := ms.Name().ShortName()
 			if err != nil {
 				logger.CDebugf(ctx, "error getting sensor %v from dependencies", msName)

--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -6,6 +6,7 @@ package movementsensor
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"strings"
 
@@ -181,15 +182,17 @@ type MovementSensor interface {
 	Accuracy(ctx context.Context, extra map[string]interface{}) (*Accuracy, error)
 }
 
-// FromDependencies is a helper for getting the named movementsensor from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (MovementSensor, error) {
-	return resource.FromDependencies[MovementSensor](deps, Named(name))
-}
-
-// FromRobot is a helper for getting the named MovementSensor from the given Robot.
-func FromRobot(r robot.Robot, name string) (MovementSensor, error) {
-	return robot.ResourceFromRobot[MovementSensor](r, Named(name))
+// GetResource is a helper for getting the named MovementSensor from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (MovementSensor, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[MovementSensor](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[MovementSensor](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all MovementSensor names from the given Robot.

--- a/components/movementsensor/wheeledodometry/wheeledodometry.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry.go
@@ -153,7 +153,7 @@ func (o *odometry) Reconfigure(ctx context.Context, deps resource.Dependencies, 
 	}
 
 	// set baseWidth and wheelCircumference from the new base properties
-	newBase, err := base.FromDependencies(deps, newConf.Base)
+	newBase, err := base.GetResource(deps, newConf.Base)
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func (o *odometry) Reconfigure(ctx context.Context, deps resource.Dependencies, 
 	for i := range newConf.LeftMotors {
 		var motorLeft, motorRight motor.Motor
 
-		motorLeft, err = motor.FromDependencies(deps, newConf.LeftMotors[i])
+		motorLeft, err = motor.GetResource(deps, newConf.LeftMotors[i])
 		if err != nil {
 			return err
 		}
@@ -185,7 +185,7 @@ func (o *odometry) Reconfigure(ctx context.Context, deps resource.Dependencies, 
 			return motor.NewPropertyUnsupportedError(properties, newConf.LeftMotors[i])
 		}
 
-		motorRight, err = motor.FromDependencies(deps, newConf.RightMotors[i])
+		motorRight, err = motor.GetResource(deps, newConf.RightMotors[i])
 		if err != nil {
 			return err
 		}

--- a/components/posetracker/pose_tracker.go
+++ b/components/posetracker/pose_tracker.go
@@ -4,6 +4,7 @@ package posetracker
 
 import (
 	"context"
+	"fmt"
 
 	pb "go.viam.com/api/component/posetracker/v1"
 
@@ -45,13 +46,15 @@ type PoseTracker interface {
 	Poses(ctx context.Context, bodyNames []string, extra map[string]interface{}) (referenceframe.FrameSystemPoses, error)
 }
 
-// FromRobot is a helper for getting the named force matrix sensor from the given Robot.
-func FromRobot(r robot.Robot, name string) (PoseTracker, error) {
-	return robot.ResourceFromRobot[PoseTracker](r, Named(name))
-}
-
-// FromDependencies is a helper for getting the named pose tracker from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (PoseTracker, error) {
-	return resource.FromDependencies[PoseTracker](deps, Named(name))
+// GetResource is a helper for getting the named PoseTracker from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (PoseTracker, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[PoseTracker](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[PoseTracker](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }

--- a/components/powersensor/powersensor.go
+++ b/components/powersensor/powersensor.go
@@ -6,6 +6,7 @@ package powersensor
 
 import (
 	"context"
+	"fmt"
 
 	pb "go.viam.com/api/component/powersensor/v1"
 
@@ -95,15 +96,17 @@ type PowerSensor interface {
 	Power(ctx context.Context, extra map[string]interface{}) (float64, error)
 }
 
-// FromDependencies is a helper for getting the named PowerSensor from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (PowerSensor, error) {
-	return resource.FromDependencies[PowerSensor](deps, Named(name))
-}
-
-// FromRobot is a helper for getting the named PowerSensor from the given Robot.
-func FromRobot(r robot.Robot, name string) (PowerSensor, error) {
-	return robot.ResourceFromRobot[PowerSensor](r, Named(name))
+// GetResource is a helper for getting the named PowerSensor from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (PowerSensor, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[PowerSensor](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[PowerSensor](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all PowerSensor names from the given Robot.

--- a/components/sensor/sensor.go
+++ b/components/sensor/sensor.go
@@ -5,6 +5,8 @@
 package sensor
 
 import (
+	"fmt"
+
 	pb "go.viam.com/api/component/sensor/v1"
 
 	"go.viam.com/rdk/data"
@@ -47,15 +49,17 @@ type Sensor interface {
 	resource.Sensor
 }
 
-// FromDependencies is a helper for getting the named sensor from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Sensor, error) {
-	return resource.FromDependencies[Sensor](deps, Named(name))
-}
-
-// FromRobot is a helper for getting the named Sensor from the given Robot.
-func FromRobot(r robot.Robot, name string) (Sensor, error) {
-	return robot.ResourceFromRobot[Sensor](r, Named(name))
+// GetResource is a helper for getting the named Sensor from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Sensor, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Sensor](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Sensor](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all sensor names from the given Robot.

--- a/components/servo/gpio/servo.go
+++ b/components/servo/gpio/servo.go
@@ -141,7 +141,7 @@ func (s *servoGPIO) Reconfigure(ctx context.Context, deps resource.Dependencies,
 
 	boardName := newConf.Board
 
-	b, err := board.FromDependencies(deps, boardName)
+	b, err := board.GetResource(deps, boardName)
 	if err != nil {
 		return errors.Wrap(err, "board doesn't exist")
 	}

--- a/components/servo/servo.go
+++ b/components/servo/servo.go
@@ -6,6 +6,7 @@ package servo
 
 import (
 	"context"
+	"fmt"
 
 	pb "go.viam.com/api/component/servo/v1"
 
@@ -83,9 +84,17 @@ func Named(name string) resource.Name {
 	return resource.NewName(API, name)
 }
 
-// FromRobot is a helper for getting the named servo from the given Robot.
-func FromRobot(r robot.Robot, name string) (Servo, error) {
-	return robot.ResourceFromRobot[Servo](r, Named(name))
+// GetResource is a helper for getting the named Servo from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Servo, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Servo](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Servo](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all servo names from the given Robot.

--- a/components/switch/switch.go
+++ b/components/switch/switch.go
@@ -3,6 +3,7 @@ package toggleswitch
 
 import (
 	"context"
+	"fmt"
 
 	pb "go.viam.com/api/component/switch/v1"
 
@@ -51,14 +52,17 @@ type Switch interface {
 	GetNumberOfPositions(ctx context.Context, extra map[string]interface{}) (uint32, []string, error)
 }
 
-// FromRobot is a helper for getting the named Switch from the given Robot.
-func FromRobot(r robot.Robot, name string) (Switch, error) {
-	return robot.ResourceFromRobot[Switch](r, Named(name))
-}
-
-// FromDependencies is a helper for getting the named button component from a collection of dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Switch, error) {
-	return resource.FromDependencies[Switch](deps, Named(name))
+// GetResource is a helper for getting the named Switch from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Switch, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Switch](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Switch](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all switch names from the given Robot.

--- a/examples/customresources/apis/gizmoapi/gizmoapi.go
+++ b/examples/customresources/apis/gizmoapi/gizmoapi.go
@@ -3,6 +3,7 @@ package gizmoapi
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
@@ -23,9 +24,17 @@ func Named(name string) resource.Name {
 	return resource.NewName(API, name)
 }
 
-// FromRobot is a helper for getting the named Gizmo from the given Robot.
-func FromRobot(r robot.Robot, name string) (Gizmo, error) {
-	return robot.ResourceFromRobot[Gizmo](r, Named(name))
+// GetResource is a helper for getting the named Gizmo from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Gizmo, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Gizmo](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Gizmo](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 func init() {

--- a/examples/customresources/apis/summationapi/summationapi.go
+++ b/examples/customresources/apis/summationapi/summationapi.go
@@ -3,6 +3,7 @@ package summationapi
 
 import (
 	"context"
+	"fmt"
 
 	"go.viam.com/utils/rpc"
 
@@ -20,9 +21,17 @@ func Named(name string) resource.Name {
 	return resource.NewName(API, name)
 }
 
-// FromRobot is a helper for getting the named Summation from the given Robot.
-func FromRobot(r robot.Robot, name string) (Summation, error) {
-	return robot.ResourceFromRobot[Summation](r, Named(name))
+// GetResource is a helper for getting the named Summation from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Summation, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Summation](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Summation](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 func init() {

--- a/examples/customresources/demos/complexmodule/client/client.go
+++ b/examples/customresources/demos/complexmodule/client/client.go
@@ -34,7 +34,7 @@ func main() {
 	}()
 
 	logger.Info("---- Testing gizmo1 (gizmoapi) -----")
-	comp1, err := gizmoapi.FromRobot(robot, "gizmo1")
+	comp1, err := gizmoapi.GetResource(robot, "gizmo1")
 	if err != nil {
 		logger.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func main() {
 	logger.Info(ret3)
 
 	logger.Info("---- Testing adder (summationapi) -----")
-	add, err := summationapi.FromRobot(robot, "adder")
+	add, err := summationapi.GetResource(robot, "adder")
 	if err != nil {
 		logger.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func main() {
 	logger.Info(nums, "sum to", retAdd)
 
 	logger.Info("---- Testing subtractor (summationapi) -----")
-	sub, err := summationapi.FromRobot(robot, "subtractor")
+	sub, err := summationapi.GetResource(robot, "subtractor")
 	if err != nil {
 		logger.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func main() {
 	logger.Info(nums, "subtract to", retSub)
 
 	logger.Info("---- Testing denali (navigation) -----")
-	nav, err := navigation.FromRobot(robot, "denali")
+	nav, err := navigation.GetResource(robot, "denali")
 	if err != nil {
 		logger.Fatal(err)
 	}
@@ -133,7 +133,7 @@ func main() {
 	}
 
 	logger.Info("---- Testing base1 (base) -----")
-	mybase, err := base.FromRobot(robot, "base1")
+	mybase, err := base.GetResource(robot, "base1")
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/examples/customresources/demos/multiplemodules/client/client.go
+++ b/examples/customresources/demos/multiplemodules/client/client.go
@@ -27,7 +27,7 @@ func main() {
 	}()
 
 	logger.Info("---- Testing gizmo1 (gizmoapi) -----")
-	comp1, err := gizmoapi.FromRobot(robot, "gizmo1")
+	comp1, err := gizmoapi.GetResource(robot, "gizmo1")
 	if err != nil {
 		logger.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func main() {
 	logger.Info(ret4)
 
 	logger.Info("---- Testing adder (summationapi) -----")
-	add, err := summationapi.FromRobot(robot, "adder")
+	add, err := summationapi.GetResource(robot, "adder")
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/examples/customresources/demos/optionaldepsmodule/module.go
+++ b/examples/customresources/demos/optionaldepsmodule/module.go
@@ -93,13 +93,13 @@ func (f *foo) Reconfigure(ctx context.Context, deps resource.Dependencies,
 		return err
 	}
 
-	f.requiredMotor, err = motor.FromDependencies(deps, fooConfig.RequiredMotor)
+	f.requiredMotor, err = motor.GetResource(deps, fooConfig.RequiredMotor)
 	if err != nil {
 		return fmt.Errorf("could not get required motor %s from dependencies",
 			fooConfig.RequiredMotor)
 	}
 
-	f.optionalMotor, err = motor.FromDependencies(deps, fooConfig.OptionalMotor)
+	f.optionalMotor, err = motor.GetResource(deps, fooConfig.OptionalMotor)
 	if err != nil {
 		f.logger.Infof("could not get optional motor %s from dependencies; continuing",
 			fooConfig.OptionalMotor)
@@ -188,7 +188,7 @@ func newMutualOptionalChild(ctx context.Context,
 		return nil, err
 	}
 
-	moc.otherMOC, err = generic.FromDependencies(deps, mutualOptionalChildConfig.OtherMOC)
+	moc.otherMOC, err = generic.GetResource(deps, mutualOptionalChildConfig.OtherMOC)
 	if err != nil {
 		moc.logger.Infof("could not get other MOC %s from dependencies; continuing",
 			mutualOptionalChildConfig.OtherMOC)

--- a/examples/customresources/models/mybase/mybase.go
+++ b/examples/customresources/models/mybase/mybase.go
@@ -57,12 +57,12 @@ func (b *myBase) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 		return err
 	}
 
-	b.left, err = motor.FromDependencies(deps, baseConfig.LeftMotor)
+	b.left, err = motor.GetResource(deps, baseConfig.LeftMotor)
 	if err != nil {
 		return errors.Wrapf(err, "unable to get motor %v for mybase", baseConfig.LeftMotor)
 	}
 
-	b.right, err = motor.FromDependencies(deps, baseConfig.RightMotor)
+	b.right, err = motor.GetResource(deps, baseConfig.RightMotor)
 	if err != nil {
 		return errors.Wrapf(err, "unable to get motor %v for mybase", baseConfig.RightMotor)
 	}

--- a/module/multiversionmodule/module.go
+++ b/module/multiversionmodule/module.go
@@ -102,7 +102,7 @@ func (c *component) Reconfigure(ctx context.Context, deps resource.Dependencies,
 	}
 	if VERSION == "v3" {
 		// Version 3 should have a motor in the deps
-		if _, err := motor.FromDependencies(deps, "motor1"); err != nil {
+		if _, err := motor.GetResource(deps, "motor1"); err != nil {
 			return errors.Wrapf(err, "failed to resolve motor %q for version 3", "motor1")
 		}
 	}

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -116,7 +116,7 @@ func newHelper(
 	var dependsOnSensor sensor.Sensor
 	var err error
 	if len(conf.DependsOn) > 0 {
-		dependsOnSensor, err = sensor.FromDependencies(deps, conf.DependsOn[0])
+		dependsOnSensor, err = sensor.GetResource(deps, conf.DependsOn[0])
 		if err != nil {
 			return nil, err
 		}

--- a/module/testmodule2/main.go
+++ b/module/testmodule2/main.go
@@ -73,7 +73,7 @@ func newHelper(
 	var dependsOnGeneric resource.Resource
 	var err error
 	if len(conf.DependsOn) > 0 {
-		dependsOnGeneric, err = generic.FromDependencies(deps, conf.DependsOn[0])
+		dependsOnGeneric, err = generic.GetResource(deps, conf.DependsOn[0])
 		if err != nil {
 			return nil, err
 		}

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -56,7 +56,7 @@ var (
 // DoCommand example:
 //
 //	// This example shows using DoCommand with an arm component.
-//	myArm, err := arm.FromRobot(machine, "my_arm")
+//	myArm, err := arm.GetResource(machine, "my_arm")
 //
 //	command := map[string]interface{}{"cmd": "test", "data1": 500}
 //	result, err := myArm.DoCommand(context.Background(), command)
@@ -64,7 +64,7 @@ var (
 // Close example:
 //
 //	// This example shows using Close with an arm component.
-//	myArm, err := arm.FromRobot(machine, "my_arm")
+//	myArm, err := arm.GetResource(machine, "my_arm")
 //
 //	err = myArm.Close(context.Background())
 type Resource interface {
@@ -172,7 +172,7 @@ type Sensor interface {
 // IsMoving example:
 //
 //	// This example shows using IsMoving with an arm component.
-//	myArm, err := arm.FromRobot(machine, "my_arm")
+//	myArm, err := arm.GetResource(machine, "my_arm")
 //
 //	// Stop all motion of the arm. It is assumed that the arm stops immediately.
 //	myArm.Stop(context.Background(), nil)
@@ -184,7 +184,7 @@ type Sensor interface {
 // Stop example:
 //
 //	// This example shows using Stop with an arm component.
-//	myArm, err := arm.FromRobot(machine, "my_arm")
+//	myArm, err := arm.GetResource(machine, "my_arm")
 //
 //	// Stop all motion of the arm. It is assumed that the arm stops immediately.
 //	err = myArm.Stop(context.Background(), nil)
@@ -201,7 +201,7 @@ type Actuator interface {
 // Geometries example:
 //
 //	// This example shows using Geometries with an arm component.
-//	myArm, err := arm.FromRobot(machine, "my_arm")
+//	myArm, err := arm.GetResource(machine, "my_arm")
 //
 //	geometries, err := myArm.Geometries(context.Background(), nil)
 //

--- a/resource/resource_provider.go
+++ b/resource/resource_provider.go
@@ -1,0 +1,6 @@
+package resource
+
+// Provider is a generic interface for looking up resources by name.
+type Provider[T Resource] interface {
+	GetResource(src any, name string) (T, error)
+}

--- a/robot/client/README.md
+++ b/robot/client/README.md
@@ -59,7 +59,7 @@ You can then query resources and also grab a resource by its name.
   	logger.Info(robot.ResourceNames())
 
 	// grab a motor by its name and query for its position
-	m1, err := motor.FromRobot(robot, "motor1")
+	m1, err := motor.GetResource(robot, "motor1")
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -492,7 +492,7 @@ func TestStatusClient(t *testing.T) {
 	client, err := New(context.Background(), listener1.Addr().String(), logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	arm1, err := arm.FromRobot(client, "arm1")
+	arm1, err := arm.GetResource(client, "arm1")
 	test.That(t, err, test.ShouldBeNil)
 	_, err = arm1.EndPosition(context.Background(), nil)
 	test.That(t, err, test.ShouldNotBeNil)
@@ -510,10 +510,10 @@ func TestStatusClient(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
 
-	_, err = base.FromRobot(client, "base1")
+	_, err = base.GetResource(client, "base1")
 	test.That(t, err, test.ShouldBeNil)
 
-	board1, err := board.FromRobot(client, "board1")
+	board1, err := board.GetResource(client, "board1")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, board1, test.ShouldNotBeNil)
 	pin, err := board1.GPIOPinByName("pin")
@@ -521,7 +521,7 @@ func TestStatusClient(t *testing.T) {
 	_, err = pin.Get(context.Background(), nil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
 
-	camera1, err := camera.FromRobot(client, "camera1")
+	camera1, err := camera.GetResource(client, "camera1")
 	test.That(t, err, test.ShouldBeNil)
 	imgBytes, metadata, err := camera1.Image(context.Background(), rutils.MimeTypeJPEG, nil)
 	test.That(t, err, test.ShouldNotBeNil)
@@ -529,7 +529,7 @@ func TestStatusClient(t *testing.T) {
 	test.That(t, imgBytes, test.ShouldBeNil)
 	test.That(t, metadata, test.ShouldResemble, camera.ImageMetadata{})
 
-	gripper1, err := gripper.FromRobot(client, "gripper1")
+	gripper1, err := gripper.GetResource(client, "gripper1")
 	test.That(t, err, test.ShouldBeNil)
 	err = gripper1.Open(context.Background(), map[string]interface{}{})
 	test.That(t, err, test.ShouldNotBeNil)
@@ -538,7 +538,7 @@ func TestStatusClient(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
 
-	motor1, err := motor.FromRobot(client, "motor1")
+	motor1, err := motor.GetResource(client, "motor1")
 	test.That(t, err, test.ShouldBeNil)
 	err = motor1.SetPower(context.Background(), 0, nil)
 	test.That(t, err, test.ShouldNotBeNil)
@@ -547,13 +547,13 @@ func TestStatusClient(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
 
-	sensorDevice, err := sensor.FromRobot(client, "sensor1")
+	sensorDevice, err := sensor.GetResource(client, "sensor1")
 	test.That(t, err, test.ShouldBeNil)
 	_, err = sensorDevice.Readings(context.Background(), make(map[string]interface{}))
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
 
-	servo1, err := servo.FromRobot(client, "servo1")
+	servo1, err := servo.GetResource(client, "servo1")
 	test.That(t, err, test.ShouldBeNil)
 	err = servo1.Move(context.Background(), 5, nil)
 	test.That(t, err, test.ShouldNotBeNil)
@@ -589,19 +589,19 @@ func TestStatusClient(t *testing.T) {
 
 	test.That(t, func() { client.RemoteByName("remote1") }, test.ShouldPanic)
 
-	arm1, err = arm.FromRobot(client, "arm1")
+	arm1, err = arm.GetResource(client, "arm1")
 	test.That(t, err, test.ShouldBeNil)
 	pos, err := arm1.EndPosition(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, spatialmath.PoseAlmostEqual(pos, pose1), test.ShouldBeTrue)
 
-	_, err = base.FromRobot(client, "base1")
+	_, err = base.GetResource(client, "base1")
 	test.That(t, err, test.ShouldBeNil)
 
-	_, err = board.FromRobot(client, "board1")
+	_, err = board.GetResource(client, "board1")
 	test.That(t, err, test.ShouldBeNil)
 
-	camera1, err = camera.FromRobot(client, "camera1")
+	camera1, err = camera.GetResource(client, "camera1")
 	test.That(t, err, test.ShouldBeNil)
 
 	frame, err := camera.DecodeImageFromCamera(context.Background(), rutils.MimeTypeRawRGBA, nil, camera1)
@@ -610,28 +610,28 @@ func TestStatusClient(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, compVal, test.ShouldEqual, 0) // exact copy, no color conversion
 
-	gripper1, err = gripper.FromRobot(client, "gripper1")
+	gripper1, err = gripper.GetResource(client, "gripper1")
 	test.That(t, err, test.ShouldBeNil)
 	err = gripper1.Open(context.Background(), map[string]interface{}{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gripperOpenCalled, test.ShouldBeTrue)
 	test.That(t, gripperGrabCalled, test.ShouldBeFalse)
 
-	inputDev, err := input.FromRobot(client, "inputController1")
+	inputDev, err := input.GetResource(client, "inputController1")
 	test.That(t, err, test.ShouldBeNil)
 	controlList, err := inputDev.Controls(context.Background(), map[string]interface{}{})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, controlList, test.ShouldResemble, []input.Control{input.AbsoluteX, input.ButtonStart})
 
-	motor1, err = motor.FromRobot(client, "motor1")
+	motor1, err = motor.GetResource(client, "motor1")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, motor1, test.ShouldNotBeNil)
 
-	motor2, err := motor.FromRobot(client, "motor2")
+	motor2, err := motor.GetResource(client, "motor2")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, motor2, test.ShouldNotBeNil)
 
-	servo1, err = servo.FromRobot(client, "servo1")
+	servo1, err = servo.GetResource(client, "servo1")
 	test.That(t, err, test.ShouldBeNil)
 	err = servo1.Move(context.Background(), 4, nil)
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -85,7 +85,7 @@ func TestConfig1(t *testing.T) {
 
 	r := setupLocalRobot(t, context.Background(), cfg, logger)
 
-	c1, err := camera.FromRobot(r, "c1")
+	c1, err := camera.GetResource(r, "c1")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, c1.Name(), test.ShouldResemble, camera.Named("c1"))
 
@@ -1181,7 +1181,7 @@ func TestConfigStartsInvalidReconfiguresValid(t *testing.T) {
 
 	// Test Component Error
 	name := base.Named("test")
-	noBase, err := base.FromRobot(r, "test")
+	noBase, err := base.GetResource(r, "test")
 	test.That(
 		t,
 		err,
@@ -1201,7 +1201,7 @@ func TestConfigStartsInvalidReconfiguresValid(t *testing.T) {
 
 	r.Reconfigure(ctx, goodConfig)
 	// Test Component Valid
-	noBase, err = base.FromRobot(r, "test")
+	noBase, err = base.GetResource(r, "test")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, noBase, test.ShouldNotBeNil)
 	// Test Service Valid
@@ -1287,7 +1287,7 @@ func TestConfigStartsValidReconfiguresInvalid(t *testing.T) {
 	}
 	test.That(t, badConfig.Ensure(false, logger), test.ShouldBeNil)
 	// Test Component Valid
-	noBase, err := base.FromRobot(r, "test")
+	noBase, err := base.GetResource(r, "test")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, noBase, test.ShouldNotBeNil)
 	// Test Service Valid
@@ -1302,7 +1302,7 @@ func TestConfigStartsValidReconfiguresInvalid(t *testing.T) {
 	r.Reconfigure(ctx, badConfig)
 	// Test Component Error
 	name := base.Named("test")
-	noBase, err = base.FromRobot(r, "test")
+	noBase, err = base.GetResource(r, "test")
 	test.That(
 		t,
 		err,

--- a/robot/impl/optional_dependencies_test.go
+++ b/robot/impl/optional_dependencies_test.go
@@ -81,13 +81,13 @@ func (oc *optionalChild) Reconfigure(ctx context.Context, deps resource.Dependen
 		return err
 	}
 
-	oc.requiredMotor, err = motor.FromDependencies(deps, optionalChildConfig.RequiredMotor)
+	oc.requiredMotor, err = motor.GetResource(deps, optionalChildConfig.RequiredMotor)
 	if err != nil {
 		return fmt.Errorf("could not get required motor %s from dependencies",
 			optionalChildConfig.RequiredMotor)
 	}
 
-	oc.optionalMotor, err = motor.FromDependencies(deps, optionalChildConfig.OptionalMotor)
+	oc.optionalMotor, err = motor.GetResource(deps, optionalChildConfig.OptionalMotor)
 	if err != nil {
 		oc.logger.Infof("could not get optional motor %s from dependencies; continuing",
 			optionalChildConfig.OptionalMotor)
@@ -672,7 +672,7 @@ func (moc *mutualOptionalChild) Reconfigure(ctx context.Context, deps resource.D
 		return err
 	}
 
-	moc.otherMOC, err = generic.FromDependencies(deps, mutualOptionalChildConfig.OtherMOC)
+	moc.otherMOC, err = generic.GetResource(deps, mutualOptionalChildConfig.OtherMOC)
 	if err != nil {
 		moc.logger.Infof("could not get other MOC %s from dependencies; continuing",
 			mutualOptionalChildConfig.OtherMOC)

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1574,7 +1574,7 @@ func TestRemoteConnClosedOnReconfigure(t *testing.T) {
 		mainRobot := setupLocalRobot(t, ctx, mainRobotCfg, logger.Sublogger("main"))
 
 		// Grab motor of remote1 to check that it won't work after switching remotes
-		motor1, err := motor.FromRobot(mainRobot, "motor")
+		motor1, err := motor.GetResource(mainRobot, "motor")
 		test.That(t, err, test.ShouldBeNil)
 
 		moving, speed, err := motor1.IsPowered(ctx, nil)
@@ -1592,7 +1592,7 @@ func TestRemoteConnClosedOnReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 
 		// Grab motor of remote2 to check that it won't work after switching remotes
-		motor2, err := motor.FromRobot(mainRobot, "motor")
+		motor2, err := motor.GetResource(mainRobot, "motor")
 		test.That(t, err, test.ShouldBeNil)
 
 		moving, speed, _ = motor2.IsPowered(ctx, nil)
@@ -1612,7 +1612,7 @@ func TestRemoteConnClosedOnReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 
 		// Check that we were able to grab the motor from remote1 through the main robot and successfully call IsPowered()
-		motor1, err = motor.FromRobot(mainRobot, "motor")
+		motor1, err = motor.GetResource(mainRobot, "motor")
 		test.That(t, err, test.ShouldBeNil)
 
 		moving, speed, err = motor1.IsPowered(ctx, nil)
@@ -1648,7 +1648,7 @@ func TestRemoteConnClosedOnReconfigure(t *testing.T) {
 		mainRobot := setupLocalRobot(t, ctx, mainRobotCfg, logger.Sublogger("main"))
 
 		// Grab arm of remote1 to check that it won't work after switching remotes
-		arm1, err := arm.FromRobot(mainRobot, "arm")
+		arm1, err := arm.GetResource(mainRobot, "arm")
 		test.That(t, err, test.ShouldBeNil)
 
 		moving, err := arm1.IsMoving(ctx)
@@ -1665,7 +1665,7 @@ func TestRemoteConnClosedOnReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 
 		// Grab motor of remote2 to check that it won't work after switching remotes
-		motor1, err := motor.FromRobot(mainRobot, "motor")
+		motor1, err := motor.GetResource(mainRobot, "motor")
 		test.That(t, err, test.ShouldBeNil)
 
 		moving, speed, _ := motor1.IsPowered(ctx, nil)
@@ -1685,7 +1685,7 @@ func TestRemoteConnClosedOnReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 
 		// Check that we were able to grab the arm from remote1 through the main robot and successfully call IsMoving()
-		arm1, err = arm.FromRobot(mainRobot, "arm")
+		arm1, err = arm.GetResource(mainRobot, "arm")
 		test.That(t, err, test.ShouldBeNil)
 
 		moving, err = arm1.IsMoving(ctx)

--- a/robot/session_test.go
+++ b/robot/session_test.go
@@ -186,7 +186,7 @@ func TestSessions(t *testing.T) {
 			roboClient, err := client.New(ctx, addr, logger.Sublogger("client"))
 			test.That(t, err, test.ShouldBeNil)
 
-			motor1, err := motor.FromRobot(roboClient, "motor1")
+			motor1, err := motor.GetResource(roboClient, "motor1")
 			test.That(t, err, test.ShouldBeNil)
 
 			t.Log("get position of motor1 which will not be safety monitored")
@@ -202,7 +202,7 @@ func TestSessions(t *testing.T) {
 			roboClient, err = client.New(ctx, addr, logger.Sublogger("client"))
 			test.That(t, err, test.ShouldBeNil)
 
-			motor1, err = motor.FromRobot(roboClient, "motor1")
+			motor1, err = motor.GetResource(roboClient, "motor1")
 			test.That(t, err, test.ShouldBeNil)
 
 			t.Log("set power of motor1 which will be safety monitored")
@@ -220,7 +220,7 @@ func TestSessions(t *testing.T) {
 			roboClient, err = client.New(ctx, addr, logger.Sublogger("client"))
 			test.That(t, err, test.ShouldBeNil)
 
-			motor2, err := motor.FromRobot(roboClient, "motor2")
+			motor2, err := motor.GetResource(roboClient, "motor2")
 			test.That(t, err, test.ShouldBeNil)
 
 			t.Log("set power of motor2 which will be safety monitored")
@@ -418,7 +418,7 @@ func TestSessionsWithRemote(t *testing.T) {
 	roboClient, err := client.New(ctx, addr, logger.Sublogger("client"))
 	test.That(t, err, test.ShouldBeNil)
 
-	motor1, err := motor.FromRobot(roboClient, "rem1motor1")
+	motor1, err := motor.GetResource(roboClient, "rem1motor1")
 	if err != nil {
 		bufSize := 1 << 20
 		traces := make([]byte, bufSize)
@@ -444,7 +444,7 @@ func TestSessionsWithRemote(t *testing.T) {
 	roboClient, err = client.New(ctx, addr, logger.Sublogger("client"))
 	test.That(t, err, test.ShouldBeNil)
 
-	motor1, err = motor.FromRobot(roboClient, "rem1motor1")
+	motor1, err = motor.GetResource(roboClient, "rem1motor1")
 	test.That(t, err, test.ShouldBeNil)
 
 	// this should cause safety monitoring
@@ -465,7 +465,7 @@ func TestSessionsWithRemote(t *testing.T) {
 	roboClient, err = client.New(ctx, addr, logger.Sublogger("client"))
 	test.That(t, err, test.ShouldBeNil)
 
-	motor1, err = motor.FromRobot(roboClient, "rem1motor1")
+	motor1, err = motor.GetResource(roboClient, "rem1motor1")
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Log("set power of rem1:motor1 which will be safety monitored")
@@ -492,7 +492,7 @@ func TestSessionsWithRemote(t *testing.T) {
 	roboClient, err = client.New(ctx, addr, logger.Sublogger("client"))
 	test.That(t, err, test.ShouldBeNil)
 
-	motor2, err := motor.FromRobot(roboClient, "rem1motor2")
+	motor2, err := motor.GetResource(roboClient, "rem1motor2")
 	if err != nil {
 		bufSize := 1 << 20
 		traces := make([]byte, bufSize)
@@ -592,9 +592,9 @@ func TestSessionsMixedClients(t *testing.T) {
 	roboClient2, err := client.New(ctx, addr, logger.Sublogger("client2"))
 	test.That(t, err, test.ShouldBeNil)
 
-	motor1Client1, err := motor.FromRobot(roboClient1, "motor1")
+	motor1Client1, err := motor.GetResource(roboClient1, "motor1")
 	test.That(t, err, test.ShouldBeNil)
-	motor1Client2, err := motor.FromRobot(roboClient2, "motor1")
+	motor1Client2, err := motor.GetResource(roboClient2, "motor1")
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, motor1Client1.SetPower(ctx, 50, nil), test.ShouldBeNil)
@@ -691,7 +691,7 @@ func TestSessionsMixedOwnersNoAuth(t *testing.T) {
 	// 4) Client 1 will disconnect. This results in the client ceasing heartbeats for the
 	//    `SetPower` operation. The robot's heartbeat thread will call `motor1.Stop`. While Client 2 sent a command
 	//    to the motor, it used Client 1's session and never sent heartbeats.
-	motor1Client1, err := motor.FromRobot(roboClient1, "motor1")
+	motor1Client1, err := motor.GetResource(roboClient1, "motor1")
 	test.That(t, err, test.ShouldBeNil)
 
 	// clients made directly with a connection will not send heartbeats.
@@ -798,7 +798,7 @@ func TestSessionsMixedOwnersImplicitAuth(t *testing.T) {
 	// 4) Client 1 will disconnect. This results in the client ceasing heartbeats for the
 	//    `SetPower` operation. As Client 2 never sent a successful command to the motor (even if it did, Client 2
 	//    won't sent heartbeats), the robot's heartbeat thread will call `motor1.Stop`.
-	motor1Client1, err := motor.FromRobot(roboClient1, "motor1")
+	motor1Client1, err := motor.GetResource(roboClient1, "motor1")
 	test.That(t, err, test.ShouldBeNil)
 
 	// clients made directly with a connection will not send heartbeats.

--- a/robot/web/stream/camera/camera.go
+++ b/robot/web/stream/camera/camera.go
@@ -19,7 +19,7 @@ import (
 func Camera(robot robot.Robot, stream gostream.Stream) (camera.Camera, error) {
 	// Stream names are slightly modified versions of the resource short name
 	shortName := stream.Name()
-	cam, err := camera.FromRobot(robot, shortName)
+	cam, err := camera.GetResource(robot, shortName)
 	if err != nil {
 		return nil, err
 	}

--- a/robot/web/stream/camera2/camera.go
+++ b/robot/web/stream/camera2/camera.go
@@ -56,7 +56,7 @@ func cropToEvenDimensions(img image.Image) (image.Image, error) {
 func Camera(robot robot.Robot, stream gostream.Stream) (camera.Camera, error) {
 	// Stream names are slightly modified versions of the resource short name
 	shortName := resource.SDPTrackNameToShortName(stream.Name())
-	cam, err := camera.FromRobot(robot, shortName)
+	cam, err := camera.GetResource(robot, shortName)
 	if err != nil {
 		return nil, err
 	}

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -173,7 +173,7 @@ func (server *Server) AddStream(ctx context.Context, req *streampb.AddStreamRequ
 
 	// return error if resource is neither a camera nor audioinput
 	_, isCamErr := cameraUtilsCamera(server.robot, streamStateToAdd.Stream)
-	_, isAudioErr := audioinput.FromRobot(server.robot, streamStateToAdd.Stream.Name())
+	_, isAudioErr := audioinput.GetResource(server.robot, streamStateToAdd.Stream.Name())
 	if isCamErr != nil && isAudioErr != nil {
 		return nil, errors.Errorf("stream is neither a camera nor audioinput. streamName: %v", streamStateToAdd.Stream)
 	}
@@ -272,7 +272,7 @@ func (server *Server) RemoveStream(ctx context.Context, req *streampb.RemoveStre
 	}
 
 	streamName := streamToRemove.Stream.Name()
-	_, isAudioResourceErr := audioinput.FromRobot(server.robot, streamName)
+	_, isAudioResourceErr := audioinput.GetResource(server.robot, streamName)
 	_, isCameraResourceErr := cameraUtilsCamera(server.robot, streamToRemove.Stream)
 
 	if isAudioResourceErr != nil && isCameraResourceErr != nil {
@@ -311,7 +311,7 @@ func (server *Server) GetStreamOptions(
 	if req.Name == "" {
 		return nil, errors.New("stream name is required")
 	}
-	cam, err := camera.FromRobot(server.robot, req.Name)
+	cam, err := camera.GetResource(server.robot, req.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get camera from robot: %w", err)
 	}
@@ -404,7 +404,7 @@ func (server *Server) resizeVideoSource(ctx context.Context, name string, width,
 	if !ok {
 		return fmt.Errorf("video source %q not found", name)
 	}
-	cam, err := camera.FromRobot(server.robot, name)
+	cam, err := camera.GetResource(server.robot, name)
 	if err != nil {
 		server.logger.Errorf("error getting camera %q from robot", name)
 		return err
@@ -436,7 +436,7 @@ func (server *Server) resetVideoSource(ctx context.Context, name string) error {
 	if !ok {
 		return fmt.Errorf("video source %q not found", name)
 	}
-	cam, err := camera.FromRobot(server.robot, name)
+	cam, err := camera.GetResource(server.robot, name)
 	if err != nil {
 		server.logger.Errorf("error getting camera %q from robot", name)
 	}
@@ -579,13 +579,13 @@ func (server *Server) removeMissingStreams() {
 		// Stream names are slightly modified versions of the resource short name
 		camName := streamState.Stream.Name()
 		shortName := resource.SDPTrackNameToShortName(camName)
-		if _, err := audioinput.FromRobot(server.robot, shortName); err == nil {
+		if _, err := audioinput.GetResource(server.robot, shortName); err == nil {
 			// `nameToStreamState` can contain names for both camera and audio resources. Leave the
 			// stream in place if its an audio resource.
 			continue
 		}
 
-		_, err := camera.FromRobot(server.robot, shortName)
+		_, err := camera.GetResource(server.robot, shortName)
 		if !resource.IsNotFoundError(err) {
 			// Cameras can go through transient states during reconfigure that don't necessarily
 			// imply the camera is missing. E.g: *resource.notAvailableError. To double-check we
@@ -633,7 +633,7 @@ func (server *Server) removeMissingStreams() {
 // refreshVideoSources checks and initializes every possible video source that could be viewed from the robot.
 func (server *Server) refreshVideoSources(ctx context.Context) {
 	for _, name := range camera.NamesFromRobot(server.robot) {
-		cam, err := camera.FromRobot(server.robot, name)
+		cam, err := camera.GetResource(server.robot, name)
 		if err != nil {
 			continue
 		}
@@ -686,7 +686,7 @@ func (server *Server) refreshVideoSources(ctx context.Context) {
 // refreshAudioSources checks and initializes every possible audio source that could be viewed from the robot.
 func (server *Server) refreshAudioSources() {
 	for _, name := range audioinput.NamesFromRobot(server.robot) {
-		input, err := audioinput.FromRobot(server.robot, name)
+		input, err := audioinput.GetResource(server.robot, name)
 		if err != nil {
 			continue
 		}
@@ -747,7 +747,7 @@ func (server *Server) startAudioStream(ctx context.Context, source gostream.Audi
 }
 
 func (server *Server) getFramerateFromCamera(name string) (int, error) {
-	cam, err := camera.FromRobot(server.robot, name)
+	cam, err := camera.GetResource(server.robot, name)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get camera from robot: %w", err)
 	}

--- a/services/baseremotecontrol/base_remote_control.go
+++ b/services/baseremotecontrol/base_remote_control.go
@@ -6,6 +6,7 @@ package baseremotecontrol
 
 import (
 	"context"
+	"fmt"
 
 	"go.viam.com/rdk/components/input"
 	"go.viam.com/rdk/data"
@@ -24,9 +25,17 @@ func Named(name string) resource.Name {
 	return resource.NewName(API, name)
 }
 
-// FromRobot is a helper for getting the named base remote control service from the given Robot.
-func FromRobot(r robot.Robot, name string) (Service, error) {
-	return robot.ResourceFromRobot[Service](r, Named(name))
+// GetResource is a helper for getting the named Base remote control service 
+// from either a collection of dependencies or the given robot.
+func GetResource(src any, name string) (Service, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Service](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Service](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 func init() {

--- a/services/baseremotecontrol/builtin/builtin.go
+++ b/services/baseremotecontrol/builtin/builtin.go
@@ -134,11 +134,11 @@ func (svc *builtIn) Reconfigure(
 	if err != nil {
 		return err
 	}
-	base1, err := base.FromDependencies(deps, svcConfig.BaseName)
+	base1, err := base.GetResource(deps, svcConfig.BaseName)
 	if err != nil {
 		return err
 	}
-	controller, err := input.FromDependencies(deps, svcConfig.InputControllerName)
+	controller, err := input.GetResource(deps, svcConfig.InputControllerName)
 	if err != nil {
 		return err
 	}

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -216,7 +216,7 @@ func syncSensorFromDeps(name string, deps resource.Dependencies, logger logging.
 	if name == "" {
 		return nil, false
 	}
-	syncSensor, err := sensor.FromDependencies(deps, name)
+	syncSensor, err := sensor.GetResource(deps, name)
 	if err != nil {
 		// see sync.Config for how this affects whether or not scheduled sync will run
 		logger.Errorw(

--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -7,6 +7,7 @@ package datamanager
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"image"
 	"reflect"
 	"slices"
@@ -40,7 +41,7 @@ func init() {
 //
 // Sync example:
 //
-//	data, err := datamanager.FromRobot(machine, "my_data_manager")
+//	data, err := datamanager.GetResource(machine, "my_data_manager")
 //	// Sync data stored on the machine to the cloud.
 //	err := data.Sync(context.Background(), nil)
 //
@@ -69,14 +70,17 @@ func Named(name string) resource.Name {
 	return resource.NewName(API, name)
 }
 
-// FromDependencies is a helper for getting the named data manager service from a collection of dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Service, error) {
-	return resource.FromDependencies[Service](deps, Named(name))
-}
-
-// FromRobot is a helper for getting the named data manager service from the given Robot.
-func FromRobot(r robot.Robot, name string) (Service, error) {
-	return robot.ResourceFromRobot[Service](r, Named(name))
+// GetResource is a helper for getting the named Data Manager service from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Service, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Service](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Service](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // NamesFromRobot is a helper for getting all data manager services from the given Robot.

--- a/services/discovery/discovery.go
+++ b/services/discovery/discovery.go
@@ -6,6 +6,7 @@ package discovery
 
 import (
 	"context"
+	"fmt"
 
 	pb "go.viam.com/api/service/discovery/v1"
 
@@ -40,15 +41,17 @@ func Named(name string) resource.Name {
 	return resource.NewName(API, name)
 }
 
-// FromRobot is a helper for getting the named discovery service from the given Robot.
-func FromRobot(r robot.Robot, name string) (Service, error) {
-	return robot.ResourceFromRobot[Service](r, Named(name))
-}
-
-// FromDependencies is a helper for getting the named discovery service from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Service, error) {
-	return resource.FromDependencies[Service](deps, Named(name))
+// GetResource is a helper for getting the named Discovery service from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Service, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Service](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Service](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // Service describes the functions that are available to the service.

--- a/services/generic/generic.go
+++ b/services/generic/generic.go
@@ -5,6 +5,8 @@
 package generic
 
 import (
+	"fmt"
+
 	pb "go.viam.com/api/service/generic/v1"
 
 	"go.viam.com/rdk/data"
@@ -36,10 +38,19 @@ func Named(name string) resource.Name {
 	return resource.NewName(API, name)
 }
 
-// FromRobot is a helper for getting the named Generic from the given Robot.
-func FromRobot(r robot.Robot, name string) (resource.Resource, error) {
-	return robot.ResourceFromRobot[resource.Resource](r, Named(name))
+// GetResource is a helper for getting the named Generic from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (resource.Resource, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[resource.Resource](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[resource.Resource](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
+
 
 // NamesFromRobot is a helper for getting all generic names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -49,7 +49,7 @@ func setupMotionServiceFromConfig(t *testing.T, configFilename string) (motion.S
 	test.That(t, err, test.ShouldBeNil)
 	myRobot, err := robotimpl.New(ctx, cfg, nil, logger)
 	test.That(t, err, test.ShouldBeNil)
-	svc, err := motion.FromRobot(myRobot, "builtin")
+	svc, err := motion.GetResource(myRobot, "builtin")
 	test.That(t, err, test.ShouldBeNil)
 	return svc, func() {
 		myRobot.Close(context.Background())

--- a/services/motion/builtin/move_on_map_test.go
+++ b/services/motion/builtin/move_on_map_test.go
@@ -48,7 +48,7 @@ func TestMoveOnMap(t *testing.T) {
 
 		injectSlam := createInjectedSlam("test_slam")
 
-		realBase, err := base.FromRobot(myRobot, "test-base")
+		realBase, err := base.GetResource(myRobot, "test-base")
 		test.That(t, err, test.ShouldBeNil)
 
 		deps := resource.Dependencies{

--- a/services/motion/builtin/testutils.go
+++ b/services/motion/builtin/testutils.go
@@ -380,7 +380,7 @@ func CreateMoveOnGlobeTestEnvironment(ctx context.Context, t *testing.T, origin 
 
 	// create fake wheeled base
 	deps := createDependencies(t, ctx, logger, geometrySize, origin, noise)
-	movementSensor, err := movementsensor.FromDependencies(deps, moveSensorName)
+	movementSensor, err := movementsensor.GetResource(deps, moveSensorName)
 	test.That(t, err, test.ShouldBeNil)
 	// create base link
 	baseLink := createBaseLink(t)
@@ -461,7 +461,7 @@ func CreateMoveOnMapTestEnvironment(
 
 	deps := createDependencies(t, ctx, logger, geomSize, &geo.Point{}, nil)
 
-	movementSensor, err := movementsensor.FromDependencies(deps, moveSensorName)
+	movementSensor, err := movementsensor.GetResource(deps, moveSensorName)
 	test.That(t, err, test.ShouldBeNil)
 	injectSlam, err := createMockSlamService("test_slam", pcdPath, origin, movementSensor)
 	test.That(t, err, test.ShouldBeNil)
@@ -521,9 +521,9 @@ func createTestKinematicBase(ctx context.Context, t *testing.T) (
 
 	// create fake wheeled base
 	deps := createDependencies(t, ctx, logger, 80, &geo.Point{}, nil)
-	movementSensor, err := movementsensor.FromDependencies(deps, moveSensorName)
+	movementSensor, err := movementsensor.GetResource(deps, moveSensorName)
 	test.That(t, err, test.ShouldBeNil)
-	b, err := base.FromDependencies(deps, baseName)
+	b, err := base.GetResource(deps, baseName)
 	test.That(t, err, test.ShouldBeNil)
 
 	startPosition, _, err := movementSensor.Position(context.Background(), nil)

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -328,13 +328,13 @@ func (svc *builtIn) Reconfigure(ctx context.Context, deps resource.Dependencies,
 	}
 
 	// Parse base from the configuration
-	baseComponent, err := base.FromDependencies(deps, svcConfig.BaseName)
+	baseComponent, err := base.GetResource(deps, svcConfig.BaseName)
 	if err != nil {
 		return err
 	}
 
 	// Parse motion services from the configuration
-	motionSvc, err := motion.FromDependencies(deps, motionServiceName)
+	motionSvc, err := motion.GetResource(deps, motionServiceName)
 	if err != nil {
 		return err
 	}
@@ -342,11 +342,11 @@ func (svc *builtIn) Reconfigure(ctx context.Context, deps resource.Dependencies,
 	var obstacleDetectorNamePairs []motion.ObstacleDetectorName
 	visionServicesByName := make(map[string]vision.Service)
 	for _, pbObstacleDetectorPair := range svcConfig.ObstacleDetectors {
-		visionSvc, err := vision.FromDependencies(deps, pbObstacleDetectorPair.VisionServiceName)
+		visionSvc, err := vision.GetResource(deps, pbObstacleDetectorPair.VisionServiceName)
 		if err != nil {
 			return err
 		}
-		camera, err := camera.FromDependencies(deps, pbObstacleDetectorPair.CameraName)
+		camera, err := camera.GetResource(deps, pbObstacleDetectorPair.CameraName)
 		if err != nil {
 			return err
 		}
@@ -358,7 +358,7 @@ func (svc *builtIn) Reconfigure(ctx context.Context, deps resource.Dependencies,
 
 	// Parse movement sensor from the configuration if map type is GPS
 	if mapType == navigation.GPSMap {
-		movementSensor, err := movementsensor.FromDependencies(deps, svcConfig.MovementSensorName)
+		movementSensor, err := movementsensor.GetResource(deps, svcConfig.MovementSensorName)
 		if err != nil {
 			return err
 		}

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -61,7 +61,7 @@ func setupNavigationServiceFromConfig(t *testing.T, configFilename string) (navi
 	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
 	myRobot, err := robotimpl.New(ctx, cfg, nil, logger)
 	test.That(t, err, test.ShouldBeNil)
-	svc, err := navigation.FromRobot(myRobot, "test_navigation")
+	svc, err := navigation.GetResource(myRobot, "test_navigation")
 	test.That(t, err, test.ShouldBeNil)
 	return svc, func() {
 		myRobot.Close(context.Background())
@@ -596,7 +596,7 @@ func TestNavSetUpFromFaultyConfig(t *testing.T) {
 		test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
 		myRobot, err := robotimpl.New(ctx, cfg, nil, logger)
 		test.That(t, err, test.ShouldBeNil)
-		_, err = navigation.FromRobot(myRobot, "test_navigation")
+		_, err = navigation.GetResource(myRobot, "test_navigation")
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, tc.expectedError)
 	}

--- a/services/navigation/navigation.go
+++ b/services/navigation/navigation.go
@@ -6,6 +6,7 @@ package navigation
 
 import (
 	"context"
+	"fmt"
 
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
@@ -219,9 +220,17 @@ func Named(name string) resource.Name {
 	return resource.NewName(API, name)
 }
 
-// FromRobot is a helper for getting the named navigation service from the given Robot.
-func FromRobot(r robot.Robot, name string) (Service, error) {
-	return robot.ResourceFromRobot[Service](r, Named(name))
+// GetResource is a helper for getting the named Navigation service from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Service, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Service](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Service](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 func mapTypeToProtobuf(mapType MapType) servicepb.MapType {

--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -8,6 +8,7 @@ package slam
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
@@ -113,15 +114,17 @@ func Named(name string) resource.Name {
 	return resource.NewName(API, name)
 }
 
-// FromRobot is a helper for getting the named SLAM service from the given Robot.
-func FromRobot(r robot.Robot, name string) (Service, error) {
-	return robot.ResourceFromRobot[Service](r, Named(name))
-}
-
-// FromDependencies is a helper for getting the named SLAM service from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Service, error) {
-	return resource.FromDependencies[Service](deps, Named(name))
+// GetResource is a helper for getting the named SLAM service from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Service, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Service](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Service](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // Service describes the functions that are available to the service.

--- a/services/vision/colordetector/color_detector.go
+++ b/services/vision/colordetector/color_detector.go
@@ -54,7 +54,7 @@ func registerColorDetector(
 		return nil, errors.Wrapf(err, "error registering color detector %q", name)
 	}
 	if conf.DefaultCamera != "" {
-		_, err = camera.FromRobot(r, conf.DefaultCamera)
+		_, err = camera.GetResource(r, conf.DefaultCamera)
 		if err != nil {
 			return nil, errors.Errorf("could not find camera %q", conf.DefaultCamera)
 		}

--- a/services/vision/mlvision/ml_model.go
+++ b/services/vision/mlvision/ml_model.go
@@ -110,7 +110,7 @@ func registerMLModelVisionService(
 	_, span := trace.StartSpan(ctx, "service::vision::registerMLModelVisionService")
 	defer span.End()
 
-	mlm, err := mlmodel.FromRobot(r, params.ModelName)
+	mlm, err := mlmodel.GetResource(r, params.ModelName)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func registerMLModelVisionService(
 	}
 
 	if params.DefaultCamera != "" {
-		_, err = camera.FromRobot(r, params.DefaultCamera)
+		_, err = camera.GetResource(r, params.DefaultCamera)
 		if err != nil {
 			return nil, errors.Errorf("could not find camera %q", params.DefaultCamera)
 		}

--- a/services/vision/vision.go
+++ b/services/vision/vision.go
@@ -7,6 +7,7 @@ package vision
 
 import (
 	"context"
+	"fmt"
 	"image"
 
 	servicepb "go.viam.com/api/service/vision/v1"
@@ -42,7 +43,7 @@ func init() {
 //
 // DetectionsFromCamera example:
 //
-//	myDetectorService, err := vision.FromRobot(machine, "my_detector")
+//	myDetectorService, err := vision.GetResource(machine, "my_detector")
 //	if err != nil {
 //		logger.Error(err)
 //		return
@@ -63,7 +64,7 @@ func init() {
 //
 //	 // add "go.viam.com/rdk/utils" to imports to use this code snippet
 //
-//		myCam, err := camera.FromRobot(machine, "my_camera")
+//		myCam, err := camera.GetResource(machine, "my_camera")
 //		if err != nil {
 //			logger.Error(err)
 //			return
@@ -71,7 +72,7 @@ func init() {
 //		// Get an image from the camera decoded as an image.Image
 //		img, err = camera.DecodeImageFromCamera(context.Background(), utils.MimeTypeJPEG, nil, myCam)
 //
-//		myDetectorService, err := vision.FromRobot(machine, "my_detector")
+//		myDetectorService, err := vision.GetResource(machine, "my_detector")
 //		if err != nil {
 //			logger.Error(err)
 //			return
@@ -89,7 +90,7 @@ func init() {
 //
 // ClassificationsFromCamera example:
 //
-//	myClassifierService, err := vision.FromRobot(machine, "my_classifier")
+//	myClassifierService, err := vision.GetResource(machine, "my_classifier")
 //	if err != nil {
 //		logger.Error(err)
 //		return
@@ -109,7 +110,7 @@ func init() {
 //
 //	 // add "go.viam.com/rdk/utils" to imports to use this code snippet
 //
-//		myCam, err := camera.FromRobot(machine, "my_camera")
+//		myCam, err := camera.GetResource(machine, "my_camera")
 //		if err != nil {
 //			logger.Error(err)
 //			return
@@ -117,7 +118,7 @@ func init() {
 //		// Get an image from the camera decoded as an image.Image
 //		img, err = camera.DecodeImageFromCamera(context.Background(), utils.MimeTypeJPEG, nil, myCam)
 //
-//		myClassifierService, err := vision.FromRobot(machine, "my_classifier")
+//		myClassifierService, err := vision.GetResource(machine, "my_classifier")
 //		if err != nil {
 //			logger.Error(err)
 //			return
@@ -135,7 +136,7 @@ func init() {
 //
 // GetObjectPointClouds example:
 //
-//	mySegmenterService, err := vision.FromRobot(machine, "my_segmenter")
+//	mySegmenterService, err := vision.GetResource(machine, "my_segmenter")
 //	if err != nil {
 //		logger.Error(err)
 //		return
@@ -225,14 +226,17 @@ func Named(name string) resource.Name {
 	return resource.NewName(API, name)
 }
 
-// FromRobot is a helper for getting the named vision service from the given Robot.
-func FromRobot(r robot.Robot, name string) (Service, error) {
-	return robot.ResourceFromRobot[Service](r, Named(name))
-}
-
-// FromDependencies is a helper for getting the named vision service from a collection of dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Service, error) {
-	return resource.FromDependencies[Service](deps, Named(name))
+// GetResource is a helper for getting the named Vision service from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Service, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Service](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Service](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // Properties returns various information regarding the current vision service,

--- a/services/vision/vision_service_builder.go
+++ b/services/vision/vision_service_builder.go
@@ -60,7 +60,7 @@ func NewService(
 	}
 
 	getCamera := func(cameraName string) (camera.Camera, error) {
-		return camera.FromDependencies(deps, cameraName)
+		return camera.GetResource(deps, cameraName)
 	}
 
 	return &vizModel{
@@ -106,7 +106,7 @@ func DeprecatedNewService(
 	logger := r.Logger()
 
 	getCamera := func(cameraName string) (camera.Camera, error) {
-		return camera.FromRobot(r, cameraName)
+		return camera.GetResource(r, cameraName)
 	}
 
 	return &vizModel{

--- a/services/vision/vision_test.go
+++ b/services/vision/vision_test.go
@@ -32,7 +32,7 @@ func TestFromRobot(t *testing.T) {
 	r.ResourceByNameFunc = func(name resource.Name) (resource.Resource, error) {
 		return svc1, nil
 	}
-	svc, err := vision.FromRobot(&r, testVisionServiceName)
+	svc, err := vision.GetResource(&r, testVisionServiceName)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, svc, test.ShouldNotBeNil)
 	result, err := svc.Detections(context.Background(), nil, nil)

--- a/services/worldstatestore/world_state_store.go
+++ b/services/worldstatestore/world_state_store.go
@@ -8,6 +8,7 @@ package worldstatestore
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 
 	commonpb "go.viam.com/api/common/v1"
@@ -42,15 +43,17 @@ func Named(name string) resource.Name {
 	return resource.NewName(API, name)
 }
 
-// FromRobot is a helper for getting the named world state store service from the given Robot.
-func FromRobot(r robot.Robot, name string) (Service, error) {
-	return robot.ResourceFromRobot[Service](r, Named(name))
-}
-
-// FromDependencies is a helper for getting the named world state store service from a collection of
-// dependencies.
-func FromDependencies(deps resource.Dependencies, name string) (Service, error) {
-	return resource.FromDependencies[Service](deps, Named(name))
+// GetResource is a helper for getting the named world state store service from either a collection of dependencies
+// or the given robot.
+func GetResource(src any, name string) (Service, error) {
+	switch v := src.(type) {
+	case resource.Dependencies:
+		return resource.FromDependencies[Service](v, Named(name))
+	case robot.Robot:
+		return robot.ResourceFromRobot[Service](v, Named(name))
+	default:
+		return nil, fmt.Errorf("unsupported source type %T", src)
+	}
 }
 
 // Service describes the functions that are available to the service.


### PR DESCRIPTION
New Interface called Provider with a GetResource method. 

GetResource is implemented in all the Resources respectively to either fetch the named resource from a collection of dependencies or from the given robot based on what was passed in. 

All instances of Resource.FromRobot and Resource.FromDependencies were replaced with Resource.GetResource. 