### PR TITLE
[APP-15934] Fix TLS cert chain to include intermediates for Linux compatibility 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1094,8 +1094,6 @@ func appendIntermediateCerts(cert *tls.Certificate, logger logging.Logger) {
 }
 
 // CreateTLSWithCert creates a tls.Config with the TLS certificate to be returned.
-// It fetches any intermediate certificates via AIA so that clients without those
-// intermediates in their system trust store (e.g. Linux) can verify the chain.
 func CreateTLSWithCert(cfg *Config) (*tls.Config, error) {
 	cert, err := tls.X509KeyPair([]byte(cfg.Cloud.TLSCertificate), []byte(cfg.Cloud.TLSPrivateKey))
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -4,9 +4,13 @@ package config
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1053,16 +1057,53 @@ func ParseAPIKeys(handler AuthHandlerConfig) map[string]string {
 	return apiKeys
 }
 
+// appendIntermediateCerts fetches any missing intermediate certificates by following
+// the AIA (Authority Information Access) URLs in the leaf certificate and appends
+// their DER-encoded bytes to cert.Certificate. This ensures clients that do not
+// perform AIA fetching (e.g. Linux) can verify the chain without needing the
+// intermediates in their system trust store.
+func appendIntermediateCerts(cert *tls.Certificate) error {
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return err
+	}
+	for _, url := range leaf.IssuingCertificateURL {
+		//nolint:noctx
+		resp, err := http.Get(url) //nolint:gosec
+		if err != nil {
+			return errors.Wrapf(err, "fetching intermediate cert from %s", url)
+		}
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return errors.Wrapf(err, "reading intermediate cert from %s", url)
+		}
+		// The response may be DER or PEM encoded.
+		if block, _ := pem.Decode(body); block != nil {
+			body = block.Bytes
+		}
+		if _, err := x509.ParseCertificate(body); err != nil {
+			return errors.Wrapf(err, "parsing intermediate cert from %s", url)
+		}
+		cert.Certificate = append(cert.Certificate, body)
+	}
+	return nil
+}
+
 // CreateTLSWithCert creates a tls.Config with the TLS certificate to be returned.
+// It fetches any intermediate certificates via AIA so that clients without those
+// intermediates in their system trust store (e.g. Linux) can verify the chain.
 func CreateTLSWithCert(cfg *Config) (*tls.Config, error) {
 	cert, err := tls.X509KeyPair([]byte(cfg.Cloud.TLSCertificate), []byte(cfg.Cloud.TLSPrivateKey))
 	if err != nil {
 		return nil, err
 	}
+	if err := appendIntermediateCerts(&cert); err != nil {
+		return nil, err
+	}
 	return &tls.Config{
 		MinVersion: tls.VersionTLS12,
 		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
-			// always return same cert
 			return &cert, nil
 		},
 	}, nil

