### PR TITLE
[APP-16062] Revert #5944 and re-apply cascade fix only

### DIFF
--- a/components/arm/fake/fake.go
+++ b/components/arm/fake/fake.go
@@ -91,7 +91,7 @@ func NewArm(ctx context.Context, deps resource.Dependencies, conf resource.Confi
 		Named:  conf.ResourceName().AsNamed(),
 		logger: logger,
 	}
-	if err := a.reconfigure(ctx, deps, conf); err != nil {
+	if err := a.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -134,8 +134,8 @@ type Arm struct {
 	armModel string
 }
 
-// reconfigure atomically reconfigures this arm in place based on the new config.
-func (a *Arm) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+// Reconfigure atomically reconfigures this arm in place based on the new config.
+func (a *Arm) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	newConf, err := resource.NativeConfig[*Config](conf)
 	if err != nil {
 		return err

--- a/components/arm/fake/fake_test.go
+++ b/components/arm/fake/fake_test.go
@@ -13,6 +13,77 @@ import (
 	"go.viam.com/rdk/resource"
 )
 
+func TestReconfigure(t *testing.T) {
+	ctx := context.Background()
+	conf0 := resource.Config{
+		Name:                "testArm",
+		ConvertedAttributes: &Config{},
+	}
+
+	conf1 := resource.Config{
+		Name: "testArm",
+		ConvertedAttributes: &Config{
+			ArmModel: xArm6Model,
+		},
+	}
+
+	conf2 := resource.Config{
+		Name: "testArm",
+		ConvertedAttributes: &Config{
+			ModelFilePath: "zero_model.json",
+		},
+	}
+
+	conf3 := resource.Config{
+		Name: "testArm",
+		ConvertedAttributes: &Config{
+			ModelFilePath: "DNE",
+		},
+	}
+
+	conf4 := resource.Config{
+		Name: "testArm",
+		ConvertedAttributes: &Config{
+			ModelFilePath: "a.json",
+			ArmModel:      ur5eModel,
+		},
+	}
+
+	a, err := NewArm(ctx, nil, conf0, logging.NewTestLogger(t))
+	test.That(t, err, test.ShouldBeNil)
+	fakeArm, _ := a.(*Arm)
+	test.That(t, fakeArm.armModel, test.ShouldResemble, "")
+
+	model, err := fakeArm.Kinematics(ctx)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fakeArm.joints, test.ShouldResemble, make([]referenceframe.Input, len(model.DoF())))
+	test.That(t, fakeArm.model, test.ShouldResemble, model)
+
+	test.That(t, fakeArm.Reconfigure(ctx, nil, conf1), test.ShouldBeNil)
+	model, err = fakeArm.Kinematics(ctx)
+	test.That(t, err, test.ShouldBeNil)
+	modelJoints := make([]referenceframe.Input, len(model.DoF()))
+	test.That(t, fakeArm.joints, test.ShouldResemble, modelJoints)
+	test.That(t, fakeArm.model, test.ShouldResemble, model)
+	test.That(t, fakeArm.armModel, test.ShouldResemble, xArm6Model)
+
+	err = fakeArm.Reconfigure(ctx, nil, conf2)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "fake arm built with zero degrees-of-freedom")
+	test.That(t, fakeArm.joints, test.ShouldResemble, modelJoints)
+	test.That(t, fakeArm.model, test.ShouldResemble, model)
+
+	err = fakeArm.Reconfigure(ctx, nil, conf3)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "only files")
+	test.That(t, fakeArm.joints, test.ShouldResemble, modelJoints)
+	test.That(t, fakeArm.model, test.ShouldResemble, model)
+
+	err = fakeArm.Reconfigure(ctx, nil, conf4)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldResemble, errAttrCfgPopulation)
+}
+
 func TestJointPositions(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
@@ -66,7 +137,7 @@ func TestGet3DModels(t *testing.T) {
 			ArmModel: ur5eModel,
 		},
 	}
-	err = fakeArm.reconfigure(ctx, nil, confWith3DModels)
+	err = fakeArm.Reconfigure(ctx, nil, confWith3DModels)
 	test.That(t, err, test.ShouldBeNil)
 	models, err = fakeArm.Get3DModels(ctx, nil)
 	test.That(t, err, test.ShouldBeNil)

--- a/components/arm/wrapper/wrapper.go
+++ b/components/arm/wrapper/wrapper.go
@@ -64,14 +64,14 @@ func NewWrapperArm(
 		logger: logger,
 		opMgr:  operation.NewSingleOperationManager(),
 	}
-	if err := a.reconfigure(ctx, deps, conf); err != nil {
+	if err := a.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
-// reconfigure atomically reconfigures this arm in place based on the new config.
-func (wrapper *Arm) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+// Reconfigure atomically reconfigures this arm in place based on the new config.
+func (wrapper *Arm) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	newConf, err := resource.NativeConfig[*Config](conf)
 	if err != nil {
 		return err

--- a/components/arm/wrapper/wrapper_test.go
+++ b/components/arm/wrapper/wrapper_test.go
@@ -1,0 +1,78 @@
+package wrapper
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/components/arm"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/testutils/inject"
+)
+
+func TestReconfigure(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+
+	cfg := resource.Config{
+		Name: "testArm",
+		ConvertedAttributes: &Config{
+			ModelFilePath: "../fake/kinematics/ur5e.json",
+			ArmName:       "does not exist0",
+		},
+	}
+
+	armName := arm.Named("foo")
+	cfg1 := resource.Config{
+		Name: "testArm",
+		ConvertedAttributes: &Config{
+			ModelFilePath: "../fake/kinematics/xarm6.json",
+			ArmName:       armName.ShortName(),
+		},
+	}
+
+	cfg1Err := resource.Config{
+		Name: "testArm",
+		ConvertedAttributes: &Config{
+			ModelFilePath: "../fake/kinematics/xarm6.json",
+			ArmName:       "dne1",
+		},
+	}
+
+	cfg2Err := resource.Config{
+		Name: "testArm",
+		ConvertedAttributes: &Config{
+			ModelFilePath: "DNE",
+			ArmName:       armName.ShortName(),
+		},
+	}
+
+	conf, err := resource.NativeConfig[*Config](cfg)
+	test.That(t, err, test.ShouldBeNil)
+
+	model, err := referenceframe.KinematicModelFromFile(conf.ModelFilePath, cfg.Name)
+	test.That(t, err, test.ShouldBeNil)
+
+	actualArm := &inject.Arm{}
+
+	wrapperArm := &Arm{
+		Named:  cfg.ResourceName().AsNamed(),
+		model:  model,
+		actual: &inject.Arm{},
+		logger: logger,
+	}
+
+	deps := resource.Dependencies{armName: actualArm}
+
+	test.That(t, wrapperArm.Reconfigure(context.Background(), deps, cfg1), test.ShouldBeNil)
+
+	err = wrapperArm.Reconfigure(context.Background(), deps, cfg1Err)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "missing from dep")
+
+	err = wrapperArm.Reconfigure(context.Background(), deps, cfg2Err)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "only files")
+}

--- a/components/base/sensorcontrolled/sensorcontrolled.go
+++ b/components/base/sensorcontrolled/sensorcontrolled.go
@@ -113,14 +113,14 @@ func createSensorBase(
 		opMgr:         operation.NewSingleOperationManager(),
 	}
 
-	if err := sb.reconfigure(ctx, deps, conf); err != nil {
+	if err := sb.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 
 	return sb, nil
 }
 
-func (sb *sensorBase) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+func (sb *sensorBase) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	newConf, err := resource.NativeConfig[*Config](conf)
 	sb.conf = newConf
 	if err != nil {

--- a/components/base/sensorcontrolled/sensorcontrolled_test.go
+++ b/components/base/sensorcontrolled/sensorcontrolled_test.go
@@ -251,6 +251,102 @@ func msDependencies(t *testing.T, msNames []string,
 	return deps, cfg
 }
 
+func TestReconfig(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+
+	deps, cfg := msDependencies(t, []string{"orientation"})
+
+	b, err := createSensorBase(ctx, deps, cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+	sb, ok := b.(*sensorBase)
+	test.That(t, ok, test.ShouldBeTrue)
+	headingOri, headingSupported, err := sb.headingFunc(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, headingSupported, test.ShouldBeTrue)
+	test.That(t, headingOri, test.ShouldEqual, orientationValue)
+	test.That(t, sb.controlFreq, test.ShouldEqual, defaultControlFreq)
+
+	deps, cfg = msDependencies(t, []string{"orientation1"})
+	err = b.Reconfigure(ctx, deps, cfg)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, headingSupported, test.ShouldBeTrue)
+	test.That(t, headingOri, test.ShouldEqual, orientationValue)
+
+	deps, cfg = msDependencies(t, []string{"setvel1"})
+	err = b.Reconfigure(ctx, deps, cfg)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, sb.velocities.Name().ShortName(), test.ShouldResemble, "setvel1")
+
+	deps, _ = msDependencies(t, []string{"setvel2"})
+	// generate a config with a non default freq
+	cfg = sBaseTestConfig([]string{"setvel2"}, 100, typeLinVel, typeAngVel)
+	err = b.Reconfigure(ctx, deps, cfg)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, sb.velocities.Name().ShortName(), test.ShouldResemble, "setvel2")
+	headingNone, headingSupported, err := sb.headingFunc(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, headingSupported, test.ShouldBeFalse)
+	test.That(t, headingNone, test.ShouldEqual, 0)
+	test.That(t, sb.controlFreq, test.ShouldEqual, 100.0)
+
+	deps, cfg = msDependencies(t, []string{"orientation3", "setvel3", "Bad"})
+	err = b.Reconfigure(ctx, deps, cfg)
+	test.That(t, err, test.ShouldBeNil)
+	headingOri, headingSupported, err = sb.headingFunc(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, headingSupported, test.ShouldBeTrue)
+	test.That(t, headingOri, test.ShouldEqual, orientationValue)
+	test.That(t, sb.velocities.Name().ShortName(), test.ShouldResemble, "setvel3")
+
+	deps, cfg = msDependencies(t, []string{"Bad", "orientation4", "setvel4", "orientation5", "setvel5"})
+	err = b.Reconfigure(ctx, deps, cfg)
+	test.That(t, err, test.ShouldBeNil)
+	headingOri, headingSupported, err = sb.headingFunc(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, headingSupported, test.ShouldBeTrue)
+	test.That(t, headingOri, test.ShouldEqual, orientationValue)
+	test.That(t, sb.velocities.Name().ShortName(), test.ShouldResemble, "setvel4")
+
+	deps, cfg = msDependencies(t, []string{"Bad", "orientation6", "setvel6", "position1", "compass1"})
+	err = b.Reconfigure(ctx, deps, cfg)
+	test.That(t, err, test.ShouldBeNil)
+	headingOri, headingSupported, err = sb.headingFunc(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, headingSupported, test.ShouldBeTrue)
+	test.That(t, headingOri, test.ShouldEqual, orientationValue)
+	test.That(t, sb.velocities.Name().ShortName(), test.ShouldResemble, "setvel6")
+	test.That(t, sb.position.Name().ShortName(), test.ShouldResemble, "position1")
+
+	deps, cfg = msDependencies(t, []string{"Bad", "setvel7", "position2", "compass2"})
+	err = b.Reconfigure(ctx, deps, cfg)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, sb.velocities.Name().ShortName(), test.ShouldResemble, "setvel7")
+	test.That(t, sb.position.Name().ShortName(), test.ShouldResemble, "position2")
+	headingCompass, headingSupported, err := sb.headingFunc(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, headingSupported, test.ShouldBeTrue)
+	test.That(t, headingCompass, test.ShouldNotEqual, orientationValue)
+	test.That(t, headingCompass, test.ShouldEqual, -compassValue)
+
+	deps, cfg = msDependencies(t, []string{"Bad"})
+	err = b.Reconfigure(ctx, deps, cfg)
+	test.That(t, sb.velocities, test.ShouldBeNil)
+	test.That(t, err, test.ShouldBeError, errNoGoodSensor)
+	headingBad, headingSupported, err := sb.headingFunc(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, headingSupported, test.ShouldBeFalse)
+	test.That(t, headingBad, test.ShouldEqual, 0)
+
+	deps, _ = msDependencies(t, []string{"setvel2"})
+	// generate a config with invalid pid types
+	cfg = sBaseTestConfig([]string{"setvel2"}, 100, wrongTypeLinVel, wrongTypeAngVel)
+	err = b.Reconfigure(ctx, deps, cfg)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "type must be 'linear_velocity' or 'angular_velocity'")
+	test.That(t, b.Close(ctx), test.ShouldBeNil)
+}
+
 func TestSensorBaseWithVelocitiesSensor(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)

--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -115,8 +115,8 @@ type wheeledBase struct {
 	name string
 }
 
-// reconfigure reconfigures the base atomically and in place.
-func (wb *wheeledBase) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+// Reconfigure reconfigures the base atomically and in place.
+func (wb *wheeledBase) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	wb.mu.Lock()
 	defer wb.mu.Unlock()
 
@@ -227,7 +227,7 @@ func createWheeledBase(
 		name:                 conf.Name,
 	}
 
