### PR TITLE
RSDK-13202 - Remove confusing validation logs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -234,20 +234,14 @@ func (c *Config) Ensure(fromCloud bool, logger logging.Logger) error {
 		// default converter. For modular resources, since lookup will fail as no converter or a typed struct is registered, implicit
 		// dependencies are gathered during robot reconfiguration itself.
 		requiredDeps, optionalDeps, err := c.Components[idx].Validate(fmt.Sprintf("%s.%d", "components", idx), resource.APITypeComponentName)
-		if err != nil {
-			resLogger := logger.Sublogger(c.Components[idx].ResourceName().String())
-			resLogger.Errorw("Component config error; starting robot without component", "name", c.Components[idx].Name, "error", err.Error())
-		} else {
+		if err == nil {
 			c.Components[idx].ImplicitDependsOn = requiredDeps
 			c.Components[idx].ImplicitOptionalDependsOn = optionalDeps
 		}
 	}
 	for idx := range len(c.Services) {
 		requiredDeps, optionalDeps, err := c.Services[idx].Validate(fmt.Sprintf("%s.%d", "services", idx), resource.APITypeServiceName)
-		if err != nil {
-			resLogger := logger.Sublogger(c.Services[idx].ResourceName().String())
-			resLogger.Errorw("Service config error; starting robot without service", "name", c.Services[idx].Name, "error", err.Error())
-		} else {
+		if err == nil {
 			c.Services[idx].ImplicitDependsOn = requiredDeps
 			c.Services[idx].ImplicitOptionalDependsOn = optionalDeps
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -174,8 +174,7 @@ func (c *Config) Ensure(fromCloud bool, logger logging.Logger) error {
 	// uniqueness within each category. Managers of each resource handle duplicates
 	// differently, and behavior is undefined.
 	//
-	// Validation of configs come later and is not needed now because each manager
-	// needs to do validation right before the resource is added.
+	// Validation of configs come later when each resource is added or modified.
 	seenJobs := make(map[string]struct{})
 	for idx := range len(c.Jobs) {
 		if _, exists := seenJobs[c.Jobs[idx].Name]; exists {

--- a/config/config.go
+++ b/config/config.go
@@ -170,14 +170,14 @@ func (c *Config) Ensure(fromCloud bool, logger logging.Logger) error {
 		return err
 	}
 
-	// Validate jobs, modules, remotes, packages, and processes, and log errors for lack of
+	// Check jobs, modules, remotes, packages, and processes, and log errors for lack of
 	// uniqueness within each category. Managers of each resource handle duplicates
 	// differently, and behavior is undefined.
+	//
+	// Validation of configs come later and is not needed now because each manager
+	// needs to do validation right before the resource is added.
 	seenJobs := make(map[string]struct{})
 	for idx := range len(c.Jobs) {
-		if err := c.Jobs[idx].Validate(fmt.Sprintf("%s.%d", "jobs", idx)); err != nil {
-			logger.Errorw("Jobs config error; starting robot without job", "name", c.Jobs[idx].Name, "error", err.Error())
-		}
 		if _, exists := seenJobs[c.Jobs[idx].Name]; exists {
 			logger.Errorf("Duplicate job %s in robot config; behavior undefined", c.Jobs[idx].Name)
 		}
@@ -185,9 +185,6 @@ func (c *Config) Ensure(fromCloud bool, logger logging.Logger) error {
 	}
 	seenModules := make(map[string]struct{})
 	for idx := range len(c.Modules) {
-		if err := c.Modules[idx].Validate(fmt.Sprintf("%s.%d", "modules", idx)); err != nil {
-			logger.Errorw("Module config error; starting robot without module", "name", c.Modules[idx].Name, "error", err.Error())
-		}
 		if _, exists := seenModules[c.Modules[idx].Name]; exists {
 			logger.Errorf("Duplicate module %s in robot config; behavior undefined", c.Modules[idx].Name)
 		}
@@ -195,9 +192,6 @@ func (c *Config) Ensure(fromCloud bool, logger logging.Logger) error {
 	}
 	seenRemotes := make(map[string]struct{})
 	for idx := range len(c.Remotes) {
-		if _, _, err := c.Remotes[idx].Validate(fmt.Sprintf("%s.%d", "remotes", idx)); err != nil {
-			logger.Errorw("Remote config error; starting robot without remote", "name", c.Remotes[idx].Name, "error", err.Error())
-		}
 		if _, exists := seenRemotes[c.Remotes[idx].Name]; exists {
 			logger.Errorf("Duplicate remote %s in robot config; behavior undefined", c.Remotes[idx].Name)
 		}
@@ -205,9 +199,6 @@ func (c *Config) Ensure(fromCloud bool, logger logging.Logger) error {
 	}
 	seenPackages := make(map[string]struct{})
 	for idx := range len(c.Packages) {
-		if err := c.Packages[idx].Validate(fmt.Sprintf("%s.%d", "packages", idx)); err != nil {
-			logger.Errorw("Package config error; starting robot without package", "name", c.Packages[idx].Name, "error", err.Error())
-		}
 		if _, exists := seenPackages[c.Packages[idx].Name]; exists {
 			logger.Errorf("Duplicate package %s in robot config; behavior undefined", c.Packages[idx].Name)
 		}
@@ -215,9 +206,6 @@ func (c *Config) Ensure(fromCloud bool, logger logging.Logger) error {
 	}
 	seenProcesses := make(map[string]struct{})
 	for idx := range len(c.Processes) {
-		if err := c.Processes[idx].Validate(fmt.Sprintf("%s.%d", "processes", idx)); err != nil {
-			logger.Errorw("Process config error; starting robot without process", "name", c.Processes[idx].Name, "error", err.Error())
-		}
 		if _, exists := seenProcesses[c.Processes[idx].Name]; exists {
 			logger.Errorf("Duplicate process %s in robot config; behavior undefined", c.Processes[idx].Name)
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/golang/geo/r3"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/pkg/errors"
-	"go.uber.org/zap/zapcore"
 	"go.viam.com/test"
 	"go.viam.com/utils"
 	"go.viam.com/utils/jwks"
@@ -185,7 +184,7 @@ func TestConfigWithLogDeclarations(t *testing.T) {
 }
 
 func TestConfigEnsure(t *testing.T) {
-	logger, logs := logging.NewObservedTestLogger(t)
+	logger := logging.NewTestLogger(t)
 	var emptyConfig config.Config
 	test.That(t, emptyConfig.Ensure(false, logger), test.ShouldBeNil)
 
@@ -222,45 +221,25 @@ func TestConfigEnsure(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, resource.GetFieldFromFieldRequiredError(err), test.ShouldEqual, "local_fqdn")
 	invalidCloud.Cloud.LocalFQDN = "yeeself"
+	test.That(t, invalidCloud.Ensure(true, logger), test.ShouldBeNil)
 
-	logs.TakeAll() // clear logs
 	invalidRemotes := config.Config{
 		Remotes: []config.Remote{{}},
 	}
-	err = invalidRemotes.Ensure(false, logger)
-	test.That(t, err, test.ShouldBeNil)
-	// Assert that some error log was output containing the snippet "Remote config error".
-	remoteConfigErrorLogs := logs.FilterMessageSnippet("Remote config error")
-	test.That(t, remoteConfigErrorLogs.Len(), test.ShouldEqual, 1)
-	test.That(t, remoteConfigErrorLogs.All()[0].Level, test.ShouldEqual, zapcore.ErrorLevel)
-
-	logs.TakeAll() // clear logs
-	invalidRemotes.Remotes[0] = config.Remote{
-		Name: "foo",
-	}
-	err = invalidRemotes.Ensure(false, logger)
-	test.That(t, err, test.ShouldBeNil)
-	// Assert that some error log was output containing the snippet "Remote config error".
-	remoteConfigErrorLogs = logs.FilterMessageSnippet("Remote config error")
-	test.That(t, remoteConfigErrorLogs.Len(), test.ShouldEqual, 1)
-	test.That(t, remoteConfigErrorLogs.All()[0].Level, test.ShouldEqual, zapcore.ErrorLevel)
-
+	test.That(t, invalidRemotes.Ensure(false, logger), test.ShouldBeNil)
+	invalidRemotes.Remotes[0] = config.Remote{Name: "foo"}
+	test.That(t, invalidRemotes.Ensure(false, logger), test.ShouldBeNil)
 	invalidRemotes.Remotes[0] = config.Remote{
 		Name:    "foo",
 		Address: "bar",
 	}
 	test.That(t, invalidRemotes.Ensure(false, logger), test.ShouldBeNil)
 
-	logs.TakeAll() // clear logs
 	invalidComponents := config.Config{
 		Components: []resource.Config{{}},
 	}
 	err = invalidComponents.Ensure(false, logger)
 	test.That(t, err, test.ShouldBeNil)
-	// Assert that some error log was output containing the snippet "Component config error".
-	componentConfigErrorLogs := logs.FilterMessageSnippet("Component config error")
-	test.That(t, componentConfigErrorLogs.Len(), test.ShouldEqual, 1)
-	test.That(t, componentConfigErrorLogs.All()[0].Level, test.ShouldEqual, zapcore.ErrorLevel)
 
 	invalidComponents.Components[0] = resource.Config{
 		Name:  "foo",
@@ -316,32 +295,47 @@ func TestConfigEnsure(t *testing.T) {
 	err = components.Ensure(false, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	logs.TakeAll() // clear logs
 	invalidProcesses := config.Config{
 		Processes: []pexec.ProcessConfig{{}},
 	}
-	err = invalidProcesses.Ensure(false, logger)
-	test.That(t, err, test.ShouldBeNil)
-	// Assert that some error log was output containing the snippet "Process config error".
-	processConfigErrorLogs := logs.FilterMessageSnippet("Process config error")
-	test.That(t, processConfigErrorLogs.Len(), test.ShouldEqual, 1)
-	test.That(t, processConfigErrorLogs.All()[0].Level, test.ShouldEqual, zapcore.ErrorLevel)
-
-	logs.TakeAll() // clear logs
+	test.That(t, invalidProcesses.Ensure(false, logger), test.ShouldBeNil)
 	invalidProcesses = config.Config{
 		Processes: []pexec.ProcessConfig{{ID: "bar"}},
 	}
-	err = invalidProcesses.Ensure(false, logger)
-	test.That(t, err, test.ShouldBeNil)
-	// Assert that some error log was output containing the snippet "Process config error".
-	processConfigErrorLogs = logs.FilterMessageSnippet("Process config error")
-	test.That(t, processConfigErrorLogs.Len(), test.ShouldEqual, 1)
-	test.That(t, processConfigErrorLogs.All()[0].Level, test.ShouldEqual, zapcore.ErrorLevel)
+	test.That(t, invalidProcesses.Ensure(false, logger), test.ShouldBeNil)
 
 	validProcesses := config.Config{
 		Processes: []pexec.ProcessConfig{{ID: "bar", Name: "foo"}},
 	}
 	test.That(t, validProcesses.Ensure(false, logger), test.ShouldBeNil)
+
+	cloudErr := "bad cloud err doing validation"
+	invalidModules := config.Config{
+		Modules: []config.Module{{
+			Name:        "testmodErr",
+			ExePath:     ".",
+			LogLevel:    "debug",
+			Type:        config.ModuleTypeRegistry,
+			ModuleID:    "mod:testmodErr",
+			Environment: map[string]string{},
+			Status: &config.AppValidationStatus{
+				Error: cloudErr,
+			},
+		}},
+	}
+	test.That(t, invalidModules.Ensure(false, logger), test.ShouldBeNil)
+
+	invalidPackages := config.Config{
+		Packages: []config.PackageConfig{{
+			Name:    "testPackage",
+			Type:    config.PackageTypeMlModel,
+			Package: "hi/package/test",
+			Status: &config.AppValidationStatus{
+				Error: cloudErr,
+			},
+		}},
+	}
+	test.That(t, invalidPackages.Ensure(false, logger), test.ShouldBeNil)
 
 	invalidNetwork := config.Config{
 		Network: config.NetworkConfig{
@@ -385,240 +379,6 @@ func TestConfigEnsure(t *testing.T) {
 	test.That(t, err.Error(), test.ShouldContainSubstring, `between`)
 
 	invalidNetwork.Network.Sessions.HeartbeatWindow = 30 * time.Millisecond
-	test.That(t, invalidNetwork.Ensure(false, logger), test.ShouldBeNil)
-
-	invalidNetwork.Network.BindAddress = "woop"
-	err = invalidNetwork.Ensure(false, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `bind_address`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `missing port`)
-
-	invalidNetwork.Network.BindAddress = "woop"
-	invalidNetwork.Network.Listener = &net.TCPListener{}
-	err = invalidNetwork.Ensure(false, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `only set one of`)
-
-	invalidAuthConfig := config.Config{
-		Auth: config.AuthConfig{},
-	}
-	test.That(t, invalidAuthConfig.Ensure(false, logger), test.ShouldBeNil)
-
-	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
-		{Type: rpc.CredentialsTypeAPIKey},
-	}
-	err = invalidAuthConfig.Ensure(false, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `auth.handlers.0`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `required`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `key`)
-
-	validAPIKeyHandler := config.AuthHandlerConfig{
-		Type: rpc.CredentialsTypeAPIKey,
-		Config: rutils.AttributeMap{
-			"key":  "foo",
-			"keys": []string{"key"},
-		},
-	}
-
-	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
-		validAPIKeyHandler,
-		validAPIKeyHandler,
-	}
-	err = invalidAuthConfig.Ensure(false, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `auth.handlers.1`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `duplicate`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `api-key`)
-
-	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
-		validAPIKeyHandler,
-		{Type: "unknown"},
-	}
-	err = invalidAuthConfig.Ensure(false, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `auth.handlers.1`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `do not know how`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `unknown`)
-
-	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
-		validAPIKeyHandler,
-	}
-	test.That(t, invalidAuthConfig.Ensure(false, logger), test.ShouldBeNil)
-
-	validAPIKeyHandler.Config = rutils.AttributeMap{
-		"keys": []string{},
-	}
-	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
-		validAPIKeyHandler,
-	}
-	err = invalidAuthConfig.Ensure(false, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `auth.handlers.0`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `required`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `keys`)
-
-	validAPIKeyHandler.Config = rutils.AttributeMap{
-		"keys": []string{"one", "two"},
-	}
-	invalidAuthConfig.Auth.Handlers = []config.AuthHandlerConfig{
-		validAPIKeyHandler,
-	}
-
-	test.That(t, invalidAuthConfig.Ensure(false, logger), test.ShouldBeNil)
-}
-
-func TestConfigEnsurePartialStart(t *testing.T) {
-	logger, logs := logging.NewObservedTestLogger(t)
-	var emptyConfig config.Config
-	test.That(t, emptyConfig.Ensure(false, logger), test.ShouldBeNil)
-
-	invalidCloud := config.Config{
-		Cloud: &config.Cloud{},
-	}
-	err := invalidCloud.Ensure(false, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `cloud`)
-	test.That(t, resource.GetFieldFromFieldRequiredError(err), test.ShouldEqual, "id")
-	invalidCloud.Cloud.ID = "some_id"
-	err = invalidCloud.Ensure(false, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, resource.GetFieldFromFieldRequiredError(err), test.ShouldEqual, "api_key")
-	err = invalidCloud.Ensure(true, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, resource.GetFieldFromFieldRequiredError(err), test.ShouldEqual, "fqdn")
-	invalidCloud.Cloud.Secret = "my_secret"
-	test.That(t, invalidCloud.Ensure(false, logger), test.ShouldBeNil)
-	test.That(t, invalidCloud.Ensure(true, logger), test.ShouldNotBeNil)
-	invalidCloud.Cloud.APIKey = config.APIKey{ID: "", Key: "key_value"}
-	err = invalidCloud.Ensure(false, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, resource.GetFieldFromFieldRequiredError(err), test.ShouldEqual, "api_key")
-	err = invalidCloud.Ensure(true, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	invalidCloud.Cloud.Secret = ""
-	invalidCloud.Cloud.APIKey = config.APIKey{ID: "key_id", Key: "key_value"}
-	test.That(t, invalidCloud.Ensure(false, logger), test.ShouldBeNil)
-	test.That(t, invalidCloud.Ensure(true, logger), test.ShouldNotBeNil)
-	invalidCloud.Cloud.APIKey = config.APIKey{}
-	invalidCloud.Cloud.FQDN = "wooself"
-	err = invalidCloud.Ensure(true, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, resource.GetFieldFromFieldRequiredError(err), test.ShouldEqual, "local_fqdn")
-	invalidCloud.Cloud.LocalFQDN = "yeeself"
-
-	test.That(t, invalidCloud.Ensure(true, logger), test.ShouldBeNil)
-
-	invalidRemotes := config.Config{
-		Remotes: []config.Remote{{}},
-	}
-	err = invalidRemotes.Ensure(false, logger)
-	test.That(t, err, test.ShouldBeNil)
-	invalidRemotes.Remotes[0].Name = "foo"
-	err = invalidRemotes.Ensure(false, logger)
-	test.That(t, err, test.ShouldBeNil)
-	invalidRemotes.Remotes[0].Address = "bar"
-	test.That(t, invalidRemotes.Ensure(false, logger), test.ShouldBeNil)
-
-	invalidComponents := config.Config{
-		Components: []resource.Config{{}},
-	}
-	err = invalidComponents.Ensure(false, logger)
-	test.That(t, err, test.ShouldBeNil)
-	invalidComponents.Components[0].Name = "foo"
-
-	c1 := resource.Config{Name: "c1"}
-	c2 := resource.Config{Name: "c2", DependsOn: []string{"c1"}}
-	c3 := resource.Config{Name: "c3", DependsOn: []string{"c1", "c2"}}
-	c4 := resource.Config{Name: "c4", DependsOn: []string{"c1", "c3"}}
-	c5 := resource.Config{Name: "c5", DependsOn: []string{"c2", "c4"}}
-	c6 := resource.Config{Name: "c6"}
-	c7 := resource.Config{Name: "c7", DependsOn: []string{"c6", "c4"}}
-	components := config.Config{
-		Components: []resource.Config{c7, c6, c5, c3, c4, c1, c2},
-	}
-	err = components.Ensure(false, logger)
-	test.That(t, err, test.ShouldBeNil)
-
-	invalidProcesses := config.Config{
-		Processes: []pexec.ProcessConfig{{}},
-	}
-	err = invalidProcesses.Ensure(false, logger)
-	test.That(t, err, test.ShouldBeNil)
-	invalidProcesses.Processes[0].Name = "foo"
-	test.That(t, invalidProcesses.Ensure(false, logger), test.ShouldBeNil)
-
-	logs.TakeAll() // clear logs
-	cloudErr := "bad cloud err doing validation"
-	invalidModules := config.Config{
-		Modules: []config.Module{{
-			Name:        "testmodErr",
-			ExePath:     ".",
-			LogLevel:    "debug",
-			Type:        config.ModuleTypeRegistry,
-			ModuleID:    "mod:testmodErr",
-			Environment: map[string]string{},
-			Status: &config.AppValidationStatus{
-				Error: cloudErr,
-			},
-		}},
-	}
-	err = invalidModules.Ensure(false, logger)
-	test.That(t, err, test.ShouldBeNil)
-	// Assert that some error log was output containing "Module config error".
-	cloudErrLogs := logs.FilterMessageSnippet("Module config error")
-	test.That(t, cloudErrLogs.Len(), test.ShouldEqual, 1)
-	test.That(t, cloudErrLogs.All()[0].Level, test.ShouldEqual, zapcore.ErrorLevel)
-
-	err = invalidModules.Ensure(false, logger)
-	test.That(t, err, test.ShouldBeNil)
-
-	logs.TakeAll() // clear logs
-	invalidPackages := config.Config{
-		Packages: []config.PackageConfig{{
-			Name:    "testPackage",
-			Type:    config.PackageTypeMlModel,
-			Package: "hi/package/test",
-			Status: &config.AppValidationStatus{
-				Error: cloudErr,
-			},
-		}},
-	}
-
-	err = invalidPackages.Ensure(false, logger)
-	test.That(t, err, test.ShouldBeNil)
-	// Assert that some error log was output containing "Package config error".
-	cloudErrLogs = logs.FilterMessageSnippet("Package config error")
-	test.That(t, cloudErrLogs.Len(), test.ShouldEqual, 1)
-	test.That(t, cloudErrLogs.All()[0].Level, test.ShouldEqual, zapcore.ErrorLevel)
-
-	err = invalidPackages.Ensure(false, logger)
-	test.That(t, err, test.ShouldBeNil)
-
-	invalidNetwork := config.Config{
-		Network: config.NetworkConfig{
-			NetworkConfigData: config.NetworkConfigData{
-				TLSCertFile: "hey",
-			},
-		},
-	}
-	err = invalidNetwork.Ensure(false, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `network`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `both tls`)
-
-	invalidNetwork.Network.TLSCertFile = ""
-	invalidNetwork.Network.TLSKeyFile = "hey"
-	err = invalidNetwork.Ensure(false, logger)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `network`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, `both tls`)
-
-	invalidNetwork.Network.TLSCertFile = "dude"
-	test.That(t, invalidNetwork.Ensure(false, logger), test.ShouldBeNil)
-
-	invalidNetwork.Network.TLSCertFile = ""
-	invalidNetwork.Network.TLSKeyFile = ""
 	test.That(t, invalidNetwork.Ensure(false, logger), test.ShouldBeNil)
 
 	invalidNetwork.Network.BindAddress = "woop"

--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -671,12 +671,6 @@ func TestDiffSanitize(t *testing.T) {
 }
 
 func modifiedConfigDiffValidate(c *config.ModifiedConfigDiff) error {
-	for idx := 0; idx < len(c.Remotes); idx++ {
-		if _, _, err := c.Remotes[idx].Validate(fmt.Sprintf("%s.%d", "remotes", idx)); err != nil {
-			return err
-		}
-	}
-
 	for idx := 0; idx < len(c.Components); idx++ {
 		requiredDeps, optionalDeps, err := c.Components[idx].Validate(fmt.Sprintf("%s.%d", "components", idx), resource.APITypeComponentName)
 		if err != nil {
@@ -686,12 +680,6 @@ func modifiedConfigDiffValidate(c *config.ModifiedConfigDiff) error {
 		c.Components[idx].ImplicitOptionalDependsOn = optionalDeps
 	}
 
-	for idx := 0; idx < len(c.Processes); idx++ {
-		if err := c.Processes[idx].Validate(fmt.Sprintf("%s.%d", "processes", idx)); err != nil {
-			return err
-		}
-	}
-
 	for idx := 0; idx < len(c.Services); idx++ {
 		requiredDeps, optionalDeps, err := c.Services[idx].Validate(fmt.Sprintf("%s.%d", "services", idx), resource.APITypeServiceName)
 		if err != nil {
@@ -699,18 +687,6 @@ func modifiedConfigDiffValidate(c *config.ModifiedConfigDiff) error {
 		}
 		c.Services[idx].ImplicitDependsOn = requiredDeps
 		c.Services[idx].ImplicitOptionalDependsOn = optionalDeps
-	}
-
-	for idx := 0; idx < len(c.Packages); idx++ {
-		if err := c.Packages[idx].Validate(fmt.Sprintf("%s.%d", "packages", idx)); err != nil {
-			return err
-		}
-	}
-
-	for idx := 0; idx < len(c.Modules); idx++ {
-		if err := c.Modules[idx].Validate(fmt.Sprintf("%s.%d", "modules", idx)); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -254,7 +254,7 @@ func (mgr *Manager) Add(ctx context.Context, confs ...config.Module) error {
 		}
 		seen[conf.Name] = struct{}{}
 
-		// The config was already validated, but we must check again before attempting to add.
+		// Validate module configs before attempting to add.
 		if err := conf.Validate(""); err != nil {
 			mgr.logger.CErrorw(ctx, "Module config validation error; skipping", "module", conf.Name, "error", err)
 			mgr.AddToFailedModules(conf.Name)

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -913,8 +913,7 @@ func (manager *resourceManager) completeConfigForRemotes(ctx context.Context, lr
 						manager.logger, fromRemoteNameToRemoteNodeName(remConf.Name).String(),
 					)
 				}
-				// The config was already validated, but we must check again before attempting
-				// to add.
+				// Validate the remote config
 				if _, _, err := remConf.Validate(""); err != nil {
 					gNode.LogAndSetLastError(
 						fmt.Errorf("remote config validation error: %w", err), "remote", remConf.Name)


### PR DESCRIPTION
we used to remove the component from the list of resources entirely, but now that we don't do that, the logs are extraneous and confusing - I believe the current set of logs when reconfiguring is sufficient without these logs
```
2026-04-21T22:01:04.697Z        INFO    rdk.resource_manager    impl/resource_manager.go:780    Now reconfiguring resource      {"resource":"rdk:component:camera/camera-1","model":"rdk:builtin:fake"}
2026-04-21T22:01:04.697Z        ERROR   rdk.resource_manager.rdk:component:camera/camera-1      resource/graph_node.go:316      resource config validation error: maximum supported pixel height or width for fake cameras is 10000 pixels      {"resource":"rdk:component:camera/camera-1","model":"rdk:builtin:fake"}
```