### PR TITLE
APP-16267 datamanager rename orphaned .prog files to .capture on startup

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -230,7 +230,7 @@ func (b *builtIn) BuiltInReconfigure(ctx context.Context, deps resource.Dependen
 	if err := os.MkdirAll(captureConfig.CaptureDir, 0o700); err != nil {
 		b.logger.Warnf("failed to create capture directory: %s", captureConfig.CaptureDir)
 	}
-	go renameProgFilesToCapture(captureConfig.CaptureDir, b.logger)
+	renameProgFilesToCapture(captureConfig.CaptureDir, b.logger)
 
 	syncSensor, syncSensorEnabled := syncSensorFromDeps(c.SelectiveSyncerName, deps, b.logger)
 	syncConfig := c.syncConfig(syncSensor, syncSensorEnabled, b.logger)

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -153,6 +153,7 @@ func (b *builtIn) Close(ctx context.Context) error {
 func renameProgFilesToCapture(dir string, logger logging.Logger) {
 	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
+			//nolint:nilerr
 			return nil
 		}
 		if filepath.Ext(path) != data.InProgressCaptureFileExt {
@@ -166,7 +167,8 @@ func renameProgFilesToCapture(dir string, logger logging.Logger) {
 	})
 }
 
-// TODO: Determine desired behavior if sync is disabled. Do we wan to allow manual syncs, then?
+// TODO: Determine desired behavior if sync is disabled. Do we want to allow
+// manual syncs, then?
 //       If so, how could a user cancel it?
 
 // Sync performs a non-scheduled sync of the data in the capture directory.

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -15,7 +15,9 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -25,6 +27,7 @@ import (
 	"google.golang.org/grpc"
 
 	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/internal/cloud"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -145,6 +148,24 @@ func (b *builtIn) Close(ctx context.Context) error {
 	return nil
 }
 
+// renameProgFilesToCapture walks dir recursively and renames any .prog files to .capture so
+// that orphaned in-progress files from a previous crash are picked up by the syncer on restart.
+func renameProgFilesToCapture(dir string, logger logging.Logger) {
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) != data.InProgressCaptureFileExt {
+			return nil
+		}
+		newPath := path[:len(path)-len(data.InProgressCaptureFileExt)] + data.CompletedCaptureFileExt
+		if renameErr := os.Rename(path, newPath); renameErr != nil {
+			logger.Warnw("failed to rename in-progress capture file on startup", "path", path, "error", renameErr)
+		}
+		return nil
+	})
+}
+
 // TODO: Determine desired behavior if sync is disabled. Do we wan to allow manual syncs, then?
 //       If so, how could a user cancel it?
 
@@ -205,6 +226,7 @@ func (b *builtIn) BuiltInReconfigure(ctx context.Context, deps resource.Dependen
 	if err := os.MkdirAll(captureConfig.CaptureDir, 0o700); err != nil {
 		b.logger.Warnf("failed to create capture directory: %s", captureConfig.CaptureDir)
 	}
+	renameProgFilesToCapture(captureConfig.CaptureDir, b.logger)
 
 	syncSensor, syncSensorEnabled := syncSensorFromDeps(c.SelectiveSyncerName, deps, b.logger)
 	syncConfig := c.syncConfig(syncSensor, syncSensorEnabled, b.logger)

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -230,7 +230,7 @@ func (b *builtIn) BuiltInReconfigure(ctx context.Context, deps resource.Dependen
 	if err := os.MkdirAll(captureConfig.CaptureDir, 0o700); err != nil {
 		b.logger.Warnf("failed to create capture directory: %s", captureConfig.CaptureDir)
 	}
-	renameProgFilesToCapture(captureConfig.CaptureDir, b.logger)
+	go renameProgFilesToCapture(captureConfig.CaptureDir, b.logger)
 
 	syncSensor, syncSensorEnabled := syncSensorFromDeps(c.SelectiveSyncerName, deps, b.logger)
 	syncConfig := c.syncConfig(syncSensor, syncSensorEnabled, b.logger)

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -151,7 +151,7 @@ func (b *builtIn) Close(ctx context.Context) error {
 // renameProgFilesToCapture walks dir recursively and renames any .prog files to .capture so
 // that orphaned in-progress files from a previous crash are picked up by the syncer on restart.
 func renameProgFilesToCapture(dir string, logger logging.Logger) {
-	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+	if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			//nolint:nilerr
 			return nil
@@ -164,7 +164,9 @@ func renameProgFilesToCapture(dir string, logger logging.Logger) {
 			logger.Warnw("failed to rename in-progress capture file on startup", "path", path, "error", renameErr)
 		}
 		return nil
-	})
+	}); err != nil {
+		logger.Warnw("failed to walk capture directory on startup", "dir", dir, "error", err)
+	}
 }
 
 // TODO: Determine desired behavior if sync is disabled. Do we want to allow

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -809,6 +809,46 @@ func TestLookupCollectorConfigsByResource(t *testing.T) {
 	})
 }
 
