### PR TITLE
RSDK-13951: continue logging to stdout if VIAM_LOGFILE is used

### DIFF
--- a/utils/env.go
+++ b/utils/env.go
@@ -106,7 +106,7 @@ const (
 	// ViamNoWindowsEventLoggerEnvVar if set will not write logs to the Windows Event Logger.
 	ViamNoWindowsEventLoggerEnvVar = "VIAM_NO_WINDOWS_EVENT_LOGGER"
 
-	// ViamLogFileEnvVar if set will write logs to the specified file (same as -log-file cli argument).
+	// ViamLogFileEnvVar if set will write logs to the specified file in addition to stdout (use -log-file cli arg to disable stdout).
 	ViamLogFileEnvVar = "VIAM_LOGFILE"
 )
 

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -135,7 +135,10 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 			utils.UncheckedError(closer.Close())
 		}()
 		registry.AddAppenderToAll(logWriter)
-	} else {
+	}
+
+	// Agent reads from stdout, so log to it if either 1) not logging to a file 2) logging to a file via env var
+	if logFilePath == "" || os.Getenv(rutils.ViamLogFileEnvVar) != "" {
 		registry.AddAppenderToAll(logging.NewStdoutAppender())
 	}
 


### PR DESCRIPTION
Use `-log-file` cli arg instead to disable stdout and log to file only.