### PR TITLE
Add missing Status() to Go module generator template

### DIFF
--- a/cli/module_generate/_templates/go/tmpl-module.go
+++ b/cli/module_generate/_templates/go/tmpl-module.go
@@ -89,6 +89,10 @@ func (s *{{.ModuleCamel}}{{.ModelPascal}}) Name() resource.Name {
 	return s.name
 }
 
+func (s *{{.ModuleCamel}}{{.ModelPascal}}) Status(ctx context.Context) (map[string]interface{}, error) {
+	return map[string]interface{}{}, nil
+}
+
 func (s *{{.ModuleCamel}}{{.ModelPascal}}) Close(context.Context) error {
 	// Put close code here
 	s.cancelFunc()


### PR DESCRIPTION
## Summary
- The `resource.Resource` interface now requires a `Status()` method
- The Go module generator template (`cli/module_generate/_templates/go/tmpl-module.go`) was missing this method
- Without it, any newly generated Go module fails to compile against the latest rdk

## Test plan
- [x] `go build ./cli/...` passes
- [ ] Generate a new Go module with `viam module generate` and verify it compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)