### PR TITLE
RSDK-13942: Add ability to write motion plan responses to JSON request files.

### DIFF
--- a/motionplan/armplanning/api.go
+++ b/motionplan/armplanning/api.go
@@ -4,6 +4,7 @@ package armplanning
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -301,5 +302,71 @@ func (req *PlanRequest) WriteToFile(fileName string) error {
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// ReadRequestAndResponseFromFile reads a PlanRequest and optionally a motionplan.Plan from a JSON
+// file written by WriteRequestAndResponseToFile. The returned plan is nil if the file contains only
+// a request.
+func ReadRequestAndResponseFromFile(fileName string) (*PlanRequest, motionplan.Plan, error) {
+	f, err := os.Open(fileName) //nolint:gosec
+	if err != nil {
+		return nil, nil, err
+	}
+	defer utils.UncheckedErrorFunc(f.Close)
+
+	decoder := json.NewDecoder(f)
+
+	req := &PlanRequest{}
+	if err = decoder.Decode(req); err != nil {
+		return nil, nil, err
+	}
+
+	plan := &motionplan.SimplePlan{}
+	if err = decoder.Decode(plan); err != nil {
+		if errors.Is(err, io.EOF) {
+			return req, nil, nil
+		}
+		return nil, nil, err
+	}
+
+	return req, plan, nil
+}
+
+// WriteRequestAndResponseToFile writes the `req` as one JSON object followed by `resp` as a second
+// JSON object. This is backwards compatible with existing `ReadRequestFromFile`
+// implementations. Also see `ReadRequestAndResponseFromFile` to pull out both sets of
+// information. `resp` can be nil. Useful for cases where the request resulted in a motion plan
+// error.
+func (req *PlanRequest) WriteRequestAndResponseToFile(filename string, resp motionplan.Plan) error {
+	file, err := os.OpenFile(filepath.Clean(filename), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	defer utils.UncheckedErrorFunc(file.Close)
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	_, err = file.Write(data)
+	if err != nil {
+		return err
+	}
+
+	if resp != nil {
+		data, err = json.Marshal(resp)
+		if err != nil {
+			return err
+		}
+
+		_, err = file.Write(data)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/motionplan/armplanning/api_test.go
+++ b/motionplan/armplanning/api_test.go
@@ -1,0 +1,80 @@
+package armplanning_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/golang/geo/r3"
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/motionplan"
+	"go.viam.com/rdk/motionplan/armplanning"
+	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/rdk/utils"
+)
+
+func TestWriteAndReadRequestAndResponse(t *testing.T) {
+	// Build a minimal frame system with a 6-DOF arm.
+	model, err := referenceframe.ParseModelJSONFile(utils.ResolveFile("components/arm/fake/kinematics/xarm6.json"), "xarm6")
+	test.That(t, err, test.ShouldBeNil)
+
+	fs := referenceframe.NewEmptyFrameSystem("")
+	err = fs.AddFrame(model, fs.World())
+	test.That(t, err, test.ShouldBeNil)
+
+	startInputs := referenceframe.FrameSystemInputs{"xarm6": make([]referenceframe.Input, 6)}
+	goalPose := spatialmath.NewPoseFromPoint(r3.Vector{X: 200, Y: 100, Z: 300})
+	goalPoses := referenceframe.FrameSystemPoses{
+		"xarm6": referenceframe.NewPoseInFrame(referenceframe.World, goalPose),
+	}
+
+	req := &armplanning.PlanRequest{
+		FrameSystem: fs,
+		StartState:  armplanning.NewPlanState(nil, startInputs),
+		Goals:       []*armplanning.PlanState{armplanning.NewPlanState(goalPoses, nil)},
+	}
+
+	// Build a trivial plan response: two identical waypoints.
+	traj := motionplan.Trajectory{
+		referenceframe.FrameSystemInputs{"xarm6": {0.1, 0.2, 0.3, 0.4, 0.5, 0.6}},
+		referenceframe.FrameSystemInputs{"xarm6": {0.7, 0.8, 0.9, 1.0, 1.1, 1.2}},
+	}
+	resp := motionplan.NewSimplePlan(nil, traj)
+
+	fileName := filepath.Join(t.TempDir(), "plan.json")
+	t.Run("WriteRequestAndResponseToFile", func(t *testing.T) {
+		err = req.WriteRequestAndResponseToFile(fileName, resp)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("ReadRequestFromFile parses the request", func(t *testing.T) {
+		got, err := armplanning.ReadRequestFromFile(fileName)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, got, test.ShouldNotBeNil)
+		test.That(t, got.FrameSystem, test.ShouldNotBeNil)
+		test.That(t, got.StartState, test.ShouldNotBeNil)
+		test.That(t, got.StartState.Configuration(), test.ShouldResemble, startInputs)
+		test.That(t, len(got.Goals), test.ShouldEqual, 1)
+	})
+
+	t.Run("ReadRequestAndResponseFromFile parses both", func(t *testing.T) {
+		gotReq, gotPlan, err := armplanning.ReadRequestAndResponseFromFile(fileName)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, gotReq, test.ShouldNotBeNil)
+		test.That(t, gotReq.StartState.Configuration(), test.ShouldResemble, startInputs)
+		test.That(t, gotPlan, test.ShouldNotBeNil)
+		test.That(t, gotPlan.Trajectory(), test.ShouldResemble, traj)
+	})
+
+	t.Run("ReadRequestAndResponseFromFile with nil response returns nil plan", func(t *testing.T) {
+		requestOnlyFile := filepath.Join(t.TempDir(), "request_only.json")
+		err = req.WriteToFile(requestOnlyFile)
+		test.That(t, err, test.ShouldBeNil)
+
+		gotReq, gotPlan, err := armplanning.ReadRequestAndResponseFromFile(requestOnlyFile)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, gotReq, test.ShouldNotBeNil)
+		test.That(t, gotPlan, test.ShouldBeNil)
+	})
+}

--- a/motionplan/armplanning/api_test.go
+++ b/motionplan/armplanning/api_test.go
@@ -24,7 +24,7 @@ func TestWriteAndReadRequestAndResponse(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	startInputs := referenceframe.FrameSystemInputs{"xarm6": make([]referenceframe.Input, 6)}
-	goalPose := spatialmath.NewPoseFromPoint(r3.Vector{X: 200, Y: 100, Z: 300})
+	goalPose := spatialmath.NewPose(r3.Vector{X: 200, Y: 100, Z: 300}, &spatialmath.OrientationVector{OZ: -1})
 	goalPoses := referenceframe.FrameSystemPoses{
 		"xarm6": referenceframe.NewPoseInFrame(referenceframe.World, goalPose),
 	}
@@ -39,6 +39,7 @@ func TestWriteAndReadRequestAndResponse(t *testing.T) {
 	traj := motionplan.Trajectory{
 		referenceframe.FrameSystemInputs{"xarm6": {0.1, 0.2, 0.3, 0.4, 0.5, 0.6}},
 		referenceframe.FrameSystemInputs{"xarm6": {0.7, 0.8, 0.9, 1.0, 1.1, 1.2}},
+		referenceframe.FrameSystemInputs{"xarm6": {0.1, 0.8, 0.3, 1.0, 1.5, 1.2}},
 	}
 	resp := motionplan.NewSimplePlan(nil, traj)
 

--- a/motionplan/armplanning/cmd-plan/cmd-plan.go
+++ b/motionplan/armplanning/cmd-plan/cmd-plan.go
@@ -117,7 +117,7 @@ func realMain() error {
 	}
 
 	logger.Infof("reading plan from %s", flag.Arg(0))
-	req, err := armplanning.ReadRequestFromFile(flag.Arg(0))
+	req, origPlan, err := armplanning.ReadRequestAndResponseFromFile(flag.Arg(0))
 	if err != nil {
 		return err
 	}
@@ -223,6 +223,10 @@ func realMain() error {
 	totalCartesion := 0.0
 	totalL2 := 0.0
 
+	if origPlan != nil {
+		mylog.Printf("Original plan length: %v Current plan length: %v\n",
+			len(origPlan.Trajectory()), len(plan.Trajectory()))
+	}
 	for idx, p := range plan.Path() {
 		mylog.Printf("step %d", idx)
 

--- a/motionplan/plan.go
+++ b/motionplan/plan.go
@@ -2,6 +2,7 @@
 package motionplan
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 
@@ -97,6 +98,27 @@ func NewGeoPlan(plan Plan, pt *geo.Point) Plan {
 		newPath = append(newPath, newStep)
 	}
 	return NewSimplePlan(newPath, plan.Trajectory())
+}
+
+type simplePlanJSON struct {
+	Path Path       `json:"path"`
+	Traj Trajectory `json:"trajectory"`
+}
+
+// MarshalJSON implements json.Marshaler for SimplePlan.
+func (plan *SimplePlan) MarshalJSON() ([]byte, error) {
+	return json.Marshal(simplePlanJSON{Path: plan.path, Traj: plan.traj})
+}
+
+// UnmarshalJSON implements json.Unmarshaler for SimplePlan.
+func (plan *SimplePlan) UnmarshalJSON(data []byte) error {
+	var planJSON simplePlanJSON
+	if err := json.Unmarshal(data, &planJSON); err != nil {
+		return err
+	}
+	plan.path = planJSON.Path
+	plan.traj = planJSON.Traj
+	return nil
 }
 
 // ExecutionState describes a plan and a particular state along it.

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -816,5 +816,5 @@ func (ms *builtIn) writePlanRequest(
 	}
 
 	ms.logger.Infof("writing plan to %s", fn)
-	return req.WriteToFile(fn)
+	return req.WriteRequestAndResponseToFile(fn, plan)
 }


### PR DESCRIPTION
Files generated by new code will still be readable by the classic `ReadRequestFromFile` implementation. And files generated by old code are still useable by cmd-plan.

Requests and responses are written as two independent JSON objects to the same file. One after the other. Parsers are lenient when the output plan does not exist.