### PR TITLE
Add env var to disable writing to Windows Event Logger

### DIFF
--- a/utils/env.go
+++ b/utils/env.go
@@ -102,6 +102,9 @@ const (
 	// ViamModuleAddress is used to pass the address a module should listen on to
 	// the module process.
 	ViamModuleAddress = "VIAM_MODULE_ADDRESS"
+
+	// ViamNoWindowsEventLoggerEnvVar if set will not write logs to the Windows Event Logger.
+	ViamNoWindowsEventLoggerEnvVar = "VIAM_NO_WINDOWS_EVENT_LOGGER"
 )
 
 // EnvTrueValues contains strings that we interpret as boolean true in env vars.

--- a/utils/env.go
+++ b/utils/env.go
@@ -105,6 +105,9 @@ const (
 
 	// ViamNoWindowsEventLoggerEnvVar if set will not write logs to the Windows Event Logger.
 	ViamNoWindowsEventLoggerEnvVar = "VIAM_NO_WINDOWS_EVENT_LOGGER"
+
+	// ViamLogFileEnvVar if set will write logs to the specified file (same as -log-file cli argument).
+	ViamLogFileEnvVar = "VIAM_LOGFILE"
 )
 
 // EnvTrueValues contains strings that we interpret as boolean true in env vars.

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -138,7 +138,9 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 		registry.AddAppenderToAll(logging.NewStdoutAppender())
 	}
 
-	logging.RegisterEventLogger(rootLogger, "viam-server")
+	if os.Getenv(rutils.ViamNoWindowsEventLoggerEnvVar) == "" {
+		logging.RegisterEventLogger(rootLogger, "viam-server")
+	}
 	config.InitLoggingSettings(rootLogger, configLogger, argsParsed.Debug)
 
 	if argsParsed.Version {

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -128,8 +128,9 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 	configLogger := rootLogger.Sublogger("config")
 	networkingLogger := rootLogger.Sublogger("networking")
 
-	if argsParsed.OutputLogFile != "" {
-		logWriter, closer := logging.NewFileAppender(argsParsed.OutputLogFile)
+	logFilePath := cmp.Or(argsParsed.OutputLogFile, os.Getenv(rutils.ViamLogFileEnvVar))
+	if logFilePath != "" {
+		logWriter, closer := logging.NewFileAppender(logFilePath)
 		defer func() {
 			utils.UncheckedError(closer.Close())
 		}()


### PR DESCRIPTION
For persistent logs without Windows Event Logger, we can update Agent to be able to pass cli args to RDK, and use `-log-file D:\\rdk.log`.