### PR TITLE
Fix dev version to use highest global tag

### DIFF
--- a/etc/dev-version.sh
+++ b/etc/dev-version.sh
@@ -21,12 +21,16 @@ if [ "$GITHUB_REF_NAME" != "main" ]; then
     exit 0
 fi
 
-# If we don't have a direct tag, use the most recent non-RC tag
-DESC=$(git describe --tags --match="v*" --exclude="*-rc*" --long | sed 's/^v//')
+# Find the highest stable tag globally (not just ancestors of HEAD).
+# Release tags are cut on release branches and are not reachable from main,
+# so `git describe` would otherwise report an older tag than the true latest.
+LATEST_TAG=$(git tag --list 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
 
-BASE_VERSION=$(echo "$DESC" | cut -d'-' -f1)
-COMMITS_SINCE_TAG=$(echo "$DESC" | cut -d'-' -f2)
-COMMIT_HASH=$(echo "$DESC" | cut -d'-' -f3 | sed 's/^g//')
+BASE_VERSION=$(echo "$LATEST_TAG" | sed 's/^v//')
+# rev-list A..HEAD is set-subtraction on reachable commits; it works even when
+# A is not an ancestor of HEAD (i.e. tag lives on a release branch).
+COMMITS_SINCE_TAG=$(git rev-list --count "${LATEST_TAG}..HEAD")
+COMMIT_HASH=$(git rev-parse --short=9 HEAD)
 
 # Calculate next version by incrementing patch number
 NEXT_VERSION=$(echo "$BASE_VERSION" | awk -F. '{$3+=1}1' OFS=.)


### PR DESCRIPTION
## Summary
- `etc/dev-version.sh` used `git describe`, which only finds tags reachable from HEAD. Because RDK cuts release tags on release branches (e.g. `v0.122.0` lives on `v0.122.0-release`, not `main`), dev builds on `main` reported a stale base version like `v0.120.1-dev.16-703c720d9` even though `v0.122.0` had already shipped.
- Switch to the highest stable tag globally (`git tag | sort -V`) and count commits with `git rev-list --count TAG..HEAD`, which works across disjoint histories.
- Result on current `main` (HEAD `703c720d9`): **`v0.122.1-dev.8-703c720d9`** instead of `v0.120.1-dev.16-703c720d9`.

Tag filter tightened to `^v[0-9]+\.[0-9]+\.[0-9]+$` so only stable tags are considered (excludes `-rc`, future `-hotfix`, etc.). The existing direct-tag path (line 9) and dirty-tree / non-main guards are unchanged.

## Test plan
- [ ] CI produces a version of the form `v0.122.1-dev.N-<sha>` on `main`
- [ ] A build from the exact `v0.122.0` commit still prints `v0.122.0` (direct-tag path)
- [ ] Builds on feature branches still print blank
- [ ] Builds with a dirty tree still print blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)