### PR TITLE
RSDK-13938 - Fix gpiostepper IsPowered to report actual power_pct

### DIFF
--- a/components/motor/gpiostepper/gpiostepper.go
+++ b/components/motor/gpiostepper/gpiostepper.go
@@ -189,9 +189,12 @@ type gpioStepper struct {
 	trackingCancel     context.CancelFunc
 	trackingDone       <-chan struct{} // closed when tracking goroutine exits
 
-	// Last commanded fraction of max step frequency (signed by direction). Written under
-	// m.lock after a successful startPWM by SetPower/GoFor/SetRPM; only meaningful while
-	// IsMoving == true, so IsPowered guards reads with that check.
+	// Fraction of max step frequency (signed by direction) corresponding to the
+	// requested PWM frequency from the last successful startPWM. Written under
+	// m.lock by SetPower/GoFor/SetRPM; only meaningful while IsMoving == true,
+	// so IsPowered guards reads with that check. Reflects what the user
+	// commanded, not what the PWM hardware was able to deliver — boards with
+	// limited PWM frequency ranges may run slower than this fraction implies.
 	powerPct float64
 }
 
@@ -225,8 +228,9 @@ func (m *gpioStepper) rpmToFreqHz(rpm float64) uint {
 }
 
 // freqToPowerPct inverts SetPower's powerPct→freqHz mapping so SetPower, GoFor,
