### PR TITLE
Move SharesRigidMotion to FrameSystem and walk raw parents

### DIFF
--- a/motionplan/collision.go
+++ b/motionplan/collision.go
@@ -207,21 +207,6 @@ func createUniqueCollisionMap(geoms []spatialmath.Geometry) (map[string]spatialm
 	return geomMap, nil
 }
 
-func firstMovingParentOrself(fs *referenceframe.FrameSystem, f referenceframe.Frame) referenceframe.Frame {
-	var err error
-	for f != fs.World() {
-		if len(f.DoF()) > 0 {
-			return f
-		}
-
-		f, err = fs.Parent(f)
-		if err != nil {
-			panic(err) // should be impossible
-		}
-	}
-	return f
-}
-
 func skipCollisionCheck(ignoreList map[string]map[string]bool, xName, yName string) bool {
 	// Skip comparing a geometry to itself
 	if xName == yName {

--- a/motionplan/constraint_checker.go
+++ b/motionplan/constraint_checker.go
@@ -543,10 +543,7 @@ func findCoparentedStaticFrames(fs *referenceframe.FrameSystem, group1, group2 [
 				continue
 			}
 
-			xFirstMoving := firstMovingParentOrself(fs, x)
-			yFirstMoving := firstMovingParentOrself(fs, y)
-
-			if xFirstMoving == yFirstMoving {
+			if fs.SharesRigidMotion(x, y) {
 				skipList = append(skipList, Collision{name1: g1Name, name2: g2Name})
 			}
 		}

--- a/referenceframe/frame_system.go
+++ b/referenceframe/frame_system.go
@@ -225,6 +225,37 @@ func (sfs *FrameSystem) Parent(frame Frame) (Frame, error) {
 	return sfs.Frame(parentName), nil
 }
 
+// SharesRigidMotion reports whether f1 and f2 always move together i.e. their
+// poses relative to each other never change with inputs. Two frames share rigid
+// motion when the closest moving frame above each in the raw kinematic chain
+// is the same. For flattened-model components this is computed at the joint
+// level, so two static links driven by different joints of the same component
+// correctly report false.
+func (sfs *FrameSystem) SharesRigidMotion(f1, f2 Frame) bool {
+	return sfs.firstMovingAncestor(f1) == sfs.firstMovingAncestor(f2)
+}
+
+// firstMovingAncestor walks the raw kinematic chain from frame toward world and
+// returns the first frame (frame itself, an intermediate ancestor, or world)
+// whose pose varies with inputs. The walk uses raw parents so flattened-model
+// internal joints are surfaced rather than masked behind the SimpleModel.
+func (sfs *FrameSystem) firstMovingAncestor(frame Frame) Frame {
+	for frame != sfs.world {
+		if len(frame.DoF()) > 0 {
+			return frame
+		}
+		parentName, exists := sfs.parents[frame.Name()]
+		if !exists {
+			return sfs.world
+		}
+		frame = sfs.Frame(parentName)
+		if frame == nil {
+			return sfs.world
+		}
+	}
+	return frame
+}
+
 // frameExists is a helper function to see if a frame with a given name already exists in the system.
 func (sfs *FrameSystem) frameExists(name string) bool {
 	_, ok := sfs.frames[name]

--- a/referenceframe/frame_system_flatten_test.go
+++ b/referenceframe/frame_system_flatten_test.go
@@ -198,3 +198,34 @@ func TestFlattenComponentLevelTransform(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, spatial.PoseAlmostCoincident(resultArm.(*PoseInFrame).Pose(), expectedPose), test.ShouldBeTrue)
 }
+
+// TestSharesRigidMotionAcrossInternalJoints verifies that two externals
+// parented to different moving internal joints of the same flattened component
+// correctly report NOT sharing rigid motion. The walk must use raw parents so
+// flattened internals are surfaced rather than masked behind the SimpleModel.
+func TestSharesRigidMotionAcrossInternalJoints(t *testing.T) {
+	model, err := ParseModelJSONFile(utils.ResolveFile("referenceframe/testfiles/test_mimic_gripper.json"), "")
+	test.That(t, err, test.ShouldBeNil)
+
+	gripperLif := NewLinkInFrame(World, spatial.NewZeroPose(), "gripper1", nil)
+	leftAttachLif := NewLinkInFrame("gripper1:left_joint", spatial.NewZeroPose(), "left_attach", nil)
+	rightAttachLif := NewLinkInFrame("gripper1:right_joint", spatial.NewZeroPose(), "right_attach", nil)
+	leftAttach2Lif := NewLinkInFrame("gripper1:left_joint", spatial.NewZeroPose(), "left_attach2", nil)
+
+	parts := []*FrameSystemPart{{FrameConfig: gripperLif, ModelFrame: model}}
+	fs, err := NewFrameSystem("test", parts, []*LinkInFrame{leftAttachLif, rightAttachLif, leftAttach2Lif})
+	test.That(t, err, test.ShouldBeNil)
+
+	leftAttach := fs.Frame("left_attach")
+	rightAttach := fs.Frame("right_attach")
+	leftAttach2 := fs.Frame("left_attach2")
+	test.That(t, leftAttach, test.ShouldNotBeNil)
+	test.That(t, rightAttach, test.ShouldNotBeNil)
+	test.That(t, leftAttach2, test.ShouldNotBeNil)
+
+	// Externals on different internal joints of the same component must NOT share rigid motion.
+	test.That(t, fs.SharesRigidMotion(leftAttach, rightAttach), test.ShouldBeFalse)
+
+	// Externals on the same internal joint DO share rigid motion.
+	test.That(t, fs.SharesRigidMotion(leftAttach, leftAttach2), test.ShouldBeTrue)
+}


### PR DESCRIPTION
motionplan's firstMovingParentOrself walked via fs.Parent, which masks internal flattened-model frames behind the owning SimpleModel. Two static externals attached to different internal joints of the same SimpleModel both resolved to that SimpleModel and were incorrectly skipped by findCoparentedStaticFrames as sharing rigid motion.

Introduce FrameSystem.SharesRigidMotion (and the underlying firstMovingAncestor) which walks the raw parent map, surfacing internal joints rather than masking them. Replace motionplan's local helper with fs.SharesRigidMotion. Add a test covering both same-joint and different-joint cases on a flattened gripper model.