-	if err := wb.reconfigure(ctx, deps, conf); err != nil {
+	if err := wb.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 

--- a/components/base/wheeled/wheeled_base_test.go
+++ b/components/base/wheeled/wheeled_base_test.go
@@ -407,7 +407,7 @@ func TestWheeledBaseReconfigure(t *testing.T) {
 	deps, _, err = newTestConf.Validate("path", resource.APITypeComponentName)
 	test.That(t, err, test.ShouldBeNil)
 	motorDeps = fakeMotorDependencies(t, deps)
-	test.That(t, wb.reconfigure(ctx, motorDeps, newTestConf), test.ShouldBeNil)
+	test.That(t, wb.Reconfigure(ctx, motorDeps, newTestConf), test.ShouldBeNil)
 
 	// Add a new motor to Left only to confirm that Reconfigure is impossible because cfg validation fails
 	newerTestCfg := newTestCfg()
@@ -435,7 +435,7 @@ func TestWheeledBaseReconfigure(t *testing.T) {
 	deps, _, err = newestTestCfg.Validate("path", resource.APITypeComponentName)
 	test.That(t, err, test.ShouldBeNil)
 	motorDeps = fakeMotorDependencies(t, deps)
-	test.That(t, wb.reconfigure(ctx, motorDeps, newestTestCfg), test.ShouldBeNil)
+	test.That(t, wb.Reconfigure(ctx, motorDeps, newestTestCfg), test.ShouldBeNil)
 }
 
 func TestValidate(t *testing.T) {

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -150,6 +150,11 @@ func (b *Board) processConfig(conf resource.Config) error {
 	return nil
 }
 
+// Reconfigure atomically reconfigures this board in place based on the new config.
+func (b *Board) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	return b.processConfig(conf)
+}
+
 // A Board provides dummy data from fake parts in order to implement a Board.
 type Board struct {
 	resource.Named

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -62,14 +62,14 @@ func NewBoard(
 		interrupts:    map[string]*digitalInterrupt{},
 	}
 
-	if err := b.reconfigure(ctx, nil, conf); err != nil {
+	if err := b.Reconfigure(ctx, nil, conf); err != nil {
 		return nil, err
 	}
 	return b, nil
 }
 
-// reconfigure reconfigures the board with interrupt pins, spi and i2c, and analogs.
-func (b *Board) reconfigure(
+// Reconfigure reconfigures the board with interrupt pins, spi and i2c, and analogs.
+func (b *Board) Reconfigure(
 	ctx context.Context,
 	_ resource.Dependencies,
 	conf resource.Config,

--- a/components/camera/replaypcd/replaypcd.go
+++ b/components/camera/replaypcd/replaypcd.go
@@ -159,7 +159,7 @@ func newPCDCamera(
 		logger: logger,
 	}
 
-	if err := cam.reconfigure(ctx, deps, conf); err != nil {
+	if err := cam.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 
@@ -366,9 +366,9 @@ func (replay *pcdCamera) Close(ctx context.Context) error {
 	return nil
 }
 
-// reconfigure finishes the bring up of the replay camera by evaluating given arguments and setting up the required cloud
+// Reconfigure finishes the bring up of the replay camera by evaluating given arguments and setting up the required cloud
 // connection.
-func (replay *pcdCamera) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+func (replay *pcdCamera) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	replay.mu.Lock()
 	defer replay.mu.Unlock()
 	if replay.closed {

--- a/components/camera/replaypcd/replaypcd_test.go
+++ b/components/camera/replaypcd/replaypcd_test.go
@@ -775,7 +775,7 @@ func TestReplayPCDReconfigure(t *testing.T) {
 
 	// Reconfigure with a new batch size
 	cfg = &Config{Source: validSource, BatchSize: &batchSize4}
-	replayCamera.(*pcdCamera).reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
+	replayCamera.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 
 	// Call NextPointCloud a couple more times, ensuring that we start over from the beginning
 	// of the dataset after calling Reconfigure
@@ -789,7 +789,7 @@ func TestReplayPCDReconfigure(t *testing.T) {
 
 	// Reconfigure again, batch size 1
 	cfg = &Config{Source: validSource, BatchSize: &batchSize1}
-	replayCamera.(*pcdCamera).reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
+	replayCamera.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 
 	// Again verify dataset starts from beginning
 	for i := 0; i < numPCDFiles; i++ {

--- a/components/camera/videosourcewrappers.go
+++ b/components/camera/videosourcewrappers.go
@@ -46,6 +46,11 @@ type sourceBasedCamera struct {
 	logging.Logger
 }
 
+// Explicitly define Reconfigure to resolve ambiguity.
+func (vs *sourceBasedCamera) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	return vs.AlwaysRebuild.Reconfigure(ctx, deps, conf)
+}
+
 // Explicitly define Name to resolve ambiguity.
 func (vs *sourceBasedCamera) Name() resource.Name {
 	return vs.Named.Name()

--- a/components/encoder/incremental/incremental_encoder.go
+++ b/components/encoder/incremental/incremental_encoder.go
@@ -103,14 +103,14 @@ func NewIncrementalEncoder(
 		pRaw:         0,
 		pState:       0,
 	}
-	if err := e.reconfigure(ctx, deps, conf); err != nil {
+	if err := e.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 	return e, nil
 }
 
-// reconfigure atomically reconfigures this encoder in place based on the new config.
-func (e *Encoder) reconfigure(
+// Reconfigure atomically reconfigures this encoder in place based on the new config.
+func (e *Encoder) Reconfigure(
 	ctx context.Context,
 	deps resource.Dependencies,
 	conf resource.Config,

--- a/components/encoder/single/single_encoder.go
+++ b/components/encoder/single/single_encoder.go
@@ -125,14 +125,14 @@ func NewSingleEncoder(
 		position:     0,
 		positionType: encoder.PositionTypeTicks,
 	}
-	if err := e.reconfigure(ctx, deps, conf); err != nil {
+	if err := e.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 	return e, nil
 }
 
-// reconfigure atomically reconfigures this encoder in place based on the new config.
-func (e *Encoder) reconfigure(
+// Reconfigure atomically reconfigures this encoder in place based on the new config.
+func (e *Encoder) Reconfigure(
 	ctx context.Context,
 	deps resource.Dependencies,
 	conf resource.Config,

--- a/components/gantry/fake/gantry.go
+++ b/components/gantry/fake/gantry.go
@@ -83,6 +83,7 @@ func NewGantry(conf resource.Config, logger logging.Logger) (gantry.Gantry, erro
 
 	return &Gantry{
 		testutils.NewUnimplementedResource(conf.ResourceName()),
+		resource.TriviallyReconfigurable{},
 		resource.TriviallyCloseable{},
 		[]float64{m.DoF()[0].Max / 2},
 		[]float64{50},
@@ -95,6 +96,7 @@ func NewGantry(conf resource.Config, logger logging.Logger) (gantry.Gantry, erro
 // Gantry is a fake gantry that can simply read and set properties.
 type Gantry struct {
 	resource.Named
+	resource.TriviallyReconfigurable
 	resource.TriviallyCloseable
 	positionsMm    []float64
 	speedsMmPerSec []float64

--- a/components/gripper/fake/gripper.go
+++ b/components/gripper/fake/gripper.go
@@ -51,14 +51,14 @@ func NewGripper(ctx context.Context, deps resource.Dependencies, conf resource.C
 		geometries: []spatialmath.Geometry{},
 		logger:     logger,
 	}
-	if err := g.reconfigure(ctx, deps, conf); err != nil {
+	if err := g.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 	return g, nil
 }
 
-// reconfigure reconfigures the gripper atomically and in place.
-func (g *Gripper) reconfigure(_ context.Context, _ resource.Dependencies, conf resource.Config) error {
+// Reconfigure reconfigures the gripper atomically and in place.
+func (g *Gripper) Reconfigure(_ context.Context, _ resource.Dependencies, conf resource.Config) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 

--- a/components/input/fake/input.go
+++ b/components/input/fake/input.go
@@ -62,7 +62,7 @@ func NewInputController(ctx context.Context, conf resource.Config, logger loggin
 		logger:     logger,
 	}
 
-	if err := c.reconfigure(ctx, nil, conf); err != nil {
+	if err := c.Reconfigure(ctx, nil, conf); err != nil {
 		return nil, err
 	}
 
@@ -91,8 +91,8 @@ type InputController struct {
 	logger        logging.Logger
 }
 
-// reconfigure updates the config of the controller.
-func (c *InputController) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+// Reconfigure updates the config of the controller.
+func (c *InputController) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	newConf, err := resource.NativeConfig[*Config](conf)
 	if err != nil {
 		return err

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -103,14 +103,14 @@ func NewMotor(ctx context.Context, deps resource.Dependencies, conf resource.Con
 		Logger: logger,
 		OpMgr:  operation.NewSingleOperationManager(),
 	}
-	if err := m.reconfigure(ctx, deps, conf); err != nil {
+	if err := m.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 	return m, nil
 }
 
-// reconfigure atomically reconfigures this motor in place based on the new config.
-func (m *Motor) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+// Reconfigure atomically reconfigures this motor in place based on the new config.
+func (m *Motor) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	newConf, err := resource.NativeConfig[*Config](conf)

--- a/components/movementsensor/merged/merged.go
+++ b/components/movementsensor/merged/merged.go
@@ -74,14 +74,14 @@ func newMergedModel(ctx context.Context, deps resource.Dependencies, conf resour
 		Named:  conf.ResourceName().AsNamed(),
 	}
 
-	if err := m.reconfigure(ctx, deps, conf); err != nil {
+	if err := m.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 
 	return &m, nil
 }
 
-func (m *merged) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+func (m *merged) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	newConf, err := resource.NativeConfig[*Config](conf)
 	if err != nil {
 		return err

--- a/components/movementsensor/merged/merged_test.go
+++ b/components/movementsensor/merged/merged_test.go
@@ -280,7 +280,7 @@ func TestCreation(t *testing.T) {
 	deps = setupDependencies(t, depmap, false, false)
 
 	// first reconfiguration with six sensors and no function errors
-	err = ms.(*merged).reconfigure(ctx, deps, conf)
+	err = ms.Reconfigure(ctx, deps, conf)
 	test.That(t, err, test.ShouldBeNil)
 
 	res := ms.Name()
@@ -346,7 +346,7 @@ func TestCreation(t *testing.T) {
 
 	// second reconfiguration with six sensors but an error in accuracy
 	deps = setupDependencies(t, depmap, true /* accuracy error */, false)
-	err = ms.(*merged).reconfigure(ctx, deps, conf)
+	err = ms.Reconfigure(ctx, deps, conf)
 	test.That(t, err, test.ShouldBeNil)
 
 	accuracies, err = ms.Accuracy(ctx, nil)

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -193,7 +193,7 @@ func newReplayMovementSensor(ctx context.Context, deps resource.Dependencies, co
 		logger: logger,
 	}
 
-	if err := replay.reconfigure(ctx, deps, conf); err != nil {
+	if err := replay.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 
@@ -390,9 +390,9 @@ func (replay *replayMovementSensor) Readings(ctx context.Context, extra map[stri
 	return movementsensor.DefaultAPIReadings(ctx, replay, extra)
 }
 
-// reconfigure finishes the bring up of the replay movement sensor by evaluating given arguments and setting up the required cloud
+// Reconfigure finishes the bring up of the replay movement sensor by evaluating given arguments and setting up the required cloud
 // connection as well as updates all required parameters upon a reconfiguration attempt, restarting the cloud connection in the process.
-func (replay *replayMovementSensor) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+func (replay *replayMovementSensor) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	replay.mu.Lock()
 	defer replay.mu.Unlock()
 	if replay.closed {

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -900,7 +900,7 @@ func TestReplayMovementSensorReconfigure(t *testing.T) {
 
 	// Reconfigure with a new batch size
 	cfg = &Config{Source: validSource, BatchSize: &batchSize4}
-	replay.(*replayMovementSensor).reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
+	replay.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 
 	// Call the default movement sensor function a couple more times, ensuring that we start over from
 	// the beginning of the dataset after calling Reconfigure
@@ -910,7 +910,7 @@ func TestReplayMovementSensorReconfigure(t *testing.T) {
 
 	// Reconfigure again, batch size 1
 	cfg = &Config{Source: validSource, BatchSize: &batchSizeNonZero}
-	replay.(*replayMovementSensor).reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
+	replay.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 
 	// Again verify dataset starts from beginning
 	for i := 0; i < allMethodsMaxDataLength[defaultReplayMovementSensorFunction]; i++ {

--- a/components/movementsensor/wheeledodometry/wheeledodometry.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry.go
@@ -120,8 +120,8 @@ func (cfg *Config) Validate(path string) ([]string, []string, error) {
 	return deps, nil, nil
 }
 
-// reconfigure automatically reconfigures this movement sensor based on the updated config.
-func (o *odometry) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+// Reconfigure automatically reconfigures this movement sensor based on the updated config.
+func (o *odometry) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	if len(o.motors) > 0 {
 		if err := o.motors[0].left.Stop(ctx, nil); err != nil {
 			return err
@@ -247,7 +247,7 @@ func newWheeledOdometry(
 		logger:       logger,
 	}
 
-	if err := o.reconfigure(ctx, deps, conf); err != nil {
+	if err := o.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 

--- a/components/movementsensor/wheeledodometry/wheeledodometry_test.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry_test.go
@@ -118,6 +118,76 @@ func TestNewWheeledOdometry(t *testing.T) {
 	test.That(t, ok, test.ShouldBeTrue)
 }
 
+func TestReconfigure(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+
+	deps := make(resource.Dependencies)
+	deps[base.Named(baseName)] = createFakeBase(0.1, 0.1, 0)
+	deps[motor.Named(leftMotorName)] = createFakeMotor(true)
+	deps[motor.Named(rightMotorName)] = createFakeMotor(false)
+
+	fakecfg := resource.Config{
+		Name: testSensorName,
+		ConvertedAttributes: &Config{
+			LeftMotors:        []string{leftMotorName},
+			RightMotors:       []string{rightMotorName},
+			Base:              baseName,
+			TimeIntervalMSecs: 500,
+		},
+	}
+	fakeSensor, err := newWheeledOdometry(ctx, deps, fakecfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+	od, ok := fakeSensor.(*odometry)
+	test.That(t, ok, test.ShouldBeTrue)
+
+	newDeps := make(resource.Dependencies)
+	newDeps[base.Named(newBaseName)] = createFakeBase(0.2, 0.2, 0)
+	newDeps[motor.Named(newLeftMotorName)] = createFakeMotor(true)
+	newDeps[motor.Named(rightMotorName)] = createFakeMotor(false)
+
+	newconf := resource.Config{
+		Name: testSensorName,
+		ConvertedAttributes: &Config{
+			LeftMotors:        []string{newLeftMotorName},
+			RightMotors:       []string{rightMotorName},
+			Base:              newBaseName,
+			TimeIntervalMSecs: 500,
+		},
+	}
+
+	err = fakeSensor.Reconfigure(ctx, newDeps, newconf)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, od.timeIntervalMSecs, test.ShouldEqual, 500)
+	props, err := od.base.Properties(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, props.WidthMeters, test.ShouldEqual, 0.2)
+	test.That(t, props.WheelCircumferenceMeters, test.ShouldEqual, 0.2)
+
+	newDeps = make(resource.Dependencies)
+	newDeps[base.Named(newBaseName)] = createFakeBase(0.2, 0.2, 0)
+	newDeps[motor.Named(newLeftMotorName)] = createFakeMotor(true)
+	newDeps[motor.Named(newRightMotorName)] = createFakeMotor(false)
+
+	newconf = resource.Config{
+		Name: testSensorName,
+		ConvertedAttributes: &Config{
+			LeftMotors:        []string{newLeftMotorName},
+			RightMotors:       []string{newRightMotorName},
+			Base:              newBaseName,
+			TimeIntervalMSecs: 200,
+		},
+	}
+
+	err = fakeSensor.Reconfigure(ctx, newDeps, newconf)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, od.timeIntervalMSecs, test.ShouldEqual, 200)
+	props, err = od.base.Properties(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, props.WidthMeters, test.ShouldEqual, 0.2)
+	test.That(t, props.WheelCircumferenceMeters, test.ShouldEqual, 0.2)
+}
+
 func TestValidateConfig(t *testing.T) {
 	cfg := Config{
 		LeftMotors:        []string{leftMotorName},

--- a/components/servo/gpio/servo.go
+++ b/components/servo/gpio/servo.go
@@ -125,14 +125,14 @@ func newGPIOServo(
 	}
 
 	// reconfigure
-	if err := servo.reconfigure(ctx, deps, conf); err != nil {
+	if err := servo.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 
 	return servo, nil
 }
 
-func (s *servoGPIO) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+func (s *servoGPIO) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/examples/customresources/demos/optionaldepsmodule/module.go
+++ b/examples/customresources/demos/optionaldepsmodule/module.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/components/motor"
@@ -18,8 +19,10 @@ import (
 )
 
 var (
-	fooModel = resource.NewModel("acme", "demo", "foo")
-	mocModel = resource.NewModel("acme", "demo", "moc" /* "mutual optional child" */)
+	fooModel           = resource.NewModel("acme", "demo", "foo")
+	mocModel           = resource.NewModel("acme", "demo", "moc" /* "mutual optional child" */)
+	pointerTargetModel = resource.NewModel("acme", "demo", "pointer-target")
+	pointerHolderModel = resource.NewModel("acme", "demo", "pointer-holder")
 )
 
 func main() {
@@ -29,9 +32,17 @@ func main() {
 	resource.RegisterComponent(generic.API, mocModel, resource.Registration[resource.Resource, *MutualOptionalChildConfig]{
 		Constructor: newMutualOptionalChild,
 	})
+	resource.RegisterComponent(generic.API, pointerTargetModel, resource.Registration[resource.Resource, *PointerTargetConfig]{
+		Constructor: newPointerTarget,
+	})
+	resource.RegisterComponent(generic.API, pointerHolderModel, resource.Registration[resource.Resource, *PointerHolderConfig]{
+		Constructor: newPointerHolder,
+	})
 
 	module.ModularMain(resource.APIModel{generic.API, fooModel},
-		resource.APIModel{generic.API, mocModel})
+		resource.APIModel{generic.API, mocModel},
+		resource.APIModel{generic.API, pointerTargetModel},
+		resource.APIModel{generic.API, pointerHolderModel})
 }
 
 // FooConfig contains a required and optional motor that the component will necessarily
@@ -173,6 +184,10 @@ func (mocCfg *MutualOptionalChildConfig) Validate(path string) ([]string, []stri
 	return nil, []string{mocCfg.OtherMOC}, nil
 }
 
+// mocInstanceCounter gives each mutualOptionalChild instance a unique ID so tests can
+// detect whether a captured `otherMOC` pointer still references the current instance.
+var mocInstanceCounter atomic.Uint64
+
 type mutualOptionalChild struct {
 	resource.Named
 	resource.TriviallyCloseable
@@ -180,7 +195,8 @@ type mutualOptionalChild struct {
 
 	logger logging.Logger
 
-	otherMOC resource.Resource
+	instanceID uint64
+	otherMOC   resource.Resource
 }
 
 func newMutualOptionalChild(ctx context.Context,
@@ -189,8 +205,9 @@ func newMutualOptionalChild(ctx context.Context,
 	logger logging.Logger,
 ) (resource.Resource, error) {
 	moc := &mutualOptionalChild{
-		Named:  conf.ResourceName().AsNamed(),
-		logger: logger,
+		Named:      conf.ResourceName().AsNamed(),
+		logger:     logger,
+		instanceID: mocInstanceCounter.Add(1),
 	}
 
 	mutualOptionalChildConfig, err := resource.NativeConfig[*MutualOptionalChildConfig](conf)
@@ -226,14 +243,24 @@ func (moc *mutualOptionalChild) DoCommand(ctx context.Context, req map[string]an
 		}
 
 		if _, exists := resp["usable"]; exists {
-			return map[string]any{"other_moc_state": "usable"}, nil
+			return map[string]any{
+				"other_moc_state":   "usable",
+				"other_instance_id": resp["instance_id"],
+			}, nil
 		}
 		return map[string]any{"other_moc_state": "unusable"}, nil
 	}
 
-	// "query" will respond with {"usable": nil}
+	// "query" responds with {"usable": nil, "instance_id": <id>}; tests use the ID to
+	// distinguish a fresh captured pointer from a stale one.
 	if cmd == "query" {
-		return map[string]any{"usable": nil}, nil
+		return map[string]any{"usable": nil, "instance_id": moc.instanceID}, nil
+	}
+
+	// "instance_id" returns just the ID so tests can fetch the current instance's ID
+	// without going through a dependent's captured pointer.
+	if cmd == "instance_id" {
+		return map[string]any{"instance_id": moc.instanceID}, nil
 	}
 
 	// The command must've been something else (unrecognized).
@@ -243,3 +270,98 @@ func (moc *mutualOptionalChild) DoCommand(ctx context.Context, req map[string]an
 // `moc` is notably missing a `Reconfigure` method. Modular resources with optional
 // dependencies should be able to leverage optional dependencies even as "always rebuild"
 // resources.
+
+// PointerTargetConfig configures a pointer-target: a module-served resource that carries
+// an optional dependency, making it eligible for rebuild by the RDK's
+// updateWeakAndOptionalDependents flow. Another module-internal resource (a pointer-holder)
+// can capture a direct Go pointer to it and exercise stale-pointer scenarios when the
+// target is rebuilt via the weak/optional path.
+type PointerTargetConfig struct {
+	OptionalDep string `json:"optional_dep"`
+}
+
+// Validate returns the optional dependency so updateWeakAndOptionalDependents considers this
+// resource for rebuilding.
+func (c *PointerTargetConfig) Validate(path string) ([]string, []string, error) {
+	var optionalDeps []string
+	if c.OptionalDep != "" {
+		optionalDeps = append(optionalDeps, c.OptionalDep)
+	}
+	return nil, optionalDeps, nil
+}
+
+// pointerTargetInstanceCounter gives each pointerTarget instance a unique ID so tests can
+// verify whether a pointer-holder's captured Go pointer references the latest instance or
+// a stale one.
+var pointerTargetInstanceCounter atomic.Uint64
+
+// pointerTarget tracks whether Close was called and carries a unique instance ID.
+// DoCommand returns an error if called after Close — this is what lets a dependent detect
+// a stale pointer to a closed instance. When alive, it returns its instance ID so callers
+// can verify they are talking to the latest instance.
+type pointerTarget struct {
+	resource.Named
+	resource.AlwaysRebuild
+	instanceID uint64
+	closed     atomic.Bool
+}
+
+func newPointerTarget(_ context.Context, _ resource.Dependencies, conf resource.Config, _ logging.Logger) (resource.Resource, error) {
+	return &pointerTarget{
+		Named:      conf.ResourceName().AsNamed(),
+		instanceID: pointerTargetInstanceCounter.Add(1),
+	}, nil
+}
+
+func (p *pointerTarget) Close(_ context.Context) error {
+	p.closed.Store(true)
+	return nil
+}
+
+func (p *pointerTarget) DoCommand(_ context.Context, _ map[string]any) (map[string]any, error) {
+	if p.closed.Load() {
+		return nil, errors.New("pointerTarget is closed")
+	}
+	return map[string]any{"instance_id": p.instanceID}, nil
+}
+
+// PointerHolderConfig configures a pointer-holder: a resource that explicitly depends on
+// a pointer-target and captures a direct Go pointer to it at construction time.
+type PointerHolderConfig struct {
+	Target string `json:"target"`
+}
+
+// Validate declares target as a required dependency so it gets resolved via `deps` at
+// construction time and a Go pointer can be captured.
+func (c *PointerHolderConfig) Validate(path string) ([]string, []string, error) {
+	if c.Target == "" {
+		return nil, nil, fmt.Errorf(`expected "target" attribute for pointer-holder %q`, path)
+	}
+	return []string{c.Target}, nil, nil
+}
+
+// pointerHolder holds a direct Go pointer to a pointerTarget captured at construction time.
+// Its DoCommand proxies through the stored pointer — this is the pattern that leaves the
+// holder with a stale reference if the target is rebuilt without notifying the holder.
+type pointerHolder struct {
+	resource.Named
+	resource.TriviallyCloseable
+	resource.AlwaysRebuild
+	target resource.Resource
+}
+
+func newPointerHolder(_ context.Context, deps resource.Dependencies, conf resource.Config, _ logging.Logger) (resource.Resource, error) {
+	cfg, err := resource.NativeConfig[*PointerHolderConfig](conf)
+	if err != nil {
+		return nil, err
+	}
+	target, ok := deps[generic.Named(cfg.Target)]
+	if !ok {
+		return nil, fmt.Errorf("pointer-holder could not find target %q in dependencies", cfg.Target)
+	}
+	return &pointerHolder{Named: conf.ResourceName().AsNamed(), target: target}, nil
+}
+
+func (p *pointerHolder) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
+	return p.target.DoCommand(ctx, cmd)
+}

--- a/examples/customresources/demos/optionaldepsmodule/module.go
+++ b/examples/customresources/demos/optionaldepsmodule/module.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync/atomic"
 
 	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/components/motor"
@@ -19,10 +18,8 @@ import (
 )
 
 var (
-	fooModel           = resource.NewModel("acme", "demo", "foo")
-	mocModel           = resource.NewModel("acme", "demo", "moc" /* "mutual optional child" */)
-	pointerTargetModel = resource.NewModel("acme", "demo", "pointer-target")
-	pointerHolderModel = resource.NewModel("acme", "demo", "pointer-holder")
+	fooModel = resource.NewModel("acme", "demo", "foo")
+	mocModel = resource.NewModel("acme", "demo", "moc" /* "mutual optional child" */)
 )
 
 func main() {
@@ -32,17 +29,9 @@ func main() {
 	resource.RegisterComponent(generic.API, mocModel, resource.Registration[resource.Resource, *MutualOptionalChildConfig]{
 		Constructor: newMutualOptionalChild,
 	})
-	resource.RegisterComponent(generic.API, pointerTargetModel, resource.Registration[resource.Resource, *PointerTargetConfig]{
-		Constructor: newPointerTarget,
-	})
-	resource.RegisterComponent(generic.API, pointerHolderModel, resource.Registration[resource.Resource, *PointerHolderConfig]{
-		Constructor: newPointerHolder,
-	})
 
 	module.ModularMain(resource.APIModel{generic.API, fooModel},
-		resource.APIModel{generic.API, mocModel},
-		resource.APIModel{generic.API, pointerTargetModel},
-		resource.APIModel{generic.API, pointerHolderModel})
+		resource.APIModel{generic.API, mocModel})
 }
 
 // FooConfig contains a required and optional motor that the component will necessarily
@@ -92,14 +81,14 @@ func newFoo(ctx context.Context,
 		logger: logger,
 	}
 
-	if err := f.reconfigure(ctx, deps, conf); err != nil {
+	if err := f.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 
 	return f, nil
 }
 
-func (f *foo) reconfigure(ctx context.Context, deps resource.Dependencies,
+func (f *foo) Reconfigure(ctx context.Context, deps resource.Dependencies,
 	conf resource.Config,
 ) error {
 	fooConfig, err := resource.NativeConfig[*FooConfig](conf)
@@ -184,10 +173,6 @@ func (mocCfg *MutualOptionalChildConfig) Validate(path string) ([]string, []stri
 	return nil, []string{mocCfg.OtherMOC}, nil
 }
 
-// mocInstanceCounter gives each mutualOptionalChild instance a unique ID so tests can
-// detect whether a captured `otherMOC` pointer still references the current instance.
-var mocInstanceCounter atomic.Uint64
-
 type mutualOptionalChild struct {
 	resource.Named
 	resource.TriviallyCloseable
@@ -195,8 +180,7 @@ type mutualOptionalChild struct {
 
 	logger logging.Logger
 
-	instanceID uint64
-	otherMOC   resource.Resource
+	otherMOC resource.Resource
 }
 
 func newMutualOptionalChild(ctx context.Context,
@@ -205,9 +189,8 @@ func newMutualOptionalChild(ctx context.Context,
 	logger logging.Logger,
 ) (resource.Resource, error) {
 	moc := &mutualOptionalChild{
-		Named:      conf.ResourceName().AsNamed(),
-		logger:     logger,
-		instanceID: mocInstanceCounter.Add(1),
+		Named:  conf.ResourceName().AsNamed(),
+		logger: logger,
 	}
 
 	mutualOptionalChildConfig, err := resource.NativeConfig[*MutualOptionalChildConfig](conf)
@@ -243,24 +226,14 @@ func (moc *mutualOptionalChild) DoCommand(ctx context.Context, req map[string]an
 		}
 
 		if _, exists := resp["usable"]; exists {
-			return map[string]any{
-				"other_moc_state":   "usable",
-				"other_instance_id": resp["instance_id"],
-			}, nil
+			return map[string]any{"other_moc_state": "usable"}, nil
 		}
 		return map[string]any{"other_moc_state": "unusable"}, nil
 	}
 
-	// "query" responds with {"usable": nil, "instance_id": <id>}; tests use the ID to
-	// distinguish a fresh captured pointer from a stale one.
+	// "query" will respond with {"usable": nil}
 	if cmd == "query" {
-		return map[string]any{"usable": nil, "instance_id": moc.instanceID}, nil
-	}
-
-	// "instance_id" returns just the ID so tests can fetch the current instance's ID
-	// without going through a dependent's captured pointer.
-	if cmd == "instance_id" {
-		return map[string]any{"instance_id": moc.instanceID}, nil
+		return map[string]any{"usable": nil}, nil
 	}
 
 	// The command must've been something else (unrecognized).
@@ -270,98 +243,3 @@ func (moc *mutualOptionalChild) DoCommand(ctx context.Context, req map[string]an
 // `moc` is notably missing a `Reconfigure` method. Modular resources with optional
 // dependencies should be able to leverage optional dependencies even as "always rebuild"
 // resources.
-
-// PointerTargetConfig configures a pointer-target: a module-served resource that carries
-// an optional dependency, making it eligible for rebuild by the RDK's
-// updateWeakAndOptionalDependents flow. Another module-internal resource (a pointer-holder)
-// can capture a direct Go pointer to it and exercise stale-pointer scenarios when the
-// target is rebuilt via the weak/optional path.
-type PointerTargetConfig struct {
-	OptionalDep string `json:"optional_dep"`
-}
-
-// Validate returns the optional dependency so updateWeakAndOptionalDependents considers this
-// resource for rebuilding.
-func (c *PointerTargetConfig) Validate(path string) ([]string, []string, error) {
-	var optionalDeps []string
-	if c.OptionalDep != "" {
-		optionalDeps = append(optionalDeps, c.OptionalDep)
-	}
-	return nil, optionalDeps, nil
-}
-
-// pointerTargetInstanceCounter gives each pointerTarget instance a unique ID so tests can
-// verify whether a pointer-holder's captured Go pointer references the latest instance or
-// a stale one.
-var pointerTargetInstanceCounter atomic.Uint64
-
-// pointerTarget tracks whether Close was called and carries a unique instance ID.
-// DoCommand returns an error if called after Close — this is what lets a dependent detect
-// a stale pointer to a closed instance. When alive, it returns its instance ID so callers
-// can verify they are talking to the latest instance.
-type pointerTarget struct {
-	resource.Named
-	resource.AlwaysRebuild
-	instanceID uint64
-	closed     atomic.Bool
-}
-
-func newPointerTarget(_ context.Context, _ resource.Dependencies, conf resource.Config, _ logging.Logger) (resource.Resource, error) {
-	return &pointerTarget{
-		Named:      conf.ResourceName().AsNamed(),
-		instanceID: pointerTargetInstanceCounter.Add(1),
-	}, nil
-}
-
-func (p *pointerTarget) Close(_ context.Context) error {
-	p.closed.Store(true)
-	return nil
-}
-
-func (p *pointerTarget) DoCommand(_ context.Context, _ map[string]any) (map[string]any, error) {
-	if p.closed.Load() {
-		return nil, errors.New("pointerTarget is closed")
-	}
-	return map[string]any{"instance_id": p.instanceID}, nil
-}
-
-// PointerHolderConfig configures a pointer-holder: a resource that explicitly depends on
-// a pointer-target and captures a direct Go pointer to it at construction time.
-type PointerHolderConfig struct {
-	Target string `json:"target"`
-}
-
-// Validate declares target as a required dependency so it gets resolved via `deps` at
-// construction time and a Go pointer can be captured.
-func (c *PointerHolderConfig) Validate(path string) ([]string, []string, error) {
-	if c.Target == "" {
-		return nil, nil, fmt.Errorf(`expected "target" attribute for pointer-holder %q`, path)
-	}
-	return []string{c.Target}, nil, nil
-}
-
-// pointerHolder holds a direct Go pointer to a pointerTarget captured at construction time.
-// Its DoCommand proxies through the stored pointer — this is the pattern that leaves the
-// holder with a stale reference if the target is rebuilt without notifying the holder.
-type pointerHolder struct {
-	resource.Named
-	resource.TriviallyCloseable
-	resource.AlwaysRebuild
-	target resource.Resource
-}
-
-func newPointerHolder(_ context.Context, deps resource.Dependencies, conf resource.Config, _ logging.Logger) (resource.Resource, error) {
-	cfg, err := resource.NativeConfig[*PointerHolderConfig](conf)
-	if err != nil {
-		return nil, err
-	}
-	target, ok := deps[generic.Named(cfg.Target)]
-	if !ok {
-		return nil, fmt.Errorf("pointer-holder could not find target %q in dependencies", cfg.Target)
-	}
-	return &pointerHolder{Named: conf.ResourceName().AsNamed(), target: target}, nil
-}
-
-func (p *pointerHolder) DoCommand(ctx context.Context, cmd map[string]any) (map[string]any, error) {
-	return p.target.DoCommand(ctx, cmd)
-}

--- a/examples/customresources/demos/simplemodule/module.go
+++ b/examples/customresources/demos/simplemodule/module.go
@@ -46,6 +46,11 @@ type counter struct {
 	total int64
 }
 
+func (c *counter) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	atomic.StoreInt64(&c.total, 0)
+	return nil
+}
+
 // DoCommand is the only method of this component. It looks up the "real" command from the map it's passed.
 // Because of this, any arbitrary commands can be received, and any data returned.
 func (c *counter) DoCommand(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {

--- a/examples/customresources/models/mybase/mybase.go
+++ b/examples/customresources/models/mybase/mybase.go
@@ -39,14 +39,14 @@ func newBase(ctx context.Context, deps resource.Dependencies, conf resource.Conf
 		Named:  conf.ResourceName().AsNamed(),
 		logger: logger,
 	}
-	if err := b.reconfigure(ctx, deps, conf); err != nil {
+	if err := b.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 	return b, nil
 }
 
-// reconfigure reconfigures with new settings.
-func (b *myBase) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+// Reconfigure reconfigures with new settings.
+func (b *myBase) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	b.left = nil
 	b.right = nil
 

--- a/examples/customresources/models/mygizmo/mygizmo.go
+++ b/examples/customresources/models/mygizmo/mygizmo.go
@@ -60,13 +60,13 @@ func NewMyGizmo(
 	g := &myActualGizmo{
 		Named: conf.ResourceName().AsNamed(),
 	}
-	if err := g.reconfigure(context.Background(), deps, conf); err != nil {
+	if err := g.Reconfigure(context.Background(), deps, conf); err != nil {
 		return nil, err
 	}
 	return g, nil
 }
 
-func (g *myActualGizmo) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+func (g *myActualGizmo) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	// This takes the generic resource.Config passed down from the parent and converts it to the
 	// model-specific (aka "native") Config structure defined above making it easier to directly access attributes.
 	gizmoConfig, err := resource.NativeConfig[*Config](conf)

--- a/examples/customresources/models/mygizmosummer/mygizmosummer.go
+++ b/examples/customresources/models/mygizmosummer/mygizmosummer.go
@@ -64,13 +64,13 @@ func NewMyGizmoSummer(
 		Named:  conf.ResourceName().AsNamed(),
 		logger: logger,
 	}
-	if err := g.reconfigure(context.Background(), deps, conf); err != nil {
+	if err := g.Reconfigure(context.Background(), deps, conf); err != nil {
 		return nil, err
 	}
 	return g, nil
 }
 
-func (g *myActualGizmo) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+func (g *myActualGizmo) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	// This takes the generic resource.Config passed down from the parent and converts it to the
 	// model-specific (aka "native") Config structure defined above making it easier to directly access attributes.
 	gizmoConfig, err := resource.NativeConfig[*Config](conf)

--- a/examples/customresources/models/mysum/mysum.go
+++ b/examples/customresources/models/mysum/mysum.go
@@ -46,7 +46,7 @@ func newMySum(ctx context.Context,
 	summer := &mySum{
 		Named: conf.ResourceName().AsNamed(),
 	}
-	if err := summer.reconfigure(ctx, deps, conf); err != nil {
+	if err := summer.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 	return summer, nil
@@ -67,7 +67,7 @@ func (m *mySum) Sum(ctx context.Context, nums []float64) (float64, error) {
 	return ret, nil
 }
 
-func (m *mySum) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+func (m *mySum) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	// This takes the generic resource.Config passed down from the parent and converts it to the
 	// model-specific (aka "native") Config structure defined above making it easier to directly access attributes.
 	sumConfig, err := resource.NativeConfig[*Config](conf)

--- a/grpc/resource.go
+++ b/grpc/resource.go
@@ -1,6 +1,9 @@
 package grpc
 
 import (
+	"context"
+	"errors"
+
 	"github.com/jhump/protoreflect/dynamic/grpcdynamic"
 	"go.viam.com/utils/rpc"
 	"google.golang.org/grpc/codes"
@@ -24,6 +27,11 @@ type ForeignResource struct {
 // connection serving it.
 func NewForeignResource(name resource.Name, conn rpc.ClientConn) *ForeignResource {
 	return &ForeignResource{Named: name.AsNamed(), conn: conn}
+}
+
+// Reconfigure always fails.
+func (res *ForeignResource) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	return errors.New("this resource cannot be reconfigured")
 }
 
 // NewStub returns a new gRPC client stub used to communicate with the resource.

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -574,6 +574,31 @@ func (mgr *Manager) addResource(ctx context.Context, conf resource.Config, deps 
 	return apiInfo.RPCClient(ctx, &mod.sharedConn, "", conf.ResourceName(), mgr.logger)
 }
 
+// ReconfigureResource updates/reconfigures a modular component with a new configuration.
+func (mgr *Manager) ReconfigureResource(ctx context.Context, conf resource.Config, deps []string) error {
+	mod, ok := mgr.getModule(conf)
+	if !ok {
+		return errors.Errorf("no module registered to serve resource api %s and model %s", conf.API, conf.Model)
+	}
+
+	mod.logger.CInfow(ctx, "Reconfiguring resource for module", "resource", conf.Name, "module", mod.cfg.Name)
+
+	confProto, err := config.ComponentConfigToProto(&conf)
+	if err != nil {
+		return err
+	}
+	_, err = mod.client.ReconfigureResource(ctx, &pb.ReconfigureResourceRequest{Config: confProto, Dependencies: deps})
+	if err != nil {
+		return err
+	}
+
+	mod.resourcesMu.Lock()
+	defer mod.resourcesMu.Unlock()
+	mod.resources[conf.ResourceName()] = &addedResource{conf, deps}
+
+	return nil
+}
+
 // Configs returns a slice of config.Module representing the currently managed
 // modules.
 func (mgr *Manager) Configs() []config.Module {
@@ -620,18 +645,13 @@ func (mgr *Manager) IsModularResource(name resource.Name) bool {
 	return ok
 }
 
-// ErrResourceNotFoundInResourceModuleMap is used to indicate the resource is not found in the modules map, possibly because it was
-// already removed.
-var ErrResourceNotFoundInResourceModuleMap = errors.New("resource not found in modules map")
-
 // RemoveResource requests the removal of a resource from a module.
 func (mgr *Manager) RemoveResource(ctx context.Context, name resource.Name) error {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 	mod, ok := mgr.rMap.Load(name)
 	if !ok {
-		mgr.logger.CWarnw(ctx, "resource not found in modules map", "name", name)
-		return ErrResourceNotFoundInResourceModuleMap
+		return errors.Errorf("resource %+v not found in module", name)
 	}
 
 	mod.logger.CInfow(ctx, "Removing resource for module", "resource", name.String(), "module", mod.cfg.Name)

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -349,6 +349,19 @@ func TestModManagerFunctions(t *testing.T) {
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, deps, test.ShouldBeNil)
 
+			t.Log("test ReconfigureResource")
+			// Reconfigure should replace the proxied object, resetting the counter
+			ret, err = counter.DoCommand(ctx, map[string]interface{}{"command": "add", "value": 73})
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, ret["total"], test.ShouldEqual, 73)
+
+			err = mgr.ReconfigureResource(ctx, cfgCounter1, nil)
+			test.That(t, err, test.ShouldBeNil)
+
+			ret, err = counter.DoCommand(ctx, map[string]interface{}{"command": "get"})
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, ret["total"], test.ShouldEqual, 0)
+
 			t.Log("test RemoveResource")
 			err = mgr.RemoveResource(ctx, rNameCounter1)
 			test.That(t, err, test.ShouldBeNil)
@@ -1484,6 +1497,21 @@ func TestRTPPassthrough(t *testing.T) {
 
 	passSource, ok = passCam.(rtppassthrough.Source)
 	test.That(t, ok, test.ShouldBeTrue)
+
+	// NOTE: This test relies on the model's Close() method hanlding terminating all subscriptions
+	greenLog(t, "ReconfigureResource eventually terminates all subscriptions when the new model doesn't impelement Reconfigure")
+	// create a sub
+	sub, err = passSource.SubscribeRTP(subCtx, 512, func(pkts []*rtp.Packet) {})
+	test.That(t, err, test.ShouldBeNil)
+
+	test.That(t, sub.Terminated.Err(), test.ShouldBeNil)
+
+	// reconfigure
+	err = mgr.ReconfigureResource(ctx, passConf, nil)
+	test.That(t, err, test.ShouldBeNil)
+
+	test.That(t, utils.SelectContextOrWait(sub.Terminated, time.Second), test.ShouldBeFalse)
+	test.That(t, sub.Terminated.Err(), test.ShouldBeError, context.Canceled)
 
 	greenLog(t, "replacing a module binary eventually cancels subscriptions")
 	// add a subscription

--- a/module/module.go
+++ b/module/module.go
@@ -104,11 +104,11 @@ type Module struct {
 	// registerMu protects the maps immediately below as resources/streams come in and out of existence
 	registerMu  sync.Mutex
 	collections map[resource.API]resource.APIResourceCollection[resource.Resource]
-	// internalDeps is keyed by a "child" resource and its values are "internal" resources that
-	// depend on the child. We use a pointer for the value such that it's stable across map growth.
-	// Similarly, the slice of `resConfigureArgs` can grow, hence we must use pointers such that
-	// modifiying in place remains valid.
-	internalDeps          map[resource.Resource][]resConfigureArgs
+	// internalDeps maps a resource's name to the slice of module-internal resources that depend
+	// on it. So internalDeps[foo] is foo's dependents within this module; each entry carries
+	// the dependent's bookkeeping (see resConfigureArgs) so we can reconstruct it when foo is
+	// rebuilt. Keying by name ensures the tracking survives remove+re-add cycles.
+	internalDeps          map[resource.Name][]resConfigureArgs
 	resLoggers            map[resource.Resource]logging.Logger
 	activeResourceStreams map[resource.Name]peerResourceState
 	streamSourceByName    map[resource.Name]rtppassthrough.Source
@@ -186,7 +186,7 @@ func NewModule(ctx context.Context, address string, logger logging.Logger) (*Mod
 		handlers:              HandlerMap{},
 		collections:           map[resource.API]resource.APIResourceCollection[resource.Resource]{},
 		resLoggers:            map[resource.Resource]logging.Logger{},
-		internalDeps:          map[resource.Resource][]resConfigureArgs{},
+		internalDeps:          map[resource.Name][]resConfigureArgs{},
 	}
 
 	if tracingEnabled {

--- a/module/module.go
+++ b/module/module.go
@@ -104,11 +104,11 @@ type Module struct {
 	// registerMu protects the maps immediately below as resources/streams come in and out of existence
 	registerMu  sync.Mutex
 	collections map[resource.API]resource.APIResourceCollection[resource.Resource]
-	// internalDeps maps a resource's name to the slice of module-internal resources that depend
-	// on it. So internalDeps[foo] is foo's dependents within this module; each entry carries
-	// the dependent's bookkeeping (see resConfigureArgs) so we can reconstruct it when foo is
-	// rebuilt. Keying by name ensures the tracking survives remove+re-add cycles.
-	internalDeps          map[resource.Name][]resConfigureArgs
+	// internalDeps is keyed by a "child" resource and its values are "internal" resources that
+	// depend on the child. We use a pointer for the value such that it's stable across map growth.
+	// Similarly, the slice of `resConfigureArgs` can grow, hence we must use pointers such that
+	// modifiying in place remains valid.
+	internalDeps          map[resource.Resource][]resConfigureArgs
 	resLoggers            map[resource.Resource]logging.Logger
 	activeResourceStreams map[resource.Name]peerResourceState
 	streamSourceByName    map[resource.Name]rtppassthrough.Source
@@ -186,7 +186,7 @@ func NewModule(ctx context.Context, address string, logger logging.Logger) (*Mod
 		handlers:              HandlerMap{},
 		collections:           map[resource.API]resource.APIResourceCollection[resource.Resource]{},
 		resLoggers:            map[resource.Resource]logging.Logger{},
-		internalDeps:          map[resource.Name][]resConfigureArgs{},
+		internalDeps:          map[resource.Resource][]resConfigureArgs{},
 	}
 
 	if tracingEnabled {

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -471,15 +471,13 @@ func TestAttributeConversion(t *testing.T) {
 				ctx context.Context, deps resource.Dependencies, cfg resource.Config, logger logging.Logger,
 			) (shell.Service, error) {
 				injectable := &inject.ShellService{}
-				if reconfigConf1.Name == "" {
-					// first time constructing
-					reconfigConf1 = cfg
-					reconfigDeps1 = deps
-				} else {
-					// subsequent constructions
+				injectable.ReconfigureFunc = func(ctx context.Context, deps resource.Dependencies, cfg resource.Config) error {
 					reconfigConf2 = cfg
 					reconfigDeps2 = deps
+					return nil
 				}
+				reconfigConf1 = cfg
+				reconfigDeps1 = deps
 				return injectable, nil
 			},
 		})

--- a/module/resources.go
+++ b/module/resources.go
@@ -17,13 +17,11 @@ import (
 	"go.viam.com/rdk/robot/framesystem"
 )
 
-// resConfigureArgs is the bookkeeping kept about a resource so it can be reconstructed
-// later. `conf` is the resource's config; `depStrings` is its own dependency list, re-resolved
-// into fresh handles via getDependenciesForConstruction at rebuild time.
-//
-// When stored in internalDeps[foo], the resConfigureArgs describes a dependent
-// of foo — so internalDeps[foo][i].depStrings is the dependent's dependencies, not foo's.
 type resConfigureArgs struct {
+	// Keep the resource object around in case we can simply reconfigure.
+	toReconfig resource.Resource
+
+	// Otherwise keep the configuration and its dependencies around to close -> reconstruct.
 	conf       *resource.Config
 	depStrings []string
 }
@@ -105,7 +103,7 @@ func (m *Module) ReconfigureResource(ctx context.Context, req *pb.ReconfigureRes
 			"resource", conf.Name, "level", logLevelStr)
 	}
 
-	if _, err = m.rebuildResource(ctx, deps, conf, logLevel); err != nil {
+	if _, err = m.reconfigureResource(ctx, deps, conf, logLevel); err != nil {
 		return nil, err
 	}
 
@@ -368,92 +366,22 @@ func (m *Module) addResource(
 		m.streamSourceByName[res.Name()] = p
 	}
 
-	// Iterate over resource foo's dependencies and update their internalDeps entry to include newly rebuilt foo as a dependent,
-	// so when we know how to reconstruct foo when it's dependencies reconstructs.
 	for _, dep := range deps {
 		// If the dependency is in the `resLogger` it is a "local resource". And we must track
-		// rebuilds on our dependencies as that invalidates resource handles.
+		// reconfigures on our dependencies as that invalidates resource handles.
 		//
 		// Dan: We could call `m.getLocalResource(dep.Name())` but that's just a linear scan over
 		// resLoggers.
 		if _, exists := m.resLoggers[dep]; exists {
-			depName := dep.Name()
-			m.internalDeps[depName] = append(m.internalDeps[depName], resConfigureArgs{
+			m.internalDeps[dep] = append(m.internalDeps[dep], resConfigureArgs{
+				toReconfig: res,
 				conf:       conf,
 				depStrings: depStrings,
 			})
 		}
 	}
 
-	// Only cascade if (a) this resource has module-internal dependents and (b) it
-	// has optional dependencies. (b) is the exact set updateWeakAndOptionalDependents rebuilds
-	// for modular resources (modules can't have weak dependencies) — the only rebuild path
-	// that bypasses viam-server's dependency propagation. Checking (a) first short-circuits the
-	// Validate call in the no-dependents case.
-	if _, hasDependents := m.internalDeps[conf.ResourceName()]; hasDependents && hasOptionalDependencies(conf) {
-		m.cascadeRebuildDependentsOf(ctx, conf.ResourceName())
-	}
-
 	return nil
-}
-
-// hasOptionalDependencies returns true if `conf` declares any optional
-// dependencies via its Validate method.
-func hasOptionalDependencies(conf *resource.Config) bool {
-	if conf.ConvertedAttributes == nil {
-		return false
-	}
-	// NOTE: We have already used Validate to calculate optional dependencies in ValidateConfig for this
-	// config, but the AddResource flow does not distinguish between optional and required dependencies
-	// (it just passes an optional dependency as a normal one as long as it's available), so we must call
-	// Validate again here. It would add more complexity to cache the already-calculated value, so for now
-	// we are OK paying the cost of Validate again.
-	_, optionalDeps, err := conf.ConvertedAttributes.Validate(conf.Name)
-	if err != nil {
-		// Validate failed; fall through to cascade conservatively rather than
-		// silently skipping work that may be needed.
-		return true
-	}
-	return len(optionalDeps) > 0
-}
-
-// cascadeRebuildDependentsOf rebuilds any module-internal dependents that hold a stale Go
-// pointer to `newResName`. The RDK's updateWeakAndOptionalDependents flow rebuilds a
-// modular resource via RemoveResource+AddResource without notifying dependents; any
-// dependent that captured a direct pointer to the rebuilt resource is left stale. This
-// closes that gap on the module side.
-//
-// Must be called with `registerMu` held; the mutex is released and reacquired around each
-// recursive rebuild call.
-//
-// Cycle handling: we seed `visited` with newResName and thread it through the recursive
-// rebuild. If a cascade would re-enter a resource already on the stack, we skip it and log
-// — one side of a mutual-optional cycle keeps a stale pointer until its next reconfigure.
-func (m *Module) cascadeRebuildDependentsOf(ctx context.Context, newResName resource.Name) {
-	dependents, ok := m.internalDeps[newResName]
-	if !ok {
-		return
-	}
-	visited := map[resource.Name]struct{}{newResName: {}}
-
-	for _, args := range dependents {
-		if _, ok := m.collections[args.conf.API]; !ok {
-			continue
-		}
-		freshDeps, err := m.getDependenciesForConstruction(ctx, args.depStrings)
-		if err != nil {
-			m.logger.Warnw("failed to get deps for cascade rebuild after resource re-add",
-				"changedResource", newResName, "dependent", args.conf.Name, "err", err)
-			continue
-		}
-		m.registerMu.Unlock()
-		_, err = m.rebuildResourceWithVisited(ctx, freshDeps, args.conf, nil, visited)
-		m.registerMu.Lock()
-		if err != nil {
-			m.logger.Warnw("failed to cascade rebuild dependent after resource re-add",
-				"changedResource", newResName, "dependent", args.conf.Name, "err", err)
-		}
-	}
 }
 
 func (m *Module) removeResource(ctx context.Context, resName resource.Name) error {
@@ -488,47 +416,28 @@ func (m *Module) removeResource(ctx context.Context, resName resource.Name) erro
 	delete(m.activeResourceStreams, res.Name())
 	delete(m.resLoggers, res)
 
-	// Clear the removed resource from any dependency chain it appears in as a dependent. We do NOT
-	// deliberately delete the name-keyed entry for `res` itself — if `res` is re-added later, the
-	// cascade step in addResource needs that entry to find stale dependents and rebuild them. (An
-	// entry that ends up empty after filtering is dropped here as routine cleanup.)
-	for depName, chainReconfigures := range m.internalDeps {
-		filtered := make([]resConfigureArgs, 0, len(chainReconfigures))
-		for _, chainRes := range chainReconfigures {
-			if chainRes.conf.ResourceName() != resName {
-				filtered = append(filtered, chainRes)
+	// The viam-server forbids removing a resource until dependents are first closed/removed. Hence
+	// it's safe to assume the value in the map for `res` is empty and simply remove the map entry.q
+	delete(m.internalDeps, res)
+
+	for dep, chainReconfiguresPtr := range m.internalDeps {
+		chainReconfigures := chainReconfiguresPtr
+		for idx, chainRes := range chainReconfigures {
+			if res == chainRes.toReconfig {
+				// Clear the removed resource from any chain of reconfigures it appears in.
+				m.internalDeps[dep] = append(chainReconfigures[:idx], chainReconfigures[idx+1:]...)
 			}
-		}
-		if len(filtered) == 0 {
-			delete(m.internalDeps, depName)
-		} else {
-			m.internalDeps[depName] = filtered
 		}
 	}
 
 	return coll.Remove(resName)
 }
 
-// rebuildResource will rebuild resource and, if successful, return the new resource
+// reconfigureResource will reconfigure a resource and, if successful, return the new resource
 // pointer/interface object.
-func (m *Module) rebuildResource(
+func (m *Module) reconfigureResource(
 	ctx context.Context, deps resource.Dependencies, conf *resource.Config, logLevel *logging.Level,
 ) (resource.Resource, error) {
-	return m.rebuildResourceWithVisited(ctx, deps, conf, logLevel, map[resource.Name]struct{}{})
-}
-
-// rebuildResourceWithVisited is the recursive body of rebuildResource. It tracks which
-// resources are currently on the cascade stack (in `visited`) to prevent infinite recursion
-// through mutual-dependency cycles. The current resource is added to `visited` on entry and
-// removed on exit (stack discipline) so that sibling branches of an outer cascade can be
-// rebuilt independently.
-func (m *Module) rebuildResourceWithVisited(
-	ctx context.Context, deps resource.Dependencies, conf *resource.Config, logLevel *logging.Level,
-	visited map[resource.Name]struct{},
-) (resource.Resource, error) {
-	visited[conf.ResourceName()] = struct{}{}
-	defer delete(visited, conf.ResourceName())
-
 	m.registerMu.Lock()
 	coll, ok := m.collections[conf.API]
 	if !ok {
@@ -546,6 +455,15 @@ func (m *Module) rebuildResourceWithVisited(
 	m.registerMu.Unlock()
 	if hasLogger && logLevel != nil {
 		resLogger.SetLevel(*logLevel)
+	}
+
+	err = res.Reconfigure(ctx, deps, *conf)
+	if err == nil {
+		return res, nil
+	}
+
+	if !resource.IsMustRebuildError(err) {
+		return nil, err
 	}
 
 	if err := res.Close(ctx); err != nil {
@@ -570,7 +488,8 @@ func (m *Module) rebuildResourceWithVisited(
 	}
 
 	if err := coll.ReplaceOne(conf.ResourceName(), newRes); err != nil {
-		return nil, multierr.Combine(err, newRes.Close(ctx))
+		m.registerMu.Unlock()
+		return nil, err
 	}
 
 	m.registerMu.Lock()
@@ -583,21 +502,12 @@ func (m *Module) rebuildResourceWithVisited(
 		m.streamSourceByName[res.Name()] = p
 	}
 
-	resName := res.Name()
-	depsToRebuild := m.internalDeps[resName]
-	// Build up a new slice to map `m.internalDeps[resName]` to.
-	newDepsToRebuild := make([]resConfigureArgs, 0, len(depsToRebuild))
-	for _, depToReconfig := range depsToRebuild {
-		if _, cycled := visited[depToReconfig.conf.ResourceName()]; cycled {
-			// This dependent is already on the cascade stack. Rebuilding would close
-			// a resource that an outer caller still holds. Keep the entry unchanged.
-			m.logger.Warnw(
-				"detected mutual-optional dependency cycle: one of these resources will always hold a closed handle to the other "+
-					"after reconstruction. Remove the optional dependency from one side to break the cycle.",
-				"resource", resName, "dependent", depToReconfig.conf.Name)
-			newDepsToRebuild = append(newDepsToRebuild, depToReconfig)
-			continue
-		}
+	depsToReconfigure := m.internalDeps[res]
+	// Build up a new slice to map `m.internalDeps[newRes]` to.
+	newDepsToReconfigure := make([]resConfigureArgs, 0, len(depsToReconfigure))
+	for _, depToReconfig := range depsToReconfigure {
+		// We are going to modify `toReconfig` at the end. Make sure changes to `dependentResConfigureArgs`
+		// get reflected in the slice.
 		deps, err := m.getDependenciesForConstruction(ctx, depToReconfig.depStrings)
 		if err != nil {
 			m.logger.Warn("Failed to get dependencies for cascading dependent reconfigure",
@@ -609,14 +519,15 @@ func (m *Module) rebuildResourceWithVisited(
 		}
 
 		// We release the `registerMu` to let other resource query/acquisition methods make
-		// progress. We do not assume `rebuildResource` is fast.
+		// progress. We do not assume `reconfigureResource` is fast.
 		//
-		// We also release the mutex as the recursive call to `rebuildResourceWithVisited`
-		// will reacquire it. And the mutex is not reentrant.
+		// We also release the mutex as the recursive call to `reconfigureResource` will reacquire
+		// it. And the mutex is not reentrant.
 		m.registerMu.Unlock()
 
 		var nilLogLevel *logging.Level // pass in nil to avoid changing the log level
-		if _, err := m.rebuildResourceWithVisited(ctx, deps, depToReconfig.conf, nilLogLevel, visited); err != nil {
+		rebuiltRes, err := m.reconfigureResource(ctx, deps, depToReconfig.conf, nilLogLevel)
+		if err != nil {
 			m.logger.Warn("Failed to cascade dependent reconfigure",
 				"changedResource", conf.Name,
 				"dependent", depToReconfig.conf.Name,
@@ -624,13 +535,15 @@ func (m *Module) rebuildResourceWithVisited(
 		}
 		m.registerMu.Lock()
 
-		newDepsToRebuild = append(newDepsToRebuild, resConfigureArgs{
+		newDepsToReconfigure = append(newDepsToReconfigure, resConfigureArgs{
+			toReconfig: rebuiltRes,
 			conf:       depToReconfig.conf,
 			depStrings: depToReconfig.depStrings,
 		})
 	}
 
-	m.internalDeps[resName] = newDepsToRebuild
+	m.internalDeps[newRes] = newDepsToReconfigure
+	delete(m.internalDeps, res)
 	m.registerMu.Unlock()
 
 	return newRes, nil

--- a/module/resources.go
+++ b/module/resources.go
@@ -17,11 +17,13 @@ import (
 	"go.viam.com/rdk/robot/framesystem"
 )
 
+// resConfigureArgs is the bookkeeping kept about a resource so it can be reconstructed
+// later. `conf` is the resource's config; `depStrings` is its own dependency list, re-resolved
+// into fresh handles via getDependenciesForConstruction at rebuild time.
+//
+// When stored in internalDeps[foo], the resConfigureArgs describes a dependent
+// of foo — so internalDeps[foo][i].depStrings is the dependent's dependencies, not foo's.
 type resConfigureArgs struct {
-	// Keep the resource object around in case we can simply reconfigure.
-	toReconfig resource.Resource
-
-	// Otherwise keep the configuration and its dependencies around to close -> reconstruct.
 	conf       *resource.Config
 	depStrings []string
 }
@@ -366,22 +368,92 @@ func (m *Module) addResource(
 		m.streamSourceByName[res.Name()] = p
 	}
 
+	// Iterate over resource foo's dependencies and update their internalDeps entry to include newly rebuilt foo as a dependent,
+	// so when we know how to reconstruct foo when it's dependencies reconstructs.
 	for _, dep := range deps {
 		// If the dependency is in the `resLogger` it is a "local resource". And we must track
-		// reconfigures on our dependencies as that invalidates resource handles.
+		// rebuilds on our dependencies as that invalidates resource handles.
 		//
 		// Dan: We could call `m.getLocalResource(dep.Name())` but that's just a linear scan over
 		// resLoggers.
 		if _, exists := m.resLoggers[dep]; exists {
-			m.internalDeps[dep] = append(m.internalDeps[dep], resConfigureArgs{
-				toReconfig: res,
+			depName := dep.Name()
+			m.internalDeps[depName] = append(m.internalDeps[depName], resConfigureArgs{
 				conf:       conf,
 				depStrings: depStrings,
 			})
 		}
 	}
 
+	// Only cascade if (a) this resource has module-internal dependents and (b) it
+	// has optional dependencies. (b) is the exact set updateWeakAndOptionalDependents rebuilds
+	// for modular resources (modules can't have weak dependencies) — the only rebuild path
+	// that bypasses viam-server's dependency propagation. Checking (a) first short-circuits the
+	// Validate call in the no-dependents case.
+	if _, hasDependents := m.internalDeps[conf.ResourceName()]; hasDependents && hasOptionalDependencies(conf) {
+		m.cascadeRebuildDependentsOf(ctx, conf.ResourceName())
+	}
+
 	return nil
+}
+
+// hasOptionalDependencies returns true if `conf` declares any optional
+// dependencies via its Validate method.
+func hasOptionalDependencies(conf *resource.Config) bool {
+	if conf.ConvertedAttributes == nil {
+		return false
+	}
+	// NOTE: We have already used Validate to calculate optional dependencies in ValidateConfig for this
+	// config, but the AddResource flow does not distinguish between optional and required dependencies
+	// (it just passes an optional dependency as a normal one as long as it's available), so we must call
+	// Validate again here. It would add more complexity to cache the already-calculated value, so for now
+	// we are OK paying the cost of Validate again.
+	_, optionalDeps, err := conf.ConvertedAttributes.Validate(conf.Name)
+	if err != nil {
+		// Validate failed; fall through to cascade conservatively rather than
+		// silently skipping work that may be needed.
+		return true
+	}
+	return len(optionalDeps) > 0
+}
+
+// cascadeRebuildDependentsOf rebuilds any module-internal dependents that hold a stale Go
+// pointer to `newResName`. The RDK's updateWeakAndOptionalDependents flow rebuilds a
+// modular resource via RemoveResource+AddResource without notifying dependents; any
+// dependent that captured a direct pointer to the rebuilt resource is left stale. This
+// closes that gap on the module side.
+//
+// Must be called with `registerMu` held; the mutex is released and reacquired around each
+// recursive rebuild call.
+//
+// Cycle handling: we seed `visited` with newResName and thread it through the recursive
+// rebuild. If a cascade would re-enter a resource already on the stack, we skip it and log
+// — one side of a mutual-optional cycle keeps a stale pointer until its next reconfigure.
+func (m *Module) cascadeRebuildDependentsOf(ctx context.Context, newResName resource.Name) {
+	dependents, ok := m.internalDeps[newResName]
+	if !ok {
+		return
+	}
+	visited := map[resource.Name]struct{}{newResName: {}}
+
+	for _, args := range dependents {
+		if _, ok := m.collections[args.conf.API]; !ok {
+			continue
+		}
+		freshDeps, err := m.getDependenciesForConstruction(ctx, args.depStrings)
+		if err != nil {
+			m.logger.Warnw("failed to get deps for cascade rebuild after resource re-add",
+				"changedResource", newResName, "dependent", args.conf.Name, "err", err)
+			continue
+		}
+		m.registerMu.Unlock()
+		_, err = m.rebuildResourceWithVisited(ctx, freshDeps, args.conf, nil, visited)
+		m.registerMu.Lock()
+		if err != nil {
+			m.logger.Warnw("failed to cascade rebuild dependent after resource re-add",
+				"changedResource", newResName, "dependent", args.conf.Name, "err", err)
+		}
+	}
 }
 
 func (m *Module) removeResource(ctx context.Context, resName resource.Name) error {
@@ -416,17 +488,21 @@ func (m *Module) removeResource(ctx context.Context, resName resource.Name) erro
 	delete(m.activeResourceStreams, res.Name())
 	delete(m.resLoggers, res)
 
-	// The viam-server forbids removing a resource until dependents are first closed/removed. Hence
-	// it's safe to assume the value in the map for `res` is empty and simply remove the map entry.q
-	delete(m.internalDeps, res)
-
-	for dep, chainReconfiguresPtr := range m.internalDeps {
-		chainReconfigures := chainReconfiguresPtr
-		for idx, chainRes := range chainReconfigures {
-			if res == chainRes.toReconfig {
-				// Clear the removed resource from any chain of reconfigures it appears in.
-				m.internalDeps[dep] = append(chainReconfigures[:idx], chainReconfigures[idx+1:]...)
+	// Clear the removed resource from any dependency chain it appears in as a dependent. We do NOT
+	// deliberately delete the name-keyed entry for `res` itself — if `res` is re-added later, the
+	// cascade step in addResource needs that entry to find stale dependents and rebuild them. (An
+	// entry that ends up empty after filtering is dropped here as routine cleanup.)
+	for depName, chainReconfigures := range m.internalDeps {
+		filtered := make([]resConfigureArgs, 0, len(chainReconfigures))
+		for _, chainRes := range chainReconfigures {
+			if chainRes.conf.ResourceName() != resName {
+				filtered = append(filtered, chainRes)
 			}
+		}
+		if len(filtered) == 0 {
+			delete(m.internalDeps, depName)
+		} else {
+			m.internalDeps[depName] = filtered
 		}
 	}
 
@@ -438,6 +514,21 @@ func (m *Module) removeResource(ctx context.Context, resName resource.Name) erro
 func (m *Module) reconfigureResource(
 	ctx context.Context, deps resource.Dependencies, conf *resource.Config, logLevel *logging.Level,
 ) (resource.Resource, error) {
+	return m.rebuildResourceWithVisited(ctx, deps, conf, logLevel, map[resource.Name]struct{}{})
+}
+
+// rebuildResourceWithVisited is the recursive body of rebuildResource. It tracks which
+// resources are currently on the cascade stack (in `visited`) to prevent infinite recursion
+// through mutual-dependency cycles. The current resource is added to `visited` on entry and
+// removed on exit (stack discipline) so that sibling branches of an outer cascade can be
+// rebuilt independently.
+func (m *Module) rebuildResourceWithVisited(
+	ctx context.Context, deps resource.Dependencies, conf *resource.Config, logLevel *logging.Level,
+	visited map[resource.Name]struct{},
+) (resource.Resource, error) {
+	visited[conf.ResourceName()] = struct{}{}
+	defer delete(visited, conf.ResourceName())
+
 	m.registerMu.Lock()
 	coll, ok := m.collections[conf.API]
 	if !ok {
@@ -488,8 +579,7 @@ func (m *Module) reconfigureResource(
 	}
 
 	if err := coll.ReplaceOne(conf.ResourceName(), newRes); err != nil {
-		m.registerMu.Unlock()
-		return nil, err
+		return nil, multierr.Combine(err, newRes.Close(ctx))
 	}
 
 	m.registerMu.Lock()
@@ -502,12 +592,21 @@ func (m *Module) reconfigureResource(
 		m.streamSourceByName[res.Name()] = p
 	}
 
-	depsToReconfigure := m.internalDeps[res]
-	// Build up a new slice to map `m.internalDeps[newRes]` to.
-	newDepsToReconfigure := make([]resConfigureArgs, 0, len(depsToReconfigure))
-	for _, depToReconfig := range depsToReconfigure {
-		// We are going to modify `toReconfig` at the end. Make sure changes to `dependentResConfigureArgs`
-		// get reflected in the slice.
+	resName := res.Name()
+	depsToRebuild := m.internalDeps[resName]
+	// Build up a new slice to map `m.internalDeps[resName]` to.
+	newDepsToRebuild := make([]resConfigureArgs, 0, len(depsToRebuild))
+	for _, depToReconfig := range depsToRebuild {
+		if _, cycled := visited[depToReconfig.conf.ResourceName()]; cycled {
+			// This dependent is already on the cascade stack. Rebuilding would close
+			// a resource that an outer caller still holds. Keep the entry unchanged.
+			m.logger.Warnw(
+				"detected mutual-optional dependency cycle: one of these resources will always hold a closed handle to the other "+
+					"after reconstruction. Remove the optional dependency from one side to break the cycle.",
+				"resource", resName, "dependent", depToReconfig.conf.Name)
+			newDepsToRebuild = append(newDepsToRebuild, depToReconfig)
+			continue
+		}
 		deps, err := m.getDependenciesForConstruction(ctx, depToReconfig.depStrings)
 		if err != nil {
 			m.logger.Warn("Failed to get dependencies for cascading dependent reconfigure",
@@ -521,13 +620,12 @@ func (m *Module) reconfigureResource(
 		// We release the `registerMu` to let other resource query/acquisition methods make
 		// progress. We do not assume `reconfigureResource` is fast.
 		//
-		// We also release the mutex as the recursive call to `reconfigureResource` will reacquire
-		// it. And the mutex is not reentrant.
+		// We also release the mutex as the recursive call to `rebuildResourceWithVisited`
+		// will reacquire it. And the mutex is not reentrant.
 		m.registerMu.Unlock()
 
 		var nilLogLevel *logging.Level // pass in nil to avoid changing the log level
-		rebuiltRes, err := m.reconfigureResource(ctx, deps, depToReconfig.conf, nilLogLevel)
-		if err != nil {
+		if _, err := m.rebuildResourceWithVisited(ctx, deps, depToReconfig.conf, nilLogLevel, visited); err != nil {
 			m.logger.Warn("Failed to cascade dependent reconfigure",
 				"changedResource", conf.Name,
 				"dependent", depToReconfig.conf.Name,
@@ -535,15 +633,13 @@ func (m *Module) reconfigureResource(
 		}
 		m.registerMu.Lock()
 
-		newDepsToReconfigure = append(newDepsToReconfigure, resConfigureArgs{
-			toReconfig: rebuiltRes,
+		newDepsToRebuild = append(newDepsToRebuild, resConfigureArgs{
 			conf:       depToReconfig.conf,
 			depStrings: depToReconfig.depStrings,
 		})
 	}
 
-	m.internalDeps[newRes] = newDepsToReconfigure
-	delete(m.internalDeps, res)
+	m.internalDeps[resName] = newDepsToRebuild
 	m.registerMu.Unlock()
 
 	return newRes, nil

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -259,6 +259,12 @@ func (h *helper) DoCommand(ctx context.Context, req map[string]interface{}) (map
 	}
 }
 
+// Reconfigure increments numReconfigurations.
+func (h *helper) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	h.numReconfigurations++
+	return nil
+}
+
 func newOther(
 	ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger,
 ) (resource.Resource, error) {
@@ -306,6 +312,12 @@ func (o *other) DoCommand(ctx context.Context, req map[string]interface{}) (map[
 	default:
 		return nil, fmt.Errorf("unknown command string %s", cmd)
 	}
+}
+
+// Reconfigure increments numReconfigurations.
+func (o *other) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	o.numReconfigurations++
+	return nil
 }
 
 func newTestMotor(
@@ -399,6 +411,12 @@ type slow struct {
 	configDuration time.Duration
 }
 
+// Reconfigure does nothing but is slow.
+func (s *slow) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	time.Sleep(s.configDuration)
+	return nil
+}
+
 // Close does nothing but is slow.
 func (s *slow) Close(ctx context.Context) error {
 	time.Sleep(s.configDuration)
@@ -435,6 +453,27 @@ type fsDependent struct {
 	resource.TriviallyCloseable
 	resource.TriviallyReconfigurable
 	fs framesystem.Service
+}
+
+// Reconfigure ensures that the framesystem is available in the dependencies passed to
+// reconfigure (not just the constructor).
+func (fd *fsDependent) Reconfigure(
+	ctx context.Context,
+	deps resource.Dependencies,
+	conf resource.Config,
+) error {
+	fs, err := framesystem.FromProvider(deps)
+	if err != nil {
+		return err
+	}
+	fsCfg, err := fs.FrameSystemConfig(ctx)
+	if err != nil {
+		return err
+	}
+	if fsCfg == nil {
+		return errors.New("received an empty framesystem config in Reconfigure")
+	}
+	return nil
 }
 
 // DoCommand always returns a stringified version of the frame system config as "fsCfg".

--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -124,7 +124,7 @@ func NewConfiguredGraphNodeWithPrefix(config Config, res Resource, resModel Mode
 	node := NewUninitializedNode()
 	node.SetNewConfig(config, nil)
 	node.setDependenciesResolved()
-	node.SwapResource(res, resModel, nil, true)
+	node.SwapResource(res, resModel, nil)
 	node.setPrefix(prefix)
 	return node
 }
@@ -240,15 +240,6 @@ func (w *GraphNode) UnsetResource() {
 	w.current = nil
 }
 
-func (w *GraphNode) incrementLogicalClock() {
-	if w.graphLogicalClock != nil {
-		w.updatedAt = w.graphLogicalClock.Add(1)
-		if w.logger != nil {
-			w.logger.Debugw("graph node logical clock updated", "updated_to", w.updatedAt)
-		}
-	}
-}
-
 // SwapResource emplaces the new resource. It may be the same as before
 // and expects the caller to close the old one. This is considered
 // to be a working resource and as such we unmark it for removal
@@ -259,7 +250,7 @@ func (w *GraphNode) incrementLogicalClock() {
 // The `ftdc` input may be nil (e.g: testing). If present, this will also updates FTDC to
 // communicate that the `Stats` method may return different values. As we'll now be calling `Stats`
 // on a potentially different underlying `Model`.
-func (w *GraphNode) SwapResource(newRes Resource, newModel Model, ftdc *ftdc.FTDC, incrementClock bool) {
+func (w *GraphNode) SwapResource(newRes Resource, newModel Model, ftdc *ftdc.FTDC) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.current = newRes
@@ -272,8 +263,8 @@ func (w *GraphNode) SwapResource(newRes Resource, newModel Model, ftdc *ftdc.FTD
 	w.unresolvedDependencies = nil
 	w.needsDependencyResolution = false
 
-	if incrementClock {
-		w.incrementLogicalClock()
+	if w.graphLogicalClock != nil {
+		w.updatedAt = w.graphLogicalClock.Add(1)
 	}
 	now := time.Now()
 	w.lastReconfigured = &now
@@ -293,7 +284,9 @@ func (w *GraphNode) MarkForRemoval() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.transitionTo(NodeStateRemoving)
-	w.incrementLogicalClock()
+	if w.graphLogicalClock != nil {
+		w.updatedAt = w.graphLogicalClock.Add(1)
+	}
 }
 
 // MarkedForRemoval returns if this node is marked for removal.
@@ -314,8 +307,8 @@ func (w *GraphNode) LogAndSetLastError(err error, args ...any) {
 	wasUsable := w.lastErr == nil
 	w.lastErr = err
 	w.transitionTo(NodeStateUnhealthy)
-	if wasUsable {
-		w.incrementLogicalClock()
+	if wasUsable && w.graphLogicalClock != nil {
+		w.updatedAt = w.graphLogicalClock.Add(1)
 	}
 	w.mu.Unlock()
 

--- a/resource/graph_node_test.go
+++ b/resource/graph_node_test.go
@@ -165,7 +165,7 @@ func lifecycleTest(t *testing.T, node *resource.GraphNode, initialDeps []string)
 
 	// but we end up configuring it
 	ourRes := &someResource{Resource: testutils.NewUnimplementedResource(generic.Named("foo"))}
-	node.SwapResource(ourRes, resource.DefaultModelFamily.WithModel("bar"), nil, true)
+	node.SwapResource(ourRes, resource.DefaultModelFamily.WithModel("bar"), nil)
 	test.That(t, node.ResourceModel(), test.ShouldResemble, resource.DefaultModelFamily.WithModel("bar"))
 	test.That(t, node.MarkedForRemoval(), test.ShouldBeFalse)
 	test.That(t, node.IsUninitialized(), test.ShouldBeFalse)
@@ -199,7 +199,7 @@ func lifecycleTest(t *testing.T, node *resource.GraphNode, initialDeps []string)
 
 	// it reconfigured
 	ourRes2 := &someResource{Resource: testutils.NewUnimplementedResource(generic.Named("foo"))}
-	node.SwapResource(ourRes2, resource.DefaultModelFamily.WithModel("baz"), nil, true)
+	node.SwapResource(ourRes2, resource.DefaultModelFamily.WithModel("baz"), nil)
 	test.That(t, node.ResourceModel(), test.ShouldResemble, resource.DefaultModelFamily.WithModel("baz"))
 	res, err = node.Resource()
 	test.That(t, err, test.ShouldBeNil)
@@ -240,7 +240,7 @@ func lifecycleTest(t *testing.T, node *resource.GraphNode, initialDeps []string)
 
 	// it reconfigured
 	ourRes3 := &someResource{Resource: testutils.NewUnimplementedResource(generic.Named("fooa"))}
-	node.SwapResource(ourRes3, resource.DefaultModelFamily.WithModel("bazz"), nil, true)
+	node.SwapResource(ourRes3, resource.DefaultModelFamily.WithModel("bazz"), nil)
 	test.That(t, node.ResourceModel(), test.ShouldResemble, resource.DefaultModelFamily.WithModel("bazz"))
 	res, err = node.Resource()
 	test.That(t, err, test.ShouldBeNil)
@@ -268,7 +268,7 @@ func lifecycleTest(t *testing.T, node *resource.GraphNode, initialDeps []string)
 	verifySameState(t, node)
 
 	ourRes4 := &someResource{Resource: testutils.NewUnimplementedResource(generic.Named("foob")), shouldErr: true}
-	node.SwapResource(ourRes4, resource.DefaultModelFamily.WithModel("bazzz"), nil, true)
+	node.SwapResource(ourRes4, resource.DefaultModelFamily.WithModel("bazzz"), nil)
 	test.That(t, node.ResourceModel(), test.ShouldResemble, resource.DefaultModelFamily.WithModel("bazzz"))
 	res, err = node.Resource()
 	test.That(t, err, test.ShouldBeNil)

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -71,6 +71,11 @@ type Resource interface {
 	// Get the Name of the resource.
 	Name() Name
 
+	// Reconfigure must reconfigure the resource atomically and in place. If this
+	// cannot be guaranteed, then usage of AlwaysRebuild or TriviallyReconfigurable
+	// is permissible.
+	Reconfigure(ctx context.Context, deps Dependencies, conf Config) error
+
 	// DoCommand sends/receives arbitrary data
 	DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error)
 
@@ -81,12 +86,6 @@ type Resource interface {
 	// Close must be idempotent.
 	// Later reconfiguration may allow a resource to be "open" again.
 	Close(ctx context.Context) error
-}
-
-// BuiltInResource represents a non-modular resource built into viam-server.
-type BuiltInResource interface {
-	// BuiltInReconfigure is used to allow existing resources temporarily continue using the now-deprecated Resource.Reconfigure.
-	BuiltInReconfigure(ctx context.Context, deps Dependencies, conf Config) error
 }
 
 // Dependencies are a set of resources that a resource requires for reconfiguration.
@@ -245,11 +244,14 @@ type Shaped interface {
 // ErrDoUnimplemented is returned if the DoCommand methods is not implemented.
 var ErrDoUnimplemented = errors.New("DoCommand unimplemented")
 
-// Deprecated: TriviallyReconfigurable is to be embedded by any resource that does not care about
+// TriviallyReconfigurable is to be embedded by any resource that does not care about
 // changes to its config or dependencies.
-//
-//nolint:revive,stylecheck // ignore exported comment check.
 type TriviallyReconfigurable struct{}
+
+// Reconfigure always succeeds.
+func (t TriviallyReconfigurable) Reconfigure(ctx context.Context, deps Dependencies, conf Config) error {
+	return nil
+}
 
 // TriviallyCloseable is to be embedded by any resource that does not care about
 // handling Closes. When is used, it is assumed that the resource does not need
@@ -277,11 +279,14 @@ type NoNativeConfig struct {
 	TriviallyValidateConfig
 }
 
-// Deprecated: AlwaysRebuild is to be embedded by any resource that must always rebuild
+// AlwaysRebuild is to be embedded by any resource that must always rebuild
 // and not reconfigure.
-//
-//nolint:revive,stylecheck // ignore exported comment check.
 type AlwaysRebuild struct{}
+
+// Reconfigure always returns a must rebuild error.
+func (a AlwaysRebuild) Reconfigure(ctx context.Context, deps Dependencies, conf Config) error {
+	return NewMustRebuildError(conf.ResourceName())
+}
 
 // Named is to be embedded by any resource that just needs to return a name.
 type Named interface {

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -977,18 +977,18 @@ func TestResourceGraphClock(t *testing.T) {
 
 	// Test basic SwapResource behavior.
 	res1 := &someResource{Named: name1.AsNamed()}
-	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"), nil, true)
+	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"), nil)
 	test.That(t, g.CurrLogicalClockValue(), test.ShouldEqual, 1)
 	test.That(t, node1.UpdatedAt(), test.ShouldEqual, 1)
 	test.That(t, node2.UpdatedAt(), test.ShouldEqual, 0)
-	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"), nil, true)
+	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"), nil)
 	test.That(t, g.CurrLogicalClockValue(), test.ShouldEqual, 2)
 	test.That(t, node1.UpdatedAt(), test.ShouldEqual, 2)
 
 	// Test multiple independent nodes.
 	node2 = &GraphNode{}
 	test.That(t, g.AddNode(name2, node2), test.ShouldBeNil)
-	node2.SwapResource(res1, DefaultModelFamily.WithModel("foo"), nil, true)
+	node2.SwapResource(res1, DefaultModelFamily.WithModel("foo"), nil)
 	test.That(t, g.CurrLogicalClockValue(), test.ShouldEqual, 3)
 	test.That(t, node1.UpdatedAt(), test.ShouldEqual, 2)
 	test.That(t, node2.UpdatedAt(), test.ShouldEqual, 3)
@@ -1001,7 +1001,7 @@ func TestResourceGraphClock(t *testing.T) {
 	test.That(t, node2.UpdatedAt(), test.ShouldEqual, 3) // node2 unchanged
 
 	// Swap resource to bring node1 back to usable state (increments clock).
-	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"), nil, true)
+	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"), nil)
 	test.That(t, g.CurrLogicalClockValue(), test.ShouldEqual, 5)
 	test.That(t, node1.UpdatedAt(), test.ShouldEqual, 5)
 	test.That(t, node2.UpdatedAt(), test.ShouldEqual, 3) // node2 unchanged
@@ -1025,7 +1025,7 @@ func TestResourceGraphClock(t *testing.T) {
 	test.That(t, node2.UpdatedAt(), test.ShouldEqual, 3) // node2 unchanged
 
 	// Swap resource to transition back to usable (should increment clock).
-	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"), nil, true)
+	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"), nil)
 	test.That(t, g.CurrLogicalClockValue(), test.ShouldEqual, 7)
 	test.That(t, node1.UpdatedAt(), test.ShouldEqual, 7)
 	test.That(t, node2.UpdatedAt(), test.ShouldEqual, 3) // node2 unchanged
@@ -1048,7 +1048,7 @@ func TestResourceGraphLastReconfigured(t *testing.T) {
 	test.That(t, node1.LastReconfigured(), test.ShouldBeNil)
 
 	res1 := &someResource{Named: name1.AsNamed()}
-	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"), nil, true)
+	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"), nil)
 	lr := node1.LastReconfigured()
 	test.That(t, lr, test.ShouldNotBeNil)
 	// Assert that after SwapResource, node's lastReconfigured time is between
@@ -1058,7 +1058,7 @@ func TestResourceGraphLastReconfigured(t *testing.T) {
 
 	// Mock a mutation with another SwapResource. Assert that lastReconfigured
 	// value changed.
-	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"), nil, true)
+	node1.SwapResource(res1, DefaultModelFamily.WithModel("foo"), nil)
 	newLR := node1.LastReconfigured()
 	test.That(t, newLR, test.ShouldNotBeNil)
 	// Assert that after another SwapResource, node's lastReconfigured time is

--- a/robot/framesystem/framesystem.go
+++ b/robot/framesystem/framesystem.go
@@ -128,7 +128,7 @@ func New(ctx context.Context, deps resource.Dependencies, logger logging.Logger)
 		components: make(map[string]resource.Resource),
 		logger:     logger,
 	}
-	if err := fs.BuiltInReconfigure(ctx, deps, resource.Config{ConvertedAttributes: &Config{}}); err != nil {
+	if err := fs.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: &Config{}}); err != nil {
 		return nil, err
 	}
 	return fs, nil
@@ -195,7 +195,7 @@ type frameSystemService struct {
 }
 
 // Reconfigure will rebuild the frame system from the newly updated robot.
-func (svc *frameSystemService) BuiltInReconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+func (svc *frameSystemService) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	svc.partsMu.Lock()
 	defer svc.partsMu.Unlock()
 

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -46,6 +46,7 @@ import (
 	icloud "go.viam.com/rdk/internal/cloud"
 	"go.viam.com/rdk/internal/otlpfile"
 	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/module/modmanager"
 	"go.viam.com/rdk/operation"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/referenceframe"
@@ -996,37 +997,33 @@ func (r *localRobot) updateWeakAndOptionalDependents(ctx context.Context) {
 			// the check in `localRobot.resourceHasWeakDependencies`.
 			switch resName {
 			case web.InternalServiceName:
-				if internalRes, ok := res.(resource.BuiltInResource); ok {
-					if err := internalRes.BuiltInReconfigure(ctxWithTimeout, allResources, resource.Config{}); err != nil {
-						r.Logger().CErrorw(
-							ctx,
-							"failed to reconfigure internal service during weak/optional dependencies update",
-							"service", resName,
-							"error", err,
-						)
-					}
+				if err := res.Reconfigure(ctxWithTimeout, allResources, resource.Config{}); err != nil {
+					r.Logger().CErrorw(
+						ctx,
+						"failed to reconfigure internal service during weak/optional dependencies update",
+						"service", resName,
+						"error", err,
+					)
 				}
 			case framesystem.InternalServiceName:
-				if internalRes, ok := res.(resource.BuiltInResource); ok {
-					fsCfg, err := r.FrameSystemConfig(ctxWithTimeout)
-					if err != nil {
-						r.Logger().CErrorw(
-							ctx,
-							"failed to reconfigure internal service during weak/optional dependencies update",
-							"service", resName,
-							"error", err,
-						)
-						break
-					}
-					err = internalRes.BuiltInReconfigure(ctxWithTimeout, components, resource.Config{ConvertedAttributes: fsCfg})
-					if err != nil {
-						r.Logger().CErrorw(
-							ctx,
-							"failed to reconfigure internal service during weak/optional dependencies update",
-							"service", resName,
-							"error", err,
-						)
-					}
+				fsCfg, err := r.FrameSystemConfig(ctxWithTimeout)
+				if err != nil {
+					r.Logger().CErrorw(
+						ctx,
+						"failed to reconfigure internal service during weak/optional dependencies update",
+						"service", resName,
+						"error", err,
+					)
+					break
+				}
+				err = res.Reconfigure(ctxWithTimeout, components, resource.Config{ConvertedAttributes: fsCfg})
+				if err != nil {
+					r.Logger().CErrorw(
+						ctx,
+						"failed to reconfigure internal service during weak/optional dependencies update",
+						"service", resName,
+						"error", err,
+					)
 				}
 			case packages.InternalServiceName, packages.DeferredServiceName, icloud.InternalServiceName:
 			default:
@@ -1072,7 +1069,7 @@ func (r *localRobot) updateWeakAndOptionalDependents(ctx context.Context) {
 			return
 		}
 
-		// Return early if resource has neither weak nor optional dependencies (root of tree)
+		// Return early if resource has neither weak nor optional dependencies.
 		if len(r.getWeakDependencyMatchers(conf.API, conf.Model)) == 0 &&
 			len(conf.ImplicitOptionalDependsOn) == 0 {
 			return
@@ -1089,27 +1086,13 @@ func (r *localRobot) updateWeakAndOptionalDependents(ctx context.Context) {
 			return
 		}
 
+		// Use the module manager to reconfigure the resource if it's a modular resource. This
+		// would be a modular resource that has optional dependencies.
 		isModular := r.manager.moduleManager.Provides(conf)
-		if internalResource, ok := res.(resource.BuiltInResource); !isModular && ok {
-			err = internalResource.BuiltInReconfigure(ctx, deps, conf)
+		if isModular {
+			err = r.manager.moduleManager.ReconfigureResource(ctx, conf, modmanager.DepsToNames(deps))
 		} else {
-			// copied from resource_manager's processResource
-			if err := r.manager.closeAndUnsetResource(ctx, resNode); err != nil {
-				r.manager.logger.CError(ctx, err)
-			}
-			var newRes resource.Resource
-			newRes, err = r.newResource(ctx, resNode, conf)
-			if err != nil {
-				r.manager.logger.CDebugw(ctx,
-					"failed to build resource of new model",
-					"name", resName,
-					"old_model", resNode.ResourceModel(),
-					"new_model", conf.Model,
-				)
-			} else if newRes != nil {
-				// will NPE if newRes is nil
-				resNode.SwapResource(newRes, conf.Model, r.manager.opts.ftdc, false)
-			}
+			err = res.Reconfigure(ctx, deps, conf)
 		}
 		if err != nil {
 			if resource.IsMustRebuildError(err) {

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/golang/geo/r3"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	v1 "go.opentelemetry.io/proto/otlp/trace/v1"
-	"go.uber.org/zap/zapcore"
 	"go.viam.com/test"
 	"go.viam.com/utils"
 	"go.viam.com/utils/rpc"
@@ -2595,17 +2594,13 @@ func TestModularResourceReconfigurationCount(t *testing.T) {
 	resp, err := h.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, resp, test.ShouldNotBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: h.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, resp["num_reconfigurations"], test.ShouldEqual, 0)
 	o, err := r.ResourceByName(genericservice.Named("o"))
 	test.That(t, err, test.ShouldBeNil)
 	resp, err = o.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, resp, test.ShouldNotBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: o.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, resp["num_reconfigurations"], test.ShouldEqual, 0)
 
 	cfg2 := &config.Config{
 		Modules: []config.Module{
@@ -2637,15 +2632,11 @@ func TestModularResourceReconfigurationCount(t *testing.T) {
 	resp, err = h.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, resp, test.ShouldNotBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: h.Name()}).Len(),
-		test.ShouldEqual, 2)
+	test.That(t, resp["num_reconfigurations"], test.ShouldEqual, 0)
 	resp, err = o.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, resp, test.ShouldNotBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: o.Name()}).Len(),
-		test.ShouldEqual, 2)
+	test.That(t, resp["num_reconfigurations"], test.ShouldEqual, 0)
 
 	cfg3 := &config.Config{
 		Modules: []config.Module{
@@ -2683,15 +2674,11 @@ func TestModularResourceReconfigurationCount(t *testing.T) {
 	resp, err = h.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, resp, test.ShouldNotBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: h.Name()}).Len(),
-		test.ShouldEqual, 2)
+	test.That(t, resp["num_reconfigurations"], test.ShouldEqual, 1)
 	resp, err = o.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, resp, test.ShouldNotBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: o.Name()}).Len(),
-		test.ShouldEqual, 2)
+	test.That(t, resp["num_reconfigurations"], test.ShouldEqual, 1)
 
 	cfg4 := &config.Config{
 		Modules: []config.Module{
@@ -2729,15 +2716,11 @@ func TestModularResourceReconfigurationCount(t *testing.T) {
 	resp, err = h.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, resp, test.ShouldNotBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: h.Name()}).Len(),
-		test.ShouldEqual, 3)
+	test.That(t, resp["num_reconfigurations"], test.ShouldEqual, 0)
 	resp, err = o.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, resp, test.ShouldNotBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: o.Name()}).Len(),
-		test.ShouldEqual, 3)
+	test.That(t, resp["num_reconfigurations"], test.ShouldEqual, 0)
 
 	test.That(t, logs.FilterMessageSnippet("Successfully constructed resource").Len(), test.ShouldEqual, 6)
 
@@ -2760,15 +2743,11 @@ func TestModularResourceReconfigurationCount(t *testing.T) {
 	resp, err = h.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, resp, test.ShouldNotBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: h.Name()}).Len(),
-		test.ShouldEqual, 4)
+	test.That(t, resp["num_reconfigurations"], test.ShouldEqual, 0)
 	resp, err = o.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, resp, test.ShouldNotBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: o.Name()}).Len(),
-		test.ShouldEqual, 4)
+	test.That(t, resp["num_reconfigurations"], test.ShouldEqual, 0)
 }
 
 func TestImplicitDepsAcrossModules(t *testing.T) {
@@ -3535,7 +3514,7 @@ func newMock(
 	logger logging.Logger,
 ) (resource.Resource, error) {
 	m := &mockResource{name: conf.Name}
-	if err := m.reconfigure(ctx, deps, conf); err != nil {
+	if err := m.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -3545,7 +3524,7 @@ func (m *mockResource) Name() resource.Name {
 	return mockNamed(m.name)
 }
 
-func (m *mockResource) reconfigure(
+func (m *mockResource) Reconfigure(
 	ctx context.Context,
 	deps resource.Dependencies,
 	conf resource.Config,

--- a/robot/impl/optional_dependencies_test.go
+++ b/robot/impl/optional_dependencies_test.go
@@ -1410,27 +1410,6 @@ func TestModularOptionalDependenciesCycles(t *testing.T) {
 		mocFresh := mocSeesMoc2 == moc2Current
 		moc2Fresh := moc2SeesMoc == mocCurrent
 		test.That(t, mocFresh != moc2Fresh, test.ShouldBeTrue)
-
-		// Ensure we hit the infinite rebuild cycle skip log. updateWeakAndOptionalDependents
-		// rebuilds both moc and moc2 but depending on the iteration order, one or both of
-		// them will log the skip. moc was added in first round reconstruction when moc2
-		// didn't exist (so moc never registered against m.internalDeps[moc2]), while moc2's
-		// later add did register against m.internalDeps[moc].
-		// 	- If moc rebuilds first, its rebuild populates m.internalDeps[moc2] as a side
-		// effect (the new moc resolves moc2 as a dependency and registers against it), then its
-		// cascade logs the cycle skip. When moc2's iteration follows, its cascade now has a
-		// populated internalDeps, hits the cycle, and logs a skip → 2 warnings total.
-		//
-		// 	- If moc2 is iterated first, m.internalDeps[moc2] is still empty when its checks to
-		// cascade rebuild dependents. The cascade is skipped because it has no dependents
-		// according to internalDeps and so only moc's iteration produces a warning → 1 warning total.
-		//
-		// The asymmetry resolves itself once both sides have been rebuilt at least once,
-		// but on this first pass the cycle-skip count can be 1 or 2 depending on
-		// updateWeakAndOptionalDependents iteration order.
-		cycleSkips := logs.FilterMessageSnippet("detected mutual-optional dependency cycle").Len()
-		test.That(t, cycleSkips, test.ShouldBeGreaterThanOrEqualTo, 1)
-		test.That(t, cycleSkips, test.ShouldBeLessThanOrEqualTo, 2)
 	}
 
 	// Reconfigure the robot to remove the original 'moc'.

--- a/robot/impl/optional_dependencies_test.go
+++ b/robot/impl/optional_dependencies_test.go
@@ -1374,29 +1374,63 @@ func TestModularOptionalDependenciesCycles(t *testing.T) {
 	lr.Reconfigure(ctx, &cfg)
 
 	{ // Assertions
-		// Assert that the first 'moc' component is still accessible (did not fail to
-		// reconstruct).
+		// In a mutual-optional cycle the cascade deliberately stops before re-adding the
+		// resource on the visited stack (see cascadeRebuildDependentsOf), so exactly one
+		// side ends up with a stale captured pointer. Which side is stale depends on the
+		// order updateWeakAndOptionalDependents iterates resources, which is non-deterministic.
+
 		mocRes, err := lr.ResourceByName(mocName)
+		test.That(t, err, test.ShouldBeNil)
+		mocRes2, err := lr.ResourceByName(mocName2)
 		test.That(t, err, test.ShouldBeNil)
 
 		// Assert that there were no more logs (still 2) about failures to "get other MOC."
 		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
 		test.That(t, msgNum, test.ShouldEqual, 2)
 
-		// Assert that, on the 'moc' component itself, `otherMOC` is now usable.
-		doCommandResp, err := mocRes.DoCommand(ctx, map[string]any{"command": "other_moc_state"})
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"other_moc_state": "usable"})
+		currentID := func(res resource.Resource) float64 {
+			resp, err := res.DoCommand(ctx, map[string]any{"command": "instance_id"})
+			test.That(t, err, test.ShouldBeNil)
+			return resp["instance_id"].(float64)
+		}
+		seenOtherID := func(res resource.Resource) float64 {
+			resp, err := res.DoCommand(ctx, map[string]any{"command": "other_moc_state"})
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, resp["other_moc_state"], test.ShouldEqual, "usable")
+			return resp["other_instance_id"].(float64)
+		}
 
-		// Assert that the second 'moc2' component is now accessible (did not fail to
-		// construct).
-		mocRes2, err := lr.ResourceByName(mocName2)
-		test.That(t, err, test.ShouldBeNil)
+		mocCurrent := currentID(mocRes)
+		moc2Current := currentID(mocRes2)
+		mocSeesMoc2 := seenOtherID(mocRes)
+		moc2SeesMoc := seenOtherID(mocRes2)
 
-		// Assert that, on the 'moc2' component itself, `otherMOC` is now usable.
-		doCommandResp, err = mocRes2.DoCommand(ctx, map[string]any{"command": "other_moc_state"})
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"other_moc_state": "usable"})
+		// One of moc / moc2 has fresh pointer to the other and the other has stale
+		// pointer to the first.
+		mocFresh := mocSeesMoc2 == moc2Current
+		moc2Fresh := moc2SeesMoc == mocCurrent
+		test.That(t, mocFresh != moc2Fresh, test.ShouldBeTrue)
+
+		// Ensure we hit the infinite rebuild cycle skip log. updateWeakAndOptionalDependents
+		// rebuilds both moc and moc2 but depending on the iteration order, one or both of
+		// them will log the skip. moc was added in first round reconstruction when moc2
+		// didn't exist (so moc never registered against m.internalDeps[moc2]), while moc2's
+		// later add did register against m.internalDeps[moc].
+		// 	- If moc rebuilds first, its rebuild populates m.internalDeps[moc2] as a side
+		// effect (the new moc resolves moc2 as a dependency and registers against it), then its
+		// cascade logs the cycle skip. When moc2's iteration follows, its cascade now has a
+		// populated internalDeps, hits the cycle, and logs a skip → 2 warnings total.
+		//
+		// 	- If moc2 is iterated first, m.internalDeps[moc2] is still empty when its checks to
+		// cascade rebuild dependents. The cascade is skipped because it has no dependents
+		// according to internalDeps and so only moc's iteration produces a warning → 1 warning total.
+		//
+		// The asymmetry resolves itself once both sides have been rebuilt at least once,
+		// but on this first pass the cycle-skip count can be 1 or 2 depending on
+		// updateWeakAndOptionalDependents iteration order.
+		cycleSkips := logs.FilterMessageSnippet("detected mutual-optional dependency cycle").Len()
+		test.That(t, cycleSkips, test.ShouldBeGreaterThanOrEqualTo, 1)
+		test.That(t, cycleSkips, test.ShouldBeLessThanOrEqualTo, 2)
 	}
 
 	// Reconfigure the robot to remove the original 'moc'.
@@ -2291,4 +2325,307 @@ func TestModularOptionalDependencyModuleCrash(t *testing.T) {
 	doCommandResp, err = fooRes.DoCommand(ctx, map[string]any{"command": "optional_motor_state"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"optional_motor_state": "moving: false"})
+}
+
+func TestModularStalePointerAfterWeakOptionalRebuild(t *testing.T) {
+	// Setup:
+	//   - pointer-target (modular) declares an optional dep. When that dep's availability
+	//     changes, the RDK's updateWeakAndOptionalDependents flow rebuilds the target by
+	//     sending RemoveResource + AddResource to the module.
+	//   - pointer-holder (modular, same module) explicitly depends_on the target and captures
+	//     a direct Go pointer to it at construction time.
+	//
+	// Each target instance carries a unique ID. After the target is rebuilt, the holder must
+	// be rebuilt too so its captured pointer references the current target instance — not the
+	// one that was just closed. The test probes both the target directly and the
+	// target-via-holder and asserts their instance IDs match. Without the cascade, the holder
+	// ends up pointing at a closed prior instance and its proxied DoCommand either errors or
+	// returns a stale ID.
+	logger := logging.NewTestLogger(t)
+	ctx := context.Background()
+
+	lr := setupLocalRobot(t, ctx, &config.Config{}, logger, WithDisableCompleteConfigWorker())
+
+	optionalDepsModulePath := testutils.BuildTempModule(t, "examples/customresources/demos/optionaldepsmodule")
+
+	targetModel := resource.NewModel("acme", "demo", "pointer-target")
+	holderModel := resource.NewModel("acme", "demo", "pointer-holder")
+	targetName := generic.Named("target1")
+	holderName := generic.Named("holder1")
+
+	cfg := config.Config{
+		Modules: []config.Module{
+			{
+				Name:    "optional-deps",
+				ExePath: optionalDepsModulePath,
+			},
+		},
+		Components: []resource.Config{
+			{
+				// The optional-dep target — its presence causes pointer-target to be
+				// rebuilt by updateWeakAndOptionalDependents on every reconfigure cycle.
+				Name:                "opt-dep",
+				API:                 motor.API,
+				Model:               fake.Model,
+				ConvertedAttributes: &fake.Config{},
+			},
+			{
+				Name:  targetName.Name,
+				API:   generic.API,
+				Model: targetModel,
+				Attributes: rutils.AttributeMap{
+					"optional_dep": "opt-dep",
+				},
+			},
+			{
+				// Explicit depends_on target1 via the config attribute; the module's
+				// Validate returns it as a required dependency so the holder captures a Go
+				// pointer to target1.
+				Name:  holderName.Name,
+				API:   generic.API,
+				Model: holderModel,
+				Attributes: rutils.AttributeMap{
+					"target": targetName.Name,
+				},
+			},
+		},
+	}
+	// Ensure fills in ImplicitOptionalDependsOn from Validate — required for
+	// updateWeakAndOptionalDependents to consider pointer-target.
+	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
+
+	// assertHolderPointsToCurrentTarget fetches the current target instance ID directly,
+	// then fetches the target instance ID via the holder (which proxies through its
+	// captured pointer), and asserts they match. A mismatch means the holder is holding
+	// a stale pointer to a previous target instance.
+	assertHolderPointsToCurrentTarget := func(label string) {
+		targetRes, err := lr.ResourceByName(targetName)
+		test.That(t, err, test.ShouldBeNil)
+		targetResp, err := targetRes.DoCommand(ctx, map[string]any{"probe": label})
+		test.That(t, err, test.ShouldBeNil)
+
+		holderRes, err := lr.ResourceByName(holderName)
+		test.That(t, err, test.ShouldBeNil)
+		holderResp, err := holderRes.DoCommand(ctx, map[string]any{"probe": label})
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, holderResp["instance_id"], test.ShouldEqual, targetResp["instance_id"])
+	}
+
+	// Initial Reconfigure — builds target_v1 and holder_v1, then
+	// updateWeakAndOptionalDependents rebuilds target (to target_v2) and the module's
+	// cascade rebuilds holder (to holder_v2) so it points at target_v2.
+	lr.Reconfigure(ctx, &cfg)
+	assertHolderPointsToCurrentTarget("initial")
+
+	// Add an unrelated motor to advance the clock and re-trigger
+	// updateWeakAndOptionalDependents — the second cascade must keep holder fresh.
+	cfg2 := cfg
+	cfg2.Components = append(append([]resource.Config{}, cfg.Components...), resource.Config{
+		Name:                "unrelated-motor",
+		API:                 motor.API,
+		Model:               fake.Model,
+		ConvertedAttributes: &fake.Config{},
+	})
+	test.That(t, cfg2.Ensure(false, logger), test.ShouldBeNil)
+	lr.Reconfigure(ctx, &cfg2)
+	assertHolderPointsToCurrentTarget("after-unrelated-change")
+}
+
+func TestModularStalePointerCascadeFanOut(t *testing.T) {
+	// Verifies that a single rebuild of a resource with multiple explicit dependents
+	// cascades to rebuild every one of them.
+	// Setup:
+	//   - One pointer-target with an optional dependency (triggers updateWeakAndOptionalDependents
+	//     on every reconfigure).
+	//   - Three pointer-holders, each depending on that target.
+	//
+	// After reconfigure, every holder should route DoCommand through the current target
+	// instance. If the cascade only rebuilds one holder (or rebuilds them against different
+	// target instances), some holder's instance_id would diverge from the others or from the
+	// target itself.
+
+	logger := logging.NewTestLogger(t)
+	ctx := context.Background()
+
+	lr := setupLocalRobot(t, ctx, &config.Config{}, logger, WithDisableCompleteConfigWorker())
+
+	optionalDepsModulePath := testutils.BuildTempModule(t, "examples/customresources/demos/optionaldepsmodule")
+
+	targetModel := resource.NewModel("acme", "demo", "pointer-target")
+	holderModel := resource.NewModel("acme", "demo", "pointer-holder")
+	targetName := generic.Named("target")
+	holderNames := []resource.Name{
+		generic.Named("holder-a"),
+		generic.Named("holder-b"),
+		generic.Named("holder-c"),
+	}
+
+	components := []resource.Config{
+		{
+			Name:                "opt-dep",
+			API:                 motor.API,
+			Model:               fake.Model,
+			ConvertedAttributes: &fake.Config{},
+		},
+		{
+			Name:  targetName.Name,
+			API:   generic.API,
+			Model: targetModel,
+			Attributes: rutils.AttributeMap{
+				"optional_dep": "opt-dep",
+			},
+		},
+	}
+	for _, hn := range holderNames {
+		components = append(components, resource.Config{
+			Name:  hn.Name,
+			API:   generic.API,
+			Model: holderModel,
+			Attributes: rutils.AttributeMap{
+				"target": targetName.Name,
+			},
+		})
+	}
+
+	cfg := config.Config{
+		Modules: []config.Module{
+			{Name: "optional-deps", ExePath: optionalDepsModulePath},
+		},
+		Components: components,
+	}
+	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
+
+	assertAllHoldersPointToCurrentTarget := func(label string) {
+		targetRes, err := lr.ResourceByName(targetName)
+		test.That(t, err, test.ShouldBeNil)
+		targetResp, err := targetRes.DoCommand(ctx, map[string]any{"probe": label})
+		test.That(t, err, test.ShouldBeNil)
+		wantID := targetResp["instance_id"]
+
+		for _, hn := range holderNames {
+			holderRes, err := lr.ResourceByName(hn)
+			test.That(t, err, test.ShouldBeNil)
+			holderResp, err := holderRes.DoCommand(ctx, map[string]any{"probe": label})
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, holderResp["instance_id"], test.ShouldEqual, wantID)
+		}
+	}
+
+	lr.Reconfigure(ctx, &cfg)
+	assertAllHoldersPointToCurrentTarget("initial")
+
+	// Push a config change to advance the clock and re-trigger updateWeakAndOptionalDependents.
+	cfg2 := cfg
+	cfg2.Components = append(append([]resource.Config{}, cfg.Components...), resource.Config{
+		Name:                "unrelated-motor",
+		API:                 motor.API,
+		Model:               fake.Model,
+		ConvertedAttributes: &fake.Config{},
+	})
+	test.That(t, cfg2.Ensure(false, logger), test.ShouldBeNil)
+	lr.Reconfigure(ctx, &cfg2)
+	assertAllHoldersPointToCurrentTarget("after-unrelated-change")
+}
+
+func TestModularStalePointerCascadeChain(t *testing.T) {
+	// Verifies that cascades propagate transitively through multi-hop explicit-dep chains.
+	// Exercises the recursive cascade inside rebuildResourceWithVisited (invoked by the outer
+	// addResource cascade), not just the single-level cascade in addResource.
+	// Setup:  target → mid-holder (depends on target) → top-holder (depends on mid-holder)
+	//
+	// When target is rebuilt:
+	//  1. addResource(target_new) cascade finds mid-holder in internalDeps[target], rebuilds it.
+	//  2. rebuildResourceWithVisited(mid-holder) runs ITS cascade over internalDeps[mid-holder],
+	//     rebuilds top-holder.
+	//  3. top-holder ends up freshly constructed, its captured pointer referencing the freshly
+	//     constructed mid-holder, which references the new target.
+	//
+	// top-holder.DoCommand proxies → mid-holder.DoCommand → target.DoCommand → returns the
+	// current target's instance_id. Any break in the chain would either error or report a
+	// stale ID.
+
+	logger := logging.NewTestLogger(t)
+	ctx := context.Background()
+
+	lr := setupLocalRobot(t, ctx, &config.Config{}, logger, WithDisableCompleteConfigWorker())
+
+	optionalDepsModulePath := testutils.BuildTempModule(t, "examples/customresources/demos/optionaldepsmodule")
+
+	targetModel := resource.NewModel("acme", "demo", "pointer-target")
+	holderModel := resource.NewModel("acme", "demo", "pointer-holder")
+	targetName := generic.Named("target")
+	midName := generic.Named("mid-holder")
+	topName := generic.Named("top-holder")
+
+	cfg := config.Config{
+		Modules: []config.Module{
+			{Name: "optional-deps", ExePath: optionalDepsModulePath},
+		},
+		Components: []resource.Config{
+			{
+				Name:                "opt-dep",
+				API:                 motor.API,
+				Model:               fake.Model,
+				ConvertedAttributes: &fake.Config{},
+			},
+			{
+				Name:  targetName.Name,
+				API:   generic.API,
+				Model: targetModel,
+				Attributes: rutils.AttributeMap{
+					"optional_dep": "opt-dep",
+				},
+			},
+			{
+				Name:  midName.Name,
+				API:   generic.API,
+				Model: holderModel,
+				Attributes: rutils.AttributeMap{
+					"target": targetName.Name,
+				},
+			},
+			{
+				Name:  topName.Name,
+				API:   generic.API,
+				Model: holderModel,
+				Attributes: rutils.AttributeMap{
+					"target": midName.Name,
+				},
+			},
+		},
+	}
+	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
+
+	// The top-holder proxies DoCommand through mid-holder, which proxies through target.
+	// If any link in the chain holds a stale pointer, the ID returned at the top won't
+	// match the target's current ID.
+	assertTopHolderReachesCurrentTarget := func(label string) {
+		targetRes, err := lr.ResourceByName(targetName)
+		test.That(t, err, test.ShouldBeNil)
+		targetResp, err := targetRes.DoCommand(ctx, map[string]any{"probe": label})
+		test.That(t, err, test.ShouldBeNil)
+
+		topRes, err := lr.ResourceByName(topName)
+		test.That(t, err, test.ShouldBeNil)
+		topResp, err := topRes.DoCommand(ctx, map[string]any{"probe": label})
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, topResp["instance_id"], test.ShouldEqual, targetResp["instance_id"])
+	}
+
+	lr.Reconfigure(ctx, &cfg)
+	assertTopHolderReachesCurrentTarget("initial")
+
+	// Push a config change to advance the clock and re-trigger the cascade.
+	cfg2 := cfg
+	cfg2.Components = append(append([]resource.Config{}, cfg.Components...), resource.Config{
+		Name:                "unrelated-motor",
+		API:                 motor.API,
+		Model:               fake.Model,
+		ConvertedAttributes: &fake.Config{},
+	})
+	test.That(t, cfg2.Ensure(false, logger), test.ShouldBeNil)
+	lr.Reconfigure(ctx, &cfg2)
+	assertTopHolderReachesCurrentTarget("after-unrelated-change")
 }

--- a/robot/impl/optional_dependencies_test.go
+++ b/robot/impl/optional_dependencies_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap/zapcore"
 	"go.viam.com/test"
 	"go.viam.com/utils"
 	gotestutils "go.viam.com/utils/testutils"
@@ -58,6 +57,7 @@ type optionalChild struct {
 
 	requiredMotor motor.Motor
 	optionalMotor motor.Motor
+	reconfigCount int
 }
 
 func newOptionalChild(ctx context.Context,
@@ -70,14 +70,26 @@ func newOptionalChild(ctx context.Context,
 		logger: logger,
 	}
 
+	if err := oc.Reconfigure(ctx, deps, conf); err != nil {
+		return nil, err
+	}
+
+	return oc, nil
+}
+
+func (oc *optionalChild) Reconfigure(ctx context.Context, deps resource.Dependencies,
+	conf resource.Config,
+) error {
+	oc.reconfigCount++
+
 	optionalChildConfig, err := resource.NativeConfig[*optionalChildConfig](conf)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	oc.requiredMotor, err = motor.FromProvider(deps, optionalChildConfig.RequiredMotor)
 	if err != nil {
-		return nil, fmt.Errorf("could not get required motor %s from dependencies",
+		return fmt.Errorf("could not get required motor %s from dependencies",
 			optionalChildConfig.RequiredMotor)
 	}
 
@@ -87,7 +99,7 @@ func newOptionalChild(ctx context.Context,
 			optionalChildConfig.OptionalMotor)
 	}
 
-	return oc, nil
+	return nil
 }
 
 func TestOptionalDependencies(t *testing.T) {
@@ -139,13 +151,14 @@ func TestOptionalDependencies(t *testing.T) {
 		ocRes, err := lr.ResourceByName(ocName)
 		test.That(t, err, test.ShouldBeNil)
 
-		// Assert that the optional child rebuilt and logged its inability to get 'm1'
+		// Assert that the optional child reconfigured and logged its inability to get 'm1'
 		// from dependencies _twice_. The first of both is from construction (invokes
-		// `reconfigure`) of the resource, and the second of both is from rebuilding the
+		// `Reconfigure`) of the resource, and the second of both is from reconfiguring of the
 		// resource due to an unconditional call to `updateWeakAndOptionalDependents` directly
 		// after `completeConfig`.
 		oc, err := resource.AsType[*optionalChild](ocRes)
 		test.That(t, err, test.ShouldBeNil)
+		test.That(t, oc.reconfigCount, test.ShouldEqual, 2)
 		msgNum := logs.FilterMessageSnippet("could not get optional motor").Len()
 		test.That(t, msgNum, test.ShouldEqual, 2)
 
@@ -196,6 +209,7 @@ func TestOptionalDependencies(t *testing.T) {
 		// "get optional motor."
 		oc, err := resource.AsType[*optionalChild](ocRes)
 		test.That(t, err, test.ShouldBeNil)
+		test.That(t, oc.reconfigCount, test.ShouldEqual, 3)
 		msgNum := logs.FilterMessageSnippet("could not get optional motor").Len()
 		test.That(t, msgNum, test.ShouldEqual, 2)
 
@@ -240,6 +254,7 @@ func TestOptionalDependencies(t *testing.T) {
 		// about failures to "get optional motor."
 		oc, err := resource.AsType[*optionalChild](ocRes)
 		test.That(t, err, test.ShouldBeNil)
+		test.That(t, oc.reconfigCount, test.ShouldEqual, 4)
 		msgNum := logs.FilterMessageSnippet("could not get optional motor").Len()
 		test.That(t, msgNum, test.ShouldEqual, 3)
 
@@ -308,8 +323,13 @@ func TestOptionalDependencies(t *testing.T) {
 		ocRes, err := lr.ResourceByName(ocName)
 		test.That(t, err, test.ShouldBeNil)
 
+		// Assert that the optional child reconfigured twice. The first is from construction
+		// (invokes `Reconfigure`) of the resource, and the second is from reconfiguring of
+		// the resource due to an unconditional call to `updateWeakAndOptionalDependents`
+		// directly after `completeConfig`.
 		oc, err := resource.AsType[*optionalChild](ocRes)
 		test.That(t, err, test.ShouldBeNil)
+		test.That(t, oc.reconfigCount, test.ShouldEqual, 2)
 
 		// Assert that there are either 3 (no new) _or_ 4 logs about an inability to "get
 		// optional motor."
@@ -663,8 +683,12 @@ func TestOptionalDependencyOnBuiltin(t *testing.T) {
 	ocRes, err := lr.ResourceByName(ocName)
 	test.That(t, err, test.ShouldBeNil)
 
+	// Assert that the optional child reconfigured twice. The first is from construction,
+	// and the second is from reconfiguring of the resource due to a call
+	// to `updateWeakAndOptionalDependents` directly after `completeConfig`.
 	oc, err := resource.AsType[*optionalChild](ocRes)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, oc.reconfigCount, test.ShouldEqual, 2)
 
 	// Assert that there is either 0 or 1 log about an inability to "get optional motor."
 	//
@@ -838,8 +862,7 @@ func TestModularOptionalDependencyOnRemote(t *testing.T) {
 	// assert that its optional dependency on the remote motor is reachable.
 	fooRes, err := lr.ResourceByName(fooName)
 	test.That(t, err, test.ShouldBeNil)
-	// constructed m, m1, f
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").Len(), test.ShouldEqual, 3)
+	test.That(t, logs.FilterMessageSnippet("Reconfiguring resource for module").Len(), test.ShouldEqual, 1)
 	doCommandResp, err := fooRes.DoCommand(ctx, map[string]any{"command": "optional_motor_state"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"optional_motor_state": "moving: false"})
@@ -859,7 +882,7 @@ func TestModularOptionalDependencyOnRemote(t *testing.T) {
 
 	// Assert that the foo component did NOT reconfigure again but its optional dependency
 	// on the remote motor is now unreachable.
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").Len(), test.ShouldEqual, 3)
+	test.That(t, logs.FilterMessageSnippet("Reconfiguring resource for module").Len(), test.ShouldEqual, 1)
 	doCommandResp, err = fooRes.DoCommand(ctx, map[string]any{"command": "optional_motor_state"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"optional_motor_state": "unreachable"})
@@ -880,8 +903,7 @@ func TestModularOptionalDependencyOnRemote(t *testing.T) {
 
 	// Assert that the foo component did NOT reconfigure, but its optional dependency on the
 	// remote motor is now reachable.
-	// m1 constructed again
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").Len(), test.ShouldEqual, 4)
+	test.That(t, logs.FilterMessageSnippet("Reconfiguring resource for module").Len(), test.ShouldEqual, 1)
 	doCommandResp, err = fooRes.DoCommand(ctx, map[string]any{"command": "optional_motor_state"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"optional_motor_state": "moving: false"})
@@ -959,8 +981,7 @@ func TestModularOptionalDependencyOnRemoteWithPrefix(t *testing.T) {
 	// assert that its optional dependency on the remote motor is reachable.
 	fooRes, err := lr.ResourceByName(fooName)
 	test.That(t, err, test.ShouldBeNil)
-	// constructs m1, m, f
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").Len(), test.ShouldEqual, 3)
+	test.That(t, logs.FilterMessageSnippet("Reconfiguring resource for module").Len(), test.ShouldEqual, 1)
 	doCommandResp, err := fooRes.DoCommand(ctx, map[string]any{"command": "optional_motor_state"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"optional_motor_state": "moving: false"})
@@ -1023,8 +1044,7 @@ func TestModularOptionalDependencyOnFullyQualifiedName(t *testing.T) {
 	// it correctly identifies m_optional via the fully qualified name.
 	fooRes, err := lr.ResourceByName(fooName)
 	test.That(t, err, test.ShouldBeNil)
-	// constructs m_required, m_optional, f
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").Len(), test.ShouldEqual, 3)
+	test.That(t, logs.FilterMessageSnippet("Reconfiguring resource for module").Len(), test.ShouldEqual, 1)
 
 	// Verify foo works and that the optional dependency is reachable.
 	doCommandResp, err := fooRes.DoCommand(ctx, map[string]any{"command": "required_motor_state"})
@@ -1070,14 +1090,14 @@ func newMutualOptionalChild(ctx context.Context,
 		logger: logger,
 	}
 
-	if err := moc.reconfigure(ctx, deps, conf); err != nil {
+	if err := moc.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 
 	return moc, nil
 }
 
-func (moc *mutualOptionalChild) reconfigure(ctx context.Context, deps resource.Dependencies,
+func (moc *mutualOptionalChild) Reconfigure(ctx context.Context, deps resource.Dependencies,
 	conf resource.Config,
 ) error {
 	moc.reconfigCount++
@@ -1157,7 +1177,7 @@ func TestOptionalDependenciesCycles(t *testing.T) {
 		// after `completeConfig`.
 		moc, err := resource.AsType[*mutualOptionalChild](mocRes)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, moc.reconfigCount, test.ShouldEqual, 1)
+		test.That(t, moc.reconfigCount, test.ShouldEqual, 2)
 		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
 		test.That(t, msgNum, test.ShouldEqual, 2)
 
@@ -1201,7 +1221,7 @@ func TestOptionalDependenciesCycles(t *testing.T) {
 		// other MOC."
 		moc, err := resource.AsType[*mutualOptionalChild](mocRes)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, moc.reconfigCount, test.ShouldEqual, 1)
+		test.That(t, moc.reconfigCount, test.ShouldEqual, 3)
 		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
 		test.That(t, msgNum, test.ShouldEqual, 2)
 
@@ -1213,8 +1233,10 @@ func TestOptionalDependenciesCycles(t *testing.T) {
 		mocRes2, err := lr.ResourceByName(mocName2)
 		test.That(t, err, test.ShouldBeNil)
 
+		// Assert that the second mutual optional child has reconfigured _two_ times.
 		moc2, err := resource.AsType[*mutualOptionalChild](mocRes2)
 		test.That(t, err, test.ShouldBeNil)
+		test.That(t, moc2.reconfigCount, test.ShouldEqual, 2)
 
 		// Assert that, on the 'moc2' component itself, `otherMOC` is now set.
 		test.That(t, moc2.otherMOC, test.ShouldNotBeNil)
@@ -1252,7 +1274,7 @@ func TestOptionalDependenciesCycles(t *testing.T) {
 		// failures to "get other MOC."
 		moc2, err := resource.AsType[*mutualOptionalChild](mocRes2)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, moc2.reconfigCount, test.ShouldEqual, 1)
+		test.That(t, moc2.reconfigCount, test.ShouldEqual, 3)
 		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
 		test.That(t, msgNum, test.ShouldEqual, 3)
 
@@ -1352,63 +1374,29 @@ func TestModularOptionalDependenciesCycles(t *testing.T) {
 	lr.Reconfigure(ctx, &cfg)
 
 	{ // Assertions
-		// In a mutual-optional cycle the cascade deliberately stops before re-adding the
-		// resource on the visited stack (see cascadeRebuildDependentsOf), so exactly one
-		// side ends up with a stale captured pointer. Which side is stale depends on the
-		// order updateWeakAndOptionalDependents iterates resources, which is non-deterministic.
-
+		// Assert that the first 'moc' component is still accessible (did not fail to
+		// reconstruct).
 		mocRes, err := lr.ResourceByName(mocName)
-		test.That(t, err, test.ShouldBeNil)
-		mocRes2, err := lr.ResourceByName(mocName2)
 		test.That(t, err, test.ShouldBeNil)
 
 		// Assert that there were no more logs (still 2) about failures to "get other MOC."
 		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
 		test.That(t, msgNum, test.ShouldEqual, 2)
 
-		currentID := func(res resource.Resource) float64 {
-			resp, err := res.DoCommand(ctx, map[string]any{"command": "instance_id"})
-			test.That(t, err, test.ShouldBeNil)
-			return resp["instance_id"].(float64)
-		}
-		seenOtherID := func(res resource.Resource) float64 {
-			resp, err := res.DoCommand(ctx, map[string]any{"command": "other_moc_state"})
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, resp["other_moc_state"], test.ShouldEqual, "usable")
-			return resp["other_instance_id"].(float64)
-		}
+		// Assert that, on the 'moc' component itself, `otherMOC` is now usable.
+		doCommandResp, err := mocRes.DoCommand(ctx, map[string]any{"command": "other_moc_state"})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"other_moc_state": "usable"})
 
-		mocCurrent := currentID(mocRes)
-		moc2Current := currentID(mocRes2)
-		mocSeesMoc2 := seenOtherID(mocRes)
-		moc2SeesMoc := seenOtherID(mocRes2)
+		// Assert that the second 'moc2' component is now accessible (did not fail to
+		// construct).
+		mocRes2, err := lr.ResourceByName(mocName2)
+		test.That(t, err, test.ShouldBeNil)
 
-		// One of moc / moc2 has fresh pointer to the other and the other has stale
-		// pointer to the first.
-		mocFresh := mocSeesMoc2 == moc2Current
-		moc2Fresh := moc2SeesMoc == mocCurrent
-		test.That(t, mocFresh != moc2Fresh, test.ShouldBeTrue)
-
-		// Ensure we hit the infinite rebuild cycle skip log. updateWeakAndOptionalDependents
-		// rebuilds both moc and moc2 but depending on the iteration order, one or both of
-		// them will log the skip. moc was added in first round reconstruction when moc2
-		// didn't exist (so moc never registered against m.internalDeps[moc2]), while moc2's
-		// later add did register against m.internalDeps[moc].
-		// 	- If moc rebuilds first, its rebuild populates m.internalDeps[moc2] as a side
-		// effect (the new moc resolves moc2 as a dependency and registers against it), then its
-		// cascade logs the cycle skip. When moc2's iteration follows, its cascade now has a
-		// populated internalDeps, hits the cycle, and logs a skip → 2 warnings total.
-		//
-		// 	- If moc2 is iterated first, m.internalDeps[moc2] is still empty when its checks to
-		// cascade rebuild dependents. The cascade is skipped because it has no dependents
-		// according to internalDeps and so only moc's iteration produces a warning → 1 warning total.
-		//
-		// The asymmetry resolves itself once both sides have been rebuilt at least once,
-		// but on this first pass the cycle-skip count can be 1 or 2 depending on
-		// updateWeakAndOptionalDependents iteration order.
-		cycleSkips := logs.FilterMessageSnippet("detected mutual-optional dependency cycle").Len()
-		test.That(t, cycleSkips, test.ShouldBeGreaterThanOrEqualTo, 1)
-		test.That(t, cycleSkips, test.ShouldBeLessThanOrEqualTo, 2)
+		// Assert that, on the 'moc2' component itself, `otherMOC` is now usable.
+		doCommandResp, err = mocRes2.DoCommand(ctx, map[string]any{"command": "other_moc_state"})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"other_moc_state": "usable"})
 	}
 
 	// Reconfigure the robot to remove the original 'moc'.
@@ -1517,10 +1505,19 @@ func TestOptionalDependencyRepeatedErrors(t *testing.T) {
 	// Get the optional child and verify initial state.
 	ocRes, err := lr.ResourceByName(ocName)
 	test.That(t, err, test.ShouldBeNil)
-	_, err = resource.AsType[*optionalChild](ocRes)
+	oc, err := resource.AsType[*optionalChild](ocRes)
 	test.That(t, err, test.ShouldBeNil)
 
+	// The optional child should have reconfigured twice:
+	// 1. Initial construction
+	// 2. updateWeakAndOptionalDependents after completeConfig
+	initialReconfigCount := oc.reconfigCount
+	test.That(t, initialReconfigCount, test.ShouldEqual, 2)
+
 	initialClockValue := lr.(*localRobot).manager.resources.CurrLogicalClockValue()
+
+	// Record reconfigCount before inducing the error.
+	reconfigCountBeforeError := oc.reconfigCount
 
 	// Clear any existing logs to make assertions cleaner.
 	logs.TakeAll()
@@ -1555,9 +1552,16 @@ func TestOptionalDependencyRepeatedErrors(t *testing.T) {
 	// should return early without additional reconfigurations of the optional child.
 	for i := 0; i < 5; i++ {
 		lr.(*localRobot).updateRemotesAndRetryResourceConfigure()
+		// The clock should NOT increment - m_unrelated is still unusable.
 		test.That(t, lr.(*localRobot).manager.resources.CurrLogicalClockValue(),
 			test.ShouldEqual, clockAfterFirstError)
 	}
+
+	// Verify the optional child reconfigured exactly once from the initial state (triggered by
+	// the first error's clock increment during lr.Reconfigure). The repeated retry calls should
+	// NOT have caused additional reconfigurations.
+	reconfigCountAfterAllUpdates := oc.reconfigCount
+	test.That(t, reconfigCountAfterAllUpdates-reconfigCountBeforeError, test.ShouldEqual, 1)
 
 	// Verify that m_unrelated failed to build 5 times (one for each retry call).
 	buildErrorLogs := logs.FilterMessageSnippet("resource build error: unknown resource type").Len()
@@ -1663,9 +1667,8 @@ func TestModularOptionalDependencyRepeatedErrors(t *testing.T) {
 	test.That(t, firstErrorLogs, test.ShouldEqual, 1)
 
 	// Verify the foo component was reconfigured once due to the first error.
-	test.That(t, logs.FilterMessageSnippet("Adding resource to module").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringType, String: fooRes.Name().Name}).Len(),
-		test.ShouldEqual, 1)
+	reconfigLogsAfterFirstError := logs.FilterMessageSnippet("Reconfiguring resource for module").Len()
+	test.That(t, reconfigLogsAfterFirstError, test.ShouldEqual, 1)
 
 	// Clear logs again to isolate just the retry attempts.
 	logs.TakeAll()
@@ -1684,9 +1687,8 @@ func TestModularOptionalDependencyRepeatedErrors(t *testing.T) {
 
 	// Verify the foo component did not reconfigure during the retry attempts. The repeated
 	// retry calls should NOT have caused additional reconfigurations.
-	test.That(t, logs.FilterMessageSnippet("Adding resource to module").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringType, String: fooRes.Name().Name}).Len(),
-		test.ShouldEqual, 0)
+	reconfigLogsAfterAllUpdates := logs.FilterMessageSnippet("Reconfiguring resource for module").Len()
+	test.That(t, reconfigLogsAfterAllUpdates, test.ShouldEqual, 0)
 
 	// Verify that m_unrelated failed to build 5 times (one for each retry call).
 	buildErrorLogs := logs.FilterMessageSnippet("resource build error: unknown resource type").Len()
@@ -1774,6 +1776,12 @@ func TestOptionalDependencyUnrelatedResourceRemoval(t *testing.T) {
 	oc, err := resource.AsType[*optionalChild](ocRes)
 	test.That(t, err, test.ShouldBeNil)
 
+	// The optional child should have reconfigured twice:
+	// 1. Initial construction
+	// 2. updateWeakAndOptionalDependents after completeConfig
+	initialReconfigCount := oc.reconfigCount
+	test.That(t, initialReconfigCount, test.ShouldEqual, 2)
+
 	// Verify both motors are accessible.
 	test.That(t, oc.requiredMotor, test.ShouldNotBeNil)
 	test.That(t, oc.optionalMotor, test.ShouldNotBeNil)
@@ -1815,6 +1823,10 @@ func TestOptionalDependencyUnrelatedResourceRemoval(t *testing.T) {
 	// Verify the clock incremented (m_unrelated was marked for removal).
 	clockAfterRemoval := lr.(*localRobot).manager.resources.CurrLogicalClockValue()
 	test.That(t, clockAfterRemoval, test.ShouldBeGreaterThan, initialClockValue)
+
+	// Verify the optional child reconfigured once (triggered by clock change from removal).
+	// This is the current behavior - any clock change triggers updateWeakAndOptionalDependents.
+	test.That(t, oc.reconfigCount, test.ShouldEqual, initialReconfigCount+1)
 
 	// Verify both motors are still accessible (the reconfiguration was successful).
 	test.That(t, oc.requiredMotor, test.ShouldNotBeNil)
@@ -1940,9 +1952,8 @@ func TestModularOptionalDependencyUnrelatedResourceRemoval(t *testing.T) {
 
 	// Verify the foo component reconfigured once (triggered by clock change from removal).
 	// This is the current behavior - any clock change triggers updateWeakAndOptionalDependents.
-	test.That(t, logs.FilterMessageSnippet("Adding resource to module").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringType, String: fooRes.Name().Name}).Len(),
-		test.ShouldEqual, 1)
+	reconfigLogsAfterRemoval := logs.FilterMessageSnippet("Reconfiguring resource for module").Len()
+	test.That(t, reconfigLogsAfterRemoval, test.ShouldEqual, 1)
 
 	// Verify both motors are still accessible through the foo component after reconfiguration.
 	doCommandResp, err = fooRes.DoCommand(ctx, map[string]any{"command": "required_motor_state"})
@@ -2099,9 +2110,8 @@ func TestModularOptionalDependencyModuleNameChange(t *testing.T) {
 	// Verify the foo component reconfigured twice: once when the old module was removed,
 	// and once when the new module's resources were added. Each removal/addition increments
 	// the clock, triggering updateWeakAndOptionalDependents.
-	test.That(t, logs.FilterMessageSnippet("Adding resource to module").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringType, String: fooRes.Name().Name}).Len(),
-		test.ShouldEqual, 2)
+	reconfigLogsAfterModuleChange := logs.FilterMessageSnippet("Reconfiguring resource for module").Len()
+	test.That(t, reconfigLogsAfterModuleChange, test.ShouldEqual, 2)
 
 	// Verify both motors are still accessible through the foo component after reconfiguration.
 	doCommandResp, err = fooRes.DoCommand(ctx, map[string]any{"command": "required_motor_state"})
@@ -2243,9 +2253,8 @@ func TestModularOptionalDependencyModuleCrash(t *testing.T) {
 	finalClockValue := lr.(*localRobot).manager.resources.CurrLogicalClockValue()
 	test.That(t, finalClockValue, test.ShouldEqual, initialClockValue)
 
-	test.That(t, logs.FilterMessageSnippet("Adding resource to module").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringType, String: fooRes.Name().Name}).Len(),
-		test.ShouldEqual, 0)
+	newReconfigCount := logs.FilterMessageSnippet("Reconfiguring resource for module").Len()
+	test.That(t, newReconfigCount, test.ShouldEqual, 0)
 
 	// --- Recovery phase ---
 
@@ -2270,10 +2279,9 @@ func TestModularOptionalDependencyModuleCrash(t *testing.T) {
 	recoveredClockValue := lr.(*localRobot).manager.resources.CurrLogicalClockValue()
 	test.That(t, recoveredClockValue, test.ShouldBeGreaterThan, initialClockValue)
 
-	// The clock increment triggers reconfiguration of foo.
-	test.That(t, logs.FilterMessageSnippet("Adding resource to module").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringType, String: fooRes.Name().Name}).Len(),
-		test.ShouldEqual, 1)
+	// The clock increment triggers one reconfiguration of foo.
+	recoveryReconfigCount := logs.FilterMessageSnippet("Reconfiguring resource for module").Len()
+	test.That(t, recoveryReconfigCount, test.ShouldEqual, 1)
 
 	// Both motors remain accessible through foo after the full crash-recovery cycle.
 	doCommandResp, err = fooRes.DoCommand(ctx, map[string]any{"command": "required_motor_state"})
@@ -2283,307 +2291,4 @@ func TestModularOptionalDependencyModuleCrash(t *testing.T) {
 	doCommandResp, err = fooRes.DoCommand(ctx, map[string]any{"command": "optional_motor_state"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"optional_motor_state": "moving: false"})
-}
-
-func TestModularStalePointerAfterWeakOptionalRebuild(t *testing.T) {
-	// Setup:
-	//   - pointer-target (modular) declares an optional dep. When that dep's availability
-	//     changes, the RDK's updateWeakAndOptionalDependents flow rebuilds the target by
-	//     sending RemoveResource + AddResource to the module.
-	//   - pointer-holder (modular, same module) explicitly depends_on the target and captures
-	//     a direct Go pointer to it at construction time.
-	//
-	// Each target instance carries a unique ID. After the target is rebuilt, the holder must
-	// be rebuilt too so its captured pointer references the current target instance — not the
-	// one that was just closed. The test probes both the target directly and the
-	// target-via-holder and asserts their instance IDs match. Without the cascade, the holder
-	// ends up pointing at a closed prior instance and its proxied DoCommand either errors or
-	// returns a stale ID.
-	logger := logging.NewTestLogger(t)
-	ctx := context.Background()
-
-	lr := setupLocalRobot(t, ctx, &config.Config{}, logger, WithDisableCompleteConfigWorker())
-
-	optionalDepsModulePath := testutils.BuildTempModule(t, "examples/customresources/demos/optionaldepsmodule")
-
-	targetModel := resource.NewModel("acme", "demo", "pointer-target")
-	holderModel := resource.NewModel("acme", "demo", "pointer-holder")
-	targetName := generic.Named("target1")
-	holderName := generic.Named("holder1")
-
-	cfg := config.Config{
-		Modules: []config.Module{
-			{
-				Name:    "optional-deps",
-				ExePath: optionalDepsModulePath,
-			},
-		},
-		Components: []resource.Config{
-			{
-				// The optional-dep target — its presence causes pointer-target to be
-				// rebuilt by updateWeakAndOptionalDependents on every reconfigure cycle.
-				Name:                "opt-dep",
-				API:                 motor.API,
-				Model:               fake.Model,
-				ConvertedAttributes: &fake.Config{},
-			},
-			{
-				Name:  targetName.Name,
-				API:   generic.API,
-				Model: targetModel,
-				Attributes: rutils.AttributeMap{
-					"optional_dep": "opt-dep",
-				},
-			},
-			{
-				// Explicit depends_on target1 via the config attribute; the module's
-				// Validate returns it as a required dependency so the holder captures a Go
-				// pointer to target1.
-				Name:  holderName.Name,
-				API:   generic.API,
-				Model: holderModel,
-				Attributes: rutils.AttributeMap{
-					"target": targetName.Name,
-				},
-			},
-		},
-	}
-	// Ensure fills in ImplicitOptionalDependsOn from Validate — required for
-	// updateWeakAndOptionalDependents to consider pointer-target.
-	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
-
-	// assertHolderPointsToCurrentTarget fetches the current target instance ID directly,
-	// then fetches the target instance ID via the holder (which proxies through its
-	// captured pointer), and asserts they match. A mismatch means the holder is holding
-	// a stale pointer to a previous target instance.
-	assertHolderPointsToCurrentTarget := func(label string) {
-		targetRes, err := lr.ResourceByName(targetName)
-		test.That(t, err, test.ShouldBeNil)
-		targetResp, err := targetRes.DoCommand(ctx, map[string]any{"probe": label})
-		test.That(t, err, test.ShouldBeNil)
-
-		holderRes, err := lr.ResourceByName(holderName)
-		test.That(t, err, test.ShouldBeNil)
-		holderResp, err := holderRes.DoCommand(ctx, map[string]any{"probe": label})
-		test.That(t, err, test.ShouldBeNil)
-
-		test.That(t, holderResp["instance_id"], test.ShouldEqual, targetResp["instance_id"])
-	}
-
-	// Initial Reconfigure — builds target_v1 and holder_v1, then
-	// updateWeakAndOptionalDependents rebuilds target (to target_v2) and the module's
-	// cascade rebuilds holder (to holder_v2) so it points at target_v2.
-	lr.Reconfigure(ctx, &cfg)
-	assertHolderPointsToCurrentTarget("initial")
-
-	// Add an unrelated motor to advance the clock and re-trigger
-	// updateWeakAndOptionalDependents — the second cascade must keep holder fresh.
-	cfg2 := cfg
-	cfg2.Components = append(append([]resource.Config{}, cfg.Components...), resource.Config{
-		Name:                "unrelated-motor",
-		API:                 motor.API,
-		Model:               fake.Model,
-		ConvertedAttributes: &fake.Config{},
-	})
-	test.That(t, cfg2.Ensure(false, logger), test.ShouldBeNil)
-	lr.Reconfigure(ctx, &cfg2)
-	assertHolderPointsToCurrentTarget("after-unrelated-change")
-}
-
-func TestModularStalePointerCascadeFanOut(t *testing.T) {
-	// Verifies that a single rebuild of a resource with multiple explicit dependents
-	// cascades to rebuild every one of them.
-	// Setup:
-	//   - One pointer-target with an optional dependency (triggers updateWeakAndOptionalDependents
-	//     on every reconfigure).
-	//   - Three pointer-holders, each depending on that target.
-	//
-	// After reconfigure, every holder should route DoCommand through the current target
-	// instance. If the cascade only rebuilds one holder (or rebuilds them against different
-	// target instances), some holder's instance_id would diverge from the others or from the
-	// target itself.
-
-	logger := logging.NewTestLogger(t)
-	ctx := context.Background()
-
-	lr := setupLocalRobot(t, ctx, &config.Config{}, logger, WithDisableCompleteConfigWorker())
-
-	optionalDepsModulePath := testutils.BuildTempModule(t, "examples/customresources/demos/optionaldepsmodule")
-
-	targetModel := resource.NewModel("acme", "demo", "pointer-target")
-	holderModel := resource.NewModel("acme", "demo", "pointer-holder")
-	targetName := generic.Named("target")
-	holderNames := []resource.Name{
-		generic.Named("holder-a"),
-		generic.Named("holder-b"),
-		generic.Named("holder-c"),
-	}
-
-	components := []resource.Config{
-		{
-			Name:                "opt-dep",
-			API:                 motor.API,
-			Model:               fake.Model,
-			ConvertedAttributes: &fake.Config{},
-		},
-		{
-			Name:  targetName.Name,
-			API:   generic.API,
-			Model: targetModel,
-			Attributes: rutils.AttributeMap{
-				"optional_dep": "opt-dep",
-			},
-		},
-	}
-	for _, hn := range holderNames {
-		components = append(components, resource.Config{
-			Name:  hn.Name,
-			API:   generic.API,
-			Model: holderModel,
-			Attributes: rutils.AttributeMap{
-				"target": targetName.Name,
-			},
-		})
-	}
-
-	cfg := config.Config{
-		Modules: []config.Module{
-			{Name: "optional-deps", ExePath: optionalDepsModulePath},
-		},
-		Components: components,
-	}
-	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
-
-	assertAllHoldersPointToCurrentTarget := func(label string) {
-		targetRes, err := lr.ResourceByName(targetName)
-		test.That(t, err, test.ShouldBeNil)
-		targetResp, err := targetRes.DoCommand(ctx, map[string]any{"probe": label})
-		test.That(t, err, test.ShouldBeNil)
-		wantID := targetResp["instance_id"]
-
-		for _, hn := range holderNames {
-			holderRes, err := lr.ResourceByName(hn)
-			test.That(t, err, test.ShouldBeNil)
-			holderResp, err := holderRes.DoCommand(ctx, map[string]any{"probe": label})
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, holderResp["instance_id"], test.ShouldEqual, wantID)
-		}
-	}
-
-	lr.Reconfigure(ctx, &cfg)
-	assertAllHoldersPointToCurrentTarget("initial")
-
-	// Push a config change to advance the clock and re-trigger updateWeakAndOptionalDependents.
-	cfg2 := cfg
-	cfg2.Components = append(append([]resource.Config{}, cfg.Components...), resource.Config{
-		Name:                "unrelated-motor",
-		API:                 motor.API,
-		Model:               fake.Model,
-		ConvertedAttributes: &fake.Config{},
-	})
-	test.That(t, cfg2.Ensure(false, logger), test.ShouldBeNil)
-	lr.Reconfigure(ctx, &cfg2)
-	assertAllHoldersPointToCurrentTarget("after-unrelated-change")
-}
-
-func TestModularStalePointerCascadeChain(t *testing.T) {
-	// Verifies that cascades propagate transitively through multi-hop explicit-dep chains.
-	// Exercises the recursive cascade inside rebuildResourceWithVisited (invoked by the outer
-	// addResource cascade), not just the single-level cascade in addResource.
-	// Setup:  target → mid-holder (depends on target) → top-holder (depends on mid-holder)
-	//
-	// When target is rebuilt:
-	//  1. addResource(target_new) cascade finds mid-holder in internalDeps[target], rebuilds it.
-	//  2. rebuildResourceWithVisited(mid-holder) runs ITS cascade over internalDeps[mid-holder],
-	//     rebuilds top-holder.
-	//  3. top-holder ends up freshly constructed, its captured pointer referencing the freshly
-	//     constructed mid-holder, which references the new target.
-	//
-	// top-holder.DoCommand proxies → mid-holder.DoCommand → target.DoCommand → returns the
-	// current target's instance_id. Any break in the chain would either error or report a
-	// stale ID.
-
-	logger := logging.NewTestLogger(t)
-	ctx := context.Background()
-
-	lr := setupLocalRobot(t, ctx, &config.Config{}, logger, WithDisableCompleteConfigWorker())
-
-	optionalDepsModulePath := testutils.BuildTempModule(t, "examples/customresources/demos/optionaldepsmodule")
-
-	targetModel := resource.NewModel("acme", "demo", "pointer-target")
-	holderModel := resource.NewModel("acme", "demo", "pointer-holder")
-	targetName := generic.Named("target")
-	midName := generic.Named("mid-holder")
-	topName := generic.Named("top-holder")
-
-	cfg := config.Config{
-		Modules: []config.Module{
-			{Name: "optional-deps", ExePath: optionalDepsModulePath},
-		},
-		Components: []resource.Config{
-			{
-				Name:                "opt-dep",
-				API:                 motor.API,
-				Model:               fake.Model,
-				ConvertedAttributes: &fake.Config{},
-			},
-			{
-				Name:  targetName.Name,
-				API:   generic.API,
-				Model: targetModel,
-				Attributes: rutils.AttributeMap{
-					"optional_dep": "opt-dep",
-				},
-			},
-			{
-				Name:  midName.Name,
-				API:   generic.API,
-				Model: holderModel,
-				Attributes: rutils.AttributeMap{
-					"target": targetName.Name,
-				},
-			},
-			{
-				Name:  topName.Name,
-				API:   generic.API,
-				Model: holderModel,
-				Attributes: rutils.AttributeMap{
-					"target": midName.Name,
-				},
-			},
-		},
-	}
-	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
-
-	// The top-holder proxies DoCommand through mid-holder, which proxies through target.
-	// If any link in the chain holds a stale pointer, the ID returned at the top won't
-	// match the target's current ID.
-	assertTopHolderReachesCurrentTarget := func(label string) {
-		targetRes, err := lr.ResourceByName(targetName)
-		test.That(t, err, test.ShouldBeNil)
-		targetResp, err := targetRes.DoCommand(ctx, map[string]any{"probe": label})
-		test.That(t, err, test.ShouldBeNil)
-
-		topRes, err := lr.ResourceByName(topName)
-		test.That(t, err, test.ShouldBeNil)
-		topResp, err := topRes.DoCommand(ctx, map[string]any{"probe": label})
-		test.That(t, err, test.ShouldBeNil)
-
-		test.That(t, topResp["instance_id"], test.ShouldEqual, targetResp["instance_id"])
-	}
-
-	lr.Reconfigure(ctx, &cfg)
-	assertTopHolderReachesCurrentTarget("initial")
-
-	// Push a config change to advance the clock and re-trigger the cascade.
-	cfg2 := cfg
-	cfg2.Components = append(append([]resource.Config{}, cfg.Components...), resource.Config{
-		Name:                "unrelated-motor",
-		API:                 motor.API,
-		Model:               fake.Model,
-		ConvertedAttributes: &fake.Config{},
-	})
-	test.That(t, cfg2.Ensure(false, logger), test.ShouldBeNil)
-	lr.Reconfigure(ctx, &cfg2)
-	assertTopHolderReachesCurrentTarget("after-unrelated-change")
 }

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -58,6 +58,7 @@ type moduleManager interface {
 	Kill()
 	Provides(conf resource.Config) bool
 	Reconfigure(ctx context.Context, conf config.Module) ([]resource.Name, error)
+	ReconfigureResource(ctx context.Context, conf resource.Config, deps []string) error
 	Remove(modName string) ([]resource.Name, error)
 	RemoveResource(ctx context.Context, name resource.Name) error
 	ResolveImplicitDependencies(ctx context.Context, conf *config.Diff)
@@ -167,7 +168,7 @@ func (manager *resourceManager) addRemote(
 			return
 		}
 	} else {
-		gNode.SwapResource(rr, builtinModel, manager.opts.ftdc, true)
+		gNode.SwapResource(rr, builtinModel, manager.opts.ftdc)
 	}
 	manager.updateRemoteResourceNames(ctx, rName, rr, c.Prefix, true)
 }
@@ -303,7 +304,7 @@ func (manager *resourceManager) updateRemoteResourceNames(
 		}
 
 		if nodeAlreadyExists {
-			gNode.SwapResource(res, unknownModel, manager.opts.ftdc, true)
+			gNode.SwapResource(res, unknownModel, manager.opts.ftdc)
 		} else {
 			// Check for a full resource name collision and log an error if there is one.
 			prefixedSimpleName := prefix + resName.Name
@@ -699,7 +700,7 @@ func (manager *resourceManager) completeConfig(
 	// order.
 	levels := manager.resources.ReverseTopologicalSortInLevels()
 	timeout := rutils.GetResourceConfigurationTimeout(manager.logger)
-	for i, resourceNames := range levels {
+	for _, resourceNames := range levels {
 		// At the start of every reconfiguration level, run updateWeakAndOptionalDependents.
 		// value.
 		//
@@ -716,11 +717,6 @@ func (manager *resourceManager) completeConfig(
 			default:
 			}
 			gNode, ok := manager.resources.Node(resName)
-			if manager.logger != nil && manager.logger.GetLevel() < 0 {
-				manager.logger.Debugw("CompleteConfig", "level", i, "resName", resName,
-					"lastWeakAndOptionalDependentsRound", lr.lastWeakAndOptionalDependentsRound.Load(),
-					"CurrLogicalClockValue", manager.resources.CurrLogicalClockValue(), "NeedsReconfigure", gNode.NeedsReconfigure())
-			}
 			if !ok || !gNode.NeedsReconfigure() {
 				continue
 			}
@@ -779,7 +775,7 @@ func (manager *resourceManager) completeConfig(
 							manager.logger, resName.String(),
 						)
 					} else {
-						verb = "rebuild"
+						verb = "reconfigur"
 					}
 					manager.logger.CInfow(ctx, fmt.Sprintf("Now %ving resource", verb), "resource", resName, "model", conf.Model)
 
@@ -804,12 +800,15 @@ func (manager *resourceManager) completeConfig(
 
 					switch {
 					case resName.API.IsComponent(), resName.API.IsService():
-						newRes, err := manager.processResource(ctxWithTimeout, conf, gNode, lr)
-						if err := manager.markChildrenForUpdate(resName); err != nil {
-							manager.logger.CErrorw(ctx,
-								"failed to mark children of resource for update",
-								"resource", resName,
-								"reason", err)
+
+						newRes, newlyBuilt, err := manager.processResource(ctxWithTimeout, conf, gNode, lr)
+						if newlyBuilt || err != nil {
+							if err := manager.markChildrenForUpdate(resName); err != nil {
+								manager.logger.CErrorw(ctx,
+									"failed to mark children of resource for update",
+									"resource", resName,
+									"reason", err)
+							}
 						}
 
 						if err != nil {
@@ -828,7 +827,7 @@ func (manager *resourceManager) completeConfig(
 							manager.logger.CErrorw(
 								ctx, "error building resource", "resource", conf.ResourceName(), "model", conf.Model, "error", ctxWithTimeout.Err())
 						} else {
-							gNode.SwapResource(newRes, conf.Model, manager.opts.ftdc, true)
+							gNode.SwapResource(newRes, conf.Model, manager.opts.ftdc)
 							manager.logger.CInfow(ctx, fmt.Sprintf("Successfully %ved resource", verb), "resource", resName, "model", conf.Model)
 						}
 
@@ -1091,17 +1090,22 @@ func (manager *resourceManager) processResource(
 	conf resource.Config,
 	gNode *resource.GraphNode,
 	lr *localRobot,
-) (resource.Resource, error) {
+) (resource.Resource, bool, error) {
 	if gNode.IsUninitialized() {
 		newRes, err := lr.newResource(ctx, gNode, conf)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
-		return newRes, nil
+		return newRes, true, nil
+	}
+
+	currentRes, err := gNode.UnsafeResource()
+	if err != nil {
+		return nil, false, err
 	}
 
 	resName := conf.ResourceName()
-	_, err := lr.getDependencies(resName, gNode)
+	deps, err := lr.getDependencies(resName, gNode)
 	if err != nil {
 		manager.logger.CDebugw(ctx,
 			"failed to get dependencies for existing resource during reconfiguration, closing and removing resource from graph node",
@@ -1109,11 +1113,28 @@ func (manager *resourceManager) processResource(
 			"old_model", gNode.ResourceModel(),
 			"new_model", conf.Model,
 		)
-		return nil, multierr.Combine(err, manager.closeAndUnsetResource(ctx, gNode))
+		return nil, false, multierr.Combine(err, manager.closeAndUnsetResource(ctx, gNode))
 	}
 
-	if gNode.ResourceModel() != conf.Model {
-		manager.logger.CInfow(ctx, "resource models differ from old",
+	isModular := manager.moduleManager.Provides(conf)
+	if gNode.ResourceModel() == conf.Model {
+		if isModular {
+			if err := manager.moduleManager.ReconfigureResource(ctx, conf, modmanager.DepsToNames(deps)); err != nil {
+				return nil, false, err
+			}
+			return currentRes, false, nil
+		}
+
+		err = currentRes.Reconfigure(ctx, deps, conf)
+		if err == nil {
+			return currentRes, false, nil
+		}
+
+		if !resource.IsMustRebuildError(err) {
+			return nil, false, err
+		}
+	} else {
+		manager.logger.CInfow(ctx, "Resource models differ so resource must be rebuilt",
 			"name", resName, "old_model", gNode.ResourceModel(), "new_model", conf.Model)
 	}
 
@@ -1135,9 +1156,9 @@ func (manager *resourceManager) processResource(
 			"old_model", gNode.ResourceModel(),
 			"new_model", conf.Model,
 		)
-		return nil, err
+		return nil, false, err
 	}
-	return newRes, nil
+	return newRes, true, nil
 }
 
 // addToBeConstructedResource adds a new, unconfigured graph node for a resource to the

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -150,8 +150,9 @@ func TestModularResources(t *testing.T) {
 		})
 		_, err = r.ResourceByName(cfg2.ResourceName())
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(mod.add), test.ShouldEqual, 2)
-		test.That(t, mod.add[1], test.ShouldResemble, cfg2)
+		test.That(t, len(mod.add), test.ShouldEqual, 1)
+		test.That(t, len(mod.reconf), test.ShouldEqual, 1)
+		test.That(t, mod.reconf[0], test.ShouldResemble, cfg2)
 
 		// Add a non-modular component
 		r.Reconfigure(context.Background(), &config.Config{
@@ -161,7 +162,8 @@ func TestModularResources(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		_, err = r.ResourceByName(cfg3.ResourceName())
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(mod.add), test.ShouldEqual, 2)
+		test.That(t, len(mod.add), test.ShouldEqual, 1)
+		test.That(t, len(mod.reconf), test.ShouldEqual, 1)
 
 		// Change the name of a modular component
 		r.Reconfigure(context.Background(), &config.Config{
@@ -173,8 +175,9 @@ func TestModularResources(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		_, err = r.ResourceByName(cfg3.ResourceName())
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, mod.add, test.ShouldResemble, []resource.Config{cfg, cfg2, cfg4})
-		test.That(t, mod.remove, test.ShouldResemble, []resource.Name{cfg2.ResourceName(), cfg.ResourceName()})
+		test.That(t, mod.add, test.ShouldResemble, []resource.Config{cfg, cfg4})
+		test.That(t, mod.remove, test.ShouldResemble, []resource.Name{cfg2.ResourceName()})
+		test.That(t, mod.reconf, test.ShouldResemble, []resource.Config{cfg2})
 		test.That(t, len(mod.state), test.ShouldEqual, 1)
 	})
 
@@ -216,8 +219,9 @@ func TestModularResources(t *testing.T) {
 		})
 		_, err = r.ResourceByName(cfg2.ResourceName())
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(mod.add), test.ShouldEqual, 2)
-		test.That(t, mod.add[1], test.ShouldResemble, cfg2)
+		test.That(t, len(mod.add), test.ShouldEqual, 1)
+		test.That(t, len(mod.reconf), test.ShouldEqual, 1)
+		test.That(t, mod.reconf[0], test.ShouldResemble, cfg2)
 	})
 
 	t.Run("close", func(t *testing.T) {
@@ -249,6 +253,7 @@ func TestModularResources(t *testing.T) {
 		test.That(t, r.manager.Close(ctx), test.ShouldBeNil)
 
 		test.That(t, len(mod.add), test.ShouldEqual, 2)
+		test.That(t, len(mod.reconf), test.ShouldEqual, 0)
 		test.That(t, len(mod.remove), test.ShouldEqual, 2)
 		expected := map[resource.Name]struct{}{
 			compCfg.ResourceName(): {},
@@ -353,6 +358,7 @@ type dummyModMan struct {
 	*modmanager.Manager
 	mu         sync.Mutex
 	add        []resource.Config
+	reconf     []resource.Config
 	remove     []resource.Name
 	compAPISvc resource.APIResourceCollection[resource.Resource]
 	svcAPISvc  resource.APIResourceCollection[resource.Resource]
@@ -377,6 +383,13 @@ func (m *dummyModMan) AddResource(ctx context.Context, conf resource.Config, dep
 		}
 	}
 	return res, nil
+}
+
+func (m *dummyModMan) ReconfigureResource(ctx context.Context, conf resource.Config, deps []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reconf = append(m.reconf, conf)
+	return nil
 }
 
 func (m *dummyModMan) RemoveResource(ctx context.Context, name resource.Name) error {

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1550,16 +1550,19 @@ func TestReconfigure(t *testing.T) {
 
 	local, ok := r.(*localRobot)
 	test.That(t, ok, test.ShouldBeTrue)
-	newService, err := manager.processResource(ctx, svc1, resource.NewUninitializedNode(), local)
+	newService, newlyBuilt, err := manager.processResource(ctx, svc1, resource.NewUninitializedNode(), local)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, newlyBuilt, test.ShouldBeTrue)
 	svcNode := resource.NewConfiguredGraphNode(svc1, newService, svc1.Model)
 	manager.resources.AddNode(svc1.ResourceName(), svcNode)
-	newService, err = manager.processResource(ctx, svc1, svcNode, local)
+	newService, newlyBuilt, err = manager.processResource(ctx, svc1, svcNode, local)
 	test.That(t, err, test.ShouldBeNil)
+	test.That(t, newlyBuilt, test.ShouldBeFalse)
 
 	mockRe, ok := newService.(*mock)
 	test.That(t, ok, test.ShouldBeTrue)
 	test.That(t, mockRe, test.ShouldNotBeNil)
+	test.That(t, mockRe.reconfigCount, test.ShouldEqual, 1)
 
 	defer func() {
 		test.That(t, local.Close(ctx), test.ShouldBeNil)
@@ -1771,7 +1774,7 @@ func TestResourceCreationPanic(t *testing.T) {
 
 		local, ok := r.(*localRobot)
 		test.That(t, ok, test.ShouldBeTrue)
-		_, err := manager.processResource(ctx, svc1, resource.NewUninitializedNode(), local)
+		_, _, err := manager.processResource(ctx, svc1, resource.NewUninitializedNode(), local)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "hello")
 	})
 
@@ -1806,7 +1809,7 @@ func TestResourceCreationPanic(t *testing.T) {
 
 		local, ok := r.(*localRobot)
 		test.That(t, ok, test.ShouldBeTrue)
-		_, err := manager.processResource(ctx, svc1, resource.NewUninitializedNode(), local)
+		_, _, err := manager.processResource(ctx, svc1, resource.NewUninitializedNode(), local)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "hello")
 	})
 }
@@ -1814,6 +1817,12 @@ func TestResourceCreationPanic(t *testing.T) {
 type mock struct {
 	resource.Named
 	resource.TriviallyCloseable
+	reconfigCount int
+}
+
+func (m *mock) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	m.reconfigCount++
+	return nil
 }
 
 // A dummyRobot implements wraps an robot.Robot. It's only use for testing purposes.
@@ -1850,6 +1859,15 @@ func (rr *dummyRobot) SetOffline(offline bool) {
 	rr.mu.Lock()
 	defer rr.mu.Unlock()
 	rr.offline = offline
+}
+
+func (rr *dummyRobot) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+	if rr.offline {
+		return errors.New("offline")
+	}
+	return errors.New("unsupported")
 }
 
 func (rr *dummyRobot) GetModelsFromModules(ctx context.Context) ([]resource.ModuleModel, error) {

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/a8m/envsubst"
 	"github.com/pkg/errors"
-	"go.uber.org/zap/zapcore"
 	"go.viam.com/test"
 	"go.viam.com/utils"
 	"go.viam.com/utils/pexec"
@@ -152,7 +151,7 @@ func TestRobotReconfigure(t *testing.T) {
 
 	t.Run("no diff", func(t *testing.T) {
 		resetComponentFailureState()
-		logger, logs := logging.NewObservedTestLogger(t)
+		logger := logging.NewTestLogger(t)
 
 		conf1 := processConfig(t, &config.Config{
 			Components: []resource.Config{
@@ -254,22 +253,18 @@ func TestRobotReconfigure(t *testing.T) {
 
 		mock1, err := robot.ResourceByName(mockNamed("mock1"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock1.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock2, err := robot.ResourceByName(mockNamed("mock2"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock2.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock2.(*mockFake2).reconfCount, test.ShouldEqual, 0)
 	})
 
 	t.Run("reconfiguring unreconfigurable", func(t *testing.T) {
 		resetComponentFailureState()
 		testReconfiguringMismatch = true
 		// processing modify will fail
-		logger, logs := logging.NewObservedTestLogger(t)
+		logger := logging.NewTestLogger(t)
 		conf1 := processConfig(t, &config.Config{
 			Components: []resource.Config{
 				{
@@ -416,9 +411,7 @@ func TestRobotReconfigure(t *testing.T) {
 
 		mock1, err := robot.ResourceByName(mockNamed("mock1"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock1.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		reconfigurableTrue = false
 		robot.Reconfigure(context.Background(), conf3)
@@ -446,9 +439,7 @@ func TestRobotReconfigure(t *testing.T) {
 			resource.DefaultServices(),
 		))
 
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock1.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		newArm1, err := robot.ResourceByName(mockNamed("arm1"))
 		test.That(t, err, test.ShouldBeNil)
@@ -1449,7 +1440,10 @@ func TestRobotReconfigure(t *testing.T) {
 
 		nextMotor2, err := robot.ResourceByName(mockNamed("m2"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, nextMotor2, test.ShouldNotPointTo, motor2)
+		// m2 lost its dependency on arm2 after looking conf6
+		// but only relies on base1 so it should never have been
+		// removed but only reconfigured.
+		test.That(t, nextMotor2, test.ShouldPointTo, motor2)
 
 		_, err = robot.ResourceByName(mockNamed("m1"))
 		test.That(t, err, test.ShouldBeNil)
@@ -1686,7 +1680,7 @@ func TestRobotReconfigure(t *testing.T) {
 
 	t.Run("incremental deps config", func(t *testing.T) {
 		resetComponentFailureState()
-		logger, logs := logging.NewObservedTestLogger(t)
+		logger := logging.NewTestLogger(t)
 		conf4 := processConfig(t, &config.Config{
 			Components: []resource.Config{
 				{
@@ -1914,39 +1908,27 @@ func TestRobotReconfigure(t *testing.T) {
 
 		mock1, err := robot.ResourceByName(mockNamed("mock1"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock1.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock2, err := robot.ResourceByName(mockNamed("mock2"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock2.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock2.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock3, err := robot.ResourceByName(mockNamed("mock3"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock3.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock3.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock4, err := robot.ResourceByName(mockNamed("mock4"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock4.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock4.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock5, err := robot.ResourceByName(mockNamed("mock5"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock5.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock5.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock6, err := robot.ResourceByName(mockNamed("mock6"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock6.Name()}).Len(),
-			test.ShouldEqual, 2)
+		test.That(t, mock6.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		sorted := robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
@@ -1961,7 +1943,7 @@ func TestRobotReconfigure(t *testing.T) {
 
 	t.Run("parent attribute change deps config", func(t *testing.T) {
 		resetComponentFailureState()
-		logger, logs := logging.NewObservedTestLogger(t)
+		logger := logging.NewTestLogger(t)
 		//nolint:dupl
 		conf7 := processConfig(t, &config.Config{
 			Components: []resource.Config{
@@ -2224,33 +2206,23 @@ func TestRobotReconfigure(t *testing.T) {
 
 		mock1, err := robot.ResourceByName(mockNamed("mock1"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock1.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock2, err := robot.ResourceByName(mockNamed("mock2"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock2.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock2.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock3, err := robot.ResourceByName(mockNamed("mock3"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock3.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock3.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock4, err := robot.ResourceByName(mockNamed("mock4"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock4.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock4.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock5, err := robot.ResourceByName(mockNamed("mock5"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock5.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock5.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		sorted := robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
@@ -2307,33 +2279,23 @@ func TestRobotReconfigure(t *testing.T) {
 
 		mock1, err = robot.ResourceByName(mockNamed("mock1"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock1.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock1.(*mockFake).reconfCount, test.ShouldEqual, 1)
 
 		mock2, err = robot.ResourceByName(mockNamed("mock2"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock2.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock2.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock3, err = robot.ResourceByName(mockNamed("mock3"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock3.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock3.(*mockFake).reconfCount, test.ShouldEqual, 1)
 
 		mock4, err = robot.ResourceByName(mockNamed("mock4"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock4.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock4.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock5, err = robot.ResourceByName(mockNamed("mock5"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock5.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock5.(*mockFake).reconfCount, test.ShouldEqual, 1)
 	})
 
 	// test starts with a working config, then reconfigures into a config where dependencies
@@ -2342,7 +2304,7 @@ func TestRobotReconfigure(t *testing.T) {
 		resetComponentFailureState()
 		testReconfiguringMismatch = true
 		reconfigurableTrue = true
-		logger, logs := logging.NewObservedTestLogger(t)
+		logger := logging.NewTestLogger(t)
 		//nolint:dupl
 		conf7 := processConfig(t, &config.Config{
 			Components: []resource.Config{
@@ -2451,8 +2413,7 @@ func TestRobotReconfigure(t *testing.T) {
 				},
 			},
 		})
-		// 4 & 6 have should_fail_reconfigure, 1 & 5 depends_on 4, armFake depends_on 5, 6
-		conf4615armFail := processConfig(t, &config.Config{
+		conf9 := processConfig(t, &config.Config{
 			Components: []resource.Config{
 				{
 					Name:  "board2",
@@ -2627,39 +2588,27 @@ func TestRobotReconfigure(t *testing.T) {
 
 		mock1, err := robot.ResourceByName(mockNamed("mock1"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock1.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock2, err := robot.ResourceByName(mockNamed("mock2"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock2.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock2.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock3, err := robot.ResourceByName(mockNamed("mock3"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock3.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock3.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock4, err := robot.ResourceByName(mockNamed("mock4"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock4.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock4.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock5, err := robot.ResourceByName(mockNamed("mock5"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock5.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock5.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock6, err := robot.ResourceByName(mockNamed("mock6"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock6.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock6.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		sorted := robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
@@ -2672,18 +2621,13 @@ func TestRobotReconfigure(t *testing.T) {
 		))
 
 		reconfigurableTrue = false
-		robot.Reconfigure(context.Background(), conf4615armFail)
+		robot.Reconfigure(context.Background(), conf9)
 
-		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
 		mockNames = []resource.Name{
-			mockNamed("mock1"),
 			mockNamed("mock2"),
 			mockNamed("mock3"),
-			mockNamed("mock4"),
-			mockNamed("mock5"),
-			mockNamed("mock6"),
 		}
-		// since we completely rebuild instead of intentionally failing reconfigure, no issues
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			boardNames,
 			resource.DefaultServices(),
@@ -2702,33 +2646,29 @@ func TestRobotReconfigure(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		_, err = robot.ResourceByName(mockNamed("mock1"))
-		test.That(t, err, test.ShouldBeNil)
+		test.That(t, err, test.ShouldNotBeNil)
 
 		mock2, err = robot.ResourceByName(mockNamed("mock2"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock2.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock2.(*mockFake).reconfCount, test.ShouldEqual, 1)
 
 		mock3, err = robot.ResourceByName(mockNamed("mock3"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock3.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock3.(*mockFake).reconfCount, test.ShouldEqual, 1)
 
 		_, err = robot.ResourceByName(mockNamed("mock4"))
-		test.That(t, err, test.ShouldBeNil)
+		test.That(t, err, test.ShouldNotBeNil)
 
 		_, err = robot.ResourceByName(mockNamed("mock5"))
-		test.That(t, err, test.ShouldBeNil)
+		test.That(t, err, test.ShouldNotBeNil)
 
+		// `mock6` is configured to be in a "failing" state.
 		_, err = robot.ResourceByName(mockNamed("mock6"))
-		test.That(t, err, test.ShouldBeNil)
+		test.That(t, err, test.ShouldNotBeNil)
 
+		// `armFake` depends on `mock6` and is therefore also in an error state.
 		_, err = robot.ResourceByName(mockNamed("armFake"))
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "reason=resource build error: unknown resource type: "+
-			"API rdk:component:mock with model rdk:builtin:fake not registered")
 
 		sorted = robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
@@ -2740,9 +2680,14 @@ func TestRobotReconfigure(t *testing.T) {
 			encoderNames,
 			[]resource.Name{
 				mockNamed("armFake"),
+				mockNamed("mock1"),
+				mockNamed("mock4"),
+				mockNamed("mock5"),
+				mockNamed("mock6"),
 			},
 		))
 
+		// This configuration will put `mock6` into a good state after two calls to "reconfigure".
 		conf9good := processConfig(t, &config.Config{
 			Components: []resource.Config{
 				{
@@ -2866,11 +2811,11 @@ func TestRobotReconfigure(t *testing.T) {
 		})
 		robot.Reconfigure(context.Background(), conf9good)
 
-		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
 		mockNames = []resource.Name{
-			mockNamed("armFake"), mockNamed("mock2"), mockNamed("mock1"), mockNamed("mock3"),
-			mockNamed("mock4"), mockNamed("mock5"), mockNamed("mock6"),
+			mockNamed("mock2"), mockNamed("mock1"), mockNamed("mock3"),
+			mockNamed("mock4"), mockNamed("mock5"),
 		}
+		test.That(t, robot.RemoteNames(), test.ShouldBeEmpty)
 
 		rdktestutils.VerifySameResourceNames(t, robot.ResourceNames(), rdktestutils.ConcatResourceNames(
 			boardNames,
@@ -2889,47 +2834,45 @@ func TestRobotReconfigure(t *testing.T) {
 		_, err = robot.ResourceByName(mockNamed("board2"))
 		test.That(t, err, test.ShouldBeNil)
 
+		// resources which failed previous reconfiguration attempts because of missing dependencies will be rebuilt,
+		// so reconfCount should be 0. resources which failed previous reconfiguration attempts because of an error
+		// during reconfiguration would not have its reconfCount reset, so reconfCount for mock4 should be 1.
 		mock1, err = robot.ResourceByName(mockNamed("mock1"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock1.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
 		mock2, err = robot.ResourceByName(mockNamed("mock2"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock2.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock2.(*mockFake).reconfCount, test.ShouldEqual, 1)
 
 		mock3, err = robot.ResourceByName(mockNamed("mock3"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock3.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock3.(*mockFake).reconfCount, test.ShouldEqual, 1)
 
 		mock4, err = robot.ResourceByName(mockNamed("mock4"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock4.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock4.(*mockFake).reconfCount, test.ShouldEqual, 1)
 
 		mock5, err = robot.ResourceByName(mockNamed("mock5"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock5.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock5.(*mockFake).reconfCount, test.ShouldEqual, 0)
 
+		// `mock6` is configured to be in a "failing" state.
 		_, err = robot.ResourceByName(mockNamed("mock6"))
-		test.That(t, err, test.ShouldBeNil)
+		test.That(t, err, test.ShouldNotBeNil)
 
+		// `armFake` depends on `mock6` and is therefore also in an error state.
 		_, err = robot.ResourceByName(mockNamed("armFake"))
-		test.That(t, err, test.ShouldBeNil)
+		test.That(t, err, test.ShouldNotBeNil)
 
 		reconfigurableTrue = true
 
 		rr, ok := robot.(*localRobot)
 		test.That(t, ok, test.ShouldBeTrue)
 
+		// The newly set configuration fixes the `mock6` component. A (second) reconfig should pick
+		// that up and consequently bubble up the working `mock6` change to anything that depended
+		// on `mock6`, notably `armFake`.
 		rr.triggerConfig <- "TestRobotReconfigure"
 
 		testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 30, func(tb testing.TB) {
@@ -2942,9 +2885,7 @@ func TestRobotReconfigure(t *testing.T) {
 		// with its `reconfCount` bumped.
 		mock6, err = robot.ResourceByName(mockNamed("mock6"))
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-			FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: mock6.Name()}).Len(),
-			test.ShouldEqual, 1)
+		test.That(t, mock6.(*mockFake).reconfCount, test.ShouldEqual, 1)
 
 		sorted = robot.(*localRobot).manager.resources.TopologicalSort()
 		sorted = rdktestutils.SubtractNames(sorted, robot.(*localRobot).manager.internalResourceNames()...)
@@ -2954,6 +2895,10 @@ func TestRobotReconfigure(t *testing.T) {
 			boardNames,
 			mockNames,
 			encoderNames,
+			[]resource.Name{
+				mockNamed("armFake"),
+				mockNamed("mock6"),
+			},
 		))
 	})
 	t.Run("complex diff", func(t *testing.T) {
@@ -3076,7 +3021,7 @@ func TestRobotReconfigure(t *testing.T) {
 }
 
 func TestReconfigureModelRebuild(t *testing.T) {
-	logger, logs := logging.NewObservedTestLogger(t)
+	logger := logging.NewTestLogger(t)
 
 	mockAPI := resource.APINamespaceRDK.WithComponentType("mock")
 	mockNamed := func(name string) resource.Name {
@@ -3116,18 +3061,14 @@ func TestReconfigureModelRebuild(t *testing.T) {
 	name1 := mockNamed("one")
 	res1, err := r.ResourceByName(name1)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: res1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, res1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 	test.That(t, res1.(*mockFake).closeCount, test.ShouldEqual, 0)
 
 	r.Reconfigure(ctx, cfg)
 	res2, err := r.ResourceByName(name1)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res2, test.ShouldEqual, res1)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: res2.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, res2.(*mockFake).reconfCount, test.ShouldEqual, 0)
 	test.That(t, res2.(*mockFake).closeCount, test.ShouldEqual, 0)
 
 	newCfg := &config.Config{
@@ -3147,18 +3088,14 @@ func TestReconfigureModelRebuild(t *testing.T) {
 	res3, err := r.ResourceByName(name1)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res3, test.ShouldNotEqual, res1)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: res1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, res1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 	test.That(t, res1.(*mockFake).closeCount, test.ShouldEqual, 1)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: res3.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, res3.(*mockFake).reconfCount, test.ShouldEqual, 0)
 	test.That(t, res3.(*mockFake).closeCount, test.ShouldEqual, 0)
 }
 
 func TestReconfigureModelSwitch(t *testing.T) {
-	logger, logs := logging.NewObservedTestLogger(t)
+	logger := logging.NewTestLogger(t)
 
 	mockAPI := resource.APINamespaceRDK.WithComponentType("mock")
 	mockNamed := func(name string) resource.Name {
@@ -3212,18 +3149,14 @@ func TestReconfigureModelSwitch(t *testing.T) {
 	name1 := mockNamed("one")
 	res1, err := r.ResourceByName(name1)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: res1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, res1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 	test.That(t, res1.(*mockFake).closeCount, test.ShouldEqual, 0)
 
 	r.Reconfigure(ctx, cfg)
 	res2, err := r.ResourceByName(name1)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res2, test.ShouldEqual, res1)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: res2.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, res2.(*mockFake).reconfCount, test.ShouldEqual, 0)
 	test.That(t, res2.(*mockFake).closeCount, test.ShouldEqual, 0)
 
 	newCfg := &config.Config{
@@ -3241,18 +3174,14 @@ func TestReconfigureModelSwitch(t *testing.T) {
 	res3, err := r.ResourceByName(name1)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res3, test.ShouldNotEqual, res1)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: res1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, res1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 	test.That(t, res1.(*mockFake).closeCount, test.ShouldEqual, 1)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: res3.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, res3.(*mockFake2).reconfCount, test.ShouldEqual, 0)
 	test.That(t, res3.(*mockFake2).closeCount, test.ShouldEqual, 0)
 }
 
 func TestReconfigureModelSwitchErr(t *testing.T) {
-	logger, logs := logging.NewObservedTestLogger(t)
+	logger := logging.NewTestLogger(t)
 
 	mockAPI := resource.APINamespaceRDK.WithComponentType("mock")
 	mockNamed := func(name string) resource.Name {
@@ -3296,9 +3225,7 @@ func TestReconfigureModelSwitchErr(t *testing.T) {
 	name1 := mockNamed("one")
 	res1, err := r.ResourceByName(name1)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: res1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, res1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 	test.That(t, res1.(*mockFake).closeCount, test.ShouldEqual, 0)
 
 	modelName2 := utils.RandomAlphaString(5)
@@ -3318,9 +3245,7 @@ func TestReconfigureModelSwitchErr(t *testing.T) {
 
 	_, err = r.ResourceByName(name1)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: res1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, res1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 	test.That(t, res1.(*mockFake).closeCount, test.ShouldEqual, 1)
 
 	r.Reconfigure(ctx, cfg)
@@ -3329,18 +3254,14 @@ func TestReconfigureModelSwitchErr(t *testing.T) {
 	res2, err := r.ResourceByName(name1)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res2, test.ShouldNotEqual, res1)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: res1.Name()}).Len(),
-		test.ShouldEqual, 2)
+	test.That(t, res1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 	test.That(t, res1.(*mockFake).closeCount, test.ShouldEqual, 1)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: res2.Name()}).Len(),
-		test.ShouldEqual, 2)
+	test.That(t, res2.(*mockFake).reconfCount, test.ShouldEqual, 0)
 	test.That(t, res2.(*mockFake).closeCount, test.ShouldEqual, 0)
 }
 
 func TestReconfigureRename(t *testing.T) {
-	logger, logs := logging.NewObservedTestLogger(t)
+	logger := logging.NewTestLogger(t)
 
 	modelName1 := utils.RandomAlphaString(5)
 	model1 := resource.DefaultModelFamily.WithModel(modelName1)
@@ -3383,9 +3304,7 @@ func TestReconfigureRename(t *testing.T) {
 	name2 := mockNamed("two")
 	res1, err := r.ResourceByName(name1)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: res1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, res1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 	test.That(t, res1.(*mockFake).closeCount, test.ShouldEqual, 0)
 	test.That(t, res1.(*mockFake).createdAt, test.ShouldEqual, 1)
 
@@ -3404,15 +3323,11 @@ func TestReconfigureRename(t *testing.T) {
 	res2, err := r.ResourceByName(name2)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res2, test.ShouldNotEqual, res1)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: res1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, res1.(*mockFake).reconfCount, test.ShouldEqual, 0)
 	test.That(t, res1.(*mockFake).closeCount, test.ShouldEqual, 1)
 	test.That(t, res1.(*mockFake).closedAt, test.ShouldEqual, 2)
 	test.That(t, res2.(*mockFake).createdAt, test.ShouldEqual, 3)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: res2.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, res2.(*mockFake).reconfCount, test.ShouldEqual, 0)
 	test.That(t, res2.(*mockFake).closeCount, test.ShouldEqual, 0)
 }
 
@@ -3726,6 +3641,9 @@ func TestResourceCloseNoHang(t *testing.T) {
 type mockFake struct {
 	resource.Named
 	createdAt        int
+	reconfCount      int
+	reconfiguredAt   int64
+	failCount        int
 	shouldRebuild    bool
 	closedAt         int64
 	closeCount       int
@@ -3744,6 +3662,24 @@ type mockFakeConfig struct {
 	ShouldFailReconfigure int      `json:"should_fail_reconfigure"`
 	Blah                  int      `json:"blah"`
 	Value                 int      `json:"value"`
+}
+
+func (m *mockFake) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	if m.logicalClock != nil {
+		m.reconfiguredAt = m.logicalClock.Add(1)
+	}
+	if m.shouldRebuild {
+		return resource.NewMustRebuildError(conf.ResourceName())
+	}
+	if c, err := resource.NativeConfig[*mockFakeConfig](conf); err == nil && m.failCount == 0 && c.ShouldFailReconfigure != 0 {
+		m.failCount = c.ShouldFailReconfigure
+	}
+	if m.failCount != 0 {
+		m.failCount--
+		return errors.Errorf("failed to reconfigure (left %d)", m.failCount)
+	}
+	m.reconfCount++
+	return nil
 }
 
 func (m *mockFake) Close(ctx context.Context) error {
@@ -3777,7 +3713,13 @@ func (m *mockFake) GetChildValue(slot string) int {
 
 type mockFake2 struct {
 	resource.Named
-	closeCount int
+	reconfCount int
+	closeCount  int
+}
+
+func (m *mockFake2) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	m.reconfCount++
+	return errors.New("oh no")
 }
 
 func (m *mockFake2) Close(ctx context.Context) error {
@@ -3790,16 +3732,34 @@ func (m *mockFake2) Close(ctx context.Context) error {
 // former can directly update the pin values of the latter.
 type mockWithDep struct {
 	resource.Named
-	parent     *mockFake
-	Slot       string
-	Value      int
-	closeCount int
+	parent      *mockFake
+	Slot        string
+	Value       int
+	reconfCount int
+	closeCount  int
 }
 
 type mockWithDepConfig struct {
 	MockDep string `json:"mock_dep"`
 	Slot    string `json:"slot"`
 	Value   int    `json:"value"`
+}
+
+func (m *mockWithDep) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	m.reconfCount++
+	convAttrs := conf.ConvertedAttributes.(*mockWithDepConfig)
+	mockDepName := convAttrs.MockDep
+	mockDep, ok := deps[mockNamed(mockDepName)]
+	if !ok {
+		return errors.New("missing dependency")
+	}
+	parent := mockDep.(*mockFake)
+	m.parent.SetChildValue(m.Slot, 0)
+	m.parent = parent
+	m.Slot = convAttrs.Slot
+	m.Value = convAttrs.Value
+	m.parent.SetChildValue(m.Slot, m.Value)
+	return nil
 }
 
 func (m *mockWithDep) Close(ctx context.Context) error {

--- a/robot/impl/robot_reconfigure_weak_dependencies_test.go
+++ b/robot/impl/robot_reconfigure_weak_dependencies_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"go.uber.org/zap/zapcore"
 	"go.viam.com/test"
 	"go.viam.com/utils"
 
@@ -26,7 +25,32 @@ import (
 type someTypeWithWeakAndStrongDeps struct {
 	resource.Named
 	resource.TriviallyCloseable
-	resources resource.Dependencies
+	resources     resource.Dependencies
+	reconfigCount int
+}
+
+func (s *someTypeWithWeakAndStrongDeps) Reconfigure(
+	ctx context.Context,
+	deps resource.Dependencies,
+	conf resource.Config,
+) error {
+	s.resources = deps
+	s.reconfigCount++
+	ourConf, err := resource.NativeConfig[*someTypeWithWeakAndStrongDepsConfig](conf)
+	if err != nil {
+		return err
+	}
+	for _, dep := range ourConf.deps {
+		if _, err := deps.Lookup(dep); err != nil {
+			return err
+		}
+	}
+	for _, dep := range ourConf.weakDeps {
+		if _, err := deps.Lookup(dep); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type someTypeWithWeakAndStrongDepsConfig struct {
@@ -43,7 +67,7 @@ func (s *someTypeWithWeakAndStrongDepsConfig) Validate(path string) ([]string, [
 }
 
 func TestUpdateWeakDependents(t *testing.T) {
-	logger, logs := logging.NewObservedTestLogger(t)
+	logger := logging.NewTestLogger(t)
 
 	var emptyCfg config.Config
 	test.That(t, emptyCfg.Ensure(false, logger), test.ShouldBeNil)
@@ -125,9 +149,7 @@ func TestUpdateWeakDependents(t *testing.T) {
 	// Assert that the weak dependency was tracked.
 	test.That(t, weak1.resources, test.ShouldHaveLength, 1)
 	test.That(t, weak1.resources, test.ShouldContainKey, base1Name)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: weak1.Name()}).Len(),
-		test.ShouldEqual, 2)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, 1)
 
 	// Reconfigure again with a new third `arm` component.
 	arm1Name := arm.Named("arm1")
@@ -162,9 +184,7 @@ func TestUpdateWeakDependents(t *testing.T) {
 	test.That(t, weak1.resources, test.ShouldHaveLength, 2)
 	test.That(t, weak1.resources, test.ShouldContainKey, base1Name)
 	test.That(t, weak1.resources, test.ShouldContainKey, arm1Name)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: weak1.Name()}).Len(),
-		test.ShouldEqual, 2)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, 2)
 
 	base2Name := base.Named("base2")
 	weakCfg5 := config.Config{
@@ -200,9 +220,7 @@ func TestUpdateWeakDependents(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "not initialized")
 	// reconfigCount will not increment as the error happens before Reconfigure is called on the resource.
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: weak1.Name()}).Len(),
-		test.ShouldEqual, 2)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, 2)
 
 	weakCfg6 := config.Config{
 		Components: []resource.Config{
@@ -237,9 +255,7 @@ func TestUpdateWeakDependents(t *testing.T) {
 	test.That(t, weak1.resources, test.ShouldContainKey, base1Name)
 	test.That(t, weak1.resources, test.ShouldContainKey, base2Name)
 	// reconfigCount will reset as the resource was destroyed after the previous configuration failure.
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: weak1.Name()}).Len(),
-		test.ShouldEqual, 3)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, 1)
 
 	weakCfg7 := config.Config{
 		Components: []resource.Config{
@@ -275,9 +291,7 @@ func TestUpdateWeakDependents(t *testing.T) {
 	test.That(t, weak1.resources, test.ShouldHaveLength, 2)
 	test.That(t, weak1.resources, test.ShouldContainKey, base1Name)
 	test.That(t, weak1.resources, test.ShouldContainKey, base2Name)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: weak1.Name()}).Len(),
-		test.ShouldEqual, 3)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, 3)
 }
 
 func TestWeakDependentsExplicitDependency(t *testing.T) {
@@ -285,7 +299,7 @@ func TestWeakDependentsExplicitDependency(t *testing.T) {
 	// The robot has 3 components:
 	//   * base1 and base2: two fake base components.
 	//   * weak1: a weak component that depends on all components and also has an explicit dependency on base1.
-	logger, logs := logging.NewObservedTestLogger(t)
+	logger := logging.NewTestLogger(t)
 
 	// Register a `Resource` that generates weak dependencies. Specifically instance of
 	// this resource will depend on every `component` resource.
@@ -369,9 +383,7 @@ func TestWeakDependentsExplicitDependency(t *testing.T) {
 	// Assert that the weak dependency was tracked.
 	test.That(t, weak1.resources, test.ShouldHaveLength, 2)
 	test.That(t, weak1.resources, test.ShouldContainKey, base1Name)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: weak1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, 1)
 
 	lRobot := robot.(*localRobot)
 	test.That(t, lRobot.lastWeakAndOptionalDependentsRound.Load(), test.ShouldEqual, 3)
@@ -413,9 +425,7 @@ func TestWeakDependentsExplicitDependency(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	weak1, err = resource.AsType[*someTypeWithWeakAndStrongDeps](weakRes)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: weak1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, 2)
 
 	test.That(t, lRobot.lastWeakAndOptionalDependentsRound.Load(), test.ShouldEqual, 4)
 
@@ -449,9 +459,7 @@ func TestWeakDependentsExplicitDependency(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	weak1, err = resource.AsType[*someTypeWithWeakAndStrongDeps](weakRes)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: weak1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, 3)
 
 	test.That(t, lRobot.lastWeakAndOptionalDependentsRound.Load(), test.ShouldEqual, 5)
 
@@ -460,16 +468,12 @@ func TestWeakDependentsExplicitDependency(t *testing.T) {
 	node, ok := lRobot.manager.resources.Node(weak1Name)
 	test.That(t, ok, test.ShouldBeTrue)
 	lRobot.getDependencies(weak1Name, node)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: weak1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, 3)
 
 	node, ok = lRobot.manager.resources.Node(base1Name)
 	test.That(t, ok, test.ShouldBeTrue)
 	lRobot.getDependencies(base1Name, node)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: weak1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, 3)
 }
 
 func TestWeakDependentsDependedOn(t *testing.T) {
@@ -478,7 +482,7 @@ func TestWeakDependentsDependedOn(t *testing.T) {
 	//   * base1: a fake base component that has an explicit dependency on weak1.
 	//   * base2: a fake base component.
 	//   * weak1: a weak component that depends on all components.
-	logger, logs := logging.NewObservedTestLogger(t)
+	logger := logging.NewTestLogger(t)
 
 	// Register a `Resource` that generates weak dependencies. Specifically, instances of
 	// this resource will depend on every `component` resource.
@@ -564,9 +568,7 @@ func TestWeakDependentsDependedOn(t *testing.T) {
 	// Assert that the weak dependency was tracked.
 	test.That(t, weak1.resources, test.ShouldHaveLength, 2)
 	test.That(t, weak1.resources, test.ShouldContainKey, base1Name)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: weak1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, 2)
 
 	lRobot := robot.(*localRobot)
 	test.That(t, lRobot.lastWeakAndOptionalDependentsRound.Load(), test.ShouldEqual, 3)
@@ -603,9 +605,7 @@ func TestWeakDependentsDependedOn(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	weak1, err = resource.AsType[*someTypeWithWeakAndStrongDeps](weakRes)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: weak1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, 3)
 
 	test.That(t, lRobot.lastWeakAndOptionalDependentsRound.Load(), test.ShouldEqual, 4)
 
@@ -639,9 +639,7 @@ func TestWeakDependentsDependedOn(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	weak1, err = resource.AsType[*someTypeWithWeakAndStrongDeps](weakRes)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: weak1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, 4)
 
 	test.That(t, lRobot.lastWeakAndOptionalDependentsRound.Load(), test.ShouldEqual, 5)
 
@@ -650,14 +648,10 @@ func TestWeakDependentsDependedOn(t *testing.T) {
 	node, ok := lRobot.manager.resources.Node(weak1Name)
 	test.That(t, ok, test.ShouldBeTrue)
 	lRobot.getDependencies(weak1Name, node)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: weak1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, 4)
 
 	node, ok = lRobot.manager.resources.Node(base1Name)
 	test.That(t, ok, test.ShouldBeTrue)
 	lRobot.getDependencies(base1Name, node)
-	test.That(t, logs.FilterMessageSnippet("Now constructing resource").
-		FilterField(zapcore.Field{Key: "resource", Type: zapcore.StringerType, Interface: weak1.Name()}).Len(),
-		test.ShouldEqual, 1)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, 4)
 }

--- a/robot/web/stream/stream_test.go
+++ b/robot/web/stream/stream_test.go
@@ -167,7 +167,7 @@ func TestAudioTrackIsNotCreatedForVideoStream(t *testing.T) {
 	//
 	// Dan: It's unclear to me if this is the intended way to do this. As signified by the nil/empty
 	//      inputs.
-	webSvc.(resource.BuiltInResource).BuiltInReconfigure(ctx, nil, resource.Config{})
+	webSvc.Reconfigure(ctx, nil, resource.Config{})
 
 	// Listing the streams now should return both `origCamera` and `newCamera`.
 	listResp, err = livestreamClient.ListStreams(ctx, &streampb.ListStreamsRequest{})

--- a/robot/web/web_c.go
+++ b/robot/web/web_c.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Reconfigure updates the stream server audio and video streams with the new resources.
-func (svc *webService) BuiltInReconfigure(ctx context.Context, _ resource.Dependencies, _ resource.Config) error {
+func (svc *webService) Reconfigure(ctx context.Context, _ resource.Dependencies, _ resource.Config) error {
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
 	if !svc.isRunning {

--- a/robot/web/web_notc.go
+++ b/robot/web/web_notc.go
@@ -5,8 +5,15 @@ package web
 import (
 	"context"
 
+	"go.viam.com/rdk/resource"
 	"go.viam.com/utils/rpc"
 )
+
+// Update updates the web service when the robot has changed. Without cgo (and
+// therefore without video streams) it is a noop.
+func (svc *webService) Reconfigure(ctx context.Context, _ resource.Dependencies, _ resource.Config) error {
+	return nil
+}
 
 // stub implementation when gostream not available
 func (svc *webService) closeStreamServer() {}

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -788,7 +788,7 @@ func TestWebWithStreams(t *testing.T) {
 	rs[cam2.Name()] = cam2
 	robot.Mu.Unlock()
 	robot.MockResourcesFromMap(rs)
-	err = svc.(resource.BuiltInResource).BuiltInReconfigure(context.Background(), rs, resource.Config{})
+	err = svc.Reconfigure(context.Background(), rs, resource.Config{})
 	test.That(t, err, test.ShouldBeNil)
 
 	// Test that new streams are available
@@ -844,7 +844,7 @@ func TestWebAddFirstStream(t *testing.T) {
 	rs[cam1.Name()] = cam1
 	robot.Mu.Unlock()
 	robot.MockResourcesFromMap(rs)
-	err = svc.(resource.BuiltInResource).BuiltInReconfigure(ctx, rs, resource.Config{})
+	err = svc.Reconfigure(ctx, rs, resource.Config{})
 	test.That(t, err, test.ShouldBeNil)
 
 	// Test that new streams are available

--- a/services/baseremotecontrol/builtin/builtin.go
+++ b/services/baseremotecontrol/builtin/builtin.go
@@ -117,7 +117,7 @@ func NewBuiltIn(
 		events:    make(chan struct{}, 1),
 	}
 	remoteSvc.state.init()
-	if err := remoteSvc.reconfigure(ctx, deps, conf); err != nil {
+	if err := remoteSvc.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 	remoteSvc.eventProcessor()
@@ -125,7 +125,7 @@ func NewBuiltIn(
 	return remoteSvc, nil
 }
 
-func (svc *builtIn) reconfigure(
+func (svc *builtIn) Reconfigure(
 	ctx context.Context,
 	deps resource.Dependencies,
 	conf resource.Config,

--- a/services/baseremotecontrol/builtin/builtin_ext_test.go
+++ b/services/baseremotecontrol/builtin/builtin_ext_test.go
@@ -175,3 +175,134 @@ func TestConnectStopsBase(t *testing.T) {
 		test.That(t, svc.Close(ctx), test.ShouldBeNil)
 	})
 }
+
+func TestReconfigure(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+
+	gamepadName := input.Named("barf")
+	gamepad, err := webgamepad.NewController(ctx, nil, resource.Config{}, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	myBaseName := base.Named("warf")
+	injectBase := inject.NewBase(myBaseName.ShortName())
+
+	setPowerVal := make(chan r3.Vector)
+	injectBase.SetPowerFunc = func(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+		setPowerVal <- angular
+		return nil
+	}
+
+	svc, err := builtin.NewBuiltIn(ctx, resource.Dependencies{
+		gamepadName: gamepad,
+		myBaseName:  injectBase,
+	}, resource.Config{
+		ConvertedAttributes: &builtin.Config{
+			BaseName:            myBaseName.Name,
+			InputControllerName: gamepadName.Name,
+		},
+	}, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	type triggerer interface {
+		TriggerEvent(ctx context.Context, event input.Event, extra map[string]interface{}) error
+	}
+
+	test.That(t, gamepad.(triggerer).TriggerEvent(ctx, input.Event{
+		Event:   input.PositionChangeAbs,
+		Control: input.AbsoluteHat0X,
+		Value:   1,
+	}, nil), test.ShouldBeNil)
+	test.That(t, <-setPowerVal, test.ShouldResemble, r3.Vector{0, 0, -1})
+
+	err = svc.Reconfigure(ctx, nil, resource.Config{
+		ConvertedAttributes: &builtin.Config{},
+	})
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "missing from")
+
+	test.That(t, gamepad.(triggerer).TriggerEvent(ctx, input.Event{
+		Event:   input.PositionChangeAbs,
+		Control: input.AbsoluteHat0X,
+		Value:   2,
+	}, nil), test.ShouldBeNil)
+	test.That(t, <-setPowerVal, test.ShouldResemble, r3.Vector{0, 0, -2})
+
+	err = svc.Reconfigure(ctx, resource.Dependencies{
+		gamepadName: gamepad,
+		myBaseName:  injectBase,
+	}, resource.Config{
+		ConvertedAttributes: &builtin.Config{
+			BaseName:            myBaseName.Name,
+			InputControllerName: gamepadName.Name,
+		},
+	})
+	test.That(t, err, test.ShouldBeNil)
+
+	test.That(t, gamepad.(triggerer).TriggerEvent(ctx, input.Event{
+		Event:   input.PositionChangeAbs,
+		Control: input.AbsoluteHat0X,
+		Value:   3,
+	}, nil), test.ShouldBeNil)
+	test.That(t, <-setPowerVal, test.ShouldResemble, r3.Vector{0, 0, -3})
+
+	gamepadName2 := input.Named("hello")
+	gamepad2, err := webgamepad.NewController(ctx, nil, resource.Config{}, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	err = svc.Reconfigure(ctx, resource.Dependencies{
+		gamepadName2: gamepad2,
+		myBaseName:   injectBase,
+	}, resource.Config{
+		ConvertedAttributes: &builtin.Config{
+			BaseName:            myBaseName.Name,
+			InputControllerName: gamepadName2.Name,
+		},
+	})
+	test.That(t, err, test.ShouldBeNil)
+
+	test.That(t, gamepad.(triggerer).TriggerEvent(ctx, input.Event{
+		Event:   input.PositionChangeAbs,
+		Control: input.AbsoluteHat0X,
+		Value:   3,
+	}, nil), test.ShouldBeNil)
+	test.That(t, gamepad2.(triggerer).TriggerEvent(ctx, input.Event{
+		Event:   input.PositionChangeAbs,
+		Control: input.AbsoluteHat0X,
+		Value:   4,
+	}, nil), test.ShouldBeNil)
+
+	test.That(t, <-setPowerVal, test.ShouldResemble, r3.Vector{0, 0, -4})
+
+	close(setPowerVal)
+
+	myBaseName2 := base.Named("warf2")
+	injectBase2 := inject.NewBase(myBaseName2.ShortName())
+
+	setPowerVal2 := make(chan r3.Vector)
+	injectBase2.SetPowerFunc = func(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
+		setPowerVal2 <- angular
+		return nil
+	}
+
+	err = svc.Reconfigure(ctx, resource.Dependencies{
+		gamepadName2: gamepad2,
+		myBaseName2:  injectBase2,
+	}, resource.Config{
+		ConvertedAttributes: &builtin.Config{
+			BaseName:            myBaseName2.Name,
+			InputControllerName: gamepadName2.Name,
+		},
+	})
+	test.That(t, err, test.ShouldBeNil)
+
+	test.That(t, gamepad2.(triggerer).TriggerEvent(ctx, input.Event{
+		Event:   input.PositionChangeAbs,
+		Control: input.AbsoluteHat0X,
+		Value:   5,
+	}, nil), test.ShouldBeNil)
+
+	test.That(t, <-setPowerVal2, test.ShouldResemble, r3.Vector{0, 0, -5})
+
+	test.That(t, svc.Close(ctx), test.ShouldBeNil)
+}

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -125,7 +125,7 @@ func New(
 		diskSummaryTracker: diskSummaryTracker,
 	}
 
-	if err := svc.BuiltInReconfigure(ctx, deps, conf); err != nil {
+	if err := svc.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 	return svc, nil
@@ -175,7 +175,7 @@ func (b *builtIn) Sync(ctx context.Context, extra map[string]interface{}) error 
 // when errors occur.
 // If an error occurs after the first Reconfigure call, data capture & data sync will continue to function using the old config
 // until a successful Reconfigure call is made or Close is called.
-func (b *builtIn) BuiltInReconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+func (b *builtIn) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	b.logger.Info("Reconfigure START")
 	defer b.logger.Info("Reconfigure END")
 	c, err := resource.NativeConfig[*Config](conf)

--- a/services/datamanager/builtin/builtin_capture_test.go
+++ b/services/datamanager/builtin/builtin_capture_test.go
@@ -181,7 +181,7 @@ func TestDataCaptureEnabled(t *testing.T) {
 			c2.MaximumCaptureFileSizeBytes = 1
 
 			// Update to new config and let it run for a bit.
-			err = b.(resource.BuiltInResource).BuiltInReconfigure(context.Background(), deps, updatedConfig)
+			err = b.Reconfigure(context.Background(), deps, updatedConfig)
 			test.That(t, err, test.ShouldBeNil)
 			oldCaptureDirFiles := getAllFileInfos(initCaptureDir)
 
@@ -248,7 +248,7 @@ func TestReconfigureResource(t *testing.T) {
 	})
 	_, deps2 := setupConfig(t, r2, enabledTabularCollectorConfigPath)
 
-	err = b.(resource.BuiltInResource).BuiltInReconfigure(context.Background(), deps2, config)
+	err = b.Reconfigure(context.Background(), deps2, config)
 	test.That(t, err, test.ShouldBeNil)
 
 	// wait for all the files on disk to

--- a/services/datamanager/builtin/builtin_sync_test.go
+++ b/services/datamanager/builtin/builtin_sync_test.go
@@ -198,7 +198,7 @@ func TestSyncEnabled(t *testing.T) {
 
 			// Set up service end config.
 			c.ScheduledSyncDisabled = tc.syncEndDisabled
-			err = b.(resource.BuiltInResource).BuiltInReconfigure(context.Background(), deps, config)
+			err = b.Reconfigure(context.Background(), deps, config)
 			test.That(t, err, test.ShouldBeNil)
 			secondReconfigure.Store(true)
 
@@ -1087,7 +1087,7 @@ func TestSyncConfigUpdateBehavior(t *testing.T) {
 			c.SyncIntervalMins = tc.newSyncIntervalMins
 			c.MaximumNumSyncThreads = tc.newMaxSyncThreads
 
-			err = b.BuiltInReconfigure(context.Background(), deps, config)
+			err = b.Reconfigure(context.Background(), deps, config)
 			test.That(t, err, test.ShouldBeNil)
 
 			newTicker := b.sync.ScheduledTicker

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -214,7 +214,7 @@ func TestReconfigure(t *testing.T) {
 
 	t.Run("returns an error if called with a resource.Config that can't be converted into a builtin.*Config", func(t *testing.T) {
 		ctx := context.Background()
-		err := b.(resource.BuiltInResource).BuiltInReconfigure(ctx, mockDeps(nil, nil), resource.Config{})
+		err := b.Reconfigure(ctx, mockDeps(nil, nil), resource.Config{})
 		expErr := errors.New("incorrect config type: NativeConfig expected *builtin.Config but got <nil>. " +
 			"Make sure the config type registered to the resource matches the one passed into NativeConfig")
 		test.That(t, err, test.ShouldBeError, expErr)
@@ -227,13 +227,13 @@ func TestReconfigure(t *testing.T) {
 			mockDeps := mockDeps(nil, nil)
 			c := &Config{}
 			test.That(t, c.getCaptureDir(logger), test.ShouldResemble, shared.ViamCaptureDotDir)
-			err := b.(resource.BuiltInResource).BuiltInReconfigure(ctx, mockDeps, resource.Config{ConvertedAttributes: c})
+			err := b.Reconfigure(ctx, mockDeps, resource.Config{ConvertedAttributes: c})
 			test.That(t, err, test.ShouldBeNil)
 		})
 
 		t.Run("returns an error if booted in an untrusted environment with a non default capture_dir", func(t *testing.T) {
 			config := resource.Config{ConvertedAttributes: &Config{CaptureDir: "/tmp/sth/else"}}
-			err := b.(resource.BuiltInResource).BuiltInReconfigure(ctx, nil, config)
+			err := b.Reconfigure(ctx, nil, config)
 			test.That(t, err, test.ShouldBeError, ErrCaptureDirectoryConfigurationDisabled)
 		})
 	})
@@ -242,7 +242,7 @@ func TestReconfigure(t *testing.T) {
 		ctx := context.Background()
 		deps := resource.Dependencies{}
 		config := resource.Config{ConvertedAttributes: &Config{}}
-		err := b.(resource.BuiltInResource).BuiltInReconfigure(ctx, deps, config)
+		err := b.Reconfigure(ctx, deps, config)
 		errExp := errors.New("Resource missing from dependencies. Resource: " +
 			"rdk-internal:service:cloud_connection/builtin")
 		test.That(t, err, test.ShouldBeError, errExp)
@@ -254,7 +254,7 @@ func TestReconfigure(t *testing.T) {
 		aa := map[resource.Name]resource.AssociatedConfig{arm.Named("arm1"): &pathologicalAssociatedConfig{}}
 		config := resource.Config{ConvertedAttributes: &Config{}, AssociatedAttributes: aa}
 		deps := mockDeps(nil, resource.Dependencies{arm.Named("arm1"): &inject.Arm{}})
-		err := b.(resource.BuiltInResource).BuiltInReconfigure(ctx, deps, config)
+		err := b.Reconfigure(ctx, deps, config)
 		test.That(t, err, test.ShouldBeError, errors.New("expected *datamanager.AssociatedConfig but got *builtin.pathologicalAssociatedConfig"))
 	})
 
@@ -271,7 +271,7 @@ func TestReconfigure(t *testing.T) {
 			},
 		})
 		config, deps := setupConfig(t, r, enabledTabularCollectorConfigPath)
-		err := b.(resource.BuiltInResource).BuiltInReconfigure(ctx, deps, config)
+		err := b.Reconfigure(ctx, deps, config)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, b, test.ShouldNotBeNil)
 		test.That(t, b.Close(context.Background()), test.ShouldBeNil)

--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -64,9 +64,6 @@ const SubtypeName = "data_manager"
 // API is a variable that identifies the data manager service resource API.
 var API = resource.APINamespaceRDK.WithServiceType(SubtypeName)
 
-// InternalServiceName is used to refer to/depend on this service internally.
-var InternalServiceName = resource.NewName(API, "builtin")
-
 // Named is a helper for getting the named datamanager's typed resource name.
 func Named(name string) resource.Name {
 	return resource.NewName(API, name)

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -156,14 +156,14 @@ func NewBuiltIn(
 		configuredDefaultExtras: make(map[string]any),
 	}
 
-	if err := ms.BuiltInReconfigure(ctx, deps, conf); err != nil {
+	if err := ms.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 	return ms, nil
 }
 
 // Reconfigure updates the motion service when the config has changed.
-func (ms *builtIn) BuiltInReconfigure(
+func (ms *builtIn) Reconfigure(
 	ctx context.Context,
 	deps resource.Dependencies,
 	conf resource.Config,

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -214,7 +214,7 @@ func NewBuiltIn(
 		Named:  conf.ResourceName().AsNamed(),
 		logger: logger,
 	}
-	if err := navSvc.reconfigure(ctx, deps, conf); err != nil {
+	if err := navSvc.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 
@@ -249,7 +249,7 @@ type builtIn struct {
 	activeBackgroundWorkers   sync.WaitGroup
 }
 
-func (svc *builtIn) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+func (svc *builtIn) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	svc.actionMu.Lock()
 	defer svc.actionMu.Unlock()
 

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -234,7 +234,7 @@ func TestNew(t *testing.T) {
 			resource.NewName(movementsensor.API, "movement_sensor"): inject.NewMovementSensor("movement_sensor"),
 		}
 
-		svc, err := NewBuiltIn(ctx, deps, resource.Config{ConvertedAttributes: cfg}, nil)
+		err := svc.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 		test.That(t, err, test.ShouldBeNil)
 		svcStruct := svc.(*builtIn)
 
@@ -256,7 +256,7 @@ func TestNew(t *testing.T) {
 			resource.NewName(movementsensor.API, "movement_sensor"): inject.NewMovementSensor("movement_sensor"),
 		}
 
-		svc, err := NewBuiltIn(ctx, deps, resource.Config{ConvertedAttributes: cfg}, nil)
+		err := svc.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 		test.That(t, err, test.ShouldBeNil)
 		svcStruct := svc.(*builtIn)
 
@@ -289,7 +289,7 @@ func TestNew(t *testing.T) {
 			resource.NewName(vision.API, "vision"):  inject.NewVisionService("vision"),
 		}
 
-		svc, err := NewBuiltIn(ctx, deps, resource.Config{ConvertedAttributes: cfg}, nil)
+		err := svc.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 		test.That(t, err, test.ShouldBeNil)
 		svcStruct := svc.(*builtIn)
 
@@ -323,7 +323,7 @@ func TestNew(t *testing.T) {
 			resource.NewName(vision.API, "vision"):  inject.NewVisionService("vision"),
 		}
 
-		svc, err := NewBuiltIn(ctx, deps, resource.Config{ConvertedAttributes: cfg}, nil)
+		err := svc.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 		test.That(t, err, test.ShouldBeNil)
 		svcStruct := svc.(*builtIn)
 
@@ -337,7 +337,7 @@ func TestNew(t *testing.T) {
 		cfg := &Config{}
 		deps := resource.Dependencies{}
 
-		_, err := NewBuiltIn(ctx, deps, resource.Config{ConvertedAttributes: cfg}, nil)
+		err := svc.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 		test.That(t, err, test.ShouldBeError, expectedErr)
 	})
 
@@ -350,7 +350,7 @@ func TestNew(t *testing.T) {
 			resource.NewName(base.API, "base"): &inject.Base{},
 		}
 
-		_, err := NewBuiltIn(ctx, deps, resource.Config{ConvertedAttributes: cfg}, nil)
+		err := svc.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 		test.That(t, err, test.ShouldBeError, expectedErr)
 	})
 
@@ -364,7 +364,7 @@ func TestNew(t *testing.T) {
 			resource.NewName(motion.API, "builtin"): injectmotion.NewMotionService("motion"),
 		}
 
-		_, err := NewBuiltIn(ctx, deps, resource.Config{ConvertedAttributes: cfg}, nil)
+		err := svc.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 		test.That(t, err, test.ShouldBeError, expectedErr)
 	})
 
@@ -386,7 +386,7 @@ func TestNew(t *testing.T) {
 			resource.NewName(movementsensor.API, "movement_sensor"): inject.NewMovementSensor("movement_sensor"),
 		}
 
-		_, err := NewBuiltIn(ctx, deps, resource.Config{ConvertedAttributes: cfg}, nil)
+		err := svc.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 		test.That(t, err, test.ShouldBeError, expectedErr)
 	})
 
@@ -408,7 +408,7 @@ func TestNew(t *testing.T) {
 			resource.NewName(movementsensor.API, "movement_sensor"): inject.NewMovementSensor("movement_sensor"),
 		}
 
-		_, err := NewBuiltIn(ctx, deps, resource.Config{ConvertedAttributes: cfg}, nil)
+		err := svc.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 		test.That(t, err, test.ShouldBeError, expectedErr)
 	})
 
@@ -431,7 +431,7 @@ func TestNew(t *testing.T) {
 			resource.NewName(movementsensor.API, "movement_sensor"): inject.NewMovementSensor("movement_sensor"),
 		}
 
-		svc, err := NewBuiltIn(ctx, deps, resource.Config{ConvertedAttributes: cfg}, nil)
+		err := svc.Reconfigure(ctx, deps, resource.Config{ConvertedAttributes: cfg})
 		test.That(t, err, test.ShouldBeNil)
 		svcStruct := svc.(*builtIn)
 
@@ -1903,7 +1903,7 @@ func createFrameSystemService(
 	conf := resource.Config{
 		ConvertedAttributes: &framesystem.Config{Parts: fsParts},
 	}
-	if err := fsSvc.(resource.BuiltInResource).BuiltInReconfigure(ctx, deps, conf); err != nil {
+	if err := fsSvc.Reconfigure(ctx, deps, conf); err != nil {
 		return nil, err
 	}
 	deps[fsSvc.Name()] = fsSvc

--- a/services/worldstatestore/fake/fake.go
+++ b/services/worldstatestore/fake/fake.go
@@ -76,6 +76,41 @@ func init() {
 		}})
 }
 
+// Reconfigure reconfigures the fake world state store.
+func (f *WorldStateStore) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	// Cancel existing background workers and wait for them to stop
+	f.mu.Lock()
+	f.cancel()
+	f.mu.Unlock()
+
+	f.activeBackgroundWorkers.Wait()
+
+	newConf, err := resource.NativeConfig[*Config](conf)
+	if err != nil {
+		return err
+	}
+
+	// Use context.Background() for background workers, not the passed ctx which may be short-lived
+	newCtx, cancel := context.WithCancel(context.Background())
+
+	f.mu.Lock()
+	f.transforms = make(map[string]*commonpb.Transform)
+	f.fps = 10
+	f.startTime = time.Now()
+	f.changeChan = make(chan worldstatestore.TransformChange, 100)
+	f.streamCtx = newCtx
+	f.cancel = cancel
+	f.worldName = newConf.WorldName
+	f.mu.Unlock()
+
+	f.logger.Infof("reconfiguring fake world state store with name: %s", newConf.WorldName)
+
+	// startWorld acquires its own locks internally, so we must not hold the lock here
+	f.startWorld()
+
+	return nil
+}
+
 // ListUUIDs returns all transform UUIDs currently in the store.
 func (f *WorldStateStore) ListUUIDs(ctx context.Context, extra map[string]any) ([][]byte, error) {
 	f.mu.RLock()

--- a/testutils/inject/shell_service.go
+++ b/testutils/inject/shell_service.go
@@ -49,6 +49,17 @@ func (s *ShellService) Status(ctx context.Context) (map[string]interface{}, erro
 	return map[string]interface{}{}, nil
 }
 
+// Reconfigure calls the injected Reconfigure or the real variant.
+func (s *ShellService) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	if s.ReconfigureFunc == nil {
+		if s.Service == nil {
+			return resource.NewMustRebuildError(conf.ResourceName())
+		}
+		return s.Service.Reconfigure(ctx, deps, conf)
+	}
+	return s.ReconfigureFunc(ctx, deps, conf)
+}
+
 // Close calls the injected Close or the real version.
 func (s *ShellService) Close(ctx context.Context) error {
 	if s.CloseFunc == nil {

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -205,8 +205,7 @@ func TestShutdown(t *testing.T) {
 		testLogger.Info("Issuing shutdown.")
 		err = rc.Shutdown(context.Background())
 
-		// flake on Windows with original 50ms x 50 attempts after replacing reconfigure with rebuild (slower shutdown, unclear why)
-		gtestutils.WaitForAssertionWithSleep(t, 200*time.Millisecond, 50, func(tb testing.TB) {
+		gtestutils.WaitForAssertionWithSleep(t, 50*time.Millisecond, 50, func(tb testing.TB) {
 			tb.Helper()
 			rdkStatus := server.Status()
 			// Asserting not nil here to ensure process is dead
@@ -739,8 +738,7 @@ func TestCloudModulesRespondToDebugAndLogChanges(t *testing.T) {
 	// to make sure we always wait long enough for a reconfigure to happen
 	waitForAssertionLongerThanRefreshInterval := func(t *testing.T, assertion func(tb testing.TB)) {
 		t.Helper()
-		// flake on Windows with original 50ms x 50 attempts after replacing reconfigure with rebuild (slower shutdown, unclear why)
-		retryInterval := 200 * time.Millisecond
+		retryInterval := 50 * time.Millisecond
 		nRuns := int(refreshInterval * 3 / retryInterval)
 		gtestutils.WaitForAssertionWithSleep(t, retryInterval, nRuns, assertion)
 	}


### PR DESCRIPTION
## Summary
Reverts #5944, then re-applies just the cascade-fix portion so the cascade-fix code can bake on main for a week or two before Remove-Reconfigure re-lands. The xarm module will need to be bumped with the cascade rebuild/reconfigure dependents fix in place so doing so before landing remove reconfigure, so this release flow de-risks the deployment.

**To reland Remove-Reconfigure: revert this PR.** This restores the post-#5944 state exactly (Remove-Reconfigure + cascade fix + active cycle test, no dropped assertions), modulo any unrelated drift on main during the bake window.

## Commits

1. **Revert of #5944** — mechanical revert of the squash that brought in Remove-Reconfigure + cascade fix together.
2. **Re-apply cascade fix only** — cherry-pick of `35a9d4c44` (the cascade-fix half of #5944). Conflicts in `module/resources.go` resolved by taking the cascade-fix side at every conflict (name-keyed `internalDeps`, `visited` cycle check, no `toReconfig` field on `resConfigureArgs`). Auto-merge added `rebuildResourceWithVisited`, `cascadeRebuildDependentsOf`, and `hasOptionalDependencies` as new functions; the post-revert `reconfigureResource` is now a one-line wrapper that delegates to `rebuildResourceWithVisited`. The wrapper keeps its old name because callers (e.g., `module/resources.go:106` in the gRPC `ReconfigureResource` handler) reference it by that name post-revert; the rename to `rebuildResource` will happen when Remove-Reconfigure re-lands.
3. **Drop cycle-skip log assertions in `TestModularOptionalDependenciesCycles`** — `ReconfigureResource` RPC bypasses `addResource`, so one direction of `m.internalDeps` for mutual-optional deps stays permanently empty. `foo` is added first before `bar` exists so `foo` skips registering against `m.internalDeps[bar]`. `bar`'s later add doesn't register `foo` against its own `internalDeps` since `addResource` only walks `bar`'s own dependencies, not its dependents; only re-adding foo would populate the entry, which `Remove+Add` does but `ReconfigureResource` RPC doesn't. The cascade walk ends up having nothing to iterate, the visited-check never runs, and the log never emits. Cycle still produces one stale pointer either way but the diagnostic warning is lost. Fresh/stale exclusivity check still runs. Remove-Reconfigure relanding re-adds the assertions.