### PR TITLE
RSDK-11975: Sanitize logs before serializing to proto

### DIFF
--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -16,6 +16,7 @@ import (
 	"go.viam.com/utils"
 	"go.viam.com/utils/protoutils"
 	"go.viam.com/utils/rpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -341,7 +342,7 @@ func isUTF8MarshallingError(err error) bool {
 		return false
 	}
 	status := status.Convert(err)
-	return status.Code() == 13 && status.Message() == "grpc: error while marshaling: string field contains invalid UTF-8"
+	return status.Code() == codes.Internal && status.Message() == "grpc: error while marshaling: string field contains invalid UTF-8"
 }
 
 // Returns whether there is more work to do or if an error was encountered


### PR DESCRIPTION
This attempts to fix an issue the sanding team ran into where trying to ship logs containing invalid UTF-8 completely halted log shipping. The core problem is that `NetAppender` is written with the assumption that any errors sending logs are caused by network issues that will eventually resolve, but this was an issue with the data being sent so would never resolve on its own. This change fixes the specific issue we observed where log messages contain invalid UTF-8 by detecting such issues, sanitizing all the messages in the failed batch, then retrying.

There's potentially a bigger change we could make to have failed log batches "decay" over time and eventually be dropped from the queue entirely, but I opted not to implement that for now since the failure we did observe is fairly easy to detect and recover from without dropping any logs.