### PR TITLE
when VIAM_HOME is present, use it as ViamDotDir, rather than appending .viam to it

### DIFF
--- a/utils/env.go
+++ b/utils/env.go
@@ -111,7 +111,7 @@ var EnvTrueValues = []string{"true", "yes", "1", "TRUE", "YES"}
 var TCPRegex = regexp.MustCompile(`:\d+$`)
 
 // ViamDotDir is the directory for Viam's cached files.
-var ViamDotDir = filepath.Join(viamHomeDir(), ".viam")
+var ViamDotDir = viamDotDir()
 
 var windowsPathRegex = regexp.MustCompile(`^(\w:)?(.+)$`)
 
@@ -149,12 +149,12 @@ func timeoutHelper(defaultTimeout time.Duration, timeoutEnvVar string, logger lo
 	return defaultTimeout, true
 }
 
-// parent directory of ViamDotDir
-func viamHomeDir() string {
+// construct the .viam path from user's home directory, or $VIAM_HOME if available.
+func viamDotDir() string {
 	if viamHome := os.Getenv(HomeEnvVar); viamHome != "" {
 		return viamHome
 	}
-	return PlatformHomeDir()
+	return filepath.Join(PlatformHomeDir(), ".viam")
 }
 
 // PlatformHomeDir wraps Getenv("HOME"), except on android, where it returns the app cache directory.


### PR DESCRIPTION
## What changed
- VIAM_HOME is now used directly as ViamDotDir, rather than doing `filepath.Join(VIAM_HOME, .viam)`
## Why
In modmanager [here](https://github.com/viamrobotics/rdk/blob/e653213807d899102dec7a22cb616bd43c2a6d65/module/modmanager/manager.go#L1097), we pass down the dotdir as VIAM_HOME.

As a result, as of #5900, modules using [ViamCaptureDotDir](https://github.com/viamrobotics/rdk/blob/main/services/datamanager/builtin/shared/default_capture_directory.go#L13) were writing to ~/.viam/.viam/capture instead of ~/.viam/capture.
## Manual test
On this branch:

> $ go run ./web/cmd/server -config /etc/viam.json
>
> 2026-04-16T21:08:51.832Z        INFO    rdk.modmanager.awinter_golang-wifi-example      utils/env.go:213        Starting module with following Viam environment variables       {"environment":["VIAM_HOME=/home/awinter/.viam", ...]}

> $ VIAM_HOME=~/.viam2 go run ./web/cmd/server -config /etc/viam.json
>
> 2026-04-16T21:01:49.562Z        INFO    rdk.modmanager.awinter_golang-wifi-example      utils/env.go:213        Starting module with following Viam environment variables       {"environment":["VIAM_HOME=/home/awinter/.viam2","VIAM_HOME=/home/awinter/.viam2", ...]}

On main:

> $ go run ./web/cmd/server -config /etc/viam.json
>
> 2026-04-16T21:03:56.735Z        INFO    rdk.modmanager.awinter_golang-wifi-example      utils/env.go:213        Starting module with following Viam environment variables       {"environment":["VIAM_HOME=/home/awinter/.viam", ...]}

> $ VIAM_HOME=~ go run ./web/cmd/server -config /etc/viam.json
>
> 2026-04-16T21:05:13.551Z        INFO    rdk.modmanager.awinter_golang-wifi-example      utils/env.go:213        Starting module with following Viam environment variables       {"environment":["VIAM_HOME=/home/awinter", "VIAM_HOME=/home/awinter/.viam", ...]}
## Other follow ups
- audit vmodutils, ViamCaptureDotDir, ViamDotDir usage across our orgs