### PR TITLE
Allow overriding VIAM_HOME; read HOME env var on Windows

### DIFF
--- a/config/reader.go
+++ b/config/reader.go
@@ -81,6 +81,11 @@ func getAgentInfo(logger logging.Logger) (*apppb.AgentInfo, error) {
 var viamPackagesDir string
 
 func init() {
+	UpdateViamPackagesDir()
+}
+
+// UpdateViamPackagesDir updates viamPackagesDir with the latest available information.
+func UpdateViamPackagesDir() {
 	viamPackagesDir = filepath.Join(rutils.ViamDotDir, PackagesDirName)
 }
 

--- a/utils/env.go
+++ b/utils/env.go
@@ -151,6 +151,10 @@ func PlatformHomeDir() string {
 		return AndroidFilesDir
 	}
 	if runtime.GOOS == "windows" { //nolint:goconst
+		// HOME is not usually set on windows, but prefer it if it is.
+		if homeEnv, found := os.LookupEnv("HOME"); found && homeEnv != "" {
+			return homeEnv
+		}
 		homedir, _ := os.UserHomeDir() //nolint:errcheck
 		if homedir != "" {
 			return homedir

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -71,15 +71,6 @@ func logViamEnvVariables(logger logging.Logger) {
 	if rutils.PlatformHomeDir() != "" {
 		viamEnvVariables["HOME"] = rutils.PlatformHomeDir()
 	}
-	// Always attempt to overwrite VIAM_HOME because we do not currently support user-defined home directories.
-	value, alreadySet := os.LookupEnv(rutils.HomeEnvVar)
-	err := os.Setenv(rutils.HomeEnvVar, rutils.ViamDotDir)
-	// if we successfully overwrite VIAM_HOME, log
-	if err == nil && alreadySet {
-		logger.Infof("Environment variable %v was overwritten from %v to %v", rutils.HomeEnvVar, value, rutils.ViamDotDir)
-	} else if err != nil && !alreadySet {
-		logger.Infof("Unable to set %v environment variable, continuing with startup", rutils.HomeEnvVar)
-	}
 	rutils.LogViamEnvVariables("Started with the following Viam environment variables", viamEnvVariables, logger)
 }
 
@@ -159,6 +150,14 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 		// used. Otherwise run network checks asynchronously.
 		nc.RunNetworkChecks(ctx, rootLogger, false /* !continueRunningTestDNS */)
 		return
+	}
+
+	// If user has set a custom VIAM_HOME, note that it is experimental.
+	if value, isSet := os.LookupEnv(rutils.HomeEnvVar); isSet {
+		rootLogger.Infof("Environment variable %v is set to %v. Support for custom %v is currently experimental. "+
+			"Continuing with startup.", rutils.HomeEnvVar, value, rutils.HomeEnvVar)
+		rootLogger.Infof("Updating .viam dir from %v to %v", rutils.ViamDotDir, value)
+		rutils.ViamDotDir = value
 	}
 
 	// log startup info locally if server fails and exits while attempting to start up

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -158,6 +158,7 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 			"Continuing with startup.", rutils.HomeEnvVar, value, rutils.HomeEnvVar)
 		rootLogger.Infof("Updating .viam dir from %v to %v", rutils.ViamDotDir, value)
 		rutils.ViamDotDir = value
+		config.UpdateViamPackagesDir()
 	}
 
 	// log startup info locally if server fails and exits while attempting to start up


### PR DESCRIPTION
* Prefer `HOME` env var if set on Windows (it's usually not)
* Allow user to override `VIAM_HOME`. If they do this, log that it's experimental:
```
2026-03-25T14:56:14.983Z	INFO	rdk	server/entrypoint.go:157	Environment variable VIAM_HOME is set to D:\.viam. Support for custom VIAM_HOME is currently experimental. Continuing with startup.
2026-03-25T14:56:14.984Z	INFO	rdk	server/entrypoint.go:159	Updating .viam dir from C:\Users\user\.viam to D:\.viam
```
I moved the `rutils.ViamDotDir` overriding earlier instead, but it seems it's still not early enough for some modules. Setting `HOME=D:\` makes them work (`VIAM_HOME` then defaults to `D:\.viam` without needing to be explicitly set).