### PR TITLE
APP-16028: add file ext for audio mime types

### DIFF
--- a/services/datamanager/builtin/sync/upload_data_capture_file.go
+++ b/services/datamanager/builtin/sync/upload_data_capture_file.go
@@ -438,6 +438,10 @@ func getFileExtFromStringMimeType(mimeType string) string {
 		return data.ExtPcd
 	case utils.MimeTypeVideoMP4:
 		return data.ExtMP4
+	case utils.MimeTypeAudioWAV:
+		return data.ExtWav
+	case utils.MimeTypeAudioMPEG:
+		return data.ExtMP3
 	case utils.MimeTypeDefault:
 		fallthrough
 	default:


### PR DESCRIPTION
The issue was that after we added audio mime types, we didn't also update the audio file extensions in the upload metadata, so it was defaulting to an empty file extension.
Capturing audio data with the following config:
```
    {
      "name": "audio_in-2",
      "api": "rdk:component:audio_in",
      "model": "viam:system-audio:microphone",
      "attributes": {},
      "service_configs": [
        {
          "type": "data_manager",
          "attributes": {
            "capture_methods": [
              {
                "method": "GetAudio",
                "capture_frequency_hz": 5,
                "disabled": false,
                "additional_params": {}
              }
            ]
          }
        }
      ]
    }
```
**Before:**
<img width="311" height="745" alt="Screenshot 2026-04-14 at 5 07 38 PM" src="https://github.com/user-attachments/assets/1c9701da-9f7e-48e6-b5b1-8f1056ea5bb8" />
**After (running rdk locally w my change):** file ext gets populated
<img width="325" height="757" alt="Screenshot 2026-04-14 at 5 07 55 PM" src="https://github.com/user-attachments/assets/9ff02d9e-ba16-4fe7-8dd0-ae1c01e1739a" />
