### PR TITLE
RSDK-13287: fix Viam Module Upload on Windows

### DIFF
--- a/cli/archive.go
+++ b/cli/archive.go
@@ -9,25 +9,11 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"go.viam.com/utils"
 	"golang.org/x/exp/maps"
 )
-
-// windowsExecutableExtensions is the set of file extensions Windows
-// treats as natively executable. When tarballing a module on Windows,
-// files with these extensions need the Unix exec bit set in their tar
-// headers so server-side validators that check tar header mode bits
-// accept the entrypoint. Windows itself doesn't store Unix-style mode
-// bits, so tar.FileInfoHeader emits 0666 — we force exec bits here.
-var windowsExecutableExtensions = map[string]bool{
-	".exe": true,
-	".bat": true,
-	".cmd": true,
-	".ps1": true,
-}
 
 // getArchiveFilePaths traverses the provided rootpaths recursively,
 // collecting the file paths of all regular files and symlinks.
@@ -117,21 +103,6 @@ func addToArchive(tw *tar.Writer, filename string) error {
 	//   the file it describes, it may be necessary to modify Header.Name
 	//   to provide the full path name of the file.
 	header.Name = filename
-
-	// On Windows, tar.FileInfoHeader emits header.Mode = 0666 for every
-	// regular file because Windows file systems don't support Unix-style
-	// executable bits. The module-upload server-side validator checks
-	// the tar header for an executable bit on the entrypoint and rejects
-	// the upload if missing — see "the module archive contains a file at
-	// the entrypoint, but that file is not marked as executable". Force
-	// the exec bit on for natively-executable Windows extensions so the
-	// validator accepts a Windows-built entrypoint.
-	if runtime.GOOS == "windows" && info.Mode().IsRegular() {
-		ext := strings.ToLower(filepath.Ext(filename))
-		if windowsExecutableExtensions[ext] {
-			header.Mode |= 0o111
-		}
-	}
 
 	err = tw.WriteHeader(header)
 	if err != nil {

--- a/cli/archive.go
+++ b/cli/archive.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"go.viam.com/utils"
@@ -103,6 +104,11 @@ func addToArchive(tw *tar.Writer, filename string) error {
 	//   the file it describes, it may be necessary to modify Header.Name
 	//   to provide the full path name of the file.
 	header.Name = filename
+
+	// File needs to be marked as executable to validate module
+	if runtime.GOOS == osWindows {
+		header.Mode |= 0o111
+	}
 
 	err = tw.WriteHeader(header)
 	if err != nil {

--- a/cli/archive.go
+++ b/cli/archive.go
@@ -9,11 +9,25 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"go.viam.com/utils"
 	"golang.org/x/exp/maps"
 )
+
+// windowsExecutableExtensions is the set of file extensions Windows
+// treats as natively executable. When tarballing a module on Windows,
+// files with these extensions need the Unix exec bit set in their tar
+// headers so server-side validators that check tar header mode bits
+// accept the entrypoint. Windows itself doesn't store Unix-style mode
+// bits, so tar.FileInfoHeader emits 0666 — we force exec bits here.
+var windowsExecutableExtensions = map[string]bool{
+	".exe": true,
+	".bat": true,
+	".cmd": true,
+	".ps1": true,
+}
 
 // getArchiveFilePaths traverses the provided rootpaths recursively,
 // collecting the file paths of all regular files and symlinks.
@@ -103,6 +117,21 @@ func addToArchive(tw *tar.Writer, filename string) error {
 	//   the file it describes, it may be necessary to modify Header.Name
 	//   to provide the full path name of the file.
 	header.Name = filename
+
+	// On Windows, tar.FileInfoHeader emits header.Mode = 0666 for every
+	// regular file because Windows file systems don't support Unix-style
+	// executable bits. The module-upload server-side validator checks
+	// the tar header for an executable bit on the entrypoint and rejects
+	// the upload if missing — see "the module archive contains a file at
+	// the entrypoint, but that file is not marked as executable". Force
+	// the exec bit on for natively-executable Windows extensions so the
+	// validator accepts a Windows-built entrypoint.
+	if runtime.GOOS == "windows" && info.Mode().IsRegular() {
+		ext := strings.ToLower(filepath.Ext(filename))
+		if windowsExecutableExtensions[ext] {
+			header.Mode |= 0o111
+		}
+	}
 
 	err = tw.WriteHeader(header)
 	if err != nil {

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -533,6 +533,12 @@ func (c *viamClient) uploadModuleFile(
 	if err != nil {
 		return nil, err
 	}
+	// Close the tarball when this function returns. Without this, on Windows
+	// the deferred RemoveFileNoError(tarballPath) in the caller fails with
+	// "file is being used by another process" because Windows enforces
+	// exclusive-access semantics on open handles. (Linux silently allows
+	// delete-while-open, masking the leak.)
+	defer vutils.UncheckedErrorFunc(file.Close)
 	stream, err := c.client.UploadModuleFile(ctx)
 	if err != nil {
 		return nil, err
@@ -583,6 +589,8 @@ func validateModuleFile(
 	if err != nil {
 		return err
 	}
+	// See uploadModuleFile for the Windows-specific reason this matters.
+	defer vutils.UncheckedErrorFunc(file.Close)
 	archive, err := gzip.NewReader(file)
 	if err != nil {
 		return err

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -533,6 +533,7 @@ func (c *viamClient) uploadModuleFile(
 	if err != nil {
 		return nil, err
 	}
+	defer vutils.UncheckedErrorFunc(file.Close)
 	stream, err := c.client.UploadModuleFile(ctx)
 	if err != nil {
 		return nil, err
@@ -583,6 +584,7 @@ func validateModuleFile(
 	if err != nil {
 		return err
 	}
+	defer vutils.UncheckedErrorFunc(file.Close)
 	archive, err := gzip.NewReader(file)
 	if err != nil {
 		return err

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -533,12 +533,6 @@ func (c *viamClient) uploadModuleFile(
 	if err != nil {
 		return nil, err
 	}
-	// Close the tarball when this function returns. Without this, on Windows
-	// the deferred RemoveFileNoError(tarballPath) in the caller fails with
-	// "file is being used by another process" because Windows enforces
-	// exclusive-access semantics on open handles. (Linux silently allows
-	// delete-while-open, masking the leak.)
-	defer vutils.UncheckedErrorFunc(file.Close)
 	stream, err := c.client.UploadModuleFile(ctx)
 	if err != nil {
 		return nil, err
@@ -589,8 +583,6 @@ func validateModuleFile(
 	if err != nil {
 		return err
 	}
-	// See uploadModuleFile for the Windows-specific reason this matters.
-	defer vutils.UncheckedErrorFunc(file.Close)
 	archive, err := gzip.NewReader(file)
 	if err != nil {
 		return err


### PR DESCRIPTION
Currently, viam module upload fails with these errors:
go:
`Error validating module: the module archive contains a file at the entrypoint “bin\gomodule.exe”, but that file is not marked as executable. For more details, please visit [Viam CLI overview](https://docs.viam.com/dev/tools/cli#module)  `

python:
```
PS C:\Users\admin\Downloads\rdk\mymodule> ../viam.exe module upload --version=1 --platform=any  --upload ./dist
Compressing... 100% (2/2 files)
2026-01-28T18:17:59.154-0500    DEBUG   utils/file.go:33        unchecked error {"error": "remove C:\\Users\\admin\\AppData\\Local\\Temp\\module-upload-4244064471.tar.gz: The process cannot access the file because it is being used by another process."}
Error: Error validating module: the module archive contains a file at the entrypoint "dist\\main.exe", but that file is not marked as executable. For more details, please visit: [Viam CLI overview](https://docs.viam.com/dev/tools/cli#module) Workaround : ( if available)
```

**Testing:**
I made a new python and go module on windows, and then tried viam module upload again, and it successfully uploaded