### PR TITLE
refactor `VoxelHistogram` function to subpackage

### DIFF
--- a/pointcloud/visualize/histogram.go
+++ b/pointcloud/visualize/histogram.go
@@ -1,0 +1,92 @@
+// Package visualize provides plotting/visualization utilities for pointcloud data.
+// It is separated from the main pointcloud package to avoid pulling heavy plotting
+// dependencies (liberation fonts, gonum/plot, go-pdf, go-hep) into binaries that
+// use pointcloud but don't need visualization.
+package visualize
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+
+	"go-hep.org/x/hep/hbook"
+	"go-hep.org/x/hep/hplot"
+	vecg "gonum.org/v1/plot/vg"
+
+	pc "go.viam.com/rdk/pointcloud"
+)
+
+// VoxelHistogram creates useful plots for determining the parameters of the voxel grid when calibrating a new sensor.
+// Histograms of the number of points in each voxel, the weights of each voxel, and the plane residuals.
+func VoxelHistogram(vg *pc.VoxelGrid, w, h int, name string) (image.Image, error) {
+	var hist *hbook.H1D
+	p := hplot.New()
+	switch name {
+	case "points":
+		p.Title.Text = "Points in Voxel"
+		p.X.Label.Text = "Pts in Voxel"
+		p.Y.Label.Text = "NVoxels"
+		hist = hbook.NewH1D(25, 0, +25)
+		for _, vox := range vg.Voxels {
+			variable := float64(len(vox.Points))
+			hist.Fill(variable, 1)
+		}
+	case "weights":
+		hist = hbook.NewH1D(40, 0, +1)
+		p.Title.Text = "Weights of Voxel"
+		p.X.Label.Text = "Voxel Weight"
+		p.Y.Label.Text = "N Vox"
+		for _, vox := range vg.Voxels {
+			variable := -9.0
+			if len(vox.Points) > 5 {
+				vox.Center = pc.GetVoxelCenter(vox.Positions())
+				vox.Normal = pc.EstimatePlaneNormalFromPoints(vox.Positions())
+				vox.Offset = pc.GetOffset(vox.Center, vox.Normal)
+				vox.Residual = pc.GetResidual(vox.Positions(), vox.GetPlane())
+				variable = pc.GetWeight(vox.Positions(), vg.Lambda(), vox.Residual)
+			}
+			hist.Fill(variable, 1)
+		}
+	case "residuals":
+		hist = hbook.NewH1D(65, 0, +6.5)
+		p.Title.Text = "Residual of Voxel"
+		p.X.Label.Text = "Voxel Residuals"
+		p.Y.Label.Text = "N Voxels"
+		for _, vox := range vg.Voxels {
+			variable := -999.
+			if len(vox.Points) > 5 {
+				vox.Center = pc.GetVoxelCenter(vox.Positions())
+				vox.Normal = pc.EstimatePlaneNormalFromPoints(vox.Positions())
+				vox.Offset = pc.GetOffset(vox.Center, vox.Normal)
+				vox.Residual = pc.GetResidual(vox.Positions(), vox.GetPlane())
+				variable = vox.Residual
+			}
+			hist.Fill(variable, 1)
+		}
+	default:
+		return nil, fmt.Errorf("%s not a plottable variable", name)
+	}
+
+	// Create a histogram of our values
+	hp := hplot.NewH1D(hist)
+	hp.Infos.Style = hplot.HInfoSummary
+	p.Add(hp)
+
+	width, err := vecg.ParseLength(fmt.Sprintf("%dpt", w))
+	if err != nil {
+		return nil, err
+	}
+	height, err := vecg.ParseLength(fmt.Sprintf("%dpt", h))
+	if err != nil {
+		return nil, err
+	}
+	imgByte, err := hplot.Show(p, width, height, "png")
+	if err != nil {
+		return nil, err
+	}
+	img, _, err := image.Decode(bytes.NewReader(imgByte))
+	if err != nil {
+		return nil, err
+	}
+	return img, nil
+}

