### PR TITLE
log VCS version in `ModularMain`

### DIFF
--- a/module/runtime.go
+++ b/module/runtime.go
@@ -2,6 +2,7 @@ package module
 
 import (
 	"context"
+	"runtime/debug"
 
 	"go.viam.com/utils"
 
@@ -13,6 +14,11 @@ import (
 // the provided APIModels added to it.
 func ModularMain(models ...resource.APIModel) {
 	mainWithArgs := func(ctx context.Context, args []string, logger logging.Logger) error {
+		info, ok := debug.ReadBuildInfo()
+		if ok {
+			logger.Infof("module version: %s, go version: %s", info.Main.Version, info.GoVersion)
+		}
+
 		mod, err := NewModuleFromArgs(ctx)
 		if err != nil {
 			return err


### PR DESCRIPTION
(this PR is not urgent + may require more discussion)
## What changed
- when a module starts, log the automatic git-derived version of the binary
## Why
- debugging running version of a module vs configured version (e.g. when the download isn't finished)
- when using reloading or shipping binaries some other way, it's useful to know what you have
- useful to immediately know the git sha of a binary when debugging
## Example log
> 2025-09-26T18:08:58.393Z	INFO		module/runtime.go:19	module version: v0.0.0-20250925000410-785d577ad693+dirty, go version: go1.25.1
## Other things to log
We have access to dependency versions I think and could in theory log API or RDK version