### PR TITLE
Implement MoveToPosition for simulated arm

### DIFF
--- a/components/arm/sim/sim.go
+++ b/components/arm/sim/sim.go
@@ -14,6 +14,7 @@ import (
 
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/motionplan/armplanning"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/spatialmath"
@@ -268,7 +269,7 @@ func (sa *simulatedArm) EndPosition(
 func (sa *simulatedArm) MoveToPosition(
 	ctx context.Context, pose spatialmath.Pose, extra map[string]interface{},
 ) error {
-	return errors.New("unimplemented -- must call with explicit joint positions")
+	return armplanning.MoveArm(ctx, sa.logger, sa, pose)
 }
 
 func (sa *simulatedArm) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error) {

--- a/components/arm/sim/sim_test.go
+++ b/components/arm/sim/sim_test.go
@@ -5,12 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/geo/r3"
 	"go.viam.com/test"
 	"go.viam.com/utils/testutils"
 
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/spatialmath"
 )
 
 func TestBasic(t *testing.T) {
@@ -180,4 +182,47 @@ func TestTimeSimulation(t *testing.T) {
 	// without further intervention.
 	err = simArm.MoveToJointPositions(ctx, []float64{1, -2, 0, 0, 0, 0}, nil)
 	test.That(t, err, test.ShouldBeNil)
+}
+
+func TestMoveToPosition(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+	resConf := resource.Config{
+		Name:  "arm",
+		API:   arm.API,
+		Model: Model,
+		ConvertedAttributes: &Config{
+			Model:        "ur5e",
+			Speed:        100.0,
+			SimulateTime: true,
+		},
+	}
+
+	simArmI, err := NewArm(ctx, nil, resConf, logger)
+	test.That(t, err, test.ShouldBeNil)
+	simArm := simArmI.(*simulatedArm)
+	defer func() {
+		err = simArm.Close(ctx)
+		test.That(t, err, test.ShouldBeNil)
+	}()
+
+	startPose, err := simArm.EndPosition(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Nudge the end-effector ~50mm along x. MoveToPosition plans + executes through joint positions.
+	target := spatialmath.NewPose(
+		r3.Vector{
+			X: startPose.Point().X + 50,
+			Y: startPose.Point().Y,
+			Z: startPose.Point().Z,
+		},
+		startPose.Orientation(),
+	)
+	err = simArm.MoveToPosition(ctx, target, nil)
+	test.That(t, err, test.ShouldBeNil)
+
+	endPose, err := simArm.EndPosition(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	// Planner tolerance is millimeter-scale; allow a small slop.
+	test.That(t, spatialmath.PoseAlmostCoincidentEps(endPose, target, 5.0), test.ShouldBeTrue)
 }


### PR DESCRIPTION
Delegates to armplanning.MoveArm, which plans to the target pose and drives the arm via MoveThroughJointPositions — so the existing operation tracking and time simulation handle the actual motion. This mirrors the wrapper arm's pattern, which hopefully matches most real arm implementations