### PR TITLE
Do not throw error if `GetGeometries()` returns a nil slice

### DIFF
--- a/components/base/client_test.go
+++ b/components/base/client_test.go
@@ -242,8 +242,9 @@ func TestClient(t *testing.T) {
 		_, err = failingBaseClient.Properties(context.Background(), nil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errPropertiesFailed.Error())
 
-		_, err = failingBaseClient.Geometries(context.Background(), nil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, base.ErrGeometriesNil(failBaseName).Error())
+		geometries, err := failingBaseClient.Geometries(context.Background(), nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, geometries, test.ShouldBeEmpty)
 
 		err = failingBaseClient.Stop(context.Background(), nil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errStopFailed.Error())

--- a/components/base/server.go
+++ b/components/base/server.go
@@ -3,7 +3,6 @@ package base
 
 import (
 	"context"
-	"fmt"
 
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/base/v1"
@@ -14,11 +13,6 @@ import (
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 )
-
-// ErrGeometriesNil is the returned error if base geometries are nil.
-var ErrGeometriesNil = func(baseName string) error {
-	return fmt.Errorf("base component %v Geometries should not return nil geometries", baseName)
-}
 
 // serviceServer implements the BaseService from base.proto.
 type serviceServer struct {
@@ -168,9 +162,6 @@ func (s *serviceServer) GetGeometries(ctx context.Context, req *commonpb.GetGeom
 	geometries, err := res.Geometries(ctx, req.Extra.AsMap())
 	if err != nil {
 		return nil, err
-	}
-	if geometries == nil {
-		return nil, ErrGeometriesNil(req.GetName())
 	}
 	return &commonpb.GetGeometriesResponse{Geometries: referenceframe.NewGeometriesToProto(geometries)}, nil
 }

--- a/components/base/server_test.go
+++ b/components/base/server_test.go
@@ -217,14 +217,14 @@ func TestServer(t *testing.T) {
 		})
 		test.That(t, err, test.ShouldBeNil)
 
-		// on a failing get properties
+		// nil geometries should produce an empty response, not an error
 		brokenBase.GeometriesFunc = func(ctx context.Context) ([]spatialmath.Geometry, error) {
 			return nil, nil
 		}
 		req = &pbcommon.GetGeometriesRequest{Name: failBaseName}
 		resp, err = server.GetGeometries(context.Background(), req)
-		test.That(t, resp, test.ShouldBeNil)
-		test.That(t, err, test.ShouldBeError, base.ErrGeometriesNil(failBaseName))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp, test.ShouldResemble, &pbcommon.GetGeometriesResponse{})
 	})
 
 	t.Run("GetStatus", func(t *testing.T) {

--- a/components/gripper/client_test.go
+++ b/components/gripper/client_test.go
@@ -209,8 +209,9 @@ func TestClient(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, errStopUnimplemented.Error())
 
-		_, err = client2.Geometries(context.Background(), extra)
-		test.That(t, err.Error(), test.ShouldContainSubstring, gripper.ErrGeometriesNil(failGripperName).Error())
+		geometries, err := client2.Geometries(context.Background(), extra)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, geometries, test.ShouldBeEmpty)
 
 		test.That(t, client2.Close(context.Background()), test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)

--- a/components/gripper/server.go
+++ b/components/gripper/server.go
@@ -3,7 +3,6 @@ package gripper
 
 import (
 	"context"
-	"fmt"
 
 	commonpb "go.viam.com/api/common/v1"
 	pb "go.viam.com/api/component/gripper/v1"
@@ -15,11 +14,6 @@ import (
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 )
-
-// ErrGeometriesNil is the returned error if gripper geometries are nil.
-var ErrGeometriesNil = func(gripperName string) error {
-	return fmt.Errorf("gripper component %v Geometries should not return nil geometries", gripperName)
-}
 
 // serviceServer implements the GripperService from gripper.proto.
 type serviceServer struct {
@@ -147,9 +141,6 @@ func (s *serviceServer) GetGeometries(ctx context.Context, req *commonpb.GetGeom
 	geometries, err := res.Geometries(ctx, req.Extra.AsMap())
 	if err != nil {
 		return nil, err
-	}
-	if geometries == nil {
-		return nil, ErrGeometriesNil(req.GetName())
 	}
 	return &commonpb.GetGeometriesResponse{Geometries: referenceframe.NewGeometriesToProto(geometries)}, nil
 }

--- a/components/gripper/server_test.go
+++ b/components/gripper/server_test.go
@@ -144,8 +144,10 @@ func TestServer(t *testing.T) {
 		_, err = gripperServer.GetGeometries(context.Background(), &pbcommon.GetGeometriesRequest{Name: testGripperName})
 		test.That(t, err, test.ShouldBeNil)
 
-		_, err = gripperServer.GetGeometries(context.Background(), &pbcommon.GetGeometriesRequest{Name: testGripperName2})
-		test.That(t, err, test.ShouldBeError, gripper.ErrGeometriesNil(testGripperName2))
+		// nil geometries should produce an empty response, not an error
+		resp, err := gripperServer.GetGeometries(context.Background(), &pbcommon.GetGeometriesRequest{Name: testGripperName2})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, resp, test.ShouldResemble, &pbcommon.GetGeometriesResponse{})
 	})
 
 	t.Run("GetCurrentInputs", func(t *testing.T) {


### PR DESCRIPTION
`base.GetGeometries` and `gripper.GetGeometries` currently return an error (`ErrGeometriesNil`) when the component's `Geometries()` method returns a nil slice without an error, on the theory that this signals an unimplemented method. 

This is inconsistent with the other components that expose GetGeometries — camera, arm, and gantry all pass a nil slice straight through to `referenceframe.NewGeometriesToProto`, which yields an empty response rather than an error. The check is also unobservable on the wire: protobuf serializes a nil `[]Geometry` and an empty `[]Geometry{}` identically, so a client cannot distinguish "no geometries" from "the server's Go code happened to return nil." 

The genuine "unimplemented" signal is `codes.Unimplemented` — (nil, nil) is a valid response meaning the component simply has no geometries. This change removes the nil-rejection from base and gripper so they behave like the rest, drops the now-unused `ErrGeometriesNil` symbol, and updates the tests that previously asserted the error to assert an empty response instead.