### PR TITLE
RSDK-13600: Validate ref before starting cloud build in cli

### DIFF
--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -117,6 +117,9 @@ func (c *viamClient) validateRefExists(ctx context.Context, cmd *cli.Command, re
 		return nil
 	}
 	if !exists {
+		if token == "" {
+			return fmt.Errorf("ref %q not found on %s (if this is a private repo, pass a token with --token)", ref, repoURL)
+		}
 		return fmt.Errorf("ref %q not found on %s", ref, repoURL)
 	}
 	return nil

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -52,6 +53,74 @@ const (
 )
 
 var moduleBuildPollingInterval = 2 * time.Second
+
+// githubRefExists calls GitHub's REST commits API to check whether a ref
+// (branch, tag, or commit SHA) exists in a repo
+var githubRefExists = func(ctx context.Context, owner, repo, ref, token string) (bool, error) {
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/commits/%s", owner, repo, ref)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return false, err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound, http.StatusUnprocessableEntity:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected status %d from github api", resp.StatusCode)
+	}
+}
+
+// parseGitHubRepo extracts owner and repo from an https://github.com/owner/repo
+// URL. If it fails to parse, it might be formatted non-uniformly, so we try the build action anyways.
+func parseGitHubRepo(repoURL string) (owner, repo string, ok bool, err error) {
+	u, parseErr := url.Parse(repoURL)
+	// not a github link: skip validation, the build action may still succeed on a non-github host
+	if parseErr != nil || u.Host != "github.com" {
+		return "", "", false, nil
+	}
+	// strip leading / from path and then get first three parts (owner, repo, path)
+	parts := strings.SplitN(strings.TrimPrefix(u.Path, "/"), "/", 3)
+	// github url but missing owner/repo: the cloud build will definitely fail, so hard-fail early
+	if len(parts) < 2 || parts[1] == "" {
+		return "", "", false, fmt.Errorf(
+			"meta.json url %q is missing the repo path (expected https://github.com/<owner>/<repo>)", repoURL)
+	}
+	return parts[0], strings.TrimSuffix(parts[1], ".git"), true, nil
+}
+
+// validateRefExists checks that ref exists on the remote at repoURL before a
+// cloud build is started, and only stops the build if the ref can be proven to not exist, or
+// else it will go through to with the build attempt (like with non-github links)
+func (c *viamClient) validateRefExists(ctx context.Context, cmd *cli.Command, repoURL, ref, token string) error {
+	owner, repo, ok, err := parseGitHubRepo(repoURL)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	exists, err := githubRefExists(ctx, owner, repo, ref, token)
+	if err != nil {
+		gArgs := parseStructFromCtx[globalArgs](cmd)
+		debugf(cmd.Root().ErrWriter, gArgs.Debug,
+			"could not verify ref %q on %s: %v — proceeding anyway", ref, repoURL, err)
+		return nil
+	}
+	if !exists {
+		return fmt.Errorf("ref %q not found on %s", ref, repoURL)
+	}
+	return nil
+}
 
 type moduleBuildStartArgs struct {
 	Module    string
@@ -136,6 +205,10 @@ func (c *viamClient) moduleBuildStartAction(ctx context.Context, cmd *cli.Comman
 	if manifest.URL == "" {
 		return "", errors.New("meta.json must have a url field set in order to start a cloud build. " +
 			"Ex: 'https://github.com/your-username/your-repo'")
+	}
+
+	if err := c.validateRefExists(ctx, cmd, manifest.URL, args.Ref, args.Token); err != nil {
+		return "", err
 	}
 
 	return c.moduleBuildStartForRepo(ctx, cmd, args, &manifest, manifest.URL)

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -86,7 +86,7 @@ func parseGitHubRepo(repoURL string) (owner, repo string, ok bool, err error) {
 	u, parseErr := url.Parse(repoURL)
 	// not a github link: skip validation, the build action may still succeed on a non-github host
 	if parseErr != nil || u.Host != "github.com" {
-		return "", "", false, nil
+		return "", "", false, nil //nolint:nilerr
 	}
 	// strip leading / from path and then get first three parts (owner, repo, path)
 	parts := strings.SplitN(strings.TrimPrefix(u.Path, "/"), "/", 3)

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -33,7 +33,7 @@ func createTestManifest(t *testing.T, path string, overrides map[string]any) str
 	defaultManifest := map[string]any{
 		"module_id":   "test:test",
 		"visibility":  "private",
-		"url":         "https://github.com/",
+		"url":         "https://github.com/test-org/test-repo",
 		"description": "a",
 		"models": []any{
 			map[string]any{
@@ -71,14 +71,68 @@ func createTestManifest(t *testing.T, path string, overrides map[string]any) str
 	return path
 }
 
+func TestValidateRefExists(t *testing.T) {
+	origGitHub := githubRefExists
+	t.Cleanup(func() { githubRefExists = origGitHub })
+
+	viamClient := &viamClient{}
+	cmd := newTestContext(t, map[string]any{})
+
+	// stub: ref exists on github
+	refFound := func(ctx context.Context, owner, repo, ref, token string) (bool, error) {
+		return true, nil
+	}
+	// stub: ref does not exist on github
+	refNotFound := func(ctx context.Context, owner, repo, ref, token string) (bool, error) {
+		return false, nil
+	}
+	// stub: should have failed to parse URL
+	shouldNotBeCalled := func(ctx context.Context, owner, repo, ref, token string) (bool, error) {
+		t.Fatal("githubRefExists should not have been called")
+		return false, nil
+	}
+
+	cases := []struct {
+		name          string
+		stub          func(context.Context, string, string, string, string) (bool, error)
+		url           string
+		ref           string
+		wantErrSubstr string
+	}{
+		{"github ref found", refFound, "https://github.com/allisonschiang/filtered-audio-fix", "reftest", ""},
+		{"github ref not found", refNotFound, "https://github.com/allisonschiang/filtered-audio-fix", "typo", "not found"},
+		{"malformed github url", shouldNotBeCalled, "https://github.com/viamrobotics", "main", "missing the repo path"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			githubRefExists = tc.stub
+			err := viamClient.validateRefExists(context.Background(), cmd, tc.url, tc.ref, "")
+			if tc.wantErrSubstr == "" {
+				test.That(t, err, test.ShouldBeNil)
+			} else {
+				test.That(t, err, test.ShouldNotBeNil)
+				test.That(t, err.Error(), test.ShouldContainSubstring, tc.wantErrSubstr)
+			}
+		})
+	}
+}
+
 func TestStartBuild(t *testing.T) {
+	// stub the ref validator so the test doesn't hit the network against
+	// the placeholder url in the test manifest
+	origGitHub := githubRefExists
+	githubRefExists = func(ctx context.Context, owner, repo, ref, token string) (bool, error) {
+		return true, nil
+	}
+	t.Cleanup(func() { githubRefExists = origGitHub })
+
 	manifest := filepath.Join(t.TempDir(), "meta.json")
 	createTestManifest(t, manifest, nil)
 	cCtx, ac, out, errOut := setup(&inject.AppServiceClient{}, nil, &inject.BuildServiceClient{
 		StartBuildFunc: func(ctx context.Context, in *v1.StartBuildRequest, opts ...grpc.CallOption) (*v1.StartBuildResponse, error) {
 			return &v1.StartBuildResponse{BuildId: "xyz123"}, nil
 		},
-	}, map[string]any{moduleFlagPath: manifest, generalFlagVersion: "1.2.3"}, "token")
+	}, map[string]any{moduleFlagPath: manifest, generalFlagVersion: "1.2.3", moduleBuildFlagRef: "main"}, "token")
 	path, err := ac.moduleBuildStartAction(context.Background(), cCtx, parseStructFromCtx[moduleBuildStartArgs](cCtx))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, path, test.ShouldEqual, "xyz123")

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -132,7 +132,7 @@ func TestStartBuild(t *testing.T) {
 		StartBuildFunc: func(ctx context.Context, in *v1.StartBuildRequest, opts ...grpc.CallOption) (*v1.StartBuildResponse, error) {
 			return &v1.StartBuildResponse{BuildId: "xyz123"}, nil
 		},
-	}, map[string]any{moduleFlagPath: manifest, generalFlagVersion: "1.2.3", moduleBuildFlagRef: "main"}, "token")
+	}, map[string]any{moduleFlagPath: manifest, generalFlagVersion: "1.2.3"}, "token")
 	path, err := ac.moduleBuildStartAction(context.Background(), cCtx, parseStructFromCtx[moduleBuildStartArgs](cCtx))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, path, test.ShouldEqual, "xyz123")

