### PR TITLE
ci: add Claude workflows and approvals gate

### DIFF
--- a/.claude/settings.ci.json
+++ b/.claude/settings.ci.json
@@ -1,0 +1,20 @@
+{
+  "permissions": {
+    "deny": [
+      "Edit(file_path=.github/**)",
+      "Write(file_path=.github/**)",
+      "Edit(file_path=**/*.pb.go)",
+      "Write(file_path=**/*.pb.go)",
+      "Edit(file_path=Makefile)",
+      "Write(file_path=Makefile)",
+      "Edit(file_path=android.make)",
+      "Write(file_path=android.make)",
+      "Edit(file_path=packaging.make)",
+      "Write(file_path=packaging.make)",
+      "Edit(file_path=go.sum)",
+      "Write(file_path=go.sum)",
+      "Edit(file_path=etc/setup.sh)",
+      "Write(file_path=etc/setup.sh)"
+    ]
+  }
+}

--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -1,0 +1,43 @@
+name: Check PR Approvals
+
+# Enforces a minimum approval count on PRs opened from `claude/**` branches.
+# To make this a required gate, add it as a required status check in the
+# branch-protection rule (or ruleset) that targets `main`.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches: [main]
+  pull_request_review:
+    types: [submitted, dismissed, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  check-approvals:
+    if: >-
+      github.repository_owner == 'viamrobotics' &&
+      startsWith(github.event.pull_request.head.ref, 'claude/')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      issues: write
+    steps:
+      # viamrobotics/claude-ci-workflows@v2.0.0
+      - name: Checkout claude-ci-workflows for composite action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: viamrobotics/claude-ci-workflows
+          ref: aa76787c145ed43f8f7b9bae4d978da4f9850001
+          path: .claude-ci-workflows
+          sparse-checkout: |
+            .github/actions/check-approvals/
+          sparse-checkout-cone-mode: false
+
+      - name: Check approvals
+        uses: ./.claude-ci-workflows/.github/actions/check-approvals
+        with:
+          pr_number: ${{ github.event.pull_request.number }}
+          min_approvals: '2'
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -1,0 +1,55 @@
+name: Claude CI Fix
+
+on:
+  workflow_run:
+    workflows: ['Pull Request Update']
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Failed workflow run ID (from gh run list)'
+        required: true
+      branch:
+        description: 'PR branch name (e.g., claude/RSDK-123)'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  call-ci-fix:
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+      issues: write
+      id-token: write
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'failure' &&
+        startsWith(github.event.workflow_run.head_branch, 'claude/')
+      )
+    # viamrobotics/claude-ci-workflows@v2.0.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@aa76787c145ed43f8f7b9bae4d978da4f9850001
+    with:
+      container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
+      run_id: ${{ github.event.workflow_run.id || inputs.run_id }}
+      branch: ${{ github.event.workflow_run.head_branch || inputs.branch }}
+      install_command: make tool-install
+      allowed_tools: 'Edit,Read,Write,Glob,Grep,Bash(make build*),Bash(make build-go*),Bash(make lint*),Bash(make lint-go*),Bash(make test-go*),Bash(make test-go-no-race*),Bash(make tool-install*),Bash(go build*),Bash(go test*),Bash(go vet*),Bash(go list *),Bash(go doc *),Bash(go mod *),Bash(gofmt *),Bash(ls *),Bash(find *),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *)'
+      max_turns: 50
+      team_mention: '@viamrobotics/rdk'
+      extra_prompt: |
+        - Run only the verification commands relevant to the files you changed: `make lint-go` and `make test-go`.
+        - Do NOT run unrelated linters or test suites — they waste turns and time.
+        - If a test or lint command fails more than twice on the same issue, commit what you have, push, and note the unresolved issue in a PR comment.
+        - For Go test failures: read the failing test AND the function under test before making changes. Understand the data flow and what the test asserts, not just the error message.
+        - Before editing code, read 1-2 similar functions or tests in the same file to understand existing patterns and conventions.
+      extra_system_prompt: >-
+        This is a Go project (go.viam.com/rdk).
+        Verify with `make lint-go` and `make test-go`. The rdk-devenv container has Go tooling pre-installed.
+        Do NOT modify generated protobuf code (files ending in `.pb.go` or under `*/pb/` directories).
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -1,0 +1,89 @@
+name: Claude Jira Implementation
+
+# Triggered by Jira webhook via middleware that calls GitHub repository_dispatch API.
+# Expected payload:
+#   curl -X POST -H "Authorization: token $GITHUB_PAT" \
+#     https://api.github.com/repos/viamrobotics/rdk/dispatches \
+#     -d '{
+#       "event_type": "jira-ticket",
+#       "client_payload": {
+#         "ticket_id": "RSDK-123",
+#         "summary": "...",
+#         "description": "...",
+#         "task_complexity": "medium",
+#         "assignee": "John Doe",
+#         "assignee_email": "john@example.com"
+#       }
+#     }'
+
+on:
+  repository_dispatch:
+    types: [jira-ticket]
+  workflow_dispatch:
+    inputs:
+      ticket_id:
+        description: 'Jira ticket ID (e.g., RSDK-123)'
+        required: true
+      summary:
+        description: 'Ticket summary'
+        required: true
+      description:
+        description: 'Ticket description'
+        required: true
+      task_complexity:
+        description: 'Task complexity: small (100 turns), medium (150), large (200)'
+        required: false
+        default: 'small'
+        type: choice
+        options:
+          - small
+          - medium
+          - large
+      assignee:
+        description: 'Atlassian display name of the responsible engineer (e.g., "John Doe")'
+        required: false
+        default: ''
+      assignee_email:
+        description: 'Atlassian email of the responsible engineer'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  call-jira:
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+      id-token: write
+    # viamrobotics/claude-ci-workflows@v2.0.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@aa76787c145ed43f8f7b9bae4d978da4f9850001
+    with:
+      container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
+      ticket_id: ${{ github.event.client_payload.ticket_id || inputs.ticket_id }}
+      summary: ${{ github.event.client_payload.summary || inputs.summary }}
+      description: ${{ github.event.client_payload.description || inputs.description }}
+      task_complexity: ${{ github.event.client_payload.task_complexity || inputs.task_complexity || 'small' }}
+      assignee: ${{ github.event.client_payload.assignee || inputs.assignee || '' }}
+      assignee_email: ${{ github.event.client_payload.assignee_email || inputs.assignee_email || '' }}
+      install_command: make tool-install
+      jira_base_url: ${{ vars.JIRA_BASE_URL }}
+      jira_user_email: ${{ vars.JIRA_USER_EMAIL }}
+      allowed_tools: 'Edit,Read,Write,Glob,Grep,Bash(make build*),Bash(make build-go*),Bash(make lint*),Bash(make lint-go*),Bash(make test-go*),Bash(make test-go-no-race*),Bash(make tool-install*),Bash(go build*),Bash(go test*),Bash(go vet*),Bash(go list *),Bash(go doc *),Bash(go mod *),Bash(gofmt *),Bash(ls *),Bash(find *),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr create*),Bash(gh pr edit*),Bash(gh pr view*),Bash(gh pr diff*)'
+      extra_prompt: |
+        - Run `make lint-go` and `make test-go` to verify your changes before committing. Fix any errors.
+        - If a test or lint command fails more than twice on the same issue, commit what you have, create the PR, and note the unresolved issue in the PR description.
+        - Add the `safe to test` label to the PR after creation so CI can run: `gh pr edit <number> --add-label "safe to test"`.
+      extra_system_prompt: >-
+        This is a Go project (go.viam.com/rdk).
+        Verify with `make lint-go` and `make test-go`. The rdk-devenv container has Go tooling pre-installed.
+        Do NOT modify generated protobuf code (files ending in `.pb.go` or under `*/pb/` directories).
+        Jira ticket IDs use the RSDK prefix (e.g., RSDK-123). Use this in branch names: claude/RSDK-123.
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CI_GITHUB_APP_ID: ${{ secrets.CI_GITHUB_APP_ID }}
+      CI_GITHUB_APP_PRIVATE_KEY: ${{ secrets.CI_GITHUB_APP_PRIVATE_KEY }}
+      SLACK_AI_WORKFLOW_ALERT_WEBHOOK_URL: ${{ secrets.SLACK_AI_WORKFLOW_ALERT_WEBHOOK_URL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}

--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -1,0 +1,51 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  on-demand:
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+      issues: write
+      id-token: write
+    if: >-
+      github.repository_owner == 'viamrobotics' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && github.event.review.state != 'approved' && github.event.review.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'claude/'))
+      )
+    # viamrobotics/claude-ci-workflows@v2.0.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@aa76787c145ed43f8f7b9bae4d978da4f9850001
+    with:
+      container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
+      install_command: make tool-install
+      allowed_tools: 'Edit,Read,Write,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(make build*),Bash(make build-go*),Bash(make lint*),Bash(make lint-go*),Bash(make test-go*),Bash(make test-go-no-race*),Bash(make tool-install*),Bash(go build*),Bash(go test*),Bash(go vet*),Bash(go list *),Bash(go doc *),Bash(go mod *),Bash(gofmt *),Bash(ls *),Bash(find *),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr review*),Bash(gh pr comment*),Bash(gh pr view*),Bash(gh pr diff*)'
+      max_turns: 50
+      extra_review_instructions: |
+        - Ensure generated protobuf code (`.pb.go` files, `*/pb/` directories) was not manually modified.
+        - Only run verification commands relevant to the files you changed: `make lint-go` and `make test-go`.
+        - Do NOT run unrelated linters or test suites — they waste turns and time.
+        - If a test or lint command fails more than twice on the same issue, commit what you have, push, and note the unresolved issue in a PR comment.
+        - For Go test failures: read the failing test AND the function under test before making changes. Understand the data flow and what the test asserts, not just the error message.
+        - Before editing code, read 1-2 similar functions or tests in the same file to understand existing patterns and conventions.
+        - NEVER use curl, python3, or WebFetch to submit GitHub reviews. Use ONLY `gh pr review` and `gh pr comment`.
+      extra_system_prompt: >-
+        This is a Go project (go.viam.com/rdk).
+        Verify with `make lint-go` and `make test-go`. The rdk-devenv container has Go tooling pre-installed.
+        Do NOT modify generated protobuf code (files ending in `.pb.go` or under `*/pb/` directories).
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# RDK — Robot Development Kit
+
+This repository is `go.viam.com/rdk` and ships three primary surfaces:
+
+- **viam-server** — the robot agent. Entrypoint: `web/cmd/server/`. Core robot implementation lives in `robot/`; the gRPC layer is in `web/server/`.
+- **Go SDK** — covers two clients:
+  - Robot client (`robot/client/`) — connects to a viam-server to drive components and services.
+  - App client (`app/`) — talks to Viam cloud APIs (`app_client.go`, `data_client.go`, `billing_client.go`, `mltraining_client.go`, `provisioning_client.go`); `viam_client.go` is the umbrella entrypoint.
+- **Viam CLI** — lives in `cli/`. See `cli/STYLEGUIDE.md` and `cli/CONTRIBUTING.md` before changing CLI code.
+
+## Layout
+
+- `components/`, `services/`, `module/` — resource implementations and the module SDK. The bulk of the code follows this pattern; before adding a new component or service, read 1–2 existing ones in the same directory.
+- `config/`, `resource/`, `motionplan/`, `referenceframe/`, `data/`, `logging/` — shared infrastructure used across the surfaces above.
+- `examples/customresources/` — sample modules. The only `.pb.go` files in the tree live here; protobuf for the main APIs comes from `go.viam.com/api`.
+
+## Conventions
+
+- Verify changes with `make lint-go` and `make test-go`. The `rdk-devenv` container has Go tooling pre-installed; locally, run `make tool-install` first.
+- Generated protobuf (`*.pb.go`), build files (`Makefile`, `*.make`), `go.sum`, and workflow files are deny-listed in `.claude/settings.ci.json`. Update `go.sum` via `go mod tidy`.


### PR DESCRIPTION
Adds three reusable Claude callers (jira, ci-fix, pr-assistant) and a check-approvals workflow that requires 2 approving reviews on any PR opened from a claude/** branch. All pinned to claude-ci-workflows@v2.0.0.