### PR TITLE
cli: fix --index-path flag binding for `data index create`

### DIFF
--- a/cli/customindex.go
+++ b/cli/customindex.go
@@ -30,7 +30,7 @@ type createCustomIndexArgs struct {
 	OrgID          string
 	CollectionType string
 	PipelineName   string
-	IndexSpecPath  string
+	IndexPath      string
 }
 
 // CreateCustomIndexAction creates a custom index for a specified organization and collection type
@@ -49,7 +49,7 @@ func CreateCustomIndexAction(ctx context.Context, cmd *cli.Command, args createC
 		return err
 	}
 
-	indexSpec, err := readJSONToByteSlices(args.IndexSpecPath)
+	indexSpec, err := readJSONToByteSlices(args.IndexPath)
 	if err != nil {
 		return fmt.Errorf("failed to read index spec from file: %w", err)
 	}


### PR DESCRIPTION
The --index-path flag value never reached the action because the struct field was named IndexSpecPath while the flag's auto-binding expected IndexPath (kebab-case 'index-path' → PascalCase 'IndexPath'). Result: args.IndexPath was always empty, the action called os.ReadFile(""), and the command always failed: 
<img width="1033" height="58" alt="image" src="https://github.com/user-attachments/assets/1c93abec-7186-4388-8732-c1a186bd5b5e" />

Renaming the struct field IndexSpecPath -> IndexPath aligns it with the flag name so the value binds and the file gets read:
```
fix-cli-index-path-binding git:(worktree-fix-cli-index-path-binding) ✗ ./bin/Darwin-arm64/viam-cli data index create --collection-type=hot-storage --index-path=./data.json --org-id=02999174-e815-446d-aee1-fe5a146a9e39
Error: Failed to read index spec from file: missing required 'key' field in index spec
```
(that failure comes after it finds the file and I don't have a required key field)
