### PR TITLE
RSDK-13842: Use a valid context for calling `Stop`.

### DIFF
--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -691,9 +691,8 @@ func (ms *builtIn) execute(ctx context.Context, trajectory motionplan.Trajectory
 			if err := ie.GoToInputs(ctx, inputs...); err != nil {
 				// If there is an error on GoToInputs, stop the component if possible before returning the error
 				if actuator, ok := r.(inputEnabledActuator); ok {
-					if stopErr := actuator.Stop(ctx, nil); stopErr != nil {
-						return errors.Wrap(err, stopErr.Error())
-					}
+					//nolint:errcheck
+					_ = actuator.Stop(context.WithoutCancel(ctx), nil)
 				}
 				return err
 			}


### PR DESCRIPTION
No observed bug here. I was just asked about a formal way to stop an existing motion service request. "Canceling the context" seemed to be one of the simplest right answers. When analyzing whether we obeyed that, this was the only thing that looked suspicious.