### PR TITLE
RSDK-13719: Auto-populate models section in meta.json

### DIFF
--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -1138,6 +1138,13 @@ func renderManifest(cmd *cli.Command, moduleID string, module modulegen.ModuleIn
 		manifest.Entrypoint = fmt.Sprintf("bin/%s", module.ModuleName)
 	}
 
+	// Auto-populate models in the manifest using the generated module inputs
+	manifest.Models = []ModuleComponent{{
+		API:          module.API,
+		Model:        module.ModelTriple,
+		MarkdownLink: &module.ModelReadmeLink,
+	}}
+
 	if err := writeManifest(filepath.Join(module.ModuleName, defaultManifestFilename), manifest); err != nil {
 		return err
 	}

--- a/cli/module_generate_test.go
+++ b/cli/module_generate_test.go
@@ -227,7 +227,11 @@ func TestGenerateModuleAction(t *testing.T) {
 		var manifest ModuleManifest
 		err = json.Unmarshal(bytes, &manifest)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(manifest.Models), test.ShouldEqual, 0)
+		test.That(t, len(manifest.Models), test.ShouldEqual, 1)
+		test.That(t, manifest.Models[0].API, test.ShouldEqual, testModule.API)
+		test.That(t, manifest.Models[0].Model, test.ShouldEqual, testModule.ModelTriple)
+		test.That(t, manifest.Models[0].MarkdownLink, test.ShouldNotBeNil)
+		test.That(t, *manifest.Models[0].MarkdownLink, test.ShouldEqual, testModule.ModelReadmeLink)
 	})
 
 	t.Run("test generate cpp stubs", func(t *testing.T) {


### PR DESCRIPTION
Improve the Viam CLI (`viam module generate`) command

When generating a new module via `viam module generate`  the resulting `meta.json` does not include the `models` entries by default. This causes confusing errors on first deploy, such as:

```
rdk.modmanager.viam_example.StdErr pexec/managed_process.go:442
\_ ModuleNotFoundError: No module named 'models.example_demo'
```

This PR updates the module generation logic to auto-populate the models field in meta.json based on the models defined during generation.

We tested it and the meta.json includes the appropriate section.

Built with Claude.