### PR TITLE
fix: scope Dependabot pip ecosystem and exclude module-generator templates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,18 @@ updates:
       - joncha1
       - 10zingpd
       - IanWhalen
+  - package-ecosystem: "pip"
+    directory: "/cli"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
+    exclude-paths:
+      - "module_generate/_templates/**"
+    assignees:
+      - joncha1
+      - 10zingpd
+      - IanWhalen

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,14 +39,8 @@ updates:
     directory: "/cli"
     schedule:
       interval: "daily"
-    allow:
-      - dependency-type: "all"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
     exclude-paths:
       - "module_generate/_templates/**"
-    assignees:
-      - joncha1
-      - 10zingpd
-      - IanWhalen


### PR DESCRIPTION
The dynamic dependency graph workflow was failing on update-pip-graph because Dependabot's pip resolver auto-discovered
cli/module_generate/_templates/python/tmpl-requirements.txt — a Go text/template, not valid pip syntax — and rejected it as unexpected_external_code.

Scope pip to /cli with exclude-paths for the templates directory so the resolver skips the template file. Mirrors the existing gomod and github-actions blocks (ignore all semver updates, same assignees) so this does not start opening pip update PRs.

The Dep worflow has been failing for a while 
https://github.com/viamrobotics/rdk/actions/workflows/dependabot/update-graph. 

I can't actually test the fix without merging to main. If this doesn't work, i'll revert and change the template filename but that requires a few more changes so trying to avoid if possible.