### PR TITLE
RSDK-11429: robot shutdown while module restarting should not error

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -647,15 +647,15 @@ func (mgr *Manager) RemoveResource(ctx context.Context, name resource.Name) erro
 	mgr.rMap.Delete(name)
 	delete(mod.resources, name)
 	_, err := mod.client.RemoveResource(ctx, &pb.RemoveResourceRequest{Name: name.String()})
-	if err != nil {
+	if err != nil && !errors.Is(err, rdkgrpc.ErrNotConnected) {
 		return err
 	}
 
 	// if the module is marked for removal, actually remove it when the final resource is closed
 	if mod.pendingRemoval && len(mod.resources) == 0 {
-		err = multierr.Combine(err, mgr.closeModule(mod, false))
+		return multierr.Combine(err, mgr.closeModule(mod, false))
 	}
-	return err
+	return nil
 }
 
 // ValidateConfig determines whether the given config is valid and returns its implicit


### PR DESCRIPTION
If the error in mod.client.RemoveResource() is a ErrNotConnected (which is returned by invoke() in conn.go), it means that the modules are disconnected. These changes will ignore that error, which makes sense because if the module is disconnected from restarting/failing, the resources are already removed and it hasn't failed. This function calls the mod.client.RemoveResource() defined in the viam.api repo

Test results
TestCrashedModelReregisteredAfterRecovery with addition of t.FailNow():
```
JobManager is shutting down.
    /Users/allison.chiang/Documents/Code/rdk/robot/impl/utils.go:42: Expected: nil
        Actual:   'error removing modular resource for closure: not connected, resource_name: rdk:component:generic/h'
```

after these changes
```
    /Users/allison.chiang/Documents/Code/rdk/robot/impl/jobmanager.go:110: 2025-10-06T17:40:45.611-0400       INFO    TestCrashedModuleModelReregisteredAfterRecovery.job_manager   jobmanager/jobmanager.go:110    JobManager is shutting down.
--- FAIL: TestCrashedModuleModelReregisteredAfterRecovery (3.32s)
```