### PR TITLE
Update generated READMEs to include prerequisites

### DIFF
--- a/cli/module_generate/_templates/README.md
+++ b/cli/module_generate/_templates/README.md
@@ -2,17 +2,23 @@
 
 Provide a description of the purpose of the module and any relevant information.
 
+## Prerequisites
+
+If your model(s) have dependencies, mention them here. For example: You must have a [board](https://docs.viam.com/components/board/) component configured to use {{.ModelTriple}}.
+{{.ModelTriple}} uses the board component to access and use the pins on the board.
+
 ## Model {{.ModelTriple}}
 
 Provide a description of the model and any relevant information.
 
 ### Configuration
+
 The following attribute template can be used to configure this model:
 
 ```json
 {
-"attribute_1": <float>,
-"attribute_2": <string>
+  "attribute_1": <float>,
+  "attribute_2": <string>
 }
 ```
 


### PR DESCRIPTION
We ran into an issue when user testing because the ultrasonic sensor didn't explain a board was needed. This is to fix future issues. See https://github.com/viam-modules/viam-ultrasonic/pull/6 for context.