### PR TITLE
RSDK-12124 Pass a framesystem client as a dependency in reconfigure in addition to constructor

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -695,8 +695,9 @@ func (mgr *Manager) ValidateConfig(ctx context.Context, conf resource.Config) ([
 	for _, dep := range resp.Dependencies {
 		switch dep {
 		case "framesystem", "$framesystem", framesystem.PublicServiceName.String():
-			mgr.logger.Warnw("Attempt to depend on framesystem detected. The framesystem is always available "+
-				"in Golang modular resources through framesystem.FromDependencies; ignoring", "ignored_dependency",
+			mgr.logger.Warnw("Do not attempt to depend on the framesystem through Validate. "+
+				"The framesystem is always available in Golang modular resources through "+
+				"framesystem.FromDependencies; ignoring", "ignored_dependency",
 				dep, "resource", conf.Name)
 		default:
 			requiredImplicitDeps = append(requiredImplicitDeps, dep)
@@ -705,8 +706,9 @@ func (mgr *Manager) ValidateConfig(ctx context.Context, conf resource.Config) ([
 	for _, optionalDep := range resp.OptionalDependencies {
 		switch optionalDep {
 		case "framesystem", "$framesystem", framesystem.PublicServiceName.String():
-			mgr.logger.Warnw("Attempt to optionally depend on framesystem detected. The framesystem is always available "+
-				"in Golang modular resources through framesystem.FromDependencies; ignoring", "ignored_dependency",
+			mgr.logger.Warnw("Do not attempt to optionally depend on the framesystem through Validate. "+
+				"The framesystem is always available in Golang modular resources through "+
+				"framesystem.FromDependencies; ignoring", "ignored_dependency",
 				optionalDep, "resource", conf.Name)
 			continue
 		default:

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -25,6 +25,7 @@ import (
 	modlib "go.viam.com/rdk/module"
 	modmanageroptions "go.viam.com/rdk/module/modmanager/options"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/robot/packages"
 	rutils "go.viam.com/rdk/utils"
 )
@@ -687,7 +688,33 @@ func (mgr *Manager) ValidateConfig(ctx context.Context, conf resource.Config) ([
 	if err != nil {
 		return nil, nil, err
 	}
-	return resp.Dependencies, resp.OptionalDependencies, nil
+
+	// RSDK-12124: Log a warning if a user tries to depend on the framesystem in some way
+	// and ignore that dependency.
+	var requiredImplicitDeps, optionalImplicitDeps []string
+	for _, dep := range resp.Dependencies {
+		switch dep {
+		case "framesystem", "$framesystem", framesystem.PublicServiceName.String():
+			mgr.logger.Warnw("Attempt to depend on framesystem detected. The framesystem is always available "+
+				"in Golang modular resources through framesystem.FromDependencies; ignoring", "ignored_dependency",
+				dep, "resource", conf.Name)
+		default:
+			requiredImplicitDeps = append(requiredImplicitDeps, dep)
+		}
+	}
+	for _, optionalDep := range resp.OptionalDependencies {
+		switch optionalDep {
+		case "framesystem", "$framesystem", framesystem.PublicServiceName.String():
+			mgr.logger.Warnw("Attempt to optionally depend on framesystem detected. The framesystem is always available "+
+				"in Golang modular resources through framesystem.FromDependencies; ignoring", "ignored_dependency",
+				optionalDep, "resource", conf.Name)
+			continue
+		default:
+			optionalImplicitDeps = append(optionalImplicitDeps, optionalDep)
+		}
+	}
+
+	return requiredImplicitDeps, optionalImplicitDeps, nil
 }
 
 // ResolveImplicitDependenciesInConfig mutates the passed in diff to add modular implicit dependencies to added

--- a/module/module.go
+++ b/module/module.go
@@ -640,6 +640,9 @@ func (m *Module) ReconfigureResource(ctx context.Context, req *pb.ReconfigureRes
 		deps[name] = c
 	}
 
+	// let modules access RobotFrameSystem (name $framesystem) without needing entire RobotClient
+	deps[framesystem.PublicServiceName] = NewFrameSystemClient(m.parent)
+
 	// it is assumed the caller robot has handled model differences
 	conf, err := config.ComponentConfigFromProto(req.Config, m.logger)
 	if err != nil {

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -419,6 +419,27 @@ type fsDependent struct {
 	fs framesystem.Service
 }
 
+// Reconfigure ensures that the framesystem is available in the dependencies passed to
+// reconfigure (not just the constructor).
+func (fd *fsDependent) Reconfigure(
+	ctx context.Context,
+	deps resource.Dependencies,
+	conf resource.Config,
+) error {
+	fs, err := framesystem.FromDependencies(deps)
+	if err != nil {
+		return err
+	}
+	fsCfg, err := fs.FrameSystemConfig(ctx)
+	if err != nil {
+		return err
+	}
+	if fsCfg == nil {
+		return errors.New("received an empty framesystem config in Reconfigure")
+	}
+	return nil
+}
+
 // DoCommand always returns a stringified version of the frame system config as "fsCfg".
 func (fd *fsDependent) DoCommand(ctx context.Context, _ map[string]interface{}) (map[string]interface{}, error) {
 	fsCfg, err := fd.fs.FrameSystemConfig(ctx)

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -87,7 +87,7 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 	resource.RegisterComponent(
 		generic.API,
 		testFSDependentModel,
-		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newFSDependent})
+		resource.Registration[resource.Resource, *fsDepConfig]{Constructor: newFSDependent})
 	err = myMod.AddModelFromRegistry(ctx, generic.API, testFSDependentModel)
 	if err != nil {
 		return err
@@ -410,6 +410,18 @@ func newFSDependent(
 		Named: conf.ResourceName().AsNamed(),
 		fs:    fs,
 	}, nil
+}
+
+type fsDepConfig struct{}
+
+// Validate INCORRECTLY returns $framesystem, framesystem, and
+// framesystem.PublicServiceName.String() as implicit dependencies (both required and
+// optional). Validate methods do NOT need to do this, as the framesystem is always
+// available in constructors and Reconfigure methods through framesystem.FromDependencies.
+// The incorrect Validate method here is only used for testing that the appropriate
+// warnings are logged.
+func (fsc *fsDepConfig) Validate(_ string) ([]string, []string, error) {
+	return []string{"$framesystem", "framesystem"}, []string{framesystem.PublicServiceName.String()}, nil
 }
 
 type fsDependent struct {

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -312,8 +312,8 @@ func TestModularFramesystemDependency(t *testing.T) {
 	// 3 warnings (4 * 3 == 12). 2 for the required implicit dependencies on "$framesystem" and
 	// "framesystem", and 1 for the optional implicit dependency on
 	// `framesystem.PublicServiceName.String()`.
-	test.That(t, logs.FilterMessageSnippet("Attempt to depend on framesystem detected").Len(),
+	test.That(t, logs.FilterMessageSnippet("Do not attempt to depend on the framesystem through Validate").Len(),
 		test.ShouldEqual, 8)
-	test.That(t, logs.FilterMessageSnippet("Attempt to optionally depend on framesystem detected").Len(),
+	test.That(t, logs.FilterMessageSnippet("Do not attempt to optionally depend on the framesystem through Validate").Len(),
 		test.ShouldEqual, 4)
 }


### PR DESCRIPTION
RSDK-12124

Adds `{framesystem.PublicServiceName: framesystem.Service}` to the dependencies passed into Golang modular resource reconfiguration. Expands the existing integration test to ensure that that happens. Also logs a warning but allows passing `$framesystem`, `framesystem`, and `rdk-internal:service:frame_system/$framesystem` as implicit required/optional dependencies (returns from `Validate`) to avoid borking users build if they happen to do the wrong thing.