### PR TITLE
referenceframe: make namedFrame JSON-serializable

### DIFF
--- a/referenceframe/frame.go
+++ b/referenceframe/frame.go
@@ -359,6 +359,44 @@ func (nf *namedFrame) Hash() int {
 	return nf.Frame.Hash() + hashString(nf.name)
 }
 
+// namedFrameJSON is the on-disk representation of a namedFrame. The wrapped inner
+// frame is stored as a raw message so it can be dispatched through frameToJSON /
+// jsonToFrame the same way any other Frame implementation would be.
+type namedFrameJSON struct {
+	Name       string          `json:"name"`
+	InnerFrame json.RawMessage `json:"inner_frame"`
+}
+
+// MarshalJSON serializes a namedFrame by recording the overriding name and
+// delegating serialization of the wrapped frame to frameToJSON so the wrapped
+// frame's concrete type is preserved.
+func (nf *namedFrame) MarshalJSON() ([]byte, error) {
+	innerJSON, err := frameToJSON(nf.Frame)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(&namedFrameJSON{
+		Name:       nf.name,
+		InnerFrame: innerJSON,
+	})
+}
+
+// UnmarshalJSON reconstructs a namedFrame, dispatching the wrapped inner frame
+// back through jsonToFrame so the correct concrete type is rebuilt.
+func (nf *namedFrame) UnmarshalJSON(data []byte) error {
+	var j namedFrameJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	inner, err := jsonToFrame(j.InnerFrame)
+	if err != nil {
+		return err
+	}
+	nf.Frame = inner
+	nf.name = j.Name
+	return nil
+}
+
 // NewNamedFrame will return a frame which has a new name but otherwise passes through all functions of the original frame.
 func NewNamedFrame(frame Frame, name string) Frame {
 	return &namedFrame{Frame: frame, name: name}

--- a/referenceframe/frame_test.go
+++ b/referenceframe/frame_test.go
@@ -207,6 +207,60 @@ func TestSerializationRotations(t *testing.T) {
 	test.That(t, f2, test.ShouldResemble, f)
 }
 
+func TestSerializationNamed(t *testing.T) {
+	// A namedFrame wraps another frame and overrides its name. Roundtripping
+	// must preserve both the override name and the wrapped frame's type/data.
+	inner, err := NewStaticFrame("inner", spatial.NewPose(r3.Vector{1, 2, 3}, &spatial.R4AA{math.Pi / 2, 4, 5, 6}))
+	test.That(t, err, test.ShouldBeNil)
+
+	nf := NewNamedFrame(inner, "outer")
+
+	data, err := frameToJSON(nf)
+	test.That(t, err, test.ShouldBeNil)
+
+	got, err := jsonToFrame(data)
+	test.That(t, err, test.ShouldBeNil)
+
+	test.That(t, got.Name(), test.ShouldEqual, "outer")
+
+	// The wrapped inner frame should roundtrip back to the same concrete type,
+	// preserving its own name and pose.
+	gotNamed, ok := got.(*namedFrame)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, gotNamed.Frame.Name(), test.ShouldEqual, "inner")
+
+	p1, err := nf.Transform(nil)
+	test.That(t, err, test.ShouldBeNil)
+	p2, err := got.Transform(nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, spatial.PoseAlmostEqual(p1, p2), test.ShouldBeTrue)
+}
+
+func TestFrameSystemMarshalWithNamedFrame(t *testing.T) {
+	// Regression test: building a FrameSystem that contains a namedFrame used
+	// to fail to marshal because *namedFrame was not a registered Frame type.
+	fs := NewEmptyFrameSystem("test")
+
+	inner, err := NewStaticFrame("inner", spatial.NewPoseFromPoint(r3.Vector{1, 2, 3}))
+	test.That(t, err, test.ShouldBeNil)
+
+	renamed := NewNamedFrame(inner, "renamed")
+	err = fs.AddFrame(renamed, fs.World())
+	test.That(t, err, test.ShouldBeNil)
+
+	data, err := json.Marshal(fs)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(data), test.ShouldBeGreaterThan, 0)
+
+	var fs2 FrameSystem
+	err = json.Unmarshal(data, &fs2)
+	test.That(t, err, test.ShouldBeNil)
+
+	got := fs2.Frame("renamed")
+	test.That(t, got, test.ShouldNotBeNil)
+	test.That(t, got.Name(), test.ShouldEqual, "renamed")
+}
+
 func TestRandomFrameInputs(t *testing.T) {
 	frame, _ := NewTranslationalFrame("", r3.Vector{X: 1}, Limit{-10, 10})
 	seed := rand.New(rand.NewSource(23))

--- a/referenceframe/register.go
+++ b/referenceframe/register.go
@@ -23,6 +23,9 @@ func init() {
 	if err := RegisterFrameImplementer((*tailGeometryStaticFrame)(nil), "tail_geometry_static"); err != nil {
 		panic(err)
 	}
+	if err := RegisterFrameImplementer((*namedFrame)(nil), "named"); err != nil {
+		panic(err)
+	}
 }
 
 // RegisterFrameImplementer allows outside packages to register their implementations of the Frame


### PR DESCRIPTION
## Summary

`FrameSystem.MarshalJSON` fails on any frame system containing a `*namedFrame` because `namedFrame` is not in the `registeredFrameImplementers` registry consulted by `frameToJSON`. The failure surfaces as:

> `Frame of type *referenceframe.namedFrame is not a registered Frame implementation`

This is a latent bug that became a practical regression once every model-component frame started getting unconditionally wrapped with `NewNamedFrame` for namespacing / mimic-joint support (`frame_system.go:1179`) — `FrameSystem.MarshalJSON` now hits a `namedFrame` on any realistic config with a model component, breaking downstream callers that persist or transport frame systems as JSON.

## Changes

- **referenceframe/register.go**: Register `*namedFrame` as `"named"` in the frame implementer registry so `frameToJSON` / `jsonToFrame` can dispatch it.
- **referenceframe/frame.go**: Add `MarshalJSON` / `UnmarshalJSON` on `*namedFrame`. The wrapped inner frame is serialized via `frameToJSON` and stored as `json.RawMessage` under `inner_frame` alongside the override `name`, so the inner frame's concrete type is preserved across the roundtrip.
- **referenceframe/frame_test.go**: Add two regression tests.

## Testing

- `TestSerializationNamed` — direct `frameToJSON` / `jsonToFrame` roundtrip of a `namedFrame` wrapping a `staticFrame`; asserts override name, inner frame's original name, and pose equality after roundtrip.
- `TestFrameSystemMarshalWithNamedFrame` — adds a `namedFrame` to a `FrameSystem` and verifies `json.Marshal` / `json.Unmarshal` both succeed and that the named frame is retrievable by its override name. This is the exact failure mode hit in production.
- Full `./referenceframe/` suite passes (excluding `TestUR20URDFWithMeshes` and `TestMeshGeometrySerialization`, which fail on `main` independently due to missing artifact assets).

**Compatibility note:** Frame systems serialized by older RDK versions (which could never contain a serialized `namedFrame` anyway) will still deserialize. Frame systems serialized with this change containing `namedFrame`s will not deserialize on older RDKs — the `"named"` frame type would be unknown there. This is an acceptable one-way compatibility break since the reverse direction was impossible before this fix.

## Claude Code Prompts Used

- "Can you investigate this error from main? [sanding frame system marshal error]"
- "Also, whatever this error is from might be from an rdk version bump in this PR... Is there any change between the RDK version before and after this that would explain this: 6d7f9ed..."
- "Draft the RDK patch. The local guard is unnecessary, we will downgrade rdk until this is fixed"
- "I have RDK cloned locally at ~/Desktop/rdk. Make your change there. Do not create a worktree, create a branch and create the patch"
- "Create a PR on the RDK repo with this change."