### PR TITLE
RSDK-11025: tests create an empty .-local folder

### DIFF
--- a/robot/packages/local_package_manager.go
+++ b/robot/packages/local_package_manager.go
@@ -49,6 +49,7 @@ type managedModuleMap map[string]*managedModule
 func NewLocalManager(conf *config.Config, logger logging.Logger) (ManagerSyncer, error) {
 	packagesDir := LocalPackagesDir(conf.PackagePath)
 	packagesDataDir := filepath.Join(packagesDir, "data")
+	// if the package path isn't set, don't generate folders because they're not used and won't get deleted
 	if conf.PackagePath != "" {
 		if err := os.MkdirAll(packagesDir, 0o700); err != nil {
 			return nil, err


### PR DESCRIPTION
When tests call functions that use NewLocalManager() without specifying a PackagePath, it creates an .-local folder that never gets used. These changes make it so MkdirAll(directory creation) happens only if package Dir isn't empty. 

tested by running tests in robot (created .-local before changes but doesn't after changes)