--- a/cli/module_reload_test.go
+++ b/cli/module_reload_test.go
@@ -21,6 +21,12 @@ import (
 )
 
 func TestConfigureModule(t *testing.T) {
+	origGitHub := githubRefExists
+	githubRefExists = func(ctx context.Context, owner, repo, ref, token string) (bool, error) {
+		return true, nil
+	}
+	t.Cleanup(func() { githubRefExists = origGitHub })
+
 	manifestPath := createTestManifest(t, "", nil)
 	cCtx, ac, out, errOut := setup(&inject.AppServiceClient{}, nil, &inject.BuildServiceClient{
 		StartBuildFunc: func(ctx context.Context, in *v1.StartBuildRequest, opts ...grpc.CallOption) (*v1.StartBuildResponse, error) {


### PR DESCRIPTION
We validate the ref (which can be a branch, SHA, and technically a tag through undocumented in the --help) by calling github's API to see if a ref exists. If its a branch, it also checks to make sure its not malformed

Testing:
valid sha:
```
viam module build start --version=0.0.1-manualtest1 --ref=631d90c682825e709ea15ad0dd51c0fad8af2a1c     

Build started, follow the logs with: viam module build logs
```
invalid sha:
`Error: Ref "deadbeef..." not found ... (if this is a private repo, pass a token with --token)   `

valid branch:
`waiting on another pr that fixes --ref=branch not working `
invalid branch:
```
viam-module build start --version=0.0.1-manualtest2 --ref=totally-fake-branch-xyz

Error: Ref "totally-fake-branch-xyz" not found on https://github.com/allisonschiang/filtered-audio-fix (if this is a private repo, pass a token with --token) 
```

malformed URL:
```
meta.json url set to https://github.com/allisonschiang
viam module build start --version=0.0.1-manualtest3 --ref="main"

Error: Meta.json url "https://github.com/allisonschiang" is missing the repo path(expected https://github.com/<owner>/<repo>)
```