--- a/pointcloud/voxel_helpers.go
+++ b/pointcloud/voxel_helpers.go
@@ -10,8 +10,8 @@ import (
 
 // helpers for Voxel attributes computation
 
-// estimatePlaneNormalFromPoints estimates the normal vector of the plane formed by the points in the []r3.Vector.
-func estimatePlaneNormalFromPoints(points []r3.Vector) r3.Vector {
+// EstimatePlaneNormalFromPoints estimates the normal vector of the plane formed by the points in the []r3.Vector.
+func EstimatePlaneNormalFromPoints(points []r3.Vector) r3.Vector {
 	// Put points in mat
 	nPoints := len(points)
 	mPt := mat.NewDense(nPoints, 3, nil)

--- a/pointcloud/voxel_segmentation.go
+++ b/pointcloud/voxel_segmentation.go
@@ -123,7 +123,7 @@ func (vg *VoxelGrid) GetPlanesFromLabels() ([]Plane, PointCloud, error) {
 				positions[i] = p
 				i++
 			}
-			normalVector := estimatePlaneNormalFromPoints(positions)
+			normalVector := EstimatePlaneNormalFromPoints(positions)
 			center := GetVoxelCenter(positions)
 			offset := GetOffset(center, normalVector)
 			currentPlane := &voxelPlane{

--- a/pointcloud/voxel_test.go
+++ b/pointcloud/voxel_test.go
@@ -73,7 +73,7 @@ func TestEstimatePlaneNormalFromPoints(t *testing.T) {
 		p := r3.Vector{rand.Float64(), rand.Float64(), 0}
 		points = append(points, p)
 	}
-	normalPlane := estimatePlaneNormalFromPoints(points)
+	normalPlane := EstimatePlaneNormalFromPoints(points)
 	test.ShouldAlmostEqual(normalPlane.X, 0.)
 	test.ShouldAlmostEqual(normalPlane.Y, 0.)
 	test.ShouldAlmostEqual(normalPlane.Z, 1.)

--- a/vision/segmentation/debug_plane_segmentation_test.go
+++ b/vision/segmentation/debug_plane_segmentation_test.go
@@ -10,6 +10,7 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
 	pc "go.viam.com/rdk/pointcloud"
+	pcviz "go.viam.com/rdk/pointcloud/visualize"
 	"go.viam.com/rdk/rimage"
 	"go.viam.com/rdk/rimage/transform"
 	"go.viam.com/rdk/utils"
@@ -93,13 +94,13 @@ func (h *segmentTestHelper) Process(
 	voxelSize := 20.
 	lam := 8.0
 	vg := pc.NewVoxelGridFromPointCloud(cloud, voxelSize, lam)
-	histPt, err := vg.VoxelHistogram(h.cameraParams.ColorCamera.Width, h.cameraParams.ColorCamera.Height, "points")
+	histPt, err := pcviz.VoxelHistogram(vg, h.cameraParams.ColorCamera.Width, h.cameraParams.ColorCamera.Height, "points")
 	test.That(t, err, test.ShouldBeNil)
 	pCtx.GotDebugImage(histPt, "voxel-histograms")
-	histWt, err := vg.VoxelHistogram(h.cameraParams.ColorCamera.Width, h.cameraParams.ColorCamera.Height, "weights")
+	histWt, err := pcviz.VoxelHistogram(vg, h.cameraParams.ColorCamera.Width, h.cameraParams.ColorCamera.Height, "weights")
 	test.That(t, err, test.ShouldBeNil)
 	pCtx.GotDebugImage(histWt, "weight-histograms")
-	histRes, err := vg.VoxelHistogram(h.cameraParams.ColorCamera.Width, h.cameraParams.ColorCamera.Height, "residuals")
+	histRes, err := pcviz.VoxelHistogram(vg, h.cameraParams.ColorCamera.Width, h.cameraParams.ColorCamera.Height, "residuals")
 	test.That(t, err, test.ShouldBeNil)
 	pCtx.GotDebugImage(histRes, "residual-histograms")
 


### PR DESCRIPTION
## What changed
## Why
Largest contributor to binary size of CLI (and presumably modules), not needed outside of tests.

CLI binary size goes down from 59 -> 53mb.