### PR TITLE
RSDK-11717 — Use timeRequested for GetImages collector timestamp

### DIFF
--- a/components/camera/collectors.go
+++ b/components/camera/collectors.go
@@ -160,7 +160,7 @@ func newGetImagesCollector(resource interface{}, params data.CollectorParams) (d
 		for _, img := range resImgs {
 			imgBytes, err := img.Bytes(ctx)
 			if err != nil {
-				return res, err
+				return res, data.NewFailedToReadError(params.ComponentName, getImages.String(), err)
 			}
 			binaries = append(binaries, data.Binary{
 				Annotations: data.Annotations{Classifications: []data.Classification{{Label: img.SourceName}}},


### PR DESCRIPTION
[RSDK-11717](https://viam.atlassian.net/browse/RSDK-11717)

This is a bug fix for a timestamp bug I found while doing testing for the above ticket. We should not be using the GetImages response metadata for both time requested and time received. It should only be used to populate time received.

[RSDK-11717]: https://viam.atlassian.net/browse/RSDK-11717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