### PR TITLE
Rebuild flattened-model schemas on FrameSystem.UnmarshalJSON

### DIFF
--- a/referenceframe/frame_system.go
+++ b/referenceframe/frame_system.go
@@ -803,7 +803,71 @@ func (sfs *FrameSystem) UnmarshalJSON(data []byte) error {
 	if sfs.componentSchemas == nil {
 		sfs.componentSchemas = map[string]*LinearInputsSchema{}
 	}
+	if sfs.mimicFrames == nil {
+		sfs.mimicFrames = map[string]*mimicInfo{}
+	}
+	sfs.rebuildFlattenedSchemas()
 	return nil
+}
+
+// rebuildFlattenedSchemas reconstructs the flattenedModels, componentSchemas, and
+// mimicFrames lookup tables from the current set of frames. These maps are populated
+// during FrameSystem construction by flattenModelIntoFS but are not part of the JSON
+// on-disk format, so they must be rebuilt after UnmarshalJSON. Without this, lookups
+// like resolveFrameInputs cannot map a component's flat input vector (keyed by
+// "arm1") onto its flattened per-joint frames ("arm1:joint1"), and any Transform
+// involving those joints fails with an incorrect-DoF error.
+//
+// A SimpleModel present in fs.frames is only treated as flattened when its namespaced
+// sub-frames ("<component>:<internal>") are also present in fs.frames; a model added
+// directly via AddFrame is not flattened and must be left alone.
+func (sfs *FrameSystem) rebuildFlattenedSchemas() {
+	for componentName, frame := range sfs.frames {
+		// The umbrella component frame may be stored bare or wrapped in a namedFrame.
+		inner := frame
+		if nf, ok := frame.(*namedFrame); ok {
+			inner = nf.Frame
+		}
+		sm, ok := inner.(*SimpleModel)
+		if !ok || len(sm.DoF()) == 0 || sm.inputSchema == nil {
+			continue
+		}
+
+		// Only treat this as a flattened component if the namespaced sub-frames are
+		// actually present in the outer frame system.
+		flattened := true
+		for _, meta := range sm.inputSchema.metas {
+			if _, exists := sfs.frames[componentName+":"+meta.frameName]; !exists {
+				flattened = false
+				break
+			}
+		}
+		if !flattened {
+			continue
+		}
+
+		sfs.flattenedModels[componentName] = sm
+
+		for internalName, mm := range sm.mimicMappings {
+			sfs.mimicFrames[componentName+":"+internalName] = &mimicInfo{
+				sourceFrameName: componentName + ":" + mm.sourceFrameName,
+				multiplier:      mm.valueMultiplier,
+				offset:          mm.valueOffset,
+			}
+		}
+
+		namespacedMetas := make([]linearInputMeta, 0, len(sm.inputSchema.metas))
+		for _, meta := range sm.inputSchema.metas {
+			namespaced := componentName + ":" + meta.frameName
+			namespacedMetas = append(namespacedMetas, linearInputMeta{
+				frameName: namespaced,
+				offset:    meta.offset,
+				dof:       meta.dof,
+				frame:     sfs.Frame(namespaced),
+			})
+		}
+		sfs.componentSchemas[componentName] = &LinearInputsSchema{metas: namespacedMetas}
+	}
 }
 
 // NewZeroInputs returns a zeroed FrameSystemInputs ensuring all frames have inputs.

