### PR TITLE
only cap infinite limits in GoodLimits, not finite explicit ranges

### DIFF
--- a/referenceframe/frame.go
+++ b/referenceframe/frame.go
@@ -81,14 +81,16 @@ func (l *Limit) Jog(val, percentJog float64) float64 {
 	return val
 }
 
-// GoodLimits gives min, max, range, but capped to -999,999.
+// GoodLimits gives min, max, range. Infinite limits are capped to +/- rangeLimit to bound
+// the search space. Finite limits are returned as-is so explicitly configured ranges
+// are not silently truncated.
 func (l *Limit) GoodLimits() (float64, float64, float64) {
 	a := l.Min
 	b := l.Max
-	if a < -1*rangeLimit {
+	if math.IsInf(a, -1) {
 		a = -1 * rangeLimit
 	}
-	if b > rangeLimit {
+	if math.IsInf(b, 1) {
 		b = rangeLimit
 	}
 	return a, b, b - a

--- a/referenceframe/frame_test.go
+++ b/referenceframe/frame_test.go
@@ -416,6 +416,20 @@ func TestLimitMethods(t *testing.T) {
 	test.That(t, b, test.ShouldEqual, 10)
 	test.That(t, c, test.ShouldEqual, 10)
 
+	// finite limits above rangeLimit must pass through unchanged (prismatic mm-scale joints)
+	prismatic := Limit{0, 2224}
+	a, b, c = prismatic.GoodLimits()
+	test.That(t, a, test.ShouldEqual, 0)
+	test.That(t, b, test.ShouldEqual, 2224)
+	test.That(t, c, test.ShouldEqual, 2224)
+
+	// infinite limits are capped to +/- rangeLimit
+	infinite := Limit{math.Inf(-1), math.Inf(1)}
+	a, b, c = infinite.GoodLimits()
+	test.That(t, a, test.ShouldEqual, -rangeLimit)
+	test.That(t, b, test.ShouldEqual, rangeLimit)
+	test.That(t, c, test.ShouldEqual, 2*rangeLimit)
+
 	d := l.Jog(5, .25)
 	test.That(t, d, test.ShouldEqual, 7.5)
 


### PR DESCRIPTION
## The issue
- `GoodLimits()` caps all joint ranges to +/- 999 which works correctly for rotational joints in radians
- Prismatic joints with explicit mm scale limits (i.e. min:0, max:2224) are silently truncated - a joint at 1112mm produces inverted bounds [1112, 999] instead of the correct [1112, 1112]

## Fix
- only apply the -/+ 999 cap when the limit is infinite
- finite / explicitly configured limits are returned as is

Reviewed all GoodLimits call sites - all use the range for step sizes or search bounds, and correctly scale with the larger finite range

## Questions
- Does not cap large but finite limits (i.e. {-1e10, 1e10}) - are there any known cases? 
- Was 999 chosen for a specific reason beyond handling infinite rotational ranges?