### PR TITLE
RSDK-13850 Fix very low capture rate

### DIFF
--- a/data/helpers_test.go
+++ b/data/helpers_test.go
@@ -13,4 +13,5 @@ func TestGetDurationFromHz(t *testing.T) {
 	test.That(t, GetDurationFromHz(1), test.ShouldEqual, time.Second)
 	test.That(t, GetDurationFromHz(1000), test.ShouldEqual, time.Millisecond)
 	test.That(t, GetDurationFromHz(0), test.ShouldEqual, 0)
+	test.That(t, GetDurationFromHz(1e-7), test.ShouldEqual, 0)
 }

--- a/services/datamanager/builtin/capture/capture.go
+++ b/services/datamanager/builtin/capture/capture.go
@@ -131,7 +131,8 @@ func (c *Capture) newCollectors(
 			}
 
 			if cfg.CaptureFrequencyHz <= 0 || data.GetDurationFromHz(cfg.CaptureFrequencyHz) <= 0 {
-				c.logger.Warnf("collector disabled due to capture_frequency_hz %f being too close to or less than zero; collector: %s", cfg.CaptureFrequencyHz, md)
+				c.logger.Warnf("collector disabled due to capture_frequency_hz %f being too close to or less than zero; collector: %s",
+					cfg.CaptureFrequencyHz, md)
 				continue
 			}
 
@@ -325,7 +326,8 @@ func (c *Capture) buildCollector(
 ) (*collectorAndConfig, error) {
 	interval := data.GetDurationFromHz(collectorConfig.CaptureFrequencyHz)
 	if interval <= 0 {
-		c.logger.Warnf("collector disabled due to capture_frequency_hz %f being too close to or less than zero; collector: %s", collectorConfig.CaptureFrequencyHz, md)
+		c.logger.Warnf("collector disabled due to capture_frequency_hz %f being too close to or less than zero; collector: %s",
+			collectorConfig.CaptureFrequencyHz, md)
 		return nil, nil
 	}
 

--- a/services/datamanager/builtin/capture/capture.go
+++ b/services/datamanager/builtin/capture/capture.go
@@ -130,8 +130,8 @@ func (c *Capture) newCollectors(
 				continue
 			}
 
-			if cfg.CaptureFrequencyHz <= 0 {
-				c.logger.Warnf("collector disabled due to config `capture_frequency_hz` being less than or equal to zero. collector: %s", md)
+			if cfg.CaptureFrequencyHz <= 0 || data.GetDurationFromHz(cfg.CaptureFrequencyHz) <= 0 {
+				c.logger.Warnf("collector disabled due to capture_frequency_hz %f being too close to or less than zero; collector: %s", cfg.CaptureFrequencyHz, md)
 				continue
 			}
 
@@ -141,7 +141,9 @@ func (c *Capture) newCollectors(
 					"error", err, "resource_name", res.Name(), "metadata", md, "data capture config", format(cfg))
 				continue
 			}
-			newCollectors[md] = newCollectorAndConfig
+			if newCollectorAndConfig != nil {
+				newCollectors[md] = newCollectorAndConfig
+			}
 		}
 	}
 	return newCollectors
