### PR TITLE
APP-4143: Preserve typed log fields in net appender

### DIFF
--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -237,22 +237,10 @@ func (nl *NetAppender) Write(e zapcore.Entry, f []zapcore.Field) error {
 
 	fields := make([]*structpb.Struct, 0, len(f))
 	for _, ff := range f {
-		// Serialize interfaces as strings.
-		if ff.String == "" && ff.Interface != nil {
-			if stringer, ok := ff.Interface.(fmt.Stringer); ok {
-				ff.String = stringer.String()
-			} else {
-				ff.String = fmt.Sprintf("%v", ff.Interface)
-			}
-			ff.Type = zapcore.StringType
-			ff.Interface = nil
-		}
-
-		field, err := protoutils.StructToStructPb(ff)
+		field, err := FieldToProto(ff)
 		if err != nil {
 			return err
 		}
-
 		fields = append(fields, field)
 	}
 	log.Fields = fields

--- a/logging/net_appender_test.go
+++ b/logging/net_appender_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/samber/lo"
+	"go.uber.org/zap/zapcore"
 	apppb "go.viam.com/api/app/v1"
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"
@@ -134,6 +135,59 @@ func TestNetLoggerSync(t *testing.T) {
 	for i := 0; i < writeBatchSize+1; i++ {
 		test.That(t, server.service.logs[i].Message, test.ShouldEqual, fmt.Sprintf("Some-info %d", i))
 	}
+}
+
+func TestNetLoggerPreservesTypedFields(t *testing.T) {
+	server := makeServerForRobotLogger(t)
+	defer server.stop()
+
+	loggerWithoutNet := NewTestLogger(t)
+	netAppender, err := newNetAppender(server.cloudConfig, nil, false, false, loggerWithoutNet)
+	test.That(t, err, test.ShouldBeNil)
+
+	logger := NewDebugLogger("test logger")
+	logger.AddAppender(netAppender)
+
+	logger.Infow("typed",
+		"count", 5,
+		"ratio", 0.5,
+		"ok", true,
+		"label", "hello",
+		"err", errors.New("boom"),
+	)
+	test.That(t, netAppender.sync(), test.ShouldBeNil)
+	netAppender.Close()
+
+	server.service.logsMu.Lock()
+	defer server.service.logsMu.Unlock()
+	test.That(t, server.service.logs, test.ShouldHaveLength, 1)
+	entry := server.service.logs[0]
+	test.That(t, entry.Message, test.ShouldEqual, "typed")
+	test.That(t, entry.Fields, test.ShouldHaveLength, 5)
+
+	byKey := map[string]map[string]any{}
+	for _, f := range entry.Fields {
+		m := f.AsMap()
+		byKey[m["Key"].(string)] = m
+	}
+
+	// Int / Bool ride in Integer; the type byte tells us how to decode.
+	test.That(t, byKey["count"]["Type"], test.ShouldEqual, float64(zapcore.Int64Type))
+	test.That(t, byKey["count"]["Integer"], test.ShouldEqual, float64(5))
+
+	test.That(t, byKey["ok"]["Type"], test.ShouldEqual, float64(zapcore.BoolType))
+	test.That(t, byKey["ok"]["Integer"], test.ShouldEqual, float64(1))
+
+	// FieldToProto encodes float64 via String to dodge int64 precision loss.
+	test.That(t, byKey["ratio"]["Type"], test.ShouldEqual, float64(zapcore.Float64Type))
+	test.That(t, byKey["ratio"]["String"], test.ShouldEqual, "0.500000")
+
+	test.That(t, byKey["label"]["Type"], test.ShouldEqual, float64(zapcore.StringType))
+	test.That(t, byKey["label"]["String"], test.ShouldEqual, "hello")
+
+	// FieldToProto flattens errors to StringType with the message as String.
+	test.That(t, byKey["err"]["Type"], test.ShouldEqual, float64(zapcore.StringType))
+	test.That(t, byKey["err"]["String"], test.ShouldEqual, "boom")
 }
 
 func TestNetLoggerSyncInvalidUTF8(t *testing.T) {

--- a/logging/net_appender_test.go
+++ b/logging/net_appender_test.go
@@ -148,12 +148,19 @@ func TestNetLoggerPreservesTypedFields(t *testing.T) {
 	logger := NewDebugLogger("test logger")
 	logger.AddAppender(netAppender)
 
+	deadline := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	logger.Infow("typed",
 		"count", 5,
 		"ratio", 0.5,
 		"ok", true,
 		"label", "hello",
 		"err", errors.New("boom"),
+		"deadline", deadline,
+		"obj", struct {
+			Name  string
+			Count int
+		}{Name: "thing", Count: 7},
+		"tags", []string{"a", "b", "c"},
 	)
 	test.That(t, netAppender.sync(), test.ShouldBeNil)
 	netAppender.Close()
@@ -163,7 +170,7 @@ func TestNetLoggerPreservesTypedFields(t *testing.T) {
 	test.That(t, server.service.logs, test.ShouldHaveLength, 1)
 	entry := server.service.logs[0]
 	test.That(t, entry.Message, test.ShouldEqual, "typed")
-	test.That(t, entry.Fields, test.ShouldHaveLength, 5)
+	test.That(t, entry.Fields, test.ShouldHaveLength, 8)
 
 	byKey := map[string]map[string]any{}
 	for _, f := range entry.Fields {
@@ -188,6 +195,24 @@ func TestNetLoggerPreservesTypedFields(t *testing.T) {
 	// FieldToProto flattens errors to StringType with the message as String.
 	test.That(t, byKey["err"]["Type"], test.ShouldEqual, float64(zapcore.StringType))
 	test.That(t, byKey["err"]["String"], test.ShouldEqual, "boom")
+
+	// time.Time stays TimeType — Integer holds unix nanos. Pre-fix, the
+	// inline stringifier collapsed this to StringType="UTC" (the location).
+	test.That(t, byKey["deadline"]["Type"], test.ShouldEqual, float64(zapcore.TimeType))
+	test.That(t, byKey["deadline"]["Integer"], test.ShouldEqual, float64(deadline.UnixNano()))
+
+	// Plain structs survive as ReflectType with the value mirrored into
+	// Interface. Pre-fix, this was fmt.Sprintf'd to "{thing 7}".
+	test.That(t, byKey["obj"]["Type"], test.ShouldEqual, float64(zapcore.ReflectType))
+	test.That(t, byKey["obj"]["Interface"], test.ShouldResemble, map[string]any{
+		"Name":  "thing",
+		"Count": float64(7),
+	})
+
+	// String slices land as ArrayMarshalerType, with the values preserved
+	// in Interface. Pre-fix, this was fmt.Sprintf'd to "[a b c]".
+	test.That(t, byKey["tags"]["Type"], test.ShouldEqual, float64(zapcore.ArrayMarshalerType))
+	test.That(t, byKey["tags"]["Interface"], test.ShouldResemble, []any{"a", "b", "c"})
 }
 
 func TestNetLoggerSyncInvalidUTF8(t *testing.T) {


### PR DESCRIPTION
## Summary

`NetAppender.Write` was inlining its own field stringifier — anything zap emitted with a non-nil `Interface` got `fmt.Sprintf`'d into `String` and forced to `StringType`, throwing away type info. Float64 fields also slipped through with their bit pattern in `Integer`, which is precision-lossy through proto's float64-only number representation.

This PR replaces that loop with a call to the existing `logging.FieldToProto`, which already handles both cases — error fields are flattened to `StringType` (same end-state as before), Float64 gets its formatted value mirrored into `String` to dodge precision loss, and any other field with `Interface` set keeps its structured form rather than being collapsed to a single line of `fmt.Sprintf` output.

This is the rdk half of [APP-4143](https://viam.atlassian.net/browse/APP-4143). The companion FE change is viamrobotics/app#11885 — that's where the user-visible win lands (the FE was filtering on `String`, dropping anything in `Integer`, so int/bool/float/duration fields never rendered). Most type info already arrives intact at app today; this PR closes the float64-precision gap and the `Interface`-stringify regression.

## Test plan

- [x] `TestNetLoggerPreservesTypedFields` in `logging/net_appender_test.go` covers Int / Bool / Float64 / String / error round-trip through the gRPC mock and asserts the wire-level `Type`/`Integer`/`String` shape.
- [x] Manual e2e against a local viam-app stack — viam-server pointed at local app, before/after diff inspected directly in `main.robot_log`. Walkthrough + actual mongo diff: https://gist.github.com/n0nick/28e0d182fede94da88dbf34616650e80
- [x] Existing `proto_conversions_test.go` already covers `FieldToProto` itself end-to-end, so this PR leans on that for the per-type encoding correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APP-4143]: https://viam.atlassian.net/browse/APP-4143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