### PR TITLE
Remove g prefix from commit hash

### DIFF
--- a/etc/dev-version.sh
+++ b/etc/dev-version.sh
@@ -26,7 +26,7 @@ DESC=$(git describe --tags --match="v*" --exclude="*-rc*" --long | sed 's/^v//')
 
 BASE_VERSION=$(echo "$DESC" | cut -d'-' -f1)
 COMMITS_SINCE_TAG=$(echo "$DESC" | cut -d'-' -f2)
-COMMIT_HASH=$(echo "$DESC" | cut -d'-' -f3)
+COMMIT_HASH=$(echo "$DESC" | cut -d'-' -f3 | sed 's/^g//')
 
 # Calculate next version by incrementing patch number
 NEXT_VERSION=$(echo "$BASE_VERSION" | awk -F. '{$3+=1}1' OFS=.)


### PR DESCRIPTION
Now the dev version will be formatted as v1.2.3-dev.9-099c853aa instead of v1.2.3-dev.9-g099c853aa.