### PR TITLE
Add UR7e and dofbot kinematics to fake/sim arms

### DIFF
--- a/components/arm/fake/fake.go
+++ b/components/arm/fake/fake.go
@@ -32,11 +32,13 @@ type Config struct {
 
 // Known values that can be provided for the ArmModel field.
 var (
-	ur5eModel  = "ur5e"
-	ur20Model  = "ur20"
-	xArm6Model = "xarm6"
-	xArm7Model = "xarm7"
-	lite6Model = "lite6"
+	ur5eModel   = "ur5e"
+	ur7eModel   = "ur7e"
+	ur20Model   = "ur20"
+	xArm6Model  = "xarm6"
+	xArm7Model  = "xarm7"
+	lite6Model  = "lite6"
+	dofbotModel = "dofbot"
 )
 
 //go:embed kinematics/fake.json
@@ -44,6 +46,9 @@ var fakejson []byte
 
 //go:embed kinematics/ur5e.json
 var ur5eJSON []byte
+
+//go:embed kinematics/ur7e.json
+var ur7eJSON []byte
 
 //go:embed kinematics/ur20.json
 var ur20JSON []byte
@@ -56,6 +61,9 @@ var xarm7JSON []byte
 
 //go:embed kinematics/lite6.json
 var lite6JSON []byte
+
+//go:embed kinematics/dofbot.json
+var dofbotJSON []byte
 
 // Validate ensures all parts of the config are valid.
 func (conf *Config) Validate(path string) ([]string, []string, error) {
@@ -307,6 +315,8 @@ func modelFromName(model, name string) (referenceframe.Model, error) {
 	switch model {
 	case ur5eModel:
 		return referenceframe.UnmarshalModelJSON(ur5eJSON, name)
+	case ur7eModel:
+		return referenceframe.UnmarshalModelJSON(ur7eJSON, name)
 	case ur20Model:
 		return referenceframe.UnmarshalModelJSON(ur20JSON, name)
 	case xArm6Model:
@@ -315,6 +325,8 @@ func modelFromName(model, name string) (referenceframe.Model, error) {
 		return referenceframe.UnmarshalModelJSON(xarm7JSON, name)
 	case lite6Model:
 		return referenceframe.UnmarshalModelJSON(lite6JSON, name)
+	case dofbotModel:
+		return referenceframe.UnmarshalModelJSON(dofbotJSON, name)
 	case Model.Name:
 		return referenceframe.UnmarshalModelJSON(fakejson, name)
 	default:

--- a/components/arm/fake/kinematics/ur7e.json
+++ b/components/arm/fake/kinematics/ur7e.json
@@ -1,0 +1,253 @@
+{
+    "name": "UR7e",
+    "kinematic_param_type": "SVA",
+    "links": [
+        {
+            "id": "base_link",
+            "parent": "world",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": 162.5
+            },
+            "geometry": {
+                "r": 60.0,
+                "l": 260.0,
+                "translation": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 130.0
+                }
+            }
+        },
+        {
+            "id": "shoulder_link",
+            "parent": "shoulder_pan_joint",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "geometry": {
+                "r": 55.0
+            }
+        },
+        {
+            "id": "upper_arm_link",
+            "parent": "shoulder_lift_joint",
+            "translation": {
+                "x": -425,
+                "y": 0,
+                "z": 0
+            },
+            "geometry": {
+                "r": 65.0,
+                "l": 550.0,
+                "translation": {
+                    "x": -212.5,
+                    "y": -130,
+                    "z": 0
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": -1,
+                        "y": 0,
+                        "z": 0,
+                        "th": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "forearm_link",
+            "parent": "elbow_joint",
+            "translation": {
+                "x": -392.2,
+                "y": 0,
+                "z": 0
+            },
+            "geometry": {
+                "r": 50.0,
+                "l": 490.0,
+                "translation": {
+                    "x": -196.1,
+                    "y": 0,
+                    "z": 0
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": -1,
+                        "y": 0,
+                        "z": 0,
+                        "th": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "wrist_1_link",
+            "parent": "wrist_1_joint",
+            "translation": {
+                "x": 0,
+                "y": -133.3,
+                "z": 0
+            },
+            "geometry": {
+                "r": 40.0,
+                "l": 230.0,
+                "translation": {
+                    "x": 0,
+                    "y": -80.65,
+                    "z": 0
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": 0,
+                        "y": -1,
+                        "z": 0,
+                        "th": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "wrist_2_link",
+            "parent": "wrist_2_joint",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": -99.7
+            },
+            "geometry": {
+                "r": 70.0,
+                "translation": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 0
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": 0,
+                        "y": 0,
+                        "z": -1,
+                        "th": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "ee_link",
+            "parent": "wrist_3_joint",
+            "translation": {
+                "x": 0,
+                "y": -99.6,
+                "z": 0
+            },
+            "orientation": {
+                "type": "ov_degrees",
+                "value": {
+                    "x": 0,
+                    "y": -1,
+                    "z": 0,
+                    "th": 90
+                }
+            },
+            "geometry": {
+                "r": 40.0,
+                "l": 170.0,
+                "translation": {
+                    "x": 0,
+                    "y": -49.85,
+                    "z": 0
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": 0,
+                        "y": -1,
+                        "z": 0,
+                        "th": 0
+                    }
+                }
+            }
+        }
+    ],
+    "joints": [
+        {
+            "id": "shoulder_pan_joint",
+            "type": "revolute",
+            "parent": "base_link",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": 1
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "shoulder_lift_joint",
+            "type": "revolute",
+            "parent": "shoulder_link",
+            "axis": {
+                "x": 0,
+                "y": -1,
+                "z": 0
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "elbow_joint",
+            "type": "revolute",
+            "parent": "upper_arm_link",
+            "axis": {
+                "x": 0,
+                "y": -1,
+                "z": 0
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "wrist_1_joint",
+            "type": "revolute",
+            "parent": "forearm_link",
+            "axis": {
+                "x": 0,
+                "y": -1,
+                "z": 0
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "wrist_2_joint",
+            "type": "revolute",
+            "parent": "wrist_1_link",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": -1
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "wrist_3_joint",
+            "type": "revolute",
+            "parent": "wrist_2_link",
+            "axis": {
+                "x": 0,
+                "y": -1,
+                "z": 0
+            },
+            "max": 360,
+            "min": -360
+        }
+    ]
+}

--- a/components/arm/sim/kinematics.go
+++ b/components/arm/sim/kinematics.go
@@ -14,11 +14,13 @@ import (
 )
 
 var (
-	ur5eModel  = "ur5e"
-	ur20Model  = "ur20"
-	xArm6Model = "xarm6"
-	xArm7Model = "xarm7"
-	lite6Model = "lite6"
+	ur5eModel   = "ur5e"
+	ur7eModel   = "ur7e"
+	ur20Model   = "ur20"
+	xArm6Model  = "xarm6"
+	xArm7Model  = "xarm7"
+	lite6Model  = "lite6"
+	dofbotModel = "dofbot"
 )
 
 //go:embed kinematics/fake.json
@@ -26,6 +28,9 @@ var fakejson []byte
 
 //go:embed kinematics/ur5e.json
 var ur5eJSON []byte
+
+//go:embed kinematics/ur7e.json
+var ur7eJSON []byte
 
 //go:embed kinematics/ur20.json
 var ur20JSON []byte
@@ -39,10 +44,15 @@ var xarm7JSON []byte
 //go:embed kinematics/lite6.json
 var lite6JSON []byte
 
+//go:embed kinematics/dofbot.json
+var dofbotJSON []byte
+
 func modelFromName(model, name string) (referenceframe.Model, error) {
 	switch model {
 	case ur5eModel:
 		return referenceframe.UnmarshalModelJSON(ur5eJSON, name)
+	case ur7eModel:
+		return referenceframe.UnmarshalModelJSON(ur7eJSON, name)
 	case ur20Model:
 		return referenceframe.UnmarshalModelJSON(ur20JSON, name)
 	case xArm6Model:
@@ -51,6 +61,8 @@ func modelFromName(model, name string) (referenceframe.Model, error) {
 		return referenceframe.UnmarshalModelJSON(xarm7JSON, name)
 	case lite6Model:
 		return referenceframe.UnmarshalModelJSON(lite6JSON, name)
+	case dofbotModel:
+		return referenceframe.UnmarshalModelJSON(dofbotJSON, name)
 	case Model.Name:
 		return referenceframe.UnmarshalModelJSON(fakejson, name)
 	default:

--- a/components/arm/sim/kinematics/ur7e.json
+++ b/components/arm/sim/kinematics/ur7e.json
@@ -1,0 +1,253 @@
+{
+    "name": "UR7e",
+    "kinematic_param_type": "SVA",
+    "links": [
+        {
+            "id": "base_link",
+            "parent": "world",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": 162.5
+            },
+            "geometry": {
+                "r": 60.0,
+                "l": 260.0,
+                "translation": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 130.0
+                }
+            }
+        },
+        {
+            "id": "shoulder_link",
+            "parent": "shoulder_pan_joint",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "geometry": {
+                "r": 55.0
+            }
+        },
+        {
+            "id": "upper_arm_link",
+            "parent": "shoulder_lift_joint",
+            "translation": {
+                "x": -425,
+                "y": 0,
+                "z": 0
+            },
+            "geometry": {
+                "r": 65.0,
+                "l": 550.0,
+                "translation": {
+                    "x": -212.5,
+                    "y": -130,
+                    "z": 0
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": -1,
+                        "y": 0,
+                        "z": 0,
+                        "th": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "forearm_link",
+            "parent": "elbow_joint",
+            "translation": {
+                "x": -392.2,
+                "y": 0,
+                "z": 0
+            },
+            "geometry": {
+                "r": 50.0,
+                "l": 490.0,
+                "translation": {
+                    "x": -196.1,
+                    "y": 0,
+                    "z": 0
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": -1,
+                        "y": 0,
+                        "z": 0,
+                        "th": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "wrist_1_link",
+            "parent": "wrist_1_joint",
+            "translation": {
+                "x": 0,
+                "y": -133.3,
+                "z": 0
+            },
+            "geometry": {
+                "r": 40.0,
+                "l": 230.0,
+                "translation": {
+                    "x": 0,
+                    "y": -80.65,
+                    "z": 0
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": 0,
+                        "y": -1,
+                        "z": 0,
+                        "th": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "wrist_2_link",
+            "parent": "wrist_2_joint",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": -99.7
+            },
+            "geometry": {
+                "r": 70.0,
+                "translation": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 0
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": 0,
+                        "y": 0,
+                        "z": -1,
+                        "th": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "ee_link",
+            "parent": "wrist_3_joint",
+            "translation": {
+                "x": 0,
+                "y": -99.6,
+                "z": 0
+            },
+            "orientation": {
+                "type": "ov_degrees",
+                "value": {
+                    "x": 0,
+                    "y": -1,
+                    "z": 0,
+                    "th": 90
+                }
+            },
+            "geometry": {
+                "r": 40.0,
+                "l": 170.0,
+                "translation": {
+                    "x": 0,
+                    "y": -49.85,
+                    "z": 0
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": 0,
+                        "y": -1,
+                        "z": 0,
+                        "th": 0
+                    }
+                }
+            }
+        }
+    ],
+    "joints": [
+        {
+            "id": "shoulder_pan_joint",
+            "type": "revolute",
+            "parent": "base_link",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": 1
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "shoulder_lift_joint",
+            "type": "revolute",
+            "parent": "shoulder_link",
+            "axis": {
+                "x": 0,
+                "y": -1,
+                "z": 0
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "elbow_joint",
+            "type": "revolute",
+            "parent": "upper_arm_link",
+            "axis": {
+                "x": 0,
+                "y": -1,
+                "z": 0
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "wrist_1_joint",
+            "type": "revolute",
+            "parent": "forearm_link",
+            "axis": {
+                "x": 0,
+                "y": -1,
+                "z": 0
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "wrist_2_joint",
+            "type": "revolute",
+            "parent": "wrist_1_link",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": -1
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "wrist_3_joint",
+            "type": "revolute",
+            "parent": "wrist_2_link",
+            "axis": {
+                "x": 0,
+                "y": -1,
+                "z": 0
+            },
+            "max": 360,
+            "min": -360
+        }
+    ]
+}


### PR DESCRIPTION
UR7e is a payload-rebrand of UR5e with identical arm geometry per the 2025 Universal Robots datasheet (same 850mm reach and link dimensions). dofbot.json was already present in both kinematics directories but was not wired into modelFromName.