+func TestRenameProgFilesToCapture(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	dir := t.TempDir()
+
+	subdir := filepath.Join(dir, "subdir")
+	test.That(t, os.MkdirAll(subdir, 0o700), test.ShouldBeNil)
+
+	// Create files that should be renamed
+	progFile1 := filepath.Join(dir, "file1.prog")
+	progFile2 := filepath.Join(subdir, "file2.prog")
+	test.That(t, os.WriteFile(progFile1, []byte("data"), 0o600), test.ShouldBeNil)
+	test.That(t, os.WriteFile(progFile2, []byte("data"), 0o600), test.ShouldBeNil)
+
+	// Create files that should NOT be renamed
+	captureFile := filepath.Join(dir, "file3.capture")
+	otherFile := filepath.Join(dir, "file4.txt")
+	test.That(t, os.WriteFile(captureFile, []byte("data"), 0o600), test.ShouldBeNil)
+	test.That(t, os.WriteFile(otherFile, []byte("data"), 0o600), test.ShouldBeNil)
+
+	renameProgFilesToCapture(dir, logger)
+
+	// .prog files should now be .capture
+	_, err := os.Stat(filepath.Join(dir, "file1.capture"))
+	test.That(t, err, test.ShouldBeNil)
+	_, err = os.Stat(filepath.Join(subdir, "file2.capture"))
+	test.That(t, err, test.ShouldBeNil)
+
+	// Original .prog files should be gone
+	_, err = os.Stat(progFile1)
+	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+	_, err = os.Stat(progFile2)
+	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+
+	// Other files should be untouched
+	_, err = os.Stat(captureFile)
+	test.That(t, err, test.ShouldBeNil)
+	_, err = os.Stat(otherFile)
+	test.That(t, err, test.ShouldBeNil)
+}
+
 func builtinWithEmptyConfig(t *testing.T, logger logging.Logger) (datamanager.Service, func()) {
 	mockDeps := mockDeps(nil, nil)
 	b, err := New(

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -812,41 +812,24 @@ func TestLookupCollectorConfigsByResource(t *testing.T) {
 func TestRenameProgFilesToCapture(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	dir := t.TempDir()
-
 	subdir := filepath.Join(dir, "subdir")
 	test.That(t, os.MkdirAll(subdir, 0o700), test.ShouldBeNil)
 
-	// Create files that should be renamed
-	progFile1 := filepath.Join(dir, "file1.prog")
-	progFile2 := filepath.Join(subdir, "file2.prog")
-	test.That(t, os.WriteFile(progFile1, []byte("data"), 0o600), test.ShouldBeNil)
-	test.That(t, os.WriteFile(progFile2, []byte("data"), 0o600), test.ShouldBeNil)
-
-	// Create files that should NOT be renamed
-	captureFile := filepath.Join(dir, "file3.capture")
-	otherFile := filepath.Join(dir, "file4.txt")
-	test.That(t, os.WriteFile(captureFile, []byte("data"), 0o600), test.ShouldBeNil)
-	test.That(t, os.WriteFile(otherFile, []byte("data"), 0o600), test.ShouldBeNil)
+	for _, p := range []string{
+		filepath.Join(dir, "file1.prog"),
+		filepath.Join(dir, "other.capture"),
+		filepath.Join(subdir, "file2.prog"),
+	} {
+		test.That(t, os.WriteFile(p, []byte("x"), 0o600), test.ShouldBeNil)
+	}
 
 	renameProgFilesToCapture(dir, logger)
 
-	// .prog files should now be .capture
-	_, err := os.Stat(filepath.Join(dir, "file1.capture"))
-	test.That(t, err, test.ShouldBeNil)
-	_, err = os.Stat(filepath.Join(subdir, "file2.capture"))
-	test.That(t, err, test.ShouldBeNil)
-
-	// Original .prog files should be gone
-	_, err = os.Stat(progFile1)
-	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
-	_, err = os.Stat(progFile2)
-	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
-
-	// Other files should be untouched
-	_, err = os.Stat(captureFile)
-	test.That(t, err, test.ShouldBeNil)
-	_, err = os.Stat(otherFile)
-	test.That(t, err, test.ShouldBeNil)
+	test.That(t, getAllFilePaths(dir), test.ShouldResemble, []string{
+		filepath.Join(dir, "file1.capture"),
+		filepath.Join(dir, "other.capture"),
+		filepath.Join(subdir, "file2.capture"),
+	})
 }
 
 func builtinWithEmptyConfig(t *testing.T, logger logging.Logger) (datamanager.Service, func()) {


### PR DESCRIPTION
- On viam-server startup, `BuiltInReconfigure` now walks the capture directory (recursively, handling subdirs per component/method) and renames any leftover `.prog` files to `.capture`
- `.prog` files orphaned by a previous crash were previously silently skipped by the syncer; they will now be uploaded on the next sync cycle
- Adds `TestRenameProgFilesToCapture` covering top-level and nested files, leaving `.capture` and unrelated files untouched

## Manual verification

https://gist.github.com/n0nick/0ed6545e53f29cffe8e625c981a0d48a
- Hard kill viam-server mid-capture (`kill -9`)
- Confirmed `.prog` files were left behind (`find ~/.viam/capture -name *.prog`)
- Started viam-server again
- Confirmed `.prog` files disappeared (after rename to `.capture` + sync)