--- a/referenceframe/frame_system_flatten_test.go
+++ b/referenceframe/frame_system_flatten_test.go
@@ -1,6 +1,7 @@
 package referenceframe
 
 import (
+	"encoding/json"
 	"math"
 	"testing"
 
@@ -197,4 +198,50 @@ func TestFlattenComponentLevelTransform(t *testing.T) {
 	expectedPose, err := model.Transform([]Input{math.Pi / 4})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, spatial.PoseAlmostCoincident(resultArm.(*PoseInFrame).Pose(), expectedPose), test.ShouldBeTrue)
+}
+
+// Regression test: a FrameSystem containing a flattened multi-DoF model must round-trip through
+// JSON while preserving the component-level input resolution. Before the fix, UnmarshalJSON left
+// componentSchemas empty, so resolveFrameInputs could not map the "arm1" 1-slot input onto its
+// flattened "arm1:shoulder_pan_joint" sub-frame, and Transform failed with an incorrect-DoF error.
+func TestFlattenedFrameSystemJSONRoundTrip(t *testing.T) {
+	model, err := ParseModelJSONFile(utils.ResolveFile("components/arm/fake/kinematics/fake.json"), "")
+	test.That(t, err, test.ShouldBeNil)
+
+	lif := NewLinkInFrame(World, spatial.NewZeroPose(), "arm1", nil)
+	cameraLif := NewLinkInFrame("arm1:base_link", spatial.NewZeroPose(), "camera", nil)
+	parts := []*FrameSystemPart{{FrameConfig: lif, ModelFrame: model}}
+	fs, err := NewFrameSystem("test", parts, []*LinkInFrame{cameraLif})
+	test.That(t, err, test.ShouldBeNil)
+
+	data, err := json.Marshal(fs)
+	test.That(t, err, test.ShouldBeNil)
+
+	var fs2 FrameSystem
+	test.That(t, json.Unmarshal(data, &fs2), test.ShouldBeNil)
+
+	// Component-level input drives the flattened joint on the restored FS.
+	inputs := []Input{math.Pi / 4}
+	li := NewZeroLinearInputs(&fs2)
+	li.Put("arm1", inputs)
+
+	// Walking from camera to world goes through arm1:base_link → arm1:shoulder_pan_joint → ...,
+	// which is exactly the path that previously failed because resolveFrameInputs returned nil.
+	result, err := fs2.Transform(li, NewPoseInFrame("camera", spatial.NewZeroPose()), World)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Original FS with the same inputs should match.
+	liOrig := NewZeroLinearInputs(fs)
+	liOrig.Put("arm1", inputs)
+	expected, err := fs.Transform(liOrig, NewPoseInFrame("camera", spatial.NewZeroPose()), World)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, spatial.PoseAlmostCoincident(
+		result.(*PoseInFrame).Pose(),
+		expected.(*PoseInFrame).Pose(),
+	), test.ShouldBeTrue)
+
+	// ComputePoses exercises the same path used by motion-planning's validatePlanRequest.
+	structured := FrameSystemInputs{"arm1": inputs}
+	_, err = structured.ComputePoses(&fs2)
+	test.That(t, err, test.ShouldBeNil)
 }


### PR DESCRIPTION
## Summary

A `FrameSystem` round-tripped through JSON lost the derived lookup tables (`componentSchemas`, `flattenedModels`, `mimicFrames`) that map a component's flat input vector onto its flattened per-joint sub-frames. After `UnmarshalJSON`, any `Transform` that reached a namespaced sub-frame (e.g. `arm1:joint_1`) would fall through `resolveFrameInputs`, find no schema, and panic with `NewIncorrectDoFError(0, 1)` — so every serialized `PlanRequest` with a multi-DoF arm panicked inside `validatePlanRequest` before planning could start.

Repro: `go run motionplan/armplanning/cmd-plan/cmd-plan.go -v <any PlanRequest JSON with a 6-DoF arm>` → `panic: array length does not match frame DoF, expected 1 but got 0`.

## Changes

- **referenceframe/frame_system.go**: `UnmarshalJSON` now initializes `mimicFrames` (was left nil) and calls a new `rebuildFlattenedSchemas()` pass. The helper walks restored frames, unwraps `*namedFrame` wrappers, and for each `*SimpleModel` with DoF > 0 repopulates `flattenedModels` / `componentSchemas` / `mimicFrames` from the inner model's already-restored `inputSchema` and `mimicMappings`. Guarded on the namespaced sub-frames actually being present in `fs.frames`, so models attached directly via `AddFrame` (which `flattenModelIntoFS` never touched) are left alone — this preserves `TestSerialization`'s behavior where `FrameNames()` would otherwise try to subtract sub-frames that don't exist.

## Testing

- Added `TestFlattenedFrameSystemJSONRoundTrip` in `referenceframe/frame_system_flatten_test.go`: builds a `NewFrameSystem` with a real flattened arm + child frame, round-trips through JSON, then drives `Transform` (camera → world) and `ComputePoses` with component-level inputs. Both paths panicked before the fix and pass after. Also compares the post-unmarshal transform against the original FS to catch silent divergence.
- Full `./referenceframe/...` and `./motionplan/...` suites pass locally (two referenceframe tests — `TestUR20URDFWithMeshes`, `TestMeshGeometrySerialization` — failed on artifact-fetch auth and are unrelated).
- Verified the original motivating repro: the panic is gone and `PlanMotion` now runs through, surfacing the actual content-level IK/collision result for the input file.

## Claude Code Prompts Used

- "Hi Claude I am hitting an issue with the following command, can you trace down what is going on? \`go run motionplan/armplanning/cmd-plan/cmd-plan.go -v erroring_file_missing_dof.json\`"
- "option 1" (in response to the diagnostic-path choice — capture the full error stack via a one-line edit in cmd-plan.go)
- "Let's go with option 1" (in response to the fix-design choice — rebuild the schemas on unmarshal rather than serialize them explicitly)
- "yes open a draft pr"