### PR TITLE
Add --builder flag to viam module build start (APP-16314)

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -108,6 +108,7 @@ const (
 	moduleBuildFlagToken       = "token"
 	moduleBuildFlagWorkdir     = "workdir"
 	moduleBuildFlagPlatforms   = "platforms"
+	moduleBuildFlagBuilder     = "builder"
 	moduleBuildFlagGroupLogs   = "group-logs"
 	moduleBuildRestartOnly     = "restart-only"
 	moduleBuildFlagNoBuild     = "no-build"
@@ -3674,6 +3675,11 @@ Example:
 									Name: moduleBuildFlagPlatforms,
 									// would use 'DefaultText' key, but defaults don't show for slice flags
 									Usage: "list of platforms to build, e.g. linux/amd64,linux/arm64 (default: build.arch in meta.json)",
+								},
+								&cli.StringFlag{
+									Name:  moduleBuildFlagBuilder,
+									Usage: formatAcceptedValues("target build service", "default", "viam-cloudbuild-test"),
+									Value: "default",
 								},
 							},
 							Action: createActionCommandWithT[moduleBuildStartArgs](ModuleBuildStartAction),

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -132,6 +132,7 @@ type moduleBuildStartArgs struct {
 	Token     string
 	Workdir   string
 	Platforms []string
+	Builder   string
 }
 
 // ModuleBuildStartAction starts a cloud build.
@@ -177,9 +178,15 @@ func (c *viamClient) moduleBuildStartForRepo(
 		Workdir:       &workdir,
 		Distro:        &manifest.Build.Distro,
 	}
+	if args.Builder != "" && args.Builder != "default" {
+		req.Builder = &args.Builder
+	}
 	res, err := c.buildClient.StartBuild(ctx, &req)
 	if err != nil {
 		return "", err
+	}
+	if msg := res.GetBuilderFallbackMessage(); msg != "" {
+		printf(cmd.Root().ErrWriter, "Warning: %s", msg)
 	}
 	// Print to stderr so that stdout only contains the buildID, which is parsed by the build-action.
 	// See https://github.com/viamrobotics/build-action/blob/main/src/index.js


### PR DESCRIPTION
## Summary

Adds `--builder` flag to `viam module build start` for targeting the new Viam Linux build service.

**Changes:**
- `cli/app.go` — adds `--builder` flag with accepted values `default | viam-cloudbuild-test` (default: `default`)
- `cli/module_build.go` — adds `Builder string` to `moduleBuildStartArgs`; sets `req.Builder` when non-default; prints `Warning: <message>` to stderr if `BuilderFallbackMessage` is set in the response (org not whitelisted)

**Depends on:** viamrobotics/api#848 — needs `go.viam.com/api` bumped to pick up `builder` field in `StartBuildRequest` and `GetBuilderFallbackMessage()` on the response.

## Test plan

- [x] `go build` clean on `cli/...`
- [x] `--builder` flag appears correctly in `viam module build start --help`
- [x] End-to-end: `viam module build start --builder viam-cloudbuild-test` against local server returns build ID for whitelisted org; server logs confirm Pub/Sub publish