### PR TITLE
fix module dep

### DIFF
--- a/resource/name.go
+++ b/resource/name.go
@@ -142,11 +142,7 @@ func (n Name) Validate() error {
 // as it's only used internally.
 func (n Name) String() string {
 	name := n.API.String()
-	if n.Remote != "" {
-		name = fmt.Sprintf("%s/%s:%s", name, n.Remote, n.Name)
-	} else {
-		name = fmt.Sprintf("%s/%s", name, n.Name)
-	}
+	name = fmt.Sprintf("%s/%s", name, n.Name)
 	return name
 }
 


### PR DESCRIPTION
just running tests, will come up with a regression test later

if resolve deps ends up resolving to a remote name, `DepsToNames` will return a list of strings with remote names in them, which is unusable by modules