@@ -321,6 +323,12 @@ func (c *Capture) buildCollector(
 	maxCaptureFileSize int64,
 	collection *mongo.Collection,
 ) (*collectorAndConfig, error) {
+	interval := data.GetDurationFromHz(collectorConfig.CaptureFrequencyHz)
+	if interval <= 0 {
+		c.logger.Warnf("collector disabled due to capture_frequency_hz %f being too close to or less than zero; collector: %s", collectorConfig.CaptureFrequencyHz, md)
+		return nil, nil
+	}
+
 	// TODO(DATA-451): validate method params
 	methodParams, err := protoutils.ConvertMapToProtoAny(collectorConfig.AdditionalParams)
 	if err != nil {
@@ -356,7 +364,7 @@ func (c *Capture) buildCollector(
 		ComponentName:   collectorConfig.Name.ShortName(),
 		ComponentType:   collectorConfig.Name.API.String(),
 		MethodName:      collectorConfig.Method,
-		Interval:        data.GetDurationFromHz(collectorConfig.CaptureFrequencyHz),
+		Interval:        interval,
 		MethodParams:    methodParams,
 		Target:          data.NewCaptureBuffer(targetDir, captureMetadata, maxCaptureFileSize),
 		// Set queue size to defaultCaptureQueueSize if it was not set in the config.

--- a/services/datamanager/builtin/capture/capture_control_test.go
+++ b/services/datamanager/builtin/capture/capture_control_test.go
@@ -81,6 +81,7 @@ func TestSetCaptureConfig(t *testing.T) {
 	toggledCollector := &mockCollector{}
 	tagsCollector := &mockCollector{}
 	noopCollector := &mockCollector{}
+	nearZeroCollector := &mockCollector{}
 
 	for _, tc := range []struct {
 		name                   string
@@ -107,6 +108,14 @@ func TestSetCaptureConfig(t *testing.T) {
 			existingColls:          collectors{fakeMD: {Resource: fakeRes, Collector: toggledCollector, Config: fakeCfg}},
 			input:                  map[string]datamanager.CaptureConfigReading{"fake-1/GetReadings": {CaptureFrequencyHz: float32Ptr(0)}},
 			expectedClosed:         toggledCollector,
+			expectedCollectorCount: 0,
+		},
+		{
+			name:                   "disables collector on near-zero frequency",
+			defaultConfigs:         CollectorConfigsByResource{fakeRes: []datamanager.DataCaptureConfig{fakeCfg}},
+			existingColls:          collectors{fakeMD: {Resource: fakeRes, Collector: nearZeroCollector, Config: fakeCfg}},
+			input:                  map[string]datamanager.CaptureConfigReading{"fake-1/GetReadings": {CaptureFrequencyHz: float32Ptr(1e-7)}},
+			expectedClosed:         nearZeroCollector,
 			expectedCollectorCount: 0,
 		},
 		{
@@ -156,6 +165,23 @@ func TestSetCaptureConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNearZeroFrequencySkipsCollector(t *testing.T) {
+	registerFakeCollector()
+	c := newTestCapture(t, nil, nil)
+
+	fakeCfg := datamanager.DataCaptureConfig{
+		Name:               resource.NewName(fakeAPI, "fake-1"),
+		Method:             "GetReadings",
+		CaptureFrequencyHz: 1e-7,
+	}
+	c.Reconfigure(context.Background(),
+		CollectorConfigsByResource{fakeRes: []datamanager.DataCaptureConfig{fakeCfg}},
+		Config{MaximumCaptureFileSizeBytes: 256 * 1024, CaptureDir: t.TempDir()},
+	)
+
+	test.That(t, len(c.collectors), test.ShouldEqual, 0)
 }
 
 var (


### PR DESCRIPTION
## Summary

- `newCollectors` only checked `capture_frequency_hz <= 0` before creating a collector. `GetDurationFromHz` treats any frequency `<= 1e-6` as zero and returns `time.Duration(0)`, but values like `1e-7` passed the `<= 0` guard, producing a collector with a zero-duration interval. A zero interval causes `timerBasedCapture` to loop continuously at maximum speed instead of capturing at a low rate.
- `buildCollector` is also called from `SetCaptureConfigs` (capture control sensor overrides), which had no frequency guard at all, leaving the same runaway risk when a near-zero frequency is supplied via the sensor.

**Fixes:**
- `newCollectors`: extend the frequency guard to also reject values where `GetDurationFromHz` would return zero, keeping it consistent with what `buildCollector` will compute.
- `buildCollector`: add an early exit when the computed interval is `<= 0`, guarding the `SetCaptureConfigs` path and any future callers.

## Test plan

- `TestGetDurationFromHz`: add assertion that `1e-7` Hz returns a zero duration, documenting the epsilon behavior.
- `TestSetCaptureConfig` — new case "disables collector on near-zero frequency": verifies that a capture control sensor returning `1e-7` Hz closes the existing collector and does not create a new one (exercises the `buildCollector` guard).
- `TestNearZeroFrequencySkipsCollector`: verifies that `Reconfigure` with a `1e-7` Hz config produces zero collectors (exercises the `newCollectors` guard).