### PR TITLE
update default http message

### DIFF
--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -793,7 +793,7 @@ func (svc *webService) initMux(options weboptions.Options) *goji.Mux {
 	// Note: used by viam-agent for health checks
 	mux.HandleFunc(pat.New("/"), func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte("healthy")); err != nil {
+		if _, err := w.Write([]byte("I am a viam-server, navigate to https://app.viam.com to manage me.")); err != nil {
 			svc.logger.Warnf("unable to write healthy response: %w", err)
 		}
 	})


### PR DESCRIPTION
Pretty minor...but "healthy" is confusing you accidentally navigate to the port. It'll also help internal development for new eng who happen to run app and viam-server on the same port.