### PR TITLE
RSDK-13765: flaky sleep based capture collector test

### DIFF
--- a/data/collector.go
+++ b/data/collector.go
@@ -24,8 +24,8 @@ import (
 	"go.viam.com/rdk/resource"
 )
 
-// The cutoff at which if interval < cutoff, a sleep based capture func is used instead of a ticker.
-var sleepCaptureCutoff = 2 * time.Millisecond
+// The cutoff at which if interval < cutoff, a timer based capture func is used instead of a ticker.
+var timerCaptureCutoff = 2 * time.Millisecond
 
 // FromDMString is used to access the 'fromDataManagement' value from a request's Extra struct.
 const FromDMString = "fromDataManagement"
@@ -125,25 +125,25 @@ func (c *collector) Collect() {
 	c.logRoutine.Add(1)
 	utils.ManagedGo(c.logCaptureErrs, c.logRoutine.Done)
 
-	// We must wait on `started` before returning. The sleep/ticker based captures rely on the clock
+	// We must wait on `started` before returning. The timer/ticker based captures rely on the clock
 	// advancing to do their first "tick". They must make an initial clock reading before unittests
 	// add an "interval". Lest the ticker never fires and a reading is never made.
 	<-started
 }
 
-// Go's time.Ticker has inconsistent performance with durations of below 1ms [0], so we use a time.Sleep based approach
+// Go's time.Ticker has inconsistent performance with durations of below 1ms [0], so we use a timer based approach
 // when the configured capture interval is below 2ms. A Ticker based approach is kept for longer capture intervals to
 // avoid wasting CPU on a thread that's idling for the vast majority of the time.
 // [0]: https://www.mail-archive.com/golang-nuts@googlegroups.com/msg46002.html
 func (c *collector) capture(started chan struct{}) {
-	if c.interval < sleepCaptureCutoff {
-		c.sleepBasedCapture(started)
+	if c.interval < timerCaptureCutoff {
+		c.timerBasedCapture(started)
 	} else {
 		c.tickerBasedCapture(started)
 	}
 }
 
-func (c *collector) sleepBasedCapture(started chan struct{}) {
+func (c *collector) timerBasedCapture(started chan struct{}) {
 	next := c.clock.Now().Add(c.interval)
 	// Register the first timer before closing started. Collect() blocks on <-started,
 	// so this guarantees that by the time Collect() returns, the mock clock (in tests)

--- a/data/collector.go
+++ b/data/collector.go
@@ -145,21 +145,22 @@ func (c *collector) capture(started chan struct{}) {
 
 func (c *collector) sleepBasedCapture(started chan struct{}) {
 	next := c.clock.Now().Add(c.interval)
-	until := c.clock.Until(next)
-
+	// Register the first timer before closing started. Collect() blocks on <-started,
+	// so this guarantees that by the time Collect() returns, the mock clock (in tests)
+	// already has a pending timer. mockClock.Add() can then never race with the goroutine
+	// registering its sleep.
+	ch := c.clock.After(c.clock.Until(next))
 	close(started)
 	for {
-		if err := c.cancelCtx.Err(); err != nil {
+		select {
+		case <-c.cancelCtx.Done():
 			return
-		}
-		c.clock.Sleep(until)
-		if err := c.cancelCtx.Err(); err != nil {
-			return
+		case <-ch:
 		}
 
 		c.getAndPushNextReading()
 		next = next.Add(c.interval)
-		until = c.clock.Until(next)
+		ch = c.clock.After(c.clock.Until(next))
 	}
 }
 

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -109,7 +109,7 @@ func TestSuccessfulWrite(t *testing.T) {
 			datatype:       CaptureTypeTabular,
 		},
 		{
-			name:           "Sleep based struct writer.",
+			name:           "Timer based struct writer.",
 			captureFunc:    structCapturer,
 			interval:       timerInterval,
 			expectReadings: 2,
@@ -125,7 +125,7 @@ func TestSuccessfulWrite(t *testing.T) {
 			datatype:       CaptureTypeBinary,
 		},
 		{
-			name:           "Sleep based binary writer.",
+			name:           "Timer based binary writer.",
 			captureFunc:    binaryCapturer,
 			interval:       timerInterval,
 			expectReadings: 2,

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
@@ -150,12 +149,6 @@ func TestSuccessfulWrite(t *testing.T) {
 			c, err := NewCollector(tc.captureFunc, params)
 			test.That(t, err, test.ShouldBeNil)
 			c.Collect()
-			// We need to avoid adding time until after the underlying goroutine has started sleeping.
-			// If we add time before that point, data will never be captured, because time will never be greater than
-			// the initially calculated time.
-			// Sleeping for 10ms is a hacky way to ensure that we don't encounter this situation. It gives 10ms
-			// for those few sequential lines in collector.go to execute, so that that occurs before we add time below.
-			time.Sleep(10 * time.Millisecond)
 			for i := 0; i < tc.expectReadings; i++ {
 				mockClock.Add(params.Interval)
 				select {
@@ -165,31 +158,7 @@ func TestSuccessfulWrite(t *testing.T) {
 				}
 			}
 
-			// If it's a sleep based collector, we need to move the clock forward one more time after calling Close.
-			// Otherwise, it will stay asleep indefinitely and Close will block forever.
-			// This loop guarantees that the clock is moved forward at least once after Close is called. After Close
-			// returns and the closed channel is closed, this loop will terminate.
-			closed := make(chan struct{})
-			sleepCollector := tc.interval < sleepCaptureCutoff
-			var wg sync.WaitGroup
-			if sleepCollector {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					for i := 0; i < 1000; i++ {
-						select {
-						case <-closed:
-							return
-						default:
-							time.Sleep(time.Millisecond * 1)
-							mockClock.Add(params.Interval)
-						}
-					}
-				}()
-			}
 			c.Close()
-			close(closed)
-			wg.Wait()
 
 			var actReadings []*v1.SensorData
 			files := getAllFiles(tmpDir)

--- a/data/collector_test.go
+++ b/data/collector_test.go
@@ -81,8 +81,8 @@ func TestNewCollector(t *testing.T) {
 // Test that the Collector correctly writes the SensorData on an interval.
 func TestSuccessfulWrite(t *testing.T) {
 	l := logging.NewTestLogger(t)
-	tickerInterval := sleepCaptureCutoff + 1
-	sleepInterval := sleepCaptureCutoff - 1
+	tickerInterval := timerCaptureCutoff + 1
+	timerInterval := timerCaptureCutoff - 1
 
 	params := CollectorParams{
 		ComponentName: "testComponent",
@@ -111,7 +111,7 @@ func TestSuccessfulWrite(t *testing.T) {
 		{
 			name:           "Sleep based struct writer.",
 			captureFunc:    structCapturer,
-			interval:       sleepInterval,
+			interval:       timerInterval,
 			expectReadings: 2,
 			expFiles:       1,
 			datatype:       CaptureTypeTabular,
@@ -127,7 +127,7 @@ func TestSuccessfulWrite(t *testing.T) {
 		{
 			name:           "Sleep based binary writer.",
 			captureFunc:    binaryCapturer,
-			interval:       sleepInterval,
+			interval:       timerInterval,
 			expectReadings: 2,
 			expFiles:       2,
 			datatype:       CaptureTypeBinary,


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                           
  Fixes a race condition in `sleepBasedCapture` where the mock clock in tests                                                                                                                                                                                                                              
  could advance before the goroutine registered its timer, causing captures to                                                                                                                                                                                                                             
  never fire.                                                                                                                                                                                                                                                                                    
                  
  ## Problem                                                                                                                                                                                                                                                                                               
                  
  The old code called `close(started)` before registering a sleep, creating a                                                                                                                                                                                                                              
  window where tests could advance the mock clock before the goroutine was
  listening:                                                                                                                                                                                                                                                                                               
                  
  1. `close(started)` unblocks `Collect()`, returning control to the test                                                                                                                                                                                                                                  
  2. Test calls `mockClock.Add(interval)` — clock advances
  3. Goroutine calls `clock.Sleep()` — too late, time already passed, sleep never fires                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                           
  Tests papered over this with a `time.Sleep(10ms)` hack, which is inherently                                                                                                                                                                                                                              
  flaky under load.                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                     
                  
  ## Fix                                                                                                                                                                                                                                                                                                   
                  
  Register the first timer via `clock.After()` **before** `close(started)`.                                                                                                                                                                                                                                
  Since `Collect()` blocks on `<-started`, the timer is guaranteed to exist in
  the mock clock by the time any caller can advance it.                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                           
  Replace the polling pattern with a `select` on `cancelCtx.Done()` and the
  timer channel. This handles cancellation atomically and means **shutdown no                                                                                                                                                                                                                              
  longer requires the clock to be advanced** — `cancel()` unblocks the goroutine                                                                                                                                                                                                                           
  immediately.                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                           
  ## Test cleanup                                                                                                                                                                                                                                                                                          
                  
  With the race gone, two workarounds are removed:
  - `time.Sleep(10ms)` before `mockClock.Add()` calls
  - The goroutine that kept advancing the mock clock during `Close()` to prevent                                                                                                                                                                                                                           
    the collector from blocking forever on shutdown
    
   I wasn't able to reproduce this flaky test locally, its a probably a case of the github CI being slow. I did run the tests a few times in CI, and they all passed