### PR TITLE
RSDK-11997 - Add pirouette tests in motion planning

### DIFF
--- a/motionplan/armplanning/real_test.go
+++ b/motionplan/armplanning/real_test.go
@@ -196,7 +196,7 @@ func TestPirouette(t *testing.T) {
 
 		// iterate through pifs and create a plan which gets the arm there
 		for i, p := range pifs {
-			t.Run(fmt.Sprintf("iteration%d-%d", iter, i), func(t *testing.T) {
+			t.Run(fmt.Sprintf("iteration-%d-%d", iter, i), func(t *testing.T) {
 				logger := logging.NewTestLogger(t)
 				// construct req and get the plan
 				goalState := NewPlanState(map[string]*referenceframe.PoseInFrame{armName: p}, nil)

--- a/motionplan/armplanning/real_test.go
+++ b/motionplan/armplanning/real_test.go
@@ -196,7 +196,7 @@ func TestPirouette(t *testing.T) {
 
 		// iterate through pifs and create a plan which gets the arm there
 		for i, p := range pifs {
-			t.Run(fmt.Sprintf("iteration: %d-%d", iter, i), func(t *testing.T) {
+			t.Run(fmt.Sprintf("iteration%d-%d", iter, i), func(t *testing.T) {
 				logger := logging.NewTestLogger(t)
 				// construct req and get the plan
 				goalState := NewPlanState(map[string]*referenceframe.PoseInFrame{armName: p}, nil)

--- a/motionplan/armplanning/real_test.go
+++ b/motionplan/armplanning/real_test.go
@@ -217,19 +217,19 @@ func TestPirouette(t *testing.T) {
 				test.That(t, err, test.ShouldBeNil)
 				j0TrajStart := allArmInputs[0][0].Value
 				j0TrajEnd := allArmInputs[len(allArmInputs)-1][0].Value
-				j0ChangeDeg := utils.RadToDeg(math.Abs(j0TrajEnd - j0TrajStart))
+				j0Change := math.Abs(j0TrajEnd - j0TrajStart)
 
 				// figure out expected change given what the ideal change in joint 0 would be
 				idealJ0Value := idealJointValues[i][0].Value
 				idealPreviousJ0Value := idealJointValues[prevIndex][0].Value
-				expectedJ0ChangeDeg := utils.RadToDeg(math.Abs(idealJ0Value-idealPreviousJ0Value)) + 1e-1 // add buffer
+				expectedJ0Change := math.Abs(idealJ0Value-idealPreviousJ0Value) + 2e-2 // add buffer of 1.15 degrees
 
 				logger.Infof("motionplan's trajectory: %v", traj)
 				logger.Infof("ideal trajectory: \n%v\n%v\n", idealJointValues[prevIndex], idealJointValues[i])
 
 				// determine if a pirouette happened
 				// in order to satisfy our desired pose in frame while execeeding the expected change in joint 0 a pirouette was necessary
-				test.That(t, j0ChangeDeg, test.ShouldBeLessThanOrEqualTo, expectedJ0ChangeDeg)
+				test.That(t, j0Change, test.ShouldBeLessThanOrEqualTo, expectedJ0Change)
 
 				// increment everything
 				prevIndex = i


### PR DESCRIPTION
Definition of a pirouette:
A pirouette is when joint 0 of a given arm does a [121 - 390] degree rotation along with some rotation on joint 1 to reach a pose `p` when instead a smaller rotation would suffice for satisfying  pose `p`.
Note: the range [121 - 390] was determined experimentally.

Test setup:
1. Define a set of joint positions.
2. Get the kinematic model of the arm and perform forward kinematics to determine the pose each of element of (1) corresponds to.
3. Construct a request which specifies which pose we would like to navigate to while also specifying the current joint positions of where the arm currently is.
4. Execute the request and get a trajectory.
5. Query the trajectory to see what the change in joint 0 is.
6. Query the set of joint positions defined in step (1) to see what the optimal change in joint 0 would be.
7. If the change in joint 0 defined in step (5) exceeds the value determined in step (6) we have a pirouette.

Video of the test and a pirouette towards the end as a comment below.