-// and SetRPM can all report a consistent IsPowered fraction based on the PWM
-// frequency the hardware actually achieved.
+// and SetRPM can all report a consistent IsPowered fraction. Callers pass the
+// *requested* freq (not the PWM readback) so the reported value reflects what
+// the user commanded even on boards whose PWM hardware caps the frequency.
 func (m *gpioStepper) freqToPowerPct(freq float64, forward bool) float64 {
 	if m.minDelay <= 0 {
 		return 0
@@ -335,6 +339,7 @@ func (m *gpioStepper) trackPosition(ctx context.Context, doneCh chan<- error,
 
 // SetPower sets the percentage of power the motor should employ between 0-1.
 func (m *gpioStepper) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+	m.logger.CDebugf(ctx, "motor (%s) SetPower powerPct=%.4f", m.Name().Name, powerPct)
 	if math.Abs(powerPct) <= .0001 {
 		return m.Stop(ctx, nil)
 	}
@@ -369,7 +374,11 @@ func (m *gpioStepper) SetPower(ctx context.Context, powerPct float64, extra map[
 		m.lock.Unlock()
 		return err
 	}
-	m.powerPct = m.freqToPowerPct(actualFreq, forward)
+	// Report power_pct from the *requested* freq, not the readback. PWM hardware
+	// (e.g. the Pi) may cap freq below what was asked; users still expect
+	// IsPowered to reflect the value they commanded. trackPosition uses
+	// actualFreq separately so position estimation stays accurate.
+	m.powerPct = m.freqToPowerPct(float64(freqHz), forward)
 	trackCtx, cancel := context.WithCancel(context.Background())
 	m.trackingCancel = cancel
 	trackingDone := make(chan struct{})
@@ -391,6 +400,8 @@ func (m *gpioStepper) GoFor(ctx context.Context, rpm, revolutions float64, extra
 	ctx, done := m.opMgr.New(ctx)
 	defer done()
 
+	m.logger.CDebugf(ctx, "motor (%s) GoFor rpm=%.4f revolutions=%.4f", m.Name().Name, rpm, revolutions)
+
 	speed := math.Abs(rpm)
 	if speed < 0.1 {
 		return multierr.Combine(m.Stop(ctx, nil), motor.NewZeroRPMError())
@@ -409,16 +420,17 @@ func (m *gpioStepper) GoFor(ctx context.Context, rpm, revolutions float64, extra
 	target := m.stepPosition.Load() + d*int64(math.Abs(revolutions)*float64(m.stepsPerRotation))
 	m.targetStepPosition.Store(target)
 
+	requestedFreq := m.rpmToFreqHz(rpm)
 	m.lock.Lock()
 	if m.trackingCancel != nil {
 		m.trackingCancel()
 	}
-	actualFreq, err := m.startPWM(ctx, forward, m.rpmToFreqHz(rpm))
+	actualFreq, err := m.startPWM(ctx, forward, requestedFreq)
 	if err != nil {
 		m.lock.Unlock()
 		return err
 	}
-	m.powerPct = m.freqToPowerPct(actualFreq, forward)
+	m.powerPct = m.freqToPowerPct(float64(requestedFreq), forward)
 	trackCtx, cancel := context.WithCancel(ctx)
 	m.trackingCancel = cancel
 	trackingDone := make(chan struct{})
@@ -464,6 +476,7 @@ func (m *gpioStepper) GoTo(ctx context.Context, rpm, positionRevolutions float64
 
 // SetRPM instructs the motor to move at the specified RPM indefinitely.
 func (m *gpioStepper) SetRPM(ctx context.Context, rpm float64, extra map[string]interface{}) error {
+	m.logger.CDebugf(ctx, "motor (%s) SetRPM rpm=%.4f", m.Name().Name, rpm)
 	if math.Abs(rpm) <= .0001 {
 		return m.Stop(ctx, nil)
 	}
@@ -479,16 +492,17 @@ func (m *gpioStepper) SetRPM(ctx context.Context, rpm float64, extra map[string]
 	}
 	m.targetStepPosition.Store(target)
 
+	requestedFreq := m.rpmToFreqHz(rpm)
 	m.lock.Lock()
 	if m.trackingCancel != nil {
 		m.trackingCancel()
 	}
-	actualFreq, err := m.startPWM(ctx, forward, m.rpmToFreqHz(rpm))
+	actualFreq, err := m.startPWM(ctx, forward, requestedFreq)
 	if err != nil {
 		m.lock.Unlock()
 		return err
 	}
-	m.powerPct = m.freqToPowerPct(actualFreq, forward)
+	m.powerPct = m.freqToPowerPct(float64(requestedFreq), forward)
 	trackCtx, cancel := context.WithCancel(context.Background())
 	m.trackingCancel = cancel
 	trackingDone := make(chan struct{})

--- a/components/motor/gpiostepper/gpiostepper.go
+++ b/components/motor/gpiostepper/gpiostepper.go
@@ -188,6 +188,11 @@ type gpioStepper struct {
 	targetStepPosition atomic.Int64
 	trackingCancel     context.CancelFunc
 	trackingDone       <-chan struct{} // closed when tracking goroutine exits
+
+	// Last commanded fraction of max step frequency (signed by direction). Written under
+	// m.lock after a successful startPWM by SetPower/GoFor/SetRPM; only meaningful while
+	// IsMoving == true, so IsPowered guards reads with that check.
+	powerPct float64
 }
 
 // stopTracking cancels the tracking goroutine and waits for it to fully exit.
@@ -217,6 +222,20 @@ func (m *gpioStepper) rpmToFreqHz(rpm float64) uint {
 		freq = 1
 	}
 	return uint(math.Round(freq))
+}
+
+// freqToPowerPct inverts SetPower's powerPct→freqHz mapping so SetPower, GoFor,
+// and SetRPM can all report a consistent IsPowered fraction based on the PWM
+// frequency the hardware actually achieved.
+func (m *gpioStepper) freqToPowerPct(freq float64, forward bool) float64 {
+	if m.minDelay <= 0 {
+		return 0
+	}
+	p := math.Min(freq*m.minDelay.Seconds(), 1.0)
+	if !forward {
+		p = -p
+	}
+	return p
 }
 
 // startPWM sets direction, enables the motor, and starts PWM on the step pin.
@@ -350,6 +369,7 @@ func (m *gpioStepper) SetPower(ctx context.Context, powerPct float64, extra map[
 		m.lock.Unlock()
 		return err
 	}
+	m.powerPct = m.freqToPowerPct(actualFreq, forward)
 	trackCtx, cancel := context.WithCancel(context.Background())
 	m.trackingCancel = cancel
 	trackingDone := make(chan struct{})
@@ -398,6 +418,7 @@ func (m *gpioStepper) GoFor(ctx context.Context, rpm, revolutions float64, extra
 		m.lock.Unlock()
 		return err
 	}
+	m.powerPct = m.freqToPowerPct(actualFreq, forward)
 	trackCtx, cancel := context.WithCancel(ctx)
 	m.trackingCancel = cancel
 	trackingDone := make(chan struct{})
@@ -467,6 +488,7 @@ func (m *gpioStepper) SetRPM(ctx context.Context, rpm float64, extra map[string]
 		m.lock.Unlock()
 		return err
 	}
+	m.powerPct = m.freqToPowerPct(actualFreq, forward)
 	trackCtx, cancel := context.WithCancel(context.Background())
 	m.trackingCancel = cancel
 	trackingDone := make(chan struct{})
@@ -518,19 +540,21 @@ func (m *gpioStepper) Stop(ctx context.Context, extra map[string]interface{}) er
 	return m.stopHardware(ctx)
 }
 
-// IsPowered returns whether or not the motor is currently on. It also returns the percent power
-// that the motor has, but stepper motors only have this set to 0% or 100%, so it's a little
-// redundant.
+// IsPowered returns whether or not the motor is currently on, and the fraction
+// of max step frequency it was last commanded to run at (signed by direction).
+// The fraction is only valid while the motor is moving; when stopped the
+// reported power is 0.
 func (m *gpioStepper) IsPowered(ctx context.Context, extra map[string]interface{}) (bool, float64, error) {
 	on, err := m.IsMoving(ctx)
 	if err != nil {
 		return on, 0.0, errors.Wrapf(err, "error in IsPowered from motor (%s)", m.Name().Name)
 	}
-	percent := 0.0
-	if on {
-		percent = 1.0
+	if !on {
+		return false, 0.0, nil
 	}
-	return on, percent, err
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return true, m.powerPct, nil
 }
 
 func (m *gpioStepper) Close(ctx context.Context) error {

--- a/components/motor/gpiostepper/gpiostepper_test.go
+++ b/components/motor/gpiostepper/gpiostepper_test.go
@@ -289,6 +289,47 @@ func TestRunning(t *testing.T) {
 		test.That(t, m.(*gpioStepper).targetStepPosition.Load(), test.ShouldEqual, 600)
 	})
 
+	t.Run("IsPowered reflects SetPower input", func(t *testing.T) {
+		m, err := newGPIOStepper(ctx, deps, c, logger)
+		test.That(t, err, test.ShouldBeNil)
+		defer m.Close(ctx)
+
+		// SetPower's reported power_pct is derived from the requested step freq, not
+		// the PWM readback, so it reflects what the user commanded even on boards
+		// that cap PWM frequency. Cases below also exercise direction signing and
+		// the upper clamp at 1.0. Tolerance covers the integer-Hz truncation in
+		// SetPower's powerPct→freqHz mapping (worst case: minDelay seconds).
+		for _, tc := range []struct {
+			name     string
+			power    float64
+			expected float64
+		}{
+			{"forward half", 0.5, 0.5},
+			{"reverse partial", -0.3, -0.3},
+			{"clamped above 1", 1.5, 1.0},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				test.That(t, m.SetPower(ctx, tc.power, nil), test.ShouldBeNil)
+				testutils.WaitForAssertion(t, func(tb testing.TB) {
+					tb.Helper()
+					on, powerPct, err := m.IsPowered(ctx, nil)
+					test.That(tb, err, test.ShouldBeNil)
+					test.That(tb, on, test.ShouldEqual, true)
+					test.That(tb, powerPct, test.ShouldAlmostEqual, tc.expected, 1e-4)
+				})
+			})
+		}
+
+		test.That(t, m.Stop(ctx, nil), test.ShouldBeNil)
+		testutils.WaitForAssertion(t, func(tb testing.TB) {
+			tb.Helper()
+			on, powerPct, err := m.IsPowered(ctx, nil)
+			test.That(tb, err, test.ShouldBeNil)
+			test.That(tb, on, test.ShouldEqual, false)
+			test.That(tb, powerPct, test.ShouldEqual, 0.0)
+		})
+	})
+
 	t.Run("motor enable", func(t *testing.T) {
 		m, err := newGPIOStepper(ctx, deps, c, logger)
 		s := m.(*gpioStepper)

--- a/components/motor/gpiostepper/gpiostepper_test.go
+++ b/components/motor/gpiostepper/gpiostepper_test.go
@@ -260,9 +260,11 @@ func TestRunning(t *testing.T) {
 			wg.Wait()
 		}()
 
-		// the motor is running. GoFor(rpm=100) at TicksPerRotation=200 maps to
-		// freqHz = round(100*200/60) = 333 Hz; with StepperDelay=30µs, that's
-		// 333 * 30e-6 ≈ 0.00999 of max step frequency.
+		// the motor is running. GoFor(rpm=100) at TicksPerRotation=200 maps to a
+		// requested freqHz = round(100*200/60) = 333 Hz; with StepperDelay=30µs,
+		// IsPowered reports 333 * 30e-6 ≈ 0.00999 of max step frequency. The
+		// reported value is derived from the requested freq, so it doesn't depend
+		// on whether the underlying board caps PWM frequency.
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
 			on, powerPct, err := m.IsPowered(ctx, nil)

--- a/components/motor/gpiostepper/gpiostepper_test.go
+++ b/components/motor/gpiostepper/gpiostepper_test.go
@@ -260,13 +260,15 @@ func TestRunning(t *testing.T) {
 			wg.Wait()
 		}()
 
-		// the motor is running
+		// the motor is running. GoFor(rpm=100) at TicksPerRotation=200 maps to
+		// freqHz = round(100*200/60) = 333 Hz; with StepperDelay=30µs, that's
+		// 333 * 30e-6 ≈ 0.00999 of max step frequency.
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
 			on, powerPct, err := m.IsPowered(ctx, nil)
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, on, test.ShouldEqual, true)
-			test.That(tb, powerPct, test.ShouldEqual, 1.0)
+			test.That(tb, powerPct, test.ShouldAlmostEqual, 333.0*30e-6, 1e-9)
 		})
 
 		// the motor finished running


### PR DESCRIPTION
## Summary
- `gpiostepper.IsPowered` always reported `1.0` while running (the 0/1 stub the in-file comment called out as "a little redundant"). Per `motor.proto`, `power_pct` should be the actual fraction (0–1, signed) of max power, so the control UI's `power_pct * 100` rendering produced "100%" regardless of what was commanded.
- Track the commanded fraction on the `gpioStepper` struct, set under `m.lock` after a successful `startPWM` in `SetPower` / `GoFor` / `SetRPM`, derived from the *requested* PWM frequency via a new `freqToPowerPct` helper that inverts SetPower's freqHz mapping. Read it from `IsPowered`, guarded by the existing `IsMoving` check so stale values don't leak after Stop.
- Reports the requested freq (not the readback) so boards that cap PWM hardware-side (e.g. Pi caps at ~8 kHz) still surface what the user commanded — `trackPosition` continues to use the readback for accurate position estimation.
- Adds debug logs at the entry of `SetPower` / `GoFor` / `SetRPM` showing the inputs each method received, which made the readback-vs-request divergence easy to diagnose on hardware.
- Updates the existing gpiostepper test that codified the old `1.0`-while-on assertion, and adds a new `IsPowered reflects SetPower input` sub-test covering forward, reverse, and the 1.0 clamp.

## Test plan
- [x] `go build ./components/motor/gpiostepper/`
- [x] `go test ./components/motor/gpiostepper/` (passes locally, ~2.8s)
- [x] Manual on Pi 4 hardware (PR build): `SetPower(0.5)` → `IsPowered` returns `true / 50.0%` (was `100%` before fix)
- [x] Regression: after `Stop()` → `IsPowered` returns `(false, 0.0)` (covered by both existing and new sub-tests)
- [x] Regression: `GoFor` / `SetRPM` paths report a `power_pct` derived from the requested step frequency (existing `IsPowered true` sub-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)