### PR TITLE
RSDK-13820: Use an atomic pointer for resource RPC APIs in robot client

### DIFF
--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -86,9 +86,16 @@ type RobotClient struct {
 	address     string
 	dialOptions []rpc.DialOption
 
+	// resourceRPCAPIs is guarded behind an atomic pointer instead of mu. This is because
+	// safety-monitoring logic in viam-server needs to access this field for remote clients
+	// on every incoming gRPC request. We do not want to wait for background work like
+	// Refresh (which holds mu) to complete before accessing this field. The field is
+	// unlikely to change during the lifetime of a client, so getting an outdated value here
+	// is completely acceptable.
+	resourceRPCAPIs atomic.Pointer[[]resource.RPCAPI]
+
 	mu                       sync.RWMutex
 	resourceNames            []resource.Name
-	resourceRPCAPIs          atomic.Pointer[[]resource.RPCAPI]
 	resourceClients          map[resource.Name]resource.Resource
 	remoteNameMap            map[resource.Name]resource.Name
 	changeChan               chan bool

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -962,16 +962,7 @@ func (rc *RobotClient) ResourceRPCAPIs() []resource.RPCAPI {
 	if resourceRPCAPIs == nil {
 		return nil
 	}
-
-	apis := make([]resource.RPCAPI, 0, len(*resourceRPCAPIs))
-	for _, v := range *resourceRPCAPIs {
-		vCopy := v
-		apis = append(
-			apis,
-			vCopy,
-		)
-	}
-	return apis
+	return *resourceRPCAPIs
 }
 
 // Logger returns the logger being used for this robot.

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -88,7 +88,7 @@ type RobotClient struct {
 
 	mu                       sync.RWMutex
 	resourceNames            []resource.Name
-	resourceRPCAPIs          []resource.RPCAPI
+	resourceRPCAPIs          atomic.Pointer[[]resource.RPCAPI]
 	resourceClients          map[resource.Name]resource.Resource
 	remoteNameMap            map[resource.Name]resource.Name
 	changeChan               chan bool
@@ -880,7 +880,7 @@ func (rc *RobotClient) updateResources(ctx context.Context) error {
 
 	rc.resourceNames = make([]resource.Name, 0, len(names))
 	rc.resourceNames = append(rc.resourceNames, names...)
-	rc.resourceRPCAPIs = rpcAPIs
+	rc.resourceRPCAPIs.Store(&rpcAPIs)
 
 	rc.updateRemoteNameMap()
 
@@ -950,10 +950,14 @@ func (rc *RobotClient) ResourceRPCAPIs() []resource.RPCAPI {
 		rc.Logger().Errorw("failed to get remote resource types", "error", err)
 		return nil
 	}
-	rc.mu.RLock()
-	defer rc.mu.RUnlock()
-	apis := make([]resource.RPCAPI, 0, len(rc.resourceRPCAPIs))
-	for _, v := range rc.resourceRPCAPIs {
+
+	resourceRPCAPIs := rc.resourceRPCAPIs.Load()
+	if resourceRPCAPIs == nil {
+		return nil
+	}
+
+	apis := make([]resource.RPCAPI, 0, len(*resourceRPCAPIs))
+	for _, v := range *resourceRPCAPIs {
 		vCopy := v
 		apis = append(
 			apis,


### PR DESCRIPTION
RSDK-13820

## What

Guards `RobotClient.resourceRPCAPIs` behind an `atomic.Pointer` instead of the existing `sync.RWMutex`.

## Why

We need to access all remotes' RPC methods on every incoming gRPC request, but those values are guarded behind mutexes that are locked for non-trivial amounts of time when we `Refresh` the clients every 10s. Waiting on the mutexes can cause small gRPC request hangs every 10s when remotes are in the config.

## Testing

Verified that previously-seen hangs in spammed gRPC requests are no longer present with this diff (+ changes from [this other PR](https://github.com/viamrobotics/rdk/pull/5959)).