### PR TITLE
RSDK-12138 Allow duplicative time_elapsed slow logger logs to be deduplicated

### DIFF
--- a/utils/ticker.go
+++ b/utils/ticker.go
@@ -18,7 +18,7 @@ func SlowLogger(ctx context.Context, msg, fieldName, fieldVal string, logger log
 		for {
 			select {
 			case <-slowTicker.C:
-				elapsed := time.Since(startTime).String()
+				elapsed := time.Since(startTime).Round(time.Second).String()
 				logger.CWarnw(ctx, msg, fieldName, fieldVal, "time_elapsed", elapsed)
 				if firstTick {
 					slowTicker.Reset(3 * time.Second)


### PR DESCRIPTION
RSDK-12138

Avoids repetitive logs about something like the web service taking a while to `Reconfigure`.

That specific slow `Reconfigure` happens a lot right now because of https://viam.atlassian.net/browse/RSDK-12138, and it can take > 2s when there are a lot of video-related resources. There's no need to keep spamming the user about it taking > 2s to happen:

```
10/5/2025, 4:02:21 PM warn rdk   utils/ticker.go:22   Waiting for internal resource to complete reconfiguration during weak/optional dependencies update   resource rdk-internal:service:web/builtin  time_elapsed 2.000677896s

10/5/2025, 4:02:16 PM warn rdk   utils/ticker.go:22   Waiting for internal resource to complete reconfiguration during weak/optional dependencies update   resource rdk-internal:service:web/builtin  time_elapsed 2.001995469s

10/5/2025, 4:02:11 PM warn rdk   utils/ticker.go:22   Waiting for internal resource to complete reconfiguration during weak/optional dependencies update   resource rdk-internal:service:web/builtin  time_elapsed 2.000076135s

10/5/2025, 4:02:06 PM warn rdk   utils/ticker.go:22   Waiting for internal resource to complete reconfiguration during weak/optional dependencies update   resource rdk-internal:service:web/builtin  time_elapsed 2.000291812s

10/5/2025, 4:02:01 PM warn rdk   utils/ticker.go:22   Waiting for internal resource to complete reconfiguration during weak/optional dependencies update   resource rdk-internal:service:web/builtin  time_elapsed 2.000940996s
```