### PR TITLE
Return richer IK solution errors. Add an interactive cmd-plan mode

### DIFF
--- a/motionplan/armplanning/cBiRRT.go
+++ b/motionplan/armplanning/cBiRRT.go
@@ -559,7 +559,7 @@ func (mp *cBiRRTMotionPlanner) sample(rSeed *node, sampleNum int) (*node, error)
 
 type solutionSolvingState struct {
 	solutions         []*node
-	failures          *IkConstraintFailures
+	failures          *IkConstraintError
 	startTime         time.Time
 	firstSolutionTime time.Duration
 	bestScore         float64
@@ -587,7 +587,7 @@ func (mp *cBiRRTMotionPlanner) process(sss *solutionSolvingState, seed reference
 		FS:            mp.fs,
 	})
 	if err != nil {
-		sss.failures.Add(step, err)
+		sss.failures.add(step, err)
 		return false
 	}
 
@@ -598,7 +598,7 @@ func (mp *cBiRRTMotionPlanner) process(sss *solutionSolvingState, seed reference
 	}
 	err = mp.checker.CheckSegmentFSConstraints(stepArc)
 	if err != nil {
-		sss.failures.Add(step, err)
+		sss.failures.add(step, err)
 		return false
 	}
 
@@ -737,7 +737,7 @@ func (mp *cBiRRTMotionPlanner) getSolutions(
 
 	solvingState := solutionSolvingState{
 		solutions:         []*node{},
-		failures:          NewIkConstraintFailures(mp.fs, mp.checker),
+		failures:          newIkConstraintError(mp.fs, mp.checker),
 		startTime:         time.Now(),
 		firstSolutionTime: time.Hour,
 		bestScore:         10000000,

--- a/motionplan/armplanning/cmd-plan/cmd-plan.go
+++ b/motionplan/armplanning/cmd-plan/cmd-plan.go
@@ -2,14 +2,20 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"runtime/pprof"
+	"slices"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	viz "github.com/viam-labs/motion-tools/client/client"
@@ -39,6 +45,7 @@ func realMain() error {
 	verbose := flag.Bool("v", false, "verbose")
 	loop := flag.Int("loop", 1, "loop")
 	cpu := flag.String("cpu", "", "cpu profiling")
+	interactive := flag.Bool("i", false, "interactive")
 
 	flag.Parse()
 
@@ -87,9 +94,19 @@ func realMain() error {
 		req.PlannerOptions.RandomSeed = *seed
 	}
 
+	logger.Infof("starting motion planning for %d goals", len(req.Goals))
+
+	mylog := log.New(os.Stdout, "", 0)
 	start := time.Now()
 
 	plan, err := armplanning.PlanMotion(ctx, logger, &req)
+	if *interactive {
+		if interactiveErr := doInteractive(req, plan, err, mylog); interactiveErr != nil {
+			logger.Fatal("Interactive mode failed:", interactiveErr)
+		}
+		return nil
+	}
+
 	if err != nil {
 		return err
 	}
@@ -98,9 +115,8 @@ func realMain() error {
 		return fmt.Errorf("path and trajectory not the same %d vs %d", len(plan.Path()), len(plan.Trajectory()))
 	}
 
-	mylog := log.New(os.Stdout, "", 0)
-
-	mylog.Printf("planning took %v", time.Since(start))
+	mylog.Printf("planning took %v for %d goals => trajectory length: %d",
+		time.Since(start).Truncate(time.Millisecond), len(req.Goals), len(plan.Trajectory()))
 
 	for *cpu != "" && time.Since(start) < (10*time.Second) {
 		ss := time.Now()
@@ -250,4 +266,141 @@ func drawPosition(req armplanning.PlanRequest, inputs referenceframe.FrameSystem
 	}
 
 	return nil
+}
+
+func doInteractive(req armplanning.PlanRequest, plan motionplan.Plan, planErr error, logger *log.Logger) error {
+	ikErr, isIkErr := planErr.(*armplanning.IkConstraintFailures)
+	if err := viz.RemoveAllSpatialObjects(); err != nil {
+		return err
+	}
+
+	if err := viz.DrawWorldState(req.WorldState, req.FrameSystem, req.StartState.Configuration()); err != nil {
+		return err
+	}
+
+	if err := viz.DrawFrameSystem(req.FrameSystem, req.StartState.Configuration()); err != nil {
+		return err
+	}
+
+	// ikIterOrder is a hack for helping index into individual failures. Such that an interactive
+	// user can deterministically reference errors.
+	var ikIterOrder []string
+	if isIkErr {
+		for key := range ikErr.FailuresByType {
+			ikIterOrder = append(ikIterOrder, key)
+		}
+
+		// We sort such that the failure index across runs of `cmd-plan` interactive mode will pull
+		// out the same error. This does not have to be sorted in string order. That's just a
+		// convenient stable comparison for now.
+		slices.Sort(ikIterOrder)
+	}
+
+	stdinReader := bufio.NewReader(os.Stdin)
+	render := true
+	for {
+		if render {
+			if planErr == nil {
+				visualize(req, plan, logger)
+			} else {
+				if ikErr != nil {
+					logger.Println("Plan error:", ikErr.OutputString(true))
+				} else {
+					logger.Println("Plan error:", planErr)
+				}
+			}
+			render = false
+		}
+
+		//nolint
+		fmt.Print("$ ") // `logger.Print` seems to add a newline.
+		cmd, err := stdinReader.ReadString('\n')
+		cmd = strings.TrimSpace(cmd)
+		switch {
+		case err != nil && errors.Is(err, io.EOF):
+			logger.Println("\nExiting...")
+			return nil
+		case cmd == "quit":
+			logger.Println("Exiting...")
+			return nil
+		case cmd == "h" || cmd == "help":
+			logger.Println("r, render")
+			logger.Println("-  Rerender the selected motion plan.")
+			logger.Println()
+			logger.Println("le, list errors")
+			logger.Println("-  If there were no IK solutions that satisfied constraints,",
+				"this will list all of the failures grouped by error string.")
+			logger.Println()
+			logger.Println("de, detailed errors")
+			logger.Println("-  If there were no IK solutions that satisfied constraints,",
+				"this will list the configuration for each failed solution.")
+			logger.Println()
+			logger.Println("re, render error <number>")
+			logger.Println("-  Renders the configuration of a failed solution.")
+			logger.Println()
+			logger.Println("`quit` or Ctrl-d to exit")
+		case cmd == "render" || cmd == "r":
+			logger.Println("Rendering motion plan")
+			render = true
+		case cmd == "list errors" || cmd == "le":
+			if ikErr == nil {
+				logger.Println("The error was not an IK error. No further diagnostics.")
+				logger.Println("  Err:", planErr)
+				continue
+			}
+
+			logger.Println("Listing errors:")
+			for _, errStr := range ikIterOrder {
+				failedSolutions := ikErr.FailuresByType[errStr]
+				logger.Printf("  Err: %q Count: %v", errStr, len(failedSolutions))
+			}
+		case cmd == "detailed errors" || cmd == "de":
+			if ikErr == nil {
+				logger.Println("The error was not an IK error. No further diagnostics.")
+				logger.Println("  Err:", planErr)
+				continue
+			}
+
+			logger.Println("Listing errors:")
+			idxCounter := 1
+			for _, errStr := range ikIterOrder {
+				failedConfigurations := ikErr.FailuresByType[errStr]
+				logger.Printf("  Err: %q Count: %v", errStr, len(failedConfigurations))
+				for _, configuration := range failedConfigurations {
+					logger.Printf("    %d Inputs: %v", idxCounter, configuration)
+					idxCounter++
+				}
+			}
+		case strings.HasPrefix(cmd, "render error ") || strings.HasPrefix(cmd, "re "):
+			pieces := strings.Split(cmd, " ")
+			errorNumberStr := pieces[len(pieces)-1]
+			errorNumber, err := strconv.Atoi(errorNumberStr)
+			if err != nil {
+				logger.Printf("Failed to parse error number. Val: %v Err: %v", errorNumberStr, err)
+				logger.Println("Usage: `re <error number>`")
+			}
+
+			idxCounter := 1
+		searchLoop:
+			for _, errStr := range ikIterOrder {
+				failedConfigurations := ikErr.FailuresByType[errStr]
+				for _, configuration := range failedConfigurations {
+					if idxCounter != errorNumber {
+						idxCounter++
+						continue
+					}
+
+					logger.Println("Rendering failed solution")
+					logger.Println("  Err:", errStr)
+					logger.Println("  Inputs:", configuration)
+					viz.DrawFrameSystem(req.FrameSystem, configuration)
+					break searchLoop
+				}
+			}
+
+		case len(cmd) == 0:
+		default:
+			logger.Println("Unknown command. Type `h` for help.")
+		}
+	}
 }

--- a/motionplan/armplanning/errors.go
+++ b/motionplan/armplanning/errors.go
@@ -26,9 +26,9 @@ func NewAlgAndConstraintMismatchErr(planAlg string) error {
 	return fmt.Errorf("cannot specify a planning algorithm other than cbirrt with topo constraints. algorithm specified was %s", planAlg)
 }
 
-// ikConstraintFailures contains information on possible solutions that fail constraint checks. This
+// IkConstraintError contains information on possible solutions that fail constraint checks. This
 // data can be used to visualize the constraint thats being violated.
-type IkConstraintFailures struct {
+type IkConstraintError struct {
 	// A map keeping track of which constraints fail
 	FailuresByType map[string][]referenceframe.FrameSystemInputs
 	// Count is the total number of failures. Equivalent to summing the size of the value slices in
@@ -39,22 +39,22 @@ type IkConstraintFailures struct {
 	Checker *motionplan.ConstraintChecker
 }
 
-func NewIkConstraintFailures(fs *referenceframe.FrameSystem, checker *motionplan.ConstraintChecker) *IkConstraintFailures {
-	return &IkConstraintFailures{
+func newIkConstraintError(fs *referenceframe.FrameSystem, checker *motionplan.ConstraintChecker) *IkConstraintError {
+	return &IkConstraintError{
 		FailuresByType: make(map[string][]referenceframe.FrameSystemInputs),
 		Fs:             fs,
 		Checker:        checker,
 	}
 }
 
-func (fail *IkConstraintFailures) Add(solution referenceframe.FrameSystemInputs, err error) {
+func (fail *IkConstraintError) add(solution referenceframe.FrameSystemInputs, err error) {
 	fail.FailuresByType[err.Error()] = append(fail.FailuresByType[err.Error()], solution)
 	fail.Count++
 }
 
 // OutputString formats the structure as a string. If pretty is true, there will be newlines and
 // indentation for prettier formatting.
-func (fail *IkConstraintFailures) OutputString(pretty bool) string {
+func (fail *IkConstraintError) OutputString(pretty bool) string {
 	// sort the map keys by the integer they map to
 	keys := make([]string, 0, len(fail.FailuresByType))
 	for k := range fail.FailuresByType {
@@ -83,6 +83,6 @@ func (fail *IkConstraintFailures) OutputString(pretty bool) string {
 	return errMsg
 }
 
-func (fail *IkConstraintFailures) Error() string {
+func (fail *IkConstraintError) Error() string {
 	return fail.OutputString(false)
 }

--- a/motionplan/armplanning/errors.go
+++ b/motionplan/armplanning/errors.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+
+	"go.viam.com/rdk/motionplan"
+	"go.viam.com/rdk/referenceframe"
 )
 
 const cutoffPercent = 10.0
@@ -23,26 +26,63 @@ func NewAlgAndConstraintMismatchErr(planAlg string) error {
 	return fmt.Errorf("cannot specify a planning algorithm other than cbirrt with topo constraints. algorithm specified was %s", planAlg)
 }
 
-func newIKConstraintErr(failures map[string]int, constraintFailCnt int) error {
+// ikConstraintFailures contains information on possible solutions that fail constraint checks. This
+// data can be used to visualize the constraint thats being violated.
+type IkConstraintFailures struct {
+	// A map keeping track of which constraints fail
+	FailuresByType map[string][]referenceframe.FrameSystemInputs
+	// Count is the total number of failures. Equivalent to summing the size of the value slices in
+	// `FailuresByType`.
+	Count int
+
+	Fs      *referenceframe.FrameSystem
+	Checker *motionplan.ConstraintChecker
+}
+
+func NewIkConstraintFailures(fs *referenceframe.FrameSystem, checker *motionplan.ConstraintChecker) *IkConstraintFailures {
+	return &IkConstraintFailures{
+		FailuresByType: make(map[string][]referenceframe.FrameSystemInputs),
+		Fs:             fs,
+		Checker:        checker,
+	}
+}
+
+func (fail *IkConstraintFailures) Add(solution referenceframe.FrameSystemInputs, err error) {
+	fail.FailuresByType[err.Error()] = append(fail.FailuresByType[err.Error()], solution)
+	fail.Count++
+}
+
+// OutputString formats the structure as a string. If pretty is true, there will be newlines and
+// indentation for prettier formatting.
+func (fail *IkConstraintFailures) OutputString(pretty bool) string {
 	// sort the map keys by the integer they map to
-	keys := make([]string, 0, len(failures))
-	for k := range failures {
+	keys := make([]string, 0, len(fail.FailuresByType))
+	for k := range fail.FailuresByType {
 		keys = append(keys, k)
 	}
 	slices.SortFunc(keys, func(a, b string) int {
-		return failures[b] - failures[a] // descending order
+		return len(fail.FailuresByType[b]) - len(fail.FailuresByType[a]) // descending order
 	})
 
 	// build the error message
 	errMsg := errIKConstraint
 	// determine if first error exceeds cutoff
-	hasErrorAboveCutoff := 100*float64(failures[keys[0]])/float64(constraintFailCnt) >= cutoffPercent
+	hasErrorAboveCutoff := 100*float64(len(fail.FailuresByType[keys[0]]))/float64(fail.Count) >= cutoffPercent
 	for _, k := range keys {
-		percentageCollision := 100 * float64(failures[k]) / float64(constraintFailCnt)
+		percentageCollision := 100 * float64(len(fail.FailuresByType[k])) / float64(fail.Count)
 		// print all errors if none exceed cutoff, else only those above cutoff
 		if !hasErrorAboveCutoff || percentageCollision >= cutoffPercent {
-			errMsg += fmt.Sprintf("{ %s: %.2f%% }, ", k, percentageCollision)
+			if pretty {
+				errMsg += fmt.Sprintf("\n  %.2f%% %s", percentageCollision, k)
+			} else {
+				errMsg += fmt.Sprintf("{ %s: %.2f%% }, ", k, percentageCollision)
+			}
 		}
 	}
-	return errors.New(errMsg)
+
+	return errMsg
+}
+
+func (fail *IkConstraintFailures) Error() string {
+	return fail.OutputString(false)
 }

--- a/motionplan/armplanning/errors_test.go
+++ b/motionplan/armplanning/errors_test.go
@@ -16,10 +16,10 @@ func TestNewIKConstraintErr(t *testing.T) {
 			errors.New("self-collision constraint: violation between gripper-1:clamp and ur5e-modular:wrist_1_link geometries"): 97,
 		}
 
-		ikError := NewIkConstraintFailures(nil, nil)
+		ikError := newIkConstraintError(nil, nil)
 		for err, cnt := range failures {
 			for range cnt {
-				ikError.Add(nil, err)
+				ikError.add(nil, err)
 			}
 		}
 		ikError.Count = constraintFailCnt
@@ -35,10 +35,10 @@ func TestNewIKConstraintErr(t *testing.T) {
 			errors.New("self-collision constraint: violation between gripper-1:clamp and ur5e-modular:wrist_1_link geometries"): 97,
 		}
 
-		ikError := NewIkConstraintFailures(nil, nil)
+		ikError := newIkConstraintError(nil, nil)
 		for err, cnt := range failures {
 			for range cnt {
-				ikError.Add(nil, err)
+				ikError.add(nil, err)
 			}
 		}
 		ikError.Count = constraintFailCnt

--- a/motionplan/armplanning/errors_test.go
+++ b/motionplan/armplanning/errors_test.go
@@ -11,25 +11,41 @@ func TestNewIKConstraintErr(t *testing.T) {
 	constraintFailCnt := 10000
 
 	t.Run("some errors exceed cutoff", func(t *testing.T) {
-		failures := map[string]int{
-			"obstacle constraint: violation between ur5e-modular:forearm_link and box1 geometries":                  2913,
-			"self-collision constraint: violation between gripper-1:clamp and ur5e-modular:wrist_1_link geometries": 97,
+		failures := map[error]int{
+			errors.New("obstacle constraint: violation between ur5e-modular:forearm_link and box1 geometries"):                  2913,
+			errors.New("self-collision constraint: violation between gripper-1:clamp and ur5e-modular:wrist_1_link geometries"): 97,
 		}
+
+		ikError := NewIkConstraintFailures(nil, nil)
+		for err, cnt := range failures {
+			for range cnt {
+				ikError.Add(nil, err)
+			}
+		}
+		ikError.Count = constraintFailCnt
 
 		expectedError := errors.New("all IK solutions failed constraints. Failures: " +
 			"{ obstacle constraint: violation between ur5e-modular:forearm_link and box1 geometries: 29.13% }, ")
-		test.That(t, newIKConstraintErr(failures, constraintFailCnt), test.ShouldBeError, expectedError)
+		test.That(t, ikError, test.ShouldBeError, expectedError)
 	})
 
 	t.Run("no errors exceed cutoff", func(t *testing.T) {
-		failures := map[string]int{
-			"self-collision constraint: violation between gripper-1:clamp and ur5e-modular:forearm_link geometries": 291,
-			"self-collision constraint: violation between gripper-1:clamp and ur5e-modular:wrist_1_link geometries": 97,
+		failures := map[error]int{
+			errors.New("self-collision constraint: violation between gripper-1:clamp and ur5e-modular:forearm_link geometries"): 291,
+			errors.New("self-collision constraint: violation between gripper-1:clamp and ur5e-modular:wrist_1_link geometries"): 97,
 		}
+
+		ikError := NewIkConstraintFailures(nil, nil)
+		for err, cnt := range failures {
+			for range cnt {
+				ikError.Add(nil, err)
+			}
+		}
+		ikError.Count = constraintFailCnt
 
 		expectedError := errors.New("all IK solutions failed constraints. Failures: " +
 			"{ self-collision constraint: violation between gripper-1:clamp and ur5e-modular:forearm_link geometries: 2.91% }, " +
 			"{ self-collision constraint: violation between gripper-1:clamp and ur5e-modular:wrist_1_link geometries: 0.97% }, ")
-		test.That(t, newIKConstraintErr(failures, constraintFailCnt), test.ShouldBeError, expectedError)
+		test.That(t, ikError, test.ShouldBeError, expectedError)
 	})
 }

--- a/motionplan/constraint2.go
+++ b/motionplan/constraint2.go
@@ -254,7 +254,7 @@ func collisionCheckFinish(internalGeoms, static []spatial.Geometry, zeroCG *coll
 	cs := cg.collisions(collisionBufferMM)
 	if len(cs) != 0 {
 		// we could choose to amalgamate all the collisions into one error but its probably saner not to and choose just the first
-		return fmt.Errorf("violation between %s and %s geometries (tolal collisions: %d)", cs[0].name1, cs[0].name2, len(cs))
+		return fmt.Errorf("violation between %s and %s geometries (total collisions: %d)", cs[0].name1, cs[0].name2, len(cs))
 	}
 	return nil
 }


### PR DESCRIPTION
```
We've found richer IK solution errors to be useful when there are frame system 
configuration errors. Resulting in goal poses that cannot be satisfied as the
goal frame is embedded inside a geometry that may not collide.

The interactive cmd-plan mode can be used for rerunning renderings or rendering
failed ik solutions.
```

The demo is [using an uncommitted](https://github.com/viam-labs/motion-tools/pull/134) version of the motion tools. Which addresses `DrawWorldState` missing meshes/pointclouds. And because performance is poor, I added some downscaling (that I sped up even further for this demo). Pointclouds are being more thoroughly addressed by the actual tools team, so expect improvements soon.

The demo is the example from where the framesystem config had the compliance/sandpaper frame embedded inside the sander block frame. Hence all IK solutions would (at the very least) fail with the sanding block colliding with the mesh.

https://github.com/user-attachments/assets/54efebe4-8667-4df1-83f6-68fa3ede10aa

