### PR TITLE
cli: enable shell autocomplete

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -32,6 +32,24 @@ go install go.viam.com/rdk/cli/viam@latest
 echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.bashrc
 ```
 
+### Shell completion
+
+The CLI can emit tab-completion scripts for your shell. Once the `viam` binary is on your `$PATH`, source the output to enable completion of commands, subcommands, and flag names:
+
+```sh
+# bash (add to ~/.bashrc)
+source <(viam completion bash)
+
+# zsh (add to ~/.zshrc)
+source <(viam completion zsh)
+
+# fish
+viam completion fish > ~/.config/fish/completions/viam.fish
+
+# PowerShell
+viam completion pwsh | Out-String | Invoke-Expression
+```
+
 ### Development
 Building (you must [install go](https://go.dev/doc/install) first):
 ```sh

--- a/cli/app.go
+++ b/cli/app.go
@@ -454,10 +454,11 @@ func formatAcceptedValues(description string, values ...string) string {
 }
 
 var app = &cli.Command{
-	Name:            "viam",
-	Usage:           "interact with your Viam machines",
-	UsageText:       "viam [global options] <command> [command options]",
-	HideHelpCommand: true,
+	Name:                  "viam",
+	Usage:                 "interact with your Viam machines",
+	UsageText:             "viam [global options] <command> [command options]",
+	EnableShellCompletion: true,
+	HideHelpCommand:       true,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:   baseURLFlag,


### PR DESCRIPTION
## Summary

- Enable urfave/cli/v3 shell completion on the root `viam` command (`cli/app.go`). This registers a hidden `viam completion <bash|zsh|fish|pwsh>` subcommand that emits the appropriate completion script, and makes every command respond to `--generate-shell-completion` so the scripts can query live completions for subcommand names and flag names.
- Add a "Shell completion" section to `cli/README.md` with install snippets for bash, zsh, fish, and PowerShell.

No new dependencies; urfave/cli v3 already ships the completion scripts.

## Test plan

- [x] `make cli` builds cleanly.
- [x] `./bin/<goos>-<goarch>/viam-cli completion zsh | head` prints the zsh script (templated with `viam`); repeat for `bash`, `fish`, `pwsh`.
- [x] `./bin/<goos>-<goarch>/viam-cli --generate-shell-completion` lists top-level commands.
- [x] `./bin/<goos>-<goarch>/viam-cli machines --generate-shell-completion` lists `machines` subcommands.
- [x] `./bin/<goos>-<goarch>/viam-cli machines list - --generate-shell-completion` lists flag names for `machines list`.
- [x] `source <(viam completion zsh)` (or bash) in a real shell → `viam <TAB>` and `viam machines <TAB>` show completions.

Not in scope: dynamic value completion (e.g. `--org-id <TAB>` listing real org IDs). Can be layered on per-flag later via `ShellComplete` funcs without revisiting this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)