### PR TITLE
Fix `SimpleModel` json roundtripping

### DIFF
--- a/referenceframe/model.go
+++ b/referenceframe/model.go
@@ -88,7 +88,7 @@ func KinematicModelFromFile(modelPath, name string) (Model, error) {
 
 // SimpleModel is a model that serially concatenates a list of Frames.
 type SimpleModel struct {
-	*baseFrame
+	baseFrame
 	// OrdTransforms is the list of transforms ordered from end effector to base
 	ordTransforms []Frame
 	modelConfig   *ModelConfigJSON
@@ -98,7 +98,7 @@ type SimpleModel struct {
 // NewSimpleModel constructs a new model.
 func NewSimpleModel(name string) *SimpleModel {
 	return &SimpleModel{
-		baseFrame: &baseFrame{name: name},
+		baseFrame: baseFrame{name: name},
 	}
 }
 
@@ -274,9 +274,6 @@ func (m *SimpleModel) UnmarshalJSON(data []byte) error {
 		frameName = ser.Model.Name
 	}
 
-	m.baseFrame = &baseFrame{name: frameName, limits: ser.Limits}
-	m.modelConfig = ser.Model
-
 	if ser.Model != nil {
 		parsed, err := ser.Model.ParseConfig(ser.Model.Name)
 		if err != nil {
@@ -288,6 +285,9 @@ func (m *SimpleModel) UnmarshalJSON(data []byte) error {
 		}
 		m.SetOrdTransforms(newModel.OrdTransforms())
 	}
+	m.baseFrame = baseFrame{name: frameName, limits: ser.Limits}
+	m.modelConfig = ser.Model
+
 	return nil
 }
 

--- a/referenceframe/model_json_test.go
+++ b/referenceframe/model_json_test.go
@@ -15,6 +15,9 @@ func TestLimitsParsing(t *testing.T) {
 
 	smodel, ok := model.(*SimpleModel)
 	test.That(t, ok, test.ShouldBeTrue)
+
+	// Set custom limits on the simple model. Such that when we roundtrip through JSON
+	// serialization, we can see those values persist.
 	smodel.limits[0].Min = 0
 	smodel.limits[0].Max = 1
 
@@ -24,6 +27,9 @@ func TestLimitsParsing(t *testing.T) {
 	simpleModelDeserialized := new(SimpleModel)
 	err = simpleModelDeserialized.UnmarshalJSON(data)
 	test.That(t, err, test.ShouldBeNil)
+
+	// Assert that the min/max member values reflect the above assignments. As well as the result of
+	// the interface `DoF` method.
 	test.That(t, simpleModelDeserialized.limits[0].Min, test.ShouldEqual, 0)
 	test.That(t, simpleModelDeserialized.limits[0].Max, test.ShouldEqual, 1)
 	test.That(t, simpleModelDeserialized.DoF()[0], test.ShouldResemble, Limit{0, 1})

--- a/referenceframe/model_json_test.go
+++ b/referenceframe/model_json_test.go
@@ -9,6 +9,26 @@ import (
 	"go.viam.com/rdk/utils"
 )
 
+func TestLimitsParsing(t *testing.T) {
+	model, err := ParseModelJSONFile(utils.ResolveFile("components/arm/fake/kinematics/xarm6.json"), "")
+	test.That(t, err, test.ShouldBeNil)
+
+	smodel, ok := model.(*SimpleModel)
+	test.That(t, ok, test.ShouldBeTrue)
+	smodel.limits[0].Min = 0
+	smodel.limits[0].Max = 1
+
+	data, err := smodel.MarshalJSON()
+	test.That(t, err, test.ShouldBeNil)
+
+	simpleModelDeserialized := new(SimpleModel)
+	err = simpleModelDeserialized.UnmarshalJSON(data)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, simpleModelDeserialized.limits[0].Min, test.ShouldEqual, 0)
+	test.That(t, simpleModelDeserialized.limits[0].Max, test.ShouldEqual, 1)
+	test.That(t, simpleModelDeserialized.DoF()[0], test.ShouldResemble, Limit{0, 1})
+}
+
 // Tests that yml files are properly parsed and correctly loaded into the model
 // Should not need to actually test the contained rotation/translation values
 // since that will be caught by tests to the actual kinematics

--- a/referenceframe/model_test.go
+++ b/referenceframe/model_test.go
@@ -65,7 +65,7 @@ func TestModelGeometries(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	frame3, err := NewStaticFrameWithGeometry("link2", offset, bc)
 	test.That(t, err, test.ShouldBeNil)
-	m := &SimpleModel{baseFrame: &baseFrame{name: "test"}}
+	m := &SimpleModel{baseFrame: baseFrame{name: "test"}}
 	m.SetOrdTransforms([]Frame{frame1, frame2, frame3})
 
 	// test zero pose of model


### PR DESCRIPTION
Limits were being written out to JSON properly. But not reflected in the deserialized obejct.