### PR TITLE
[APP-15934] Fetch and cache intermediate certs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1099,13 +1099,103 @@ func appendIntermediateCerts(cert *tls.Certificate, logger logging.Logger) {
 	}
 }
 
+// tlsIntermediateCache is the on-disk structure for caching intermediate TLS certificates.
+// Intermediates are stored as raw DER bytes; encoding/json marshals []byte as base64.
+type tlsIntermediateCache struct {
+	LeafCertPEM   string   `json:"leaf_cert_pem"`
+	Intermediates [][]byte `json:"intermediates"`
+}
+
+func getTLSCacheFilePath(partID string) string {
+	return filepath.Join(rutils.ViamDotDir, fmt.Sprintf("cached_tls_intermediates_%s.json", partID))
+}
+
+func readTLSIntermediateCache(path string) (*tlsIntermediateCache, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer utils.UncheckedErrorFunc(f.Close)
+	var c tlsIntermediateCache
+	if err := json.NewDecoder(f).Decode(&c); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func writeTLSIntermediateCache(path string, c *tlsIntermediateCache, partID string) error {
+	if err := os.MkdirAll(rutils.ViamDotDir, 0o700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	return artifact.AtomicStore(path, bytes.NewReader(data), partID)
+}
+
+// loadOrFetchIntermediateCerts appends intermediate certificates to cert, using a disk
+// cache keyed by leafCertPEM to avoid redundant AIA HTTP fetches. If the leaf cert PEM
+// matches the cache, cached intermediates are used and no network request is made. If
+// the leaf has rotated or no cache exists, intermediates are fetched via AIA and the
+// cache is updated. partID is used to name the cache file; if empty, caching is skipped.
+func loadOrFetchIntermediateCerts(cert *tls.Certificate, leafCertPEM, partID string, logger logging.Logger) {
+	if partID == "" {
+		appendIntermediateCerts(cert, logger)
+		return
+	}
+
+	cachePath := getTLSCacheFilePath(partID)
+
+	cached, err := readTLSIntermediateCache(cachePath)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		logger.Debugw("no TLS intermediate cache found; fetching from AIA")
+	case err != nil:
+		logger.Warnw("error reading TLS intermediate cache; fetching from AIA", "error", err)
+	case cached.LeafCertPEM == leafCertPEM:
+		logger.Debugw("TLS intermediate cache hit; skipping AIA fetch")
+		beforeCache := len(cert.Certificate)
+		for _, der := range cached.Intermediates {
+			if _, err := x509.ParseCertificate(der); err != nil {
+				logger.Warnw("cached intermediate cert is invalid; re-fetching from AIA", "error", err)
+				cert.Certificate = cert.Certificate[:beforeCache]
+				goto fetch
+			}
+			cert.Certificate = append(cert.Certificate, der)
+		}
+		return
+	default:
+		logger.Debugw("leaf cert rotated; re-fetching intermediates from AIA")
+	}
+
+fetch:
+	before := len(cert.Certificate)
+	appendIntermediateCerts(cert, logger)
+	fetched := cert.Certificate[before:]
+
+	if len(fetched) == 0 {
+		return
+	}
+
+	newCache := tlsIntermediateCache{
+		LeafCertPEM:   leafCertPEM,
+		Intermediates: make([][]byte, len(fetched)),
+	}
+	copy(newCache.Intermediates, fetched)
+
+	if err := writeTLSIntermediateCache(cachePath, &newCache, partID); err != nil {
+		logger.Warnw("failed to write TLS intermediate cache", "error", err)
+	}
+}
+
 // CreateTLSWithCert creates a tls.Config with the TLS certificate to be returned.
 func CreateTLSWithCert(cfg *Config) (*tls.Config, error) {
 	cert, err := tls.X509KeyPair([]byte(cfg.Cloud.TLSCertificate), []byte(cfg.Cloud.TLSPrivateKey))
 	if err != nil {
 		return nil, err
 	}
-	appendIntermediateCerts(&cert, logging.NewLogger("tls"))
+	loadOrFetchIntermediateCerts(&cert, cfg.Cloud.TLSCertificate, cfg.Cloud.ID, logging.NewLogger("tls"))
 	return &tls.Config{
 		MinVersion: tls.VersionTLS12,
 		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -1207,7 +1207,7 @@ func CreateTLSWithCert(cfg *Config) (*tls.Config, error) {
 // ProcessConfig processes robot configs.
 func ProcessConfig(in *Config) (*Config, error) {
 	out := *in
-	if in.Cloud != nil && !in.Network.NoTLS {
+	if in.Cloud != nil {
 		// We expect a cloud config from app to always contain a non-empty `TLSCertificate` field.
 		// We do this empty string check just to cope with unexpected input, such as cached configs
 		// that are hand altered to have their `TLSCertificate` removed.

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -1054,12 +1055,12 @@ func ParseAPIKeys(handler AuthHandlerConfig) map[string]string {
 }
 
 // CreateTLSWithCert creates a tls.Config with the TLS certificate to be returned.
-func CreateTLSWithCert(cfg *Config) (*tls.Config, error) {
+func CreateTLSWithCert(ctx context.Context, cfg *Config) (*tls.Config, error) {
 	cert, err := tls.X509KeyPair([]byte(cfg.Cloud.TLSCertificate), []byte(cfg.Cloud.TLSPrivateKey))
 	if err != nil {
 		return nil, err
 	}
-	loadOrFetchIntermediateCerts(&cert, cfg.Cloud.TLSCertificate, cfg.Cloud.ID, logging.NewLogger("tls"))
+	loadOrFetchIntermediateCerts(ctx, &cert, cfg.Cloud.TLSCertificate, cfg.Cloud.ID, logging.NewLogger("tls"))
 	return &tls.Config{
 		MinVersion: tls.VersionTLS12,
 		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
@@ -1069,14 +1070,14 @@ func CreateTLSWithCert(cfg *Config) (*tls.Config, error) {
 }
 
 // ProcessConfig processes robot configs.
-func ProcessConfig(in *Config) (*Config, error) {
+func ProcessConfig(ctx context.Context, in *Config) (*Config, error) {
 	out := *in
 	if in.Cloud != nil {
 		// We expect a cloud config from app to always contain a non-empty `TLSCertificate` field.
 		// We do this empty string check just to cope with unexpected input, such as cached configs
 		// that are hand altered to have their `TLSCertificate` removed.
 		if in.Cloud.TLSCertificate != "" {
-			tlsConfig, err := CreateTLSWithCert(in)
+			tlsConfig, err := CreateTLSWithCert(ctx, in)
 			if err != nil {
 				return nil, err
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -1094,8 +1094,6 @@ func appendIntermediateCerts(cert *tls.Certificate, logger logging.Logger) {
 }
 
 // CreateTLSWithCert creates a tls.Config with the TLS certificate to be returned.
-// It fetches any intermediate certificates via AIA so that clients without those
-// intermediates in their system trust store (e.g. Linux) can verify the chain.
 func CreateTLSWithCert(cfg *Config) (*tls.Config, error) {
 	cert, err := tls.X509KeyPair([]byte(cfg.Cloud.TLSCertificate), []byte(cfg.Cloud.TLSPrivateKey))
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -4,9 +4,13 @@ package config
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1053,16 +1057,53 @@ func ParseAPIKeys(handler AuthHandlerConfig) map[string]string {
 	return apiKeys
 }
 
+// appendIntermediateCerts fetches any missing intermediate certificates by following
+// the AIA (Authority Information Access) URLs in the leaf certificate and appends
+// their DER-encoded bytes to cert.Certificate. This ensures clients that do not
+// perform AIA fetching (e.g. Linux) can verify the chain without needing the
+// intermediates in their system trust store.
+func appendIntermediateCerts(cert *tls.Certificate) error {
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return err
+	}
+	for _, url := range leaf.IssuingCertificateURL {
+		//nolint:noctx
+		resp, err := http.Get(url) //nolint:gosec
+		if err != nil {
+			return errors.Wrapf(err, "fetching intermediate cert from %s", url)
+		}
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return errors.Wrapf(err, "reading intermediate cert from %s", url)
+		}
+		// The response may be DER or PEM encoded.
+		if block, _ := pem.Decode(body); block != nil {
+			body = block.Bytes
+		}
+		if _, err := x509.ParseCertificate(body); err != nil {
+			return errors.Wrapf(err, "parsing intermediate cert from %s", url)
+		}
+		cert.Certificate = append(cert.Certificate, body)
+	}
+	return nil
+}
+
 // CreateTLSWithCert creates a tls.Config with the TLS certificate to be returned.
+// It fetches any intermediate certificates via AIA so that clients without those
+// intermediates in their system trust store (e.g. Linux) can verify the chain.
 func CreateTLSWithCert(cfg *Config) (*tls.Config, error) {
 	cert, err := tls.X509KeyPair([]byte(cfg.Cloud.TLSCertificate), []byte(cfg.Cloud.TLSPrivateKey))
 	if err != nil {
 		return nil, err
 	}
+	if err := appendIntermediateCerts(&cert); err != nil {
+		return nil, err
+	}
 	return &tls.Config{
 		MinVersion: tls.VersionTLS12,
 		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
-			// always return same cert
 			return &cert, nil
 		},
 	}, nil

--- a/config/config.go
+++ b/config/config.go
@@ -1062,32 +1062,35 @@ func ParseAPIKeys(handler AuthHandlerConfig) map[string]string {
 // their DER-encoded bytes to cert.Certificate. This ensures clients that do not
 // perform AIA fetching (e.g. Linux) can verify the chain without needing the
 // intermediates in their system trust store.
-func appendIntermediateCerts(cert *tls.Certificate) error {
+func appendIntermediateCerts(cert *tls.Certificate, logger logging.Logger) {
 	leaf, err := x509.ParseCertificate(cert.Certificate[0])
 	if err != nil {
-		return err
+		logger.Debugw("failed to parse leaf certificate; skipping intermediate fetch", "error", err)
+		return
 	}
-	for _, url := range leaf.IssuingCertificateURL {
-		//nolint:noctx
-		resp, err := http.Get(url) //nolint:gosec
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	for _, aiaURL := range leaf.IssuingCertificateURL {
+		resp, err := client.Get(aiaURL) //nolint:gosec
 		if err != nil {
-			return errors.Wrapf(err, "fetching intermediate cert from %s", url)
+			logger.Debugw("failed to fetch intermediate cert", "url", aiaURL, "error", err)
+			continue
 		}
 		body, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
-			return errors.Wrapf(err, "reading intermediate cert from %s", url)
+			logger.Debugw("failed to read intermediate cert", "url", aiaURL, "error", err)
+			continue
 		}
-		// The response may be DER or PEM encoded.
 		if block, _ := pem.Decode(body); block != nil {
 			body = block.Bytes
 		}
 		if _, err := x509.ParseCertificate(body); err != nil {
-			return errors.Wrapf(err, "parsing intermediate cert from %s", url)
+			logger.Debugw("failed to parse intermediate cert", "url", aiaURL, "error", err)
+			continue
 		}
 		cert.Certificate = append(cert.Certificate, body)
 	}
-	return nil
 }
 
 // CreateTLSWithCert creates a tls.Config with the TLS certificate to be returned.
@@ -1098,9 +1101,7 @@ func CreateTLSWithCert(cfg *Config) (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := appendIntermediateCerts(&cert); err != nil {
-		return nil, err
-	}
+	appendIntermediateCerts(&cert, logging.NewLogger("tls"))
 	return &tls.Config{
 		MinVersion: tls.VersionTLS12,
 		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -1077,7 +1077,7 @@ func appendIntermediateCerts(cert *tls.Certificate, logger logging.Logger) {
 		if err != nil {
 			continue
 		}
-		resp, err := client.Do(req) //nolint:gosec
+		resp, err := client.Do(req) 
 		if err != nil {
 			logger.Debugw("failed to fetch intermediate cert", "url", aiaURL, "error", err)
 			continue

--- a/config/config.go
+++ b/config/config.go
@@ -1059,18 +1059,18 @@ func ParseAPIKeys(handler AuthHandlerConfig) map[string]string {
 	return apiKeys
 }
 
-// appendIntermediateCerts fetches any missing intermediate certificates by following
-// the AIA (Authority Information Access) URLs in the leaf certificate and appends
-// their DER-encoded bytes to cert.Certificate. This ensures clients that do not
-// perform AIA fetching (e.g. Linux) can verify the chain without needing the
-// intermediates in their system trust store.
-func appendIntermediateCerts(cert *tls.Certificate, logger logging.Logger) {
+// fetchIntermediateCerts fetches intermediate certificates by following the AIA
+// (Authority Information Access) URLs in the leaf certificate, returning their
+// DER-encoded bytes. This ensures clients that do not perform AIA fetching
+// can verify the chain without needing the intermediates in their system trust store.
+func fetchIntermediateCerts(cert *tls.Certificate, logger logging.Logger) [][]byte {
 	leaf, err := x509.ParseCertificate(cert.Certificate[0])
 	if err != nil {
 		logger.Debugw("failed to parse leaf certificate; skipping intermediate fetch", "error", err)
-		return
+		return nil
 	}
 
+	var intermediates [][]byte
 	client := &http.Client{Timeout: 10 * time.Second}
 	for _, aiaURL := range leaf.IssuingCertificateURL {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, aiaURL, nil)
@@ -1095,14 +1095,15 @@ func appendIntermediateCerts(cert *tls.Certificate, logger logging.Logger) {
 			logger.Debugw("failed to parse intermediate cert", "url", aiaURL, "error", err)
 			continue
 		}
-		cert.Certificate = append(cert.Certificate, body)
+		intermediates = append(intermediates, body)
 	}
+	return intermediates
 }
 
-// tlsIntermediateCache is the on-disk structure for caching intermediate TLS certificates.
+// intermediateTLSCertCache is the on-disk structure for caching intermediate TLS certificates.
 // Intermediates are stored as raw DER bytes; encoding/json marshals []byte as base64.
-type tlsIntermediateCache struct {
-	LeafCertPEM   string   `json:"leaf_cert_pem"`
+type intermediateTLSCertCache struct {
+	LeafCert      string   `json:"leaf_cert_pem"`
 	Intermediates [][]byte `json:"intermediates"`
 }
 
@@ -1110,28 +1111,26 @@ func getTLSCacheFilePath(partID string) string {
 	return filepath.Join(rutils.ViamDotDir, fmt.Sprintf("cached_tls_intermediates_%s.json", partID))
 }
 
-func readTLSIntermediateCache(path string) (*tlsIntermediateCache, error) {
+func readintermediateTLSCertCache(path string) (*intermediateTLSCertCache, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
 	defer utils.UncheckedErrorFunc(f.Close)
-	var c tlsIntermediateCache
+	var c intermediateTLSCertCache
 	if err := json.NewDecoder(f).Decode(&c); err != nil {
 		return nil, err
 	}
 	return &c, nil
 }
 
-func writeTLSIntermediateCache(path string, c *tlsIntermediateCache, partID string) error {
-	if err := os.MkdirAll(rutils.ViamDotDir, 0o700); err != nil {
-		return err
-	}
+func writeintermediateTLSCertCache(path string, c *intermediateTLSCertCache) error {
 	data, err := json.Marshal(c)
 	if err != nil {
 		return err
 	}
-	return artifact.AtomicStore(path, bytes.NewReader(data), partID)
+	//nolint:gosec
+	return os.WriteFile(path, data, 0o640)
 }
 
 // loadOrFetchIntermediateCerts appends intermediate certificates to cert, using a disk
@@ -1141,50 +1140,50 @@ func writeTLSIntermediateCache(path string, c *tlsIntermediateCache, partID stri
 // cache is updated. partID is used to name the cache file; if empty, caching is skipped.
 func loadOrFetchIntermediateCerts(cert *tls.Certificate, leafCertPEM, partID string, logger logging.Logger) {
 	if partID == "" {
-		appendIntermediateCerts(cert, logger)
+		cert.Certificate = append(cert.Certificate, fetchIntermediateCerts(cert, logger)...)
 		return
 	}
 
 	cachePath := getTLSCacheFilePath(partID)
 
-	cached, err := readTLSIntermediateCache(cachePath)
+	cached, err := readintermediateTLSCertCache(cachePath)
 	switch {
 	case errors.Is(err, os.ErrNotExist):
 		logger.Debugw("no TLS intermediate cache found; fetching from AIA")
 	case err != nil:
 		logger.Warnw("error reading TLS intermediate cache; fetching from AIA", "error", err)
-	case cached.LeafCertPEM == leafCertPEM:
+	case cached.LeafCert == leafCertPEM:
 		logger.Debugw("TLS intermediate cache hit; skipping AIA fetch")
-		beforeCache := len(cert.Certificate)
-		for _, der := range cached.Intermediates {
-			if _, err := x509.ParseCertificate(der); err != nil {
+		validIntermediates := make([][]byte, 0, len(cached.Intermediates))
+		cacheValid := true
+		for _, encodedCert := range cached.Intermediates {
+			if _, err := x509.ParseCertificate(encodedCert); err != nil {
 				logger.Warnw("cached intermediate cert is invalid; re-fetching from AIA", "error", err)
-				cert.Certificate = cert.Certificate[:beforeCache]
-				goto fetch
+				cacheValid = false
+				break
 			}
-			cert.Certificate = append(cert.Certificate, der)
+			validIntermediates = append(validIntermediates, encodedCert)
 		}
-		return
+		if cacheValid {
+			cert.Certificate = append(cert.Certificate, validIntermediates...)
+			return
+		}
 	default:
 		logger.Debugw("leaf cert rotated; re-fetching intermediates from AIA")
 	}
 
-fetch:
-	before := len(cert.Certificate)
-	appendIntermediateCerts(cert, logger)
-	fetched := cert.Certificate[before:]
-
+	fetched := fetchIntermediateCerts(cert, logger)
 	if len(fetched) == 0 {
 		return
 	}
 
-	newCache := tlsIntermediateCache{
-		LeafCertPEM:   leafCertPEM,
-		Intermediates: make([][]byte, len(fetched)),
-	}
-	copy(newCache.Intermediates, fetched)
+	cert.Certificate = append(cert.Certificate, fetched...)
 
-	if err := writeTLSIntermediateCache(cachePath, &newCache, partID); err != nil {
+	newCache := intermediateTLSCertCache{
+		LeafCert:      leafCertPEM,
+		Intermediates: fetched,
+	}
+	if err := writeintermediateTLSCertCache(cachePath, &newCache); err != nil {
 		logger.Warnw("failed to write TLS intermediate cache", "error", err)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -3,15 +3,10 @@ package config
 
 import (
 	"bytes"
-	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
-	"io"
 	"net"
-	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -21,7 +16,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"go.viam.com/utils"
 	"go.viam.com/utils/artifact"
 	"go.viam.com/utils/jwks"
 	"go.viam.com/utils/pexec"
@@ -1057,135 +1051,6 @@ func ParseAPIKeys(handler AuthHandlerConfig) map[string]string {
 		}
 	}
 	return apiKeys
-}
-
-// fetchIntermediateCerts fetches intermediate certificates by following the AIA
-// (Authority Information Access) URLs in the leaf certificate, returning their
-// DER-encoded bytes. This ensures clients that do not perform AIA fetching
-// can verify the chain without needing the intermediates in their system trust store.
-func fetchIntermediateCerts(cert *tls.Certificate, logger logging.Logger) [][]byte {
-	leaf, err := x509.ParseCertificate(cert.Certificate[0])
-	if err != nil {
-		logger.Debugw("failed to parse leaf certificate; skipping intermediate fetch", "error", err)
-		return nil
-	}
-
-	var intermediates [][]byte
-	client := &http.Client{Timeout: 10 * time.Second}
-	for _, aiaURL := range leaf.IssuingCertificateURL {
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, aiaURL, nil)
-		if err != nil {
-			continue
-		}
-		resp, err := client.Do(req)
-		if err != nil {
-			logger.Debugw("failed to fetch intermediate cert", "url", aiaURL, "error", err)
-			continue
-		}
-		body, err := io.ReadAll(resp.Body)
-		utils.UncheckedError(resp.Body.Close())
-		if err != nil {
-			logger.Debugw("failed to read intermediate cert", "url", aiaURL, "error", err)
-			continue
-		}
-		if block, _ := pem.Decode(body); block != nil {
-			body = block.Bytes
-		}
-		if _, err := x509.ParseCertificate(body); err != nil {
-			logger.Debugw("failed to parse intermediate cert", "url", aiaURL, "error", err)
-			continue
-		}
-		intermediates = append(intermediates, body)
-	}
-	return intermediates
-}
-
-// intermediateTLSCertCache is the on-disk structure for caching intermediate TLS certificates.
-// Intermediates are stored as raw DER bytes; encoding/json marshals []byte as base64.
-type intermediateTLSCertCache struct {
-	LeafCert      string   `json:"leaf_cert_pem"`
-	Intermediates [][]byte `json:"intermediates"`
-}
-
-func getTLSCacheFilePath(partID string) string {
-	return filepath.Join(rutils.ViamDotDir, fmt.Sprintf("cached_tls_intermediates_%s.json", partID))
-}
-
-func readintermediateTLSCertCache(path string) (*intermediateTLSCertCache, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer utils.UncheckedErrorFunc(f.Close)
-	var c intermediateTLSCertCache
-	if err := json.NewDecoder(f).Decode(&c); err != nil {
-		return nil, err
-	}
-	return &c, nil
-}
-
-func writeintermediateTLSCertCache(path string, c *intermediateTLSCertCache) error {
-	data, err := json.Marshal(c)
-	if err != nil {
-		return err
-	}
-	//nolint:gosec
-	return os.WriteFile(path, data, 0o640)
-}
-
-// loadOrFetchIntermediateCerts appends intermediate certificates to cert, using a disk
-// cache keyed by leafCertPEM to avoid redundant AIA HTTP fetches. If the leaf cert PEM
-// matches the cache, cached intermediates are used and no network request is made. If
-// the leaf has rotated or no cache exists, intermediates are fetched via AIA and the
-// cache is updated. partID is used to name the cache file; if empty, caching is skipped.
-func loadOrFetchIntermediateCerts(cert *tls.Certificate, leafCertPEM, partID string, logger logging.Logger) {
-	if partID == "" {
-		cert.Certificate = append(cert.Certificate, fetchIntermediateCerts(cert, logger)...)
-		return
-	}
-
-	cachePath := getTLSCacheFilePath(partID)
-
-	cached, err := readintermediateTLSCertCache(cachePath)
-	switch {
-	case errors.Is(err, os.ErrNotExist):
-		logger.Debugw("no TLS intermediate cache found; fetching from AIA")
-	case err != nil:
-		logger.Warnw("error reading TLS intermediate cache; fetching from AIA", "error", err)
-	case cached.LeafCert == leafCertPEM:
-		logger.Debugw("TLS intermediate cache hit; skipping AIA fetch")
-		validIntermediates := make([][]byte, 0, len(cached.Intermediates))
-		cacheValid := true
-		for _, encodedCert := range cached.Intermediates {
-			if _, err := x509.ParseCertificate(encodedCert); err != nil {
-				logger.Warnw("cached intermediate cert is invalid; re-fetching from AIA", "error", err)
-				cacheValid = false
-				break
-			}
-			validIntermediates = append(validIntermediates, encodedCert)
-		}
-		if cacheValid {
-			cert.Certificate = append(cert.Certificate, validIntermediates...)
-			return
-		}
-	default:
-		logger.Debugw("leaf cert rotated; re-fetching intermediates from AIA")
-	}
-
-	fetched := fetchIntermediateCerts(cert, logger)
-	if len(fetched) == 0 {
-		return
-	}
-
-	cert.Certificate = append(cert.Certificate, fetched...)
-
-	newCache := intermediateTLSCertCache{
-		LeafCert:      leafCertPEM,
-		Intermediates: fetched,
-	}
-	if err := writeintermediateTLSCertCache(cachePath, &newCache); err != nil {
-		logger.Warnw("failed to write TLS intermediate cache", "error", err)
-	}
 }
 
 // CreateTLSWithCert creates a tls.Config with the TLS certificate to be returned.

--- a/config/config.go
+++ b/config/config.go
@@ -1071,7 +1071,7 @@ func CreateTLSWithCert(cfg *Config) (*tls.Config, error) {
 // ProcessConfig processes robot configs.
 func ProcessConfig(in *Config) (*Config, error) {
 	out := *in
-	if in.Cloud != nil {
+	if in.Cloud != nil && !in.Network.NoTLS {
 		// We expect a cloud config from app to always contain a non-empty `TLSCertificate` field.
 		// We do this empty string check just to cope with unexpected input, such as cached configs
 		// that are hand altered to have their `TLSCertificate` removed.

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -20,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.viam.com/utils"
 	"go.viam.com/utils/artifact"
 	"go.viam.com/utils/jwks"
 	"go.viam.com/utils/pexec"
@@ -1071,13 +1073,17 @@ func appendIntermediateCerts(cert *tls.Certificate, logger logging.Logger) {
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	for _, aiaURL := range leaf.IssuingCertificateURL {
-		resp, err := client.Get(aiaURL) //nolint:gosec
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, aiaURL, nil)
+		if err != nil {
+			continue
+		}
+		resp, err := client.Do(req) //nolint:gosec
 		if err != nil {
 			logger.Debugw("failed to fetch intermediate cert", "url", aiaURL, "error", err)
 			continue
 		}
 		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		utils.UncheckedError(resp.Body.Close())
 		if err != nil {
 			logger.Debugw("failed to read intermediate cert", "url", aiaURL, "error", err)
 			continue

--- a/config/config.go
+++ b/config/config.go
@@ -1077,7 +1077,7 @@ func appendIntermediateCerts(cert *tls.Certificate, logger logging.Logger) {
 		if err != nil {
 			continue
 		}
-		resp, err := client.Do(req) 
+		resp, err := client.Do(req)
 		if err != nil {
 			logger.Debugw("failed to fetch intermediate cert", "url", aiaURL, "error", err)
 			continue

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -794,7 +794,7 @@ ph2C/7IgjA==
 		cert, err := tls.X509KeyPair([]byte(cfg.Cloud.TLSCertificate), []byte(cfg.Cloud.TLSPrivateKey))
 		test.That(t, err, test.ShouldBeNil)
 
-		tlsCfg, err := config.CreateTLSWithCert(cfg)
+		tlsCfg, err := config.CreateTLSWithCert(context.Background(), cfg)
 		test.That(t, err, test.ShouldBeNil)
 
 		observed, err := tlsCfg.GetCertificate(&tls.ClientHelloInfo{})
@@ -803,7 +803,7 @@ ph2C/7IgjA==
 	})
 	t.Run("cert error", func(t *testing.T) {
 		cfg := &config.Config{Cloud: &config.Cloud{TLSCertificate: "abcd", TLSPrivateKey: "abcd"}}
-		_, err := config.CreateTLSWithCert(cfg)
+		_, err := config.CreateTLSWithCert(context.Background(), cfg)
 		test.That(t, err, test.ShouldBeError, errors.New("tls: failed to find any PEM data in certificate input"))
 	})
 }
@@ -865,7 +865,7 @@ ph2C/7IgjA==
 	expectedRemoteNoCloud := remote
 	expectedRemoteDiffManagerNoCloud := remoteDiffManager
 
-	tlsCfg, err := config.CreateTLSWithCert(cloudWTLSCfg)
+	tlsCfg, err := config.CreateTLSWithCert(context.Background(), cloudWTLSCfg)
 	test.That(t, err, test.ShouldBeNil)
 
 	expectedCloudWTLSCfg := &config.Config{Cloud: cloudWTLS, Remotes: []config.Remote{}}
@@ -895,7 +895,7 @@ ph2C/7IgjA==
 		{TestName: "remotes cloud and cert", Config: remotesCloudWTLSCfg, Expected: expectedRemotesCloudWTLSCfg},
 	} {
 		t.Run(tc.TestName, func(t *testing.T) {
-			observed, err := config.ProcessConfig(tc.Config)
+			observed, err := config.ProcessConfig(context.Background(), tc.Config)
 			test.That(t, err, test.ShouldBeNil)
 			// TLSConfig holds funcs, which do not resemble each other so check separately and nil them out after.
 			if tc.Expected.Network.TLSConfig != nil {
@@ -914,7 +914,7 @@ ph2C/7IgjA==
 
 	t.Run("cert error", func(t *testing.T) {
 		cfg := &config.Config{Cloud: &config.Cloud{TLSCertificate: "abcd", TLSPrivateKey: "abcd"}}
-		_, err := config.ProcessConfig(cfg)
+		_, err := config.ProcessConfig(context.Background(), cfg)
 		test.That(t, err, test.ShouldBeError, errors.New("tls: failed to find any PEM data in certificate input"))
 	})
 }

--- a/config/tls_intermediates.go
+++ b/config/tls_intermediates.go
@@ -57,7 +57,7 @@ func writeIntermediateTLSCertCache(path string, c *intermediateTLSCertCache) err
 // (Authority Information Access) URLs in the leaf certificate, returning their
 // DER-encoded bytes. This ensures clients that do not perform AIA fetching
 // can verify the chain without needing the intermediates in their system trust store.
-func fetchIntermediateCerts(cert *tls.Certificate, logger logging.Logger) [][]byte {
+func fetchIntermediateCerts(ctx context.Context, cert *tls.Certificate, logger logging.Logger) [][]byte {
 	leaf, err := x509.ParseCertificate(cert.Certificate[0])
 	if err != nil {
 		logger.Debugw("failed to parse leaf certificate; skipping intermediate fetch", "error", err)
@@ -67,7 +67,7 @@ func fetchIntermediateCerts(cert *tls.Certificate, logger logging.Logger) [][]by
 	var intermediates [][]byte
 	client := &http.Client{Timeout: 10 * time.Second}
 	for _, aiaURL := range leaf.IssuingCertificateURL {
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, aiaURL, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, aiaURL, nil)
 		if err != nil {
 			continue
 		}
@@ -99,9 +99,9 @@ func fetchIntermediateCerts(cert *tls.Certificate, logger logging.Logger) [][]by
 // matches the cache, cached intermediates are used and no network request is made. If
 // the leaf has rotated or no cache exists, intermediates are fetched via AIA and the
 // cache is updated. partID is used to name the cache file; if empty, caching is skipped.
-func loadOrFetchIntermediateCerts(cert *tls.Certificate, leafCertPEM, partID string, logger logging.Logger) {
+func loadOrFetchIntermediateCerts(ctx context.Context, cert *tls.Certificate, leafCertPEM, partID string, logger logging.Logger) {
 	if partID == "" {
-		cert.Certificate = append(cert.Certificate, fetchIntermediateCerts(cert, logger)...)
+		cert.Certificate = append(cert.Certificate, fetchIntermediateCerts(ctx, cert, logger)...)
 		return
 	}
 
@@ -133,7 +133,7 @@ func loadOrFetchIntermediateCerts(cert *tls.Certificate, leafCertPEM, partID str
 		logger.Debugw("leaf cert rotated; re-fetching intermediates from AIA")
 	}
 
-	fetched := fetchIntermediateCerts(cert, logger)
+	fetched := fetchIntermediateCerts(ctx, cert, logger)
 	if len(fetched) == 0 {
 		return
 	}

--- a/config/tls_intermediates.go
+++ b/config/tls_intermediates.go
@@ -1,0 +1,150 @@
+package config
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+	"go.viam.com/utils"
+
+	"go.viam.com/rdk/logging"
+	rutils "go.viam.com/rdk/utils"
+)
+
+// intermediateTLSCertCache is the on-disk structure for caching intermediate TLS certificates.
+// Intermediates are stored as raw DER bytes; encoding/json marshals []byte as base64.
+type intermediateTLSCertCache struct {
+	LeafCertPEM   string   `json:"leaf_cert_pem"`
+	Intermediates [][]byte `json:"intermediates"`
+}
+
+func getTLSCacheFilePath(partID string) string {
+	return filepath.Join(rutils.ViamDotDir, fmt.Sprintf("cached_tls_intermediates_%s.json", partID))
+}
+
+func readIntermediateTLSCertCache(path string) (*intermediateTLSCertCache, error) {
+	f, err := os.Open(path) //nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	defer utils.UncheckedErrorFunc(f.Close)
+	var c intermediateTLSCertCache
+	if err := json.NewDecoder(f).Decode(&c); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func writeIntermediateTLSCertCache(path string, c *intermediateTLSCertCache) error {
+	data, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	//nolint:gosec
+	return os.WriteFile(path, data, 0o640)
+}
+
+// fetchIntermediateCerts fetches intermediate certificates by following the AIA
+// (Authority Information Access) URLs in the leaf certificate, returning their
+// DER-encoded bytes. This ensures clients that do not perform AIA fetching
+// can verify the chain without needing the intermediates in their system trust store.
+func fetchIntermediateCerts(cert *tls.Certificate, logger logging.Logger) [][]byte {
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		logger.Debugw("failed to parse leaf certificate; skipping intermediate fetch", "error", err)
+		return nil
+	}
+
+	var intermediates [][]byte
+	client := &http.Client{Timeout: 10 * time.Second}
+	for _, aiaURL := range leaf.IssuingCertificateURL {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, aiaURL, nil)
+		if err != nil {
+			continue
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			logger.Debugw("failed to fetch intermediate cert", "url", aiaURL, "error", err)
+			continue
+		}
+		body, err := io.ReadAll(resp.Body)
+		utils.UncheckedError(resp.Body.Close())
+		if err != nil {
+			logger.Debugw("failed to read intermediate cert", "url", aiaURL, "error", err)
+			continue
+		}
+		if block, _ := pem.Decode(body); block != nil {
+			body = block.Bytes
+		}
+		if _, err := x509.ParseCertificate(body); err != nil {
+			logger.Debugw("failed to parse intermediate cert", "url", aiaURL, "error", err)
+			continue
+		}
+		intermediates = append(intermediates, body)
+	}
+	return intermediates
+}
+
+// loadOrFetchIntermediateCerts appends intermediate certificates to cert, using a disk
+// cache keyed by leafCertPEM to avoid redundant AIA HTTP fetches. If the leaf cert PEM
+// matches the cache, cached intermediates are used and no network request is made. If
+// the leaf has rotated or no cache exists, intermediates are fetched via AIA and the
+// cache is updated. partID is used to name the cache file; if empty, caching is skipped.
+func loadOrFetchIntermediateCerts(cert *tls.Certificate, leafCertPEM, partID string, logger logging.Logger) {
+	if partID == "" {
+		cert.Certificate = append(cert.Certificate, fetchIntermediateCerts(cert, logger)...)
+		return
+	}
+
+	cachePath := getTLSCacheFilePath(partID)
+
+	cached, err := readIntermediateTLSCertCache(cachePath)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		logger.Debugw("no TLS intermediate cache found; fetching from AIA")
+	case err != nil:
+		logger.Warnw("error reading TLS intermediate cache; fetching from AIA", "error", err)
+	case cached.LeafCertPEM == leafCertPEM:
+		logger.Debugw("TLS intermediate cache hit; skipping AIA fetch")
+		validIntermediates := make([][]byte, 0, len(cached.Intermediates))
+		cacheValid := true
+		for _, encodedCert := range cached.Intermediates {
+			if _, err := x509.ParseCertificate(encodedCert); err != nil {
+				logger.Warnw("cached intermediate cert is invalid; re-fetching from AIA", "error", err)
+				cacheValid = false
+				break
+			}
+			validIntermediates = append(validIntermediates, encodedCert)
+		}
+		if cacheValid {
+			cert.Certificate = append(cert.Certificate, validIntermediates...)
+			return
+		}
+	default:
+		logger.Debugw("leaf cert rotated; re-fetching intermediates from AIA")
+	}
+
+	fetched := fetchIntermediateCerts(cert, logger)
+	if len(fetched) == 0 {
+		return
+	}
+
+	cert.Certificate = append(cert.Certificate, fetched...)
+
+	newCache := intermediateTLSCertCache{
+		LeafCertPEM:   leafCertPEM,
+		Intermediates: fetched,
+	}
+	if err := writeIntermediateTLSCertCache(cachePath, &newCache); err != nil {
+		logger.Warnw("failed to write TLS intermediate cache", "error", err)
+	}
+}

--- a/config/tls_intermediates_test.go
+++ b/config/tls_intermediates_test.go
@@ -1,0 +1,248 @@
+package config
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/logging"
+	rutils "go.viam.com/rdk/utils"
+)
+
+// makeSelfSignedCert creates a minimal self-signed certificate and returns the
+// tls.Certificate and the PEM-encoded certificate string.
+func makeSelfSignedCert(t *testing.T, aiaURLs []string) (tls.Certificate, string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	test.That(t, err, test.ShouldBeNil)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IssuingCertificateURL: aiaURLs,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	test.That(t, err, test.ShouldBeNil)
+
+	certPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	test.That(t, err, test.ShouldBeNil)
+	keyPEM := string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}))
+
+	tlsCert, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM))
+	test.That(t, err, test.ShouldBeNil)
+
+	return tlsCert, certPEM
+}
+
+// makeFakeIntermediateDER returns the DER bytes of a self-signed cert to use as a
+// stand-in intermediate in tests.
+func makeFakeIntermediateDER(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	test.That(t, err, test.ShouldBeNil)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "fake-intermediate"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	test.That(t, err, test.ShouldBeNil)
+	return der
+}
+
+func TestLoadOrFetchIntermediateCerts(t *testing.T) {
+	t.Run("cache hit", func(t *testing.T) {
+		dir := t.TempDir()
+		origDir := rutils.ViamDotDir
+		rutils.ViamDotDir = dir
+		defer func() { rutils.ViamDotDir = origDir }()
+
+		cert, leafPEM := makeSelfSignedCert(t, nil)
+		intermediateDER := makeFakeIntermediateDER(t)
+
+		// Pre-populate cache.
+		partID := "test-part"
+		cache := intermediateTLSCertCache{
+			LeafCertPEM:   leafPEM,
+			Intermediates: [][]byte{intermediateDER},
+		}
+		data, err := json.Marshal(cache)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, os.WriteFile(getTLSCacheFilePath(partID), data, 0o640), test.ShouldBeNil)
+
+		loadOrFetchIntermediateCerts(&cert, leafPEM, partID, logging.NewTestLogger(t))
+
+		// Leaf + cached intermediate should be present.
+		test.That(t, len(cert.Certificate), test.ShouldEqual, 2)
+		test.That(t, cert.Certificate[1], test.ShouldResemble, intermediateDER)
+	})
+
+	t.Run("cache miss no AIA URLs", func(t *testing.T) {
+		dir := t.TempDir()
+		origDir := rutils.ViamDotDir
+		rutils.ViamDotDir = dir
+		defer func() { rutils.ViamDotDir = origDir }()
+
+		// Cert has no AIA URLs so fetch returns nothing.
+		cert, leafPEM := makeSelfSignedCert(t, nil)
+		partID := "test-part"
+
+		loadOrFetchIntermediateCerts(&cert, leafPEM, partID, logging.NewTestLogger(t))
+
+		// Only the leaf should be present; no cache file written.
+		test.That(t, len(cert.Certificate), test.ShouldEqual, 1)
+		_, err := os.Stat(getTLSCacheFilePath(partID))
+		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+	})
+
+	t.Run("cache miss fetches and caches", func(t *testing.T) {
+		intermediateDER := makeFakeIntermediateDER(t)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/pkix-cert")
+			_, _ = w.Write(intermediateDER)
+		}))
+		defer server.Close()
+
+		dir := t.TempDir()
+		origDir := rutils.ViamDotDir
+		rutils.ViamDotDir = dir
+		defer func() { rutils.ViamDotDir = origDir }()
+
+		cert, leafPEM := makeSelfSignedCert(t, []string{server.URL})
+		partID := "test-part"
+
+		loadOrFetchIntermediateCerts(&cert, leafPEM, partID, logging.NewTestLogger(t))
+
+		// Intermediate should be appended.
+		test.That(t, len(cert.Certificate), test.ShouldEqual, 2)
+		test.That(t, cert.Certificate[1], test.ShouldResemble, intermediateDER)
+
+		// Cache file should have been written.
+		cached, err := readIntermediateTLSCertCache(getTLSCacheFilePath(partID))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, cached.LeafCertPEM, test.ShouldEqual, leafPEM)
+		test.That(t, len(cached.Intermediates), test.ShouldEqual, 1)
+		test.That(t, cached.Intermediates[0], test.ShouldResemble, intermediateDER)
+	})
+
+	t.Run("leaf rotated does not use stale cache", func(t *testing.T) {
+		dir := t.TempDir()
+		origDir := rutils.ViamDotDir
+		rutils.ViamDotDir = dir
+		defer func() { rutils.ViamDotDir = origDir }()
+
+		partID := "test-part"
+
+		// Write cache with a different (old) leaf PEM.
+		_, oldLeafPEM := makeSelfSignedCert(t, nil)
+		oldIntermediate := makeFakeIntermediateDER(t)
+		cache := intermediateTLSCertCache{
+			LeafCertPEM:   oldLeafPEM,
+			Intermediates: [][]byte{oldIntermediate},
+		}
+		data, err := json.Marshal(cache)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, os.WriteFile(getTLSCacheFilePath(partID), data, 0o640), test.ShouldBeNil)
+
+		// New cert with no AIA URLs — fetch will return nothing.
+		newCert, newLeafPEM := makeSelfSignedCert(t, nil)
+
+		loadOrFetchIntermediateCerts(&newCert, newLeafPEM, partID, logging.NewTestLogger(t))
+
+		// Old cached intermediate should NOT be used; fetch returned nothing so only leaf.
+		test.That(t, len(newCert.Certificate), test.ShouldEqual, 1)
+	})
+
+	t.Run("corrupt JSON cache falls back to fetch", func(t *testing.T) {
+		dir := t.TempDir()
+		origDir := rutils.ViamDotDir
+		rutils.ViamDotDir = dir
+		defer func() { rutils.ViamDotDir = origDir }()
+
+		partID := "test-part"
+		test.That(t, os.WriteFile(getTLSCacheFilePath(partID), []byte("not json"), 0o640), test.ShouldBeNil)
+
+		cert, leafPEM := makeSelfSignedCert(t, nil)
+		loadOrFetchIntermediateCerts(&cert, leafPEM, partID, logging.NewTestLogger(t))
+
+		// Falls back to fetch (returns nothing due to no AIA); only leaf present.
+		test.That(t, len(cert.Certificate), test.ShouldEqual, 1)
+	})
+
+	t.Run("corrupt DER in cache re-fetches from AIA", func(t *testing.T) {
+		intermediateDER := makeFakeIntermediateDER(t)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/pkix-cert")
+			_, _ = w.Write(intermediateDER)
+		}))
+		defer server.Close()
+
+		dir := t.TempDir()
+		origDir := rutils.ViamDotDir
+		rutils.ViamDotDir = dir
+		defer func() { rutils.ViamDotDir = origDir }()
+
+		// Cert has AIA URL pointing at the mock server so re-fetch can succeed.
+		cert, leafPEM := makeSelfSignedCert(t, []string{server.URL})
+		partID := "test-part"
+
+		// Write cache with the correct leaf PEM but a corrupt intermediate DER.
+		cache := intermediateTLSCertCache{
+			LeafCertPEM:   leafPEM,
+			Intermediates: [][]byte{[]byte("not a valid DER cert")},
+		}
+		data, err := json.Marshal(cache)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, os.WriteFile(getTLSCacheFilePath(partID), data, 0o640), test.ShouldBeNil)
+
+		loadOrFetchIntermediateCerts(&cert, leafPEM, partID, logging.NewTestLogger(t))
+
+		// Corrupt DER triggers re-fetch from AIA; fresh intermediate should be present.
+		test.That(t, len(cert.Certificate), test.ShouldEqual, 2)
+		test.That(t, cert.Certificate[1], test.ShouldResemble, intermediateDER)
+	})
+}
+
+func TestIntermediateTLSCertCache(t *testing.T) {
+	t.Run("round trip", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "cache.json")
+
+		intermediateDER := makeFakeIntermediateDER(t)
+		original := &intermediateTLSCertCache{
+			LeafCertPEM:   "some-pem",
+			Intermediates: [][]byte{intermediateDER},
+		}
+
+		test.That(t, writeIntermediateTLSCertCache(path, original), test.ShouldBeNil)
+
+		read, err := readIntermediateTLSCertCache(path)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, read.LeafCertPEM, test.ShouldEqual, original.LeafCertPEM)
+		test.That(t, read.Intermediates, test.ShouldResemble, original.Intermediates)
+	})
+}

--- a/config/tls_intermediates_test.go
+++ b/config/tls_intermediates_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -92,7 +93,7 @@ func TestLoadOrFetchIntermediateCerts(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, os.WriteFile(getTLSCacheFilePath(partID), data, 0o640), test.ShouldBeNil)
 
-		loadOrFetchIntermediateCerts(&cert, leafPEM, partID, logging.NewTestLogger(t))
+		loadOrFetchIntermediateCerts(context.Background(), &cert, leafPEM, partID, logging.NewTestLogger(t))
 
 		// Leaf + cached intermediate should be present.
 		test.That(t, len(cert.Certificate), test.ShouldEqual, 2)
@@ -109,7 +110,7 @@ func TestLoadOrFetchIntermediateCerts(t *testing.T) {
 		cert, leafPEM := makeSelfSignedCert(t, nil)
 		partID := "test-part"
 
-		loadOrFetchIntermediateCerts(&cert, leafPEM, partID, logging.NewTestLogger(t))
+		loadOrFetchIntermediateCerts(context.Background(), &cert, leafPEM, partID, logging.NewTestLogger(t))
 
 		// Only the leaf should be present; no cache file written.
 		test.That(t, len(cert.Certificate), test.ShouldEqual, 1)
@@ -134,7 +135,7 @@ func TestLoadOrFetchIntermediateCerts(t *testing.T) {
 		cert, leafPEM := makeSelfSignedCert(t, []string{server.URL})
 		partID := "test-part"
 
-		loadOrFetchIntermediateCerts(&cert, leafPEM, partID, logging.NewTestLogger(t))
+		loadOrFetchIntermediateCerts(context.Background(), &cert, leafPEM, partID, logging.NewTestLogger(t))
 
 		// Intermediate should be appended.
 		test.That(t, len(cert.Certificate), test.ShouldEqual, 2)
@@ -170,7 +171,7 @@ func TestLoadOrFetchIntermediateCerts(t *testing.T) {
 		// New cert with no AIA URLs — fetch will return nothing.
 		newCert, newLeafPEM := makeSelfSignedCert(t, nil)
 
-		loadOrFetchIntermediateCerts(&newCert, newLeafPEM, partID, logging.NewTestLogger(t))
+		loadOrFetchIntermediateCerts(context.Background(), &newCert, newLeafPEM, partID, logging.NewTestLogger(t))
 
 		// Old cached intermediate should NOT be used; fetch returned nothing so only leaf.
 		test.That(t, len(newCert.Certificate), test.ShouldEqual, 1)
@@ -186,7 +187,7 @@ func TestLoadOrFetchIntermediateCerts(t *testing.T) {
 		test.That(t, os.WriteFile(getTLSCacheFilePath(partID), []byte("not json"), 0o640), test.ShouldBeNil)
 
 		cert, leafPEM := makeSelfSignedCert(t, nil)
-		loadOrFetchIntermediateCerts(&cert, leafPEM, partID, logging.NewTestLogger(t))
+		loadOrFetchIntermediateCerts(context.Background(), &cert, leafPEM, partID, logging.NewTestLogger(t))
 
 		// Falls back to fetch (returns nothing due to no AIA); only leaf present.
 		test.That(t, len(cert.Certificate), test.ShouldEqual, 1)
@@ -219,7 +220,7 @@ func TestLoadOrFetchIntermediateCerts(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, os.WriteFile(getTLSCacheFilePath(partID), data, 0o640), test.ShouldBeNil)
 
-		loadOrFetchIntermediateCerts(&cert, leafPEM, partID, logging.NewTestLogger(t))
+		loadOrFetchIntermediateCerts(context.Background(), &cert, leafPEM, partID, logging.NewTestLogger(t))
 
 		// Corrupt DER triggers re-fetch from AIA; fresh intermediate should be present.
 		test.That(t, len(cert.Certificate), test.ShouldEqual, 2)

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1356,7 +1356,7 @@ func RobotFromConfig(
 	logger logging.Logger,
 	opts ...Option,
 ) (robot.LocalRobot, error) {
-	processedCfg, err := config.ProcessConfig(cfg)
+	processedCfg, err := config.ProcessConfig(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -2,6 +2,8 @@
 package weboptions
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net"
@@ -96,25 +98,37 @@ func FromConfig(cfg *config.Config) (Options, error) {
 		options.FQDN = cfg.Cloud.FQDN
 		options.SignalingAddress = cfg.Cloud.SignalingAddress
 
-		// NOTE(RDK-148):
-		// when we are managed and no explicit bind address is set,
-		// we will listen everywhere on 8080. We assume this to be
-		// secure because authentication is required. NOTE: If you do not want
-		// the UI to function without a specific secret being input, then you
-		// must set up a dedicated auth handler in the config. Otherwise, the
-		// secret for this robot will be baked into the UI. There may be a
-		// future feature to disable the baked in credentials from the managed
-		// interface.
-		if cfg.Network.BindAddressDefaultSet {
-			options.Network.BindAddress = ":8080"
-		}
+		if cfg.Cloud.TLSCertificate != "" {
+			// override
+			options.Network.TLSConfig = cfg.Network.TLSConfig
 
-		if cfg.Cloud.TLSCertificate != "" && !cfg.Network.NoTLS {
+			// NOTE(RDK-148):
+			// when we are managed and no explicit bind address is set,
+			// we will listen everywhere on 8080. We assume this to be
+			// secure because TLS will be enabled in addition to
+			// authentication. NOTE: If you do not want the UI to function
+			// without a specific secret being input, then you must set up
+			// a dedicated auth handler in the config. Otherwise, the secret
+			// for this robot will be baked into the UI. There may be a future
+			// feature to disable the baked in credentials from the managed
+			// interface.
+			if cfg.Network.BindAddressDefaultSet {
+				options.Network.BindAddress = ":8080"
+			}
+
 			// This will only happen if we're switching from a local config to a cloud config.
 			if cfg.Network.TLSConfig == nil {
 				return Options{}, errors.New("switching from local config to cloud config not currently supported")
 			}
-			options.Network.TLSConfig = cfg.Network.TLSConfig
+			cert, err := cfg.Network.TLSConfig.GetCertificate(&tls.ClientHelloInfo{})
+			if err != nil {
+				return Options{}, err
+			}
+			leaf, err := x509.ParseCertificate(cert.Certificate[0])
+			if err != nil {
+				return Options{}, err
+			}
+			options.Auth.TLSAuthEntities = leaf.DNSNames
 		}
 
 		options.Auth.Handlers = make([]config.AuthHandlerConfig, len(cfg.Auth.Handlers))

--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -96,28 +96,25 @@ func FromConfig(cfg *config.Config) (Options, error) {
 		options.FQDN = cfg.Cloud.FQDN
 		options.SignalingAddress = cfg.Cloud.SignalingAddress
 
-		if cfg.Cloud.TLSCertificate != "" {
-			// NOTE(RDK-148):
-			// when we are managed and no explicit bind address is set,
-			// we will listen everywhere on 8080. We assume this to be
-			// secure because TLS will be enabled in addition to
-			// authentication. NOTE: If you do not want the UI to function
-			// without a specific secret being input, then you must set up
-			// a dedicated auth handler in the config. Otherwise, the secret
-			// for this robot will be baked into the UI. There may be a future
-			// feature to disable the baked in credentials from the managed
-			// interface.
-			if cfg.Network.BindAddressDefaultSet {
-				options.Network.BindAddress = ":8080"
-			}
+		// NOTE(RDK-148):
+		// when we are managed and no explicit bind address is set,
+		// we will listen everywhere on 8080. We assume this to be
+		// secure because authentication is required. NOTE: If you do not want
+		// the UI to function without a specific secret being input, then you
+		// must set up a dedicated auth handler in the config. Otherwise, the
+		// secret for this robot will be baked into the UI. There may be a
+		// future feature to disable the baked in credentials from the managed
+		// interface.
+		if cfg.Network.BindAddressDefaultSet {
+			options.Network.BindAddress = ":8080"
+		}
 
-			if !cfg.Network.NoTLS {
-				// This will only happen if we're switching from a local config to a cloud config.
-				if cfg.Network.TLSConfig == nil {
-					return Options{}, errors.New("switching from local config to cloud config not currently supported")
-				}
-				options.Network.TLSConfig = cfg.Network.TLSConfig
+		if cfg.Cloud.TLSCertificate != "" && !cfg.Network.NoTLS {
+			// This will only happen if we're switching from a local config to a cloud config.
+			if cfg.Network.TLSConfig == nil {
+				return Options{}, errors.New("switching from local config to cloud config not currently supported")
 			}
+			options.Network.TLSConfig = cfg.Network.TLSConfig
 		}
 
 		options.Auth.Handlers = make([]config.AuthHandlerConfig, len(cfg.Auth.Handlers))

--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -114,13 +114,11 @@ func FromConfig(cfg *config.Config) (Options, error) {
 			}
 
 			if !cfg.Network.NoTLS {
-				// override
-				options.Network.TLSConfig = cfg.Network.TLSConfig
-
 				// This will only happen if we're switching from a local config to a cloud config.
 				if cfg.Network.TLSConfig == nil {
 					return Options{}, errors.New("switching from local config to cloud config not currently supported")
 				}
+				options.Network.TLSConfig = cfg.Network.TLSConfig
 				cert, err := cfg.Network.TLSConfig.GetCertificate(&tls.ClientHelloInfo{})
 				if err != nil {
 					return Options{}, err

--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -117,7 +117,7 @@ func FromConfig(cfg *config.Config) (Options, error) {
 			}
 
 			// This will only happen if we're switching from a local config to a cloud config.
-			if cfg.Network.TLSConfig == nil {
+			if cfg.Network.TLSConfig == nil && !cfg.Network.NoTLS {
 				return Options{}, errors.New("switching from local config to cloud config not currently supported")
 			}
 			cert, err := cfg.Network.TLSConfig.GetCertificate(&tls.ClientHelloInfo{})

--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -2,8 +2,6 @@
 package weboptions
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"net"
@@ -119,15 +117,6 @@ func FromConfig(cfg *config.Config) (Options, error) {
 					return Options{}, errors.New("switching from local config to cloud config not currently supported")
 				}
 				options.Network.TLSConfig = cfg.Network.TLSConfig
-				cert, err := cfg.Network.TLSConfig.GetCertificate(&tls.ClientHelloInfo{})
-				if err != nil {
-					return Options{}, err
-				}
-				leaf, err := x509.ParseCertificate(cert.Certificate[0])
-				if err != nil {
-					return Options{}, err
-				}
-				options.Auth.TLSAuthEntities = leaf.DNSNames
 			}
 		}
 

--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -99,9 +99,6 @@ func FromConfig(cfg *config.Config) (Options, error) {
 		options.SignalingAddress = cfg.Cloud.SignalingAddress
 
 		if cfg.Cloud.TLSCertificate != "" {
-			// override
-			options.Network.TLSConfig = cfg.Network.TLSConfig
-
 			// NOTE(RDK-148):
 			// when we are managed and no explicit bind address is set,
 			// we will listen everywhere on 8080. We assume this to be
@@ -116,19 +113,24 @@ func FromConfig(cfg *config.Config) (Options, error) {
 				options.Network.BindAddress = ":8080"
 			}
 
-			// This will only happen if we're switching from a local config to a cloud config.
-			if cfg.Network.TLSConfig == nil && !cfg.Network.NoTLS {
-				return Options{}, errors.New("switching from local config to cloud config not currently supported")
+			if !cfg.Network.NoTLS {
+				// override
+				options.Network.TLSConfig = cfg.Network.TLSConfig
+
+				// This will only happen if we're switching from a local config to a cloud config.
+				if cfg.Network.TLSConfig == nil {
+					return Options{}, errors.New("switching from local config to cloud config not currently supported")
+				}
+				cert, err := cfg.Network.TLSConfig.GetCertificate(&tls.ClientHelloInfo{})
+				if err != nil {
+					return Options{}, err
+				}
+				leaf, err := x509.ParseCertificate(cert.Certificate[0])
+				if err != nil {
+					return Options{}, err
+				}
+				options.Auth.TLSAuthEntities = leaf.DNSNames
 			}
-			cert, err := cfg.Network.TLSConfig.GetCertificate(&tls.ClientHelloInfo{})
-			if err != nil {
-				return Options{}, err
-			}
-			leaf, err := x509.ParseCertificate(cert.Certificate[0])
-			if err != nil {
-				return Options{}, err
-			}
-			options.Auth.TLSAuthEntities = leaf.DNSNames
 		}
 
 		options.Auth.Handlers = make([]config.AuthHandlerConfig, len(cfg.Auth.Handlers))

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -339,8 +339,8 @@ func (s *robotServer) createWebOptions(cfg *config.Config) (weboptions.Options, 
 
 // A wrapper around actual config processing that also applies options from the
 // robot server.
-func (s *robotServer) processConfig(in *config.Config) (*config.Config, error) {
-	out, err := config.ProcessConfig(in)
+func (s *robotServer) processConfig(ctx context.Context, in *config.Config) (*config.Config, error) {
+	out, err := config.ProcessConfig(ctx, in)
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +391,7 @@ func (s *robotServer) configWatcher(ctx context.Context, currCfg *config.Config,
 		case <-ctx.Done():
 			return
 		case cfg := <-watcher.Config():
-			processedConfig, err := s.processConfig(cfg)
+			processedConfig, err := s.processConfig(ctx, cfg)
 			if err != nil {
 				s.configLogger.Errorw("reconfiguration aborted: error processing config", "error", err)
 				continue
@@ -549,7 +549,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 		<-slowWatcher
 	}()
 	s.configLogger.CInfo(ctx, "Processing initial robot config...")
-	fullProcessedConfig, err := s.processConfig(cfg)
+	fullProcessedConfig, err := s.processConfig(ctx, cfg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

[APP-15934](https://viam.atlassian.net/browse/APP-15934) Local SOW app mode does not work on Linux

* **TLS intermediate cert chain**: Local SOW app mode wasn't working on Linux because the OS does not natively build the chain from the robot's leaf cert to the root cert. Although the root cert is trusted, Linux cannot bridge the gap to the intermediate since the server was only sending the leaf cert. macOS handles this natively via AIA (Authority Information Access) fetching, which is why it worked. This PR makes `CreateTLSWithCert` fetch intermediate certs from the AIA URLs embedded in the leaf cert and cache them to disk (keyed by leaf cert PEM), so that:
  - Clients that do not perform AIA fetching can verify the full chain up to the root
  - AIA HTTP fetches are skipped on subsequent config updates if the leaf cert hasn't rotated
  - Offline startups can use cached intermediates from a prior successful fetch

## Testing
- [x] Verify Linux client can connect to a robot over the local network without `no_tls` (cert chain fix)

[APP-15934]: https://viam.atlassian.net/browse/APP-15934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