### PR TITLE
Viam module download id flag not working

### DIFF
--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -1090,14 +1090,14 @@ func getNextModuleUploadRequest(file *os.File) (*apppb.UploadModuleFileRequest, 
 
 type downloadModuleFlags struct {
 	Destination string
-	ModuleID    string
+	ID          string
 	OrgID       string
 	Version     string
 	Platform    string
 }
 
 func (c *viamClient) downloadModuleAction(ctx context.Context, cmd *cli.Command, flags downloadModuleFlags) (string, error) {
-	moduleID := flags.ModuleID
+	moduleID := flags.ID
 	if moduleID == "" {
 		manifest, err := loadManifest(defaultManifestFilename)
 		if err != nil {


### PR DESCRIPTION
Testing:
I created a module, then deleted the meta.json so the error would show if the id was properly being passed (because it defaults to looking at meta.json

Before fix:
```
➜  stuxnetdemo git:(viam-module-download-id-flag) ✗ viam module download --id allisonorg:demoapp                       
Error: Trying to get package ID from meta.json: cannot find meta.json: open meta.json: no such file or directory
```

After fix:
```
➜  stuxnetdemo git:(viam-module-download-id-flag) ✗ ../bin/Darwin-arm64/viam-cli module download --id allisonorg:demoapp
Info: using default platform darwin/arm64
```
