### PR TITLE
[APP-15934] Make no TLS mode actually disable TLS

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1071,7 +1071,7 @@ func CreateTLSWithCert(cfg *Config) (*tls.Config, error) {
 // ProcessConfig processes robot configs.
 func ProcessConfig(in *Config) (*Config, error) {
 	out := *in
-	if in.Cloud != nil {
+	if in.Cloud != nil && !in.Network.NoTLS {
 		// We expect a cloud config from app to always contain a non-empty `TLSCertificate` field.
 		// We do this empty string check just to cope with unexpected input, such as cached configs
 		// that are hand altered to have their `TLSCertificate` removed.

--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -2,8 +2,6 @@
 package weboptions
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"net"
@@ -116,19 +114,13 @@ func FromConfig(cfg *config.Config) (Options, error) {
 				options.Network.BindAddress = ":8080"
 			}
 
-			// This will only happen if we're switching from a local config to a cloud config.
-			if cfg.Network.TLSConfig == nil {
-				return Options{}, errors.New("switching from local config to cloud config not currently supported")
+			if !cfg.Network.NoTLS {
+				// This will only happen if we're switching from a local config to a cloud config.
+				if cfg.Network.TLSConfig == nil {
+					return Options{}, errors.New("switching from local config to cloud config not currently supported")
+				}
+				options.Network.TLSConfig = cfg.Network.TLSConfig
 			}
-			cert, err := cfg.Network.TLSConfig.GetCertificate(&tls.ClientHelloInfo{})
-			if err != nil {
-				return Options{}, err
-			}
-			leaf, err := x509.ParseCertificate(cert.Certificate[0])
-			if err != nil {
-				return Options{}, err
-			}
-			options.Auth.TLSAuthEntities = leaf.DNSNames
 		}
 
 		options.Auth.Handlers = make([]config.AuthHandlerConfig, len(cfg.Auth.Handlers))

--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -97,9 +97,6 @@ func FromConfig(cfg *config.Config) (Options, error) {
 		options.SignalingAddress = cfg.Cloud.SignalingAddress
 
 		if cfg.Cloud.TLSCertificate != "" {
-			// override
-			options.Network.TLSConfig = cfg.Network.TLSConfig
-
 			// NOTE(RDK-148):
 			// when we are managed and no explicit bind address is set,
 			// we will listen everywhere on 8080. We assume this to be


### PR DESCRIPTION
## Description

[APP-15934](https://viam.atlassian.net/browse/APP-15934) Local SOW app mode does not work on Linux

* `no_tls: true` now actually disables TLS: The `no_tls` config option was not putting `viam-server` into a true no-TLS mode. A TLS config was still being populated from the cloud cert and used in the dial logic for the internal signaling server connection, causing TLS errors for clients expecting plaintext. This PR ensures `no_tls: true` fully skips TLS config creation and propagation. Clients connecting in this mode must set `SignalingInsecure: true`.

## Testing
- [x] Verify `no_tls: true` starts the server in plaintext mode with no TLS errors
- [x] Verify `no_tls: true` client connection works with `SignalingInsecure: true`
- [x] Verify normal TLS mode is unaffected on macOS and Linux

[APP-15934]: https://viam.atlassian.net/browse/APP-15934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