### PR TITLE
RSDK-13707, RSDK-13505: retry on rpc DeadlineExceeded (fix flaky test)

### DIFF
--- a/examples/customresources/demos/complexmodule/moduletest/module_test.go
+++ b/examples/customresources/demos/complexmodule/moduletest/module_test.go
@@ -15,6 +15,8 @@ import (
 	"go.viam.com/test"
 	goutils "go.viam.com/utils"
 	"go.viam.com/utils/rpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"go.viam.com/rdk/components/base"
 	"go.viam.com/rdk/components/motor"
@@ -305,7 +307,7 @@ func connect(port int, logger logging.Logger) (robot.Robot, error) {
 			client.WithDisableSessions(), // TODO(PRODUCT-343): add session support to modules
 		)
 		dialCancel()
-		if !errors.Is(err, context.DeadlineExceeded) {
+		if !errors.Is(err, context.DeadlineExceeded) && status.Code(err) != codes.DeadlineExceeded {
 			return rc, err
 		}
 		select {

--- a/examples/customresources/demos/multiplemodules/moduletest/module_test.go
+++ b/examples/customresources/demos/multiplemodules/moduletest/module_test.go
@@ -19,6 +19,8 @@ import (
 	goutils "go.viam.com/utils"
 	"go.viam.com/utils/rpc"
 	gtestutils "go.viam.com/utils/testutils"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/config"
@@ -244,7 +246,7 @@ func connect(port int, logger logging.Logger, dialOpts ...rpc.DialOption) (robot
 			client.WithDisableSessions(), // TODO(PRODUCT-343): add session support to modules
 		)
 		dialCancel()
-		if !errors.Is(err, context.DeadlineExceeded) {
+		if !errors.Is(err, context.DeadlineExceeded) && status.Code(err) != codes.DeadlineExceeded {
 			return rc, err
 		}
 		select {


### PR DESCRIPTION
This test flakes with `rpc error: code = DeadlineExceeded desc = context deadline exceeded` which is different from the standard `context deadline exceeded` that we already retry for up to 30s on. `dialCtx` is only 500ms and it's possible some VM hiccup causes the initial setup or dial to take longer (`RobotClient.New` makes a few gRPC calls after the `Dial`).