### PR TITLE
RSDK-13823 Fix incorrect max capture file size

### DIFF
--- a/services/datamanager/builtin/capture/capture.go
+++ b/services/datamanager/builtin/capture/capture.go
@@ -60,7 +60,7 @@ type Capture struct {
 	collectors   collectors
 	// captureDir is only stored on Capture so that we can detect when it changs
 	captureDir string
-	// maxCaptureFileSize is only stored on Capture so that we can detect when it changs
+	// maxCaptureFileSize is only stored on Capture so that we can detect when it changes
 	maxCaptureFileSize int64
 	mongoMU            sync.Mutex
 	mongo              captureMongo
@@ -309,7 +309,7 @@ func (c *Capture) initializeOrUpdateCollector(
 		}
 	}
 
-	return c.buildCollector(res, md, collectorConfig, c.maxCaptureFileSize, collection)
+	return c.buildCollector(res, md, collectorConfig, config.MaximumCaptureFileSizeBytes, collection)
 }
 
 // buildCollector constructs and starts a new collector, assuming the base config was already validated.

--- a/services/datamanager/builtin/capture/capture_control_test.go
+++ b/services/datamanager/builtin/capture/capture_control_test.go
@@ -2,11 +2,14 @@ package capture
 
 import (
 	"context"
+	"os"
 	"sync"
 	"testing"
 
 	"github.com/benbjohnson/clock"
+	v1 "go.viam.com/api/app/datasync/v1"
 	"go.viam.com/test"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/logging"
@@ -151,6 +154,77 @@ func TestSetCaptureConfig(t *testing.T) {
 			if tc.expectedNewTags != nil {
 				test.That(t, c.collectors[fakeMD].Config.Tags, test.ShouldResemble, tc.expectedNewTags)
 			}
+		})
+	}
+}
+
+var (
+	registerFileSizeCollectorOnce sync.Once
+	fileSizeCollectorTarget       data.CaptureBufferedWriter
+)
+
+// TestMaxCaptureFileSize verifies that the MaximumCaptureFileSizeBytes config is correctly
+// passed to the collector's capture buffer, and that changing it triggers a collector rebuild.
+func TestMaxCaptureFileSize(t *testing.T) {
+	const method = "GetFileSizeTestReadings"
+	registerFileSizeCollectorOnce.Do(func() {
+		data.RegisterCollector(
+			data.MethodMetadata{API: fakeAPI, MethodName: method},
+			func(_ interface{}, params data.CollectorParams) (data.Collector, error) {
+				fileSizeCollectorTarget = params.Target
+				return &mockCollector{}, nil
+			},
+		)
+	})
+
+	for _, tc := range []struct {
+		name           string
+		maxSizeChanges []int64 // MaximumCaptureFileSizeBytes for each successive Reconfigure call
+		expectedFiles  int
+	}{
+		{
+			name:           "configured max file size batches multiple readings into one file",
+			maxSizeChanges: []int64{256 * 1024},
+			expectedFiles:  1,
+		},
+		{
+			name:           "changing max file size to 1 rebuilds collector and generates one file per reading",
+			maxSizeChanges: []int64{256 * 1024, 1},
+			expectedFiles:  3,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			captureDir := t.TempDir()
+			fakeCfg := datamanager.DataCaptureConfig{
+				Name:               resource.NewName(fakeAPI, "fake-1"),
+				Method:             method,
+				CaptureFrequencyHz: 1.0,
+				CaptureDirectory:   captureDir,
+			}
+			c := &Capture{
+				logger:     logging.NewTestLogger(t),
+				clk:        clock.New(),
+				collectors: make(collectors),
+			}
+
+			for _, maxSize := range tc.maxSizeChanges {
+				c.Reconfigure(context.Background(),
+					CollectorConfigsByResource{fakeRes: []datamanager.DataCaptureConfig{fakeCfg}},
+					Config{MaximumCaptureFileSizeBytes: maxSize, CaptureDir: captureDir},
+				)
+			}
+
+			tabularReading := &v1.SensorData{
+				Metadata: &v1.SensorMetadata{},
+				Data:     &v1.SensorData_Struct{Struct: &structpb.Struct{}},
+			}
+			for range 3 {
+				test.That(t, fileSizeCollectorTarget.WriteTabular(tabularReading), test.ShouldBeNil)
+			}
+
+			entries, err := os.ReadDir(fileSizeCollectorTarget.Path())
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, len(entries), test.ShouldEqual, tc.expectedFiles)
 		})
 	}
 }

--- a/services/datamanager/builtin/config.go
+++ b/services/datamanager/builtin/config.go
@@ -124,6 +124,8 @@ func (c *Config) captureConfig(logger logging.Logger) capture.Config {
 	if c.MaximumCaptureFileSizeBytes != 0 {
 		maximumCaptureFileSizeBytes = c.MaximumCaptureFileSizeBytes
 	}
+	c.MaximumCaptureFileSizeBytes = maximumCaptureFileSizeBytes
+
 	return capture.Config{
 		CaptureDisabled:             c.CaptureDisabled,
 		CaptureDir:                  c.getCaptureDir(logger),


### PR DESCRIPTION
## Summary

On first startup, `c.maxCaptureFileSize` on the `Capture` struct is `0` (Go zero value) because it is assigned from the incoming config *after* `newCollectors` is called. This meant every new collector was initialized with a `CaptureBuffer` with `maxCaptureFileSize=0`.

If a machine gets into a state where reconfigure is not called again, `WriteTabular` rotates to a new file on every single write — since any `Size() > 0` after the metadata header is written — producing one capture file per reading instead of batching up to the configured 256KB limit. This can cause a large accumulation of tiny files, which compounds with the data manager's directory-walking logic (disk summary, file deletion, sync scheduling) to progressively degrade performance on resource-constrained devices.

On subsequent reconfigures, `c.maxCaptureFileSize` holds the value from the *previous* reconfigure. This is intentional — it serves as a change-detection sentinel — but was also being incorrectly used to initialize new collectors, meaning a collector rebuilt due to a file size config change would receive the old value rather than the new one.

### Changes

**`capture.go`** — the actual bug fix: `initializeOrUpdateCollector` now passes `config.MaximumCaptureFileSizeBytes` directly to `buildCollector` instead of `c.maxCaptureFileSize`. `c.maxCaptureFileSize` is intentionally kept at the previous value during `newCollectors` so that change detection (`c.maxCaptureFileSize != config.MaximumCaptureFileSizeBytes`) works correctly on subsequent reconfigures. Using it as the value for new collectors was the bug.

**`config.go`** — consistency fix: `captureConfig` now writes the resolved `MaximumCaptureFileSizeBytes` (with default applied) back to `c`, consistent with the pattern used throughout `syncConfig` for all other fields.

## Testing

Wrote `TestMaxCaptureFileSize` in `capture_control_test.go`, which registers a collector constructor that captures the `CaptureBufferedWriter` passed to it, then calls `Reconfigure` with various `MaximumCaptureFileSizeBytes` values and writes 3 tabular readings to the resulting buffer, asserting on the number of files created.

- **Configured max file size (256KB)**: 3 readings produce 1 file, confirming the buffer was initialized with the correct value
- **Changing max file size from 256KB to 1**: collector is rebuilt and 3 readings produce 3 files (one per reading), confirming both change detection and the new buffer size are correct

Also confirmed via the collector initialization log line: `MaximumCaptureFileSize: 0 Bytes` before the fix, `MaximumCaptureFileSize: 256.00 KB` after.

**Manual testing**
Wasn't able to reproduce a state where max size remains at 0 (seems like under normal conditions, a second reconfigure gets called, replacing the 0 value with the default). **However**, I was able to confirm that we are one step behind when updating the max if we have it set in the data manager config, and this update fixes that.