--- a/config/config.go
+++ b/config/config.go
@@ -1062,32 +1062,35 @@ func ParseAPIKeys(handler AuthHandlerConfig) map[string]string {
 // their DER-encoded bytes to cert.Certificate. This ensures clients that do not
 // perform AIA fetching (e.g. Linux) can verify the chain without needing the
 // intermediates in their system trust store.
-func appendIntermediateCerts(cert *tls.Certificate) error {
+func appendIntermediateCerts(cert *tls.Certificate, logger logging.Logger) {
 	leaf, err := x509.ParseCertificate(cert.Certificate[0])
 	if err != nil {
-		return err
+		logger.Debugw("failed to parse leaf certificate; skipping intermediate fetch", "error", err)
+		return
 	}
-	for _, url := range leaf.IssuingCertificateURL {
-		//nolint:noctx
-		resp, err := http.Get(url) //nolint:gosec
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	for _, aiaURL := range leaf.IssuingCertificateURL {
+		resp, err := client.Get(aiaURL) //nolint:gosec
 		if err != nil {
-			return errors.Wrapf(err, "fetching intermediate cert from %s", url)
+			logger.Debugw("failed to fetch intermediate cert", "url", aiaURL, "error", err)
+			continue
 		}
 		body, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
-			return errors.Wrapf(err, "reading intermediate cert from %s", url)
+			logger.Debugw("failed to read intermediate cert", "url", aiaURL, "error", err)
+			continue
 		}
-		// The response may be DER or PEM encoded.
 		if block, _ := pem.Decode(body); block != nil {
 			body = block.Bytes
 		}
 		if _, err := x509.ParseCertificate(body); err != nil {
-			return errors.Wrapf(err, "parsing intermediate cert from %s", url)
+			logger.Debugw("failed to parse intermediate cert", "url", aiaURL, "error", err)
+			continue
 		}
 		cert.Certificate = append(cert.Certificate, body)
 	}
-	return nil
 }
 
 // CreateTLSWithCert creates a tls.Config with the TLS certificate to be returned.
@@ -1098,9 +1101,7 @@ func CreateTLSWithCert(cfg *Config) (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := appendIntermediateCerts(&cert); err != nil {
-		return nil, err
-	}
+	appendIntermediateCerts(&cert, logging.NewLogger("tls"))
 	return &tls.Config{
 		MinVersion: tls.VersionTLS12,
 		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -1077,7 +1077,7 @@ func appendIntermediateCerts(cert *tls.Certificate, logger logging.Logger) {
 		if err != nil {
 			continue
 		}
-		resp, err := client.Do(req) //nolint:gosec
+		resp, err := client.Do(req) 
 		if err != nil {
 			logger.Debugw("failed to fetch intermediate cert", "url", aiaURL, "error", err)
 			continue

--- a/config/config.go
+++ b/config/config.go
@@ -1071,7 +1071,7 @@ func CreateTLSWithCert(cfg *Config) (*tls.Config, error) {
 // ProcessConfig processes robot configs.
 func ProcessConfig(in *Config) (*Config, error) {
 	out := *in
-	if in.Cloud != nil {
+	if in.Cloud != nil && !in.Network.NoTLS {
 		// We expect a cloud config from app to always contain a non-empty `TLSCertificate` field.
 		// We do this empty string check just to cope with unexpected input, such as cached configs
 		// that are hand altered to have their `TLSCertificate` removed.

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -20,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.viam.com/utils"
 	"go.viam.com/utils/artifact"
 	"go.viam.com/utils/jwks"
 	"go.viam.com/utils/pexec"
@@ -1071,13 +1073,17 @@ func appendIntermediateCerts(cert *tls.Certificate, logger logging.Logger) {
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	for _, aiaURL := range leaf.IssuingCertificateURL {
-		resp, err := client.Get(aiaURL) //nolint:gosec
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, aiaURL, nil)
+		if err != nil {
+			continue
+		}
+		resp, err := client.Do(req) //nolint:gosec
 		if err != nil {
 			logger.Debugw("failed to fetch intermediate cert", "url", aiaURL, "error", err)
 			continue
 		}
 		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		utils.UncheckedError(resp.Body.Close())
 		if err != nil {
 			logger.Debugw("failed to read intermediate cert", "url", aiaURL, "error", err)
 			continue

--- a/config/config.go
+++ b/config/config.go
@@ -1077,7 +1077,7 @@ func appendIntermediateCerts(cert *tls.Certificate, logger logging.Logger) {
 		if err != nil {
 			continue
 		}
-		resp, err := client.Do(req) 
+		resp, err := client.Do(req)
 		if err != nil {
 			logger.Debugw("failed to fetch intermediate cert", "url", aiaURL, "error", err)
 			continue

--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -114,13 +114,11 @@ func FromConfig(cfg *config.Config) (Options, error) {
 			}
 
 			if !cfg.Network.NoTLS {
-				// override
-				options.Network.TLSConfig = cfg.Network.TLSConfig
-
 				// This will only happen if we're switching from a local config to a cloud config.
 				if cfg.Network.TLSConfig == nil {
 					return Options{}, errors.New("switching from local config to cloud config not currently supported")
 				}
+				options.Network.TLSConfig = cfg.Network.TLSConfig
 				cert, err := cfg.Network.TLSConfig.GetCertificate(&tls.ClientHelloInfo{})
 				if err != nil {
 					return Options{}, err

--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -117,7 +117,7 @@ func FromConfig(cfg *config.Config) (Options, error) {
 			}
 
 			// This will only happen if we're switching from a local config to a cloud config.
-			if cfg.Network.TLSConfig == nil {
+			if cfg.Network.TLSConfig == nil && !cfg.Network.NoTLS {
 				return Options{}, errors.New("switching from local config to cloud config not currently supported")
 			}
 			cert, err := cfg.Network.TLSConfig.GetCertificate(&tls.ClientHelloInfo{})

--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -2,8 +2,6 @@
 package weboptions
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"net"
@@ -119,15 +117,6 @@ func FromConfig(cfg *config.Config) (Options, error) {
 					return Options{}, errors.New("switching from local config to cloud config not currently supported")
 				}
 				options.Network.TLSConfig = cfg.Network.TLSConfig
-				cert, err := cfg.Network.TLSConfig.GetCertificate(&tls.ClientHelloInfo{})
-				if err != nil {
-					return Options{}, err
-				}
-				leaf, err := x509.ParseCertificate(cert.Certificate[0])
-				if err != nil {
-					return Options{}, err
-				}
-				options.Auth.TLSAuthEntities = leaf.DNSNames
 			}
 		}
 

--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -99,9 +99,6 @@ func FromConfig(cfg *config.Config) (Options, error) {
 		options.SignalingAddress = cfg.Cloud.SignalingAddress
 
 		if cfg.Cloud.TLSCertificate != "" {
-			// override
-			options.Network.TLSConfig = cfg.Network.TLSConfig
-
 			// NOTE(RDK-148):
 			// when we are managed and no explicit bind address is set,
 			// we will listen everywhere on 8080. We assume this to be
@@ -116,19 +113,24 @@ func FromConfig(cfg *config.Config) (Options, error) {
 				options.Network.BindAddress = ":8080"
 			}
 
-			// This will only happen if we're switching from a local config to a cloud config.
-			if cfg.Network.TLSConfig == nil && !cfg.Network.NoTLS {
-				return Options{}, errors.New("switching from local config to cloud config not currently supported")
+			if !cfg.Network.NoTLS {
+				// override
+				options.Network.TLSConfig = cfg.Network.TLSConfig
+
+				// This will only happen if we're switching from a local config to a cloud config.
+				if cfg.Network.TLSConfig == nil {
+					return Options{}, errors.New("switching from local config to cloud config not currently supported")
+				}
+				cert, err := cfg.Network.TLSConfig.GetCertificate(&tls.ClientHelloInfo{})
+				if err != nil {
+					return Options{}, err
+				}
+				leaf, err := x509.ParseCertificate(cert.Certificate[0])
+				if err != nil {
+					return Options{}, err
+				}
+				options.Auth.TLSAuthEntities = leaf.DNSNames
 			}
-			cert, err := cfg.Network.TLSConfig.GetCertificate(&tls.ClientHelloInfo{})
-			if err != nil {
-				return Options{}, err
-			}
-			leaf, err := x509.ParseCertificate(cert.Certificate[0])
-			if err != nil {
-				return Options{}, err
-			}
-			options.Auth.TLSAuthEntities = leaf.DNSNames
 		}
 
 		options.Auth.Handlers = make([]config.AuthHandlerConfig, len(cfg.Auth.Handlers))


### PR DESCRIPTION
## Description

[APP-15934](https://viam.atlassian.net/browse/APP-15934) Local SOW app mode does not work on Linux

* **TLS intermediate cert chain**: Local SOW app mode wasn't working on Linux because the OS does not natively build the chain from the robot's leaf cert to the root cert. Although the root cert is trusted, Linux cannot bridge the gap to the intermediate since the server was only sending the leaf cert. macOS handles this natively via AIA (Authority Information Access) fetching, which is why it worked. This PR makes `CreateTLSWithCert` fetch intermediate certs from the AIA URLs embedded in the leaf cert at startup and include them in the TLS handshake, so clients that do not perform AIA fetching can verify the full chain up to the root.
    * Fetching is best-effort with a 10s timeout — if the AIA endpoint is unreachable, the server starts anyway with just the leaf cert.
* **`no_tls: true` now actually disables TLS**: The `no_tls` config option was not putting `viam-server` into a true no-TLS mode. A TLS config was still being populated from the cloud cert and used in the dial logic for the internal signaling server connection, causing TLS errors for clients expecting plaintext. This PR ensures `no_tls: true` fully skips TLS config creation and propagation. Clients connecting in this mode must set `SignalingInsecure: true`.

## Testing
- [x] Verify Linux client can connect to a robot over the local network without `no_tls` (cert chain fix)
- [x] Verify `no_tls: true` starts the server in plaintext mode with no TLS errors
- [x] Verify `no_tls: true` client connection works with `SignalingInsecure: true`
- [x] Verify normal TLS mode is unaffected on macOS and Linux

[APP-15934]: https://viam.atlassian.net/browse/APP-15934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