### PR TITLE
RSDK-13983: Invalidate stale client caches on modular component reconfiguration.

### DIFF
--- a/components/arm/client.go
+++ b/components/arm/client.go
@@ -47,6 +47,8 @@ func NewClientFromConn(
 	}, nil
 }
 
+// Reconfigure invalidates the cached `model` value. It's expected to be invoked when this `client`
+// represents an rdk <-> modular arm connection and the arm rebuilds.
 func (c *client) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	c.mu.Lock()
 	c.model = nil

--- a/components/arm/client.go
+++ b/components/arm/client.go
@@ -21,7 +21,6 @@ import (
 // client implements ArmServiceClient.
 type client struct {
 	resource.Named
-	resource.TriviallyReconfigurable
 	resource.TriviallyCloseable
 	name   string
 	client pb.ArmServiceClient
@@ -46,6 +45,14 @@ func NewClientFromConn(
 		client: pbClient,
 		logger: logger,
 	}, nil
+}
+
+func (c *client) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	c.mu.Lock()
+	c.model = nil
+	c.mu.Unlock()
+
+	return nil
 }
 
 func (c *client) EndPosition(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {

--- a/components/gantry/client.go
+++ b/components/gantry/client.go
@@ -21,7 +21,6 @@ import (
 type client struct {
 	resource.Named
 	resource.Shaped
-	resource.TriviallyReconfigurable
 	resource.TriviallyCloseable
 	name   string
 	client pb.GantryServiceClient
@@ -46,6 +45,14 @@ func NewClientFromConn(
 		client: c,
 		logger: logger,
 	}, nil
+}
+
+func (c *client) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	c.mu.Lock()
+	c.model = nil
+	c.mu.Unlock()
+
+	return nil
 }
 
 func (c *client) Position(ctx context.Context, extra map[string]interface{}) ([]float64, error) {

--- a/components/gantry/client.go
+++ b/components/gantry/client.go
@@ -47,6 +47,8 @@ func NewClientFromConn(
 	}, nil
 }
 
+// Reconfigure invalidates the cached `model` value. It's expected to be invoked when this `client`
+// represents an rdk <-> modular gantry connection and the gantry rebuilds.
 func (c *client) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	c.mu.Lock()
 	c.model = nil

--- a/components/gripper/client.go
+++ b/components/gripper/client.go
@@ -45,6 +45,8 @@ func NewClientFromConn(
 	}, nil
 }
 
+// Reconfigure invalidates the cached `model` value. It's expected to be invoked when this `client`
+// represents an rdk <-> modular gripper connection and the gripper rebuilds.
 func (c *client) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
 	c.mu.Lock()
 	c.model = nil

--- a/components/gripper/client.go
+++ b/components/gripper/client.go
@@ -20,7 +20,6 @@ import (
 // client implements GripperServiceClient.
 type client struct {
 	resource.Named
-	resource.TriviallyReconfigurable
 	resource.TriviallyCloseable
 	name   string
 	client pb.GripperServiceClient
@@ -44,6 +43,14 @@ func NewClientFromConn(
 		client: pb.NewGripperServiceClient(conn),
 		logger: logger,
 	}, nil
+}
+
+func (c *client) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+	c.mu.Lock()
+	c.model = nil
+	c.mu.Unlock()
+
+	return nil
 }
 
 func (c *client) Open(ctx context.Context, extra map[string]interface{}) error {

--- a/examples/customresources/demos/fakearmmodule/Makefile
+++ b/examples/customresources/demos/fakearmmodule/Makefile
@@ -1,0 +1,9 @@
+.PHONY: module
+
+default: run-module
+
+module:
+	go build ./
+
+run-module: module
+	go run ../../../../web/cmd/server -config module.json

--- a/examples/customresources/demos/fakearmmodule/module.go
+++ b/examples/customresources/demos/fakearmmodule/module.go
@@ -1,0 +1,20 @@
+// Package main is a test module that exposes a fake arm under a custom model.
+// The component implementation is reused from the built-in RDK fake arm package.
+package main
+
+import (
+	"go.viam.com/rdk/components/arm"
+	"go.viam.com/rdk/components/arm/fake"
+	"go.viam.com/rdk/module"
+	"go.viam.com/rdk/resource"
+)
+
+var myModel = resource.NewModel("acme", "demo", "fakearm")
+
+func main() {
+	resource.RegisterComponent(arm.API, myModel, resource.Registration[arm.Arm, *fake.Config]{
+		Constructor: fake.NewArm,
+	})
+
+	module.ModularMain(resource.APIModel{API: arm.API, Model: myModel})
+}

--- a/examples/customresources/demos/fakearmmodule/module.json
+++ b/examples/customresources/demos/fakearmmodule/module.json
@@ -1,0 +1,22 @@
+{
+	"modules": [
+		{
+			"name": "FakeArmModule",
+			"executable_path": "./fakearmmodule"
+		}
+	],
+	"components": [
+		{
+			"namespace": "rdk",
+			"type": "arm",
+			"name": "arm1",
+			"model": "acme:demo:fakearm",
+			"attributes": {
+				"arm-model": "ur5e"
+			}
+		}
+	],
+	"network": {
+		"bind_address": ":8080"
+	}
+}

--- a/robot/framesystem/framesystem.go
+++ b/robot/framesystem/framesystem.go
@@ -210,7 +210,6 @@ func (svc *frameSystemService) Reconfigure(ctx context.Context, deps resource.De
 		components[name.Name] = r
 	}
 	svc.components = components
-	svc.logger.Info("Reconfigured. Known components:", components)
 
 	fsCfg, err := resource.NativeConfig[*Config](conf)
 	if err != nil {

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1091,6 +1091,8 @@ func (r *localRobot) updateWeakAndOptionalDependents(ctx context.Context) {
 		isModular := r.manager.moduleManager.Provides(conf)
 		if isModular {
 			err = r.manager.moduleManager.ReconfigureResource(ctx, conf, modmanager.DepsToNames(deps))
+			// For modular resources `res` is a client object. We call reconfigure to clear caches.
+			goutils.UncheckedError(res.Reconfigure(ctx, deps, conf))
 		} else {
 			err = res.Reconfigure(ctx, deps, conf)
 		}

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -1122,6 +1122,8 @@ func (manager *resourceManager) processResource(
 			if err := manager.moduleManager.ReconfigureResource(ctx, conf, modmanager.DepsToNames(deps)); err != nil {
 				return nil, false, err
 			}
+			// For modular resources, `currentRes` is a client object. Call reconfigure to clear caches.
+			goutils.UncheckedError(currentRes.Reconfigure(ctx, deps, conf))
 			return currentRes, false, nil
 		}
 

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -389,3 +389,87 @@ func TestModularFramesystemDependency(t *testing.T) {
 	test.That(t, resp["fsCfg"], test.ShouldContainSubstring, "foo")
 	test.That(t, resp["fsCfg"], test.ShouldContainSubstring, "myParentIsFoo")
 }
+
+func TestLite6ArmGeometryLabels(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	ctx := context.Background()
+
+	fakeArmModulePath := rtestutils.BuildTempModule(t, "examples/customresources/demos/fakearmmodule")
+
+	cfg := &config.Config{
+		Modules: []config.Module{
+			{
+				Name:    "fakearmmodule",
+				ExePath: fakeArmModulePath,
+			},
+		},
+		Components: []resource.Config{
+			{
+				Name:       "myArm",
+				API:        arm.API,
+				Model:      resource.NewModel("acme", "demo", "fakearm"),
+				Attributes: rutils.AttributeMap{"arm-model": "lite6"},
+				Frame: &referenceframe.LinkConfig{
+					Parent: referenceframe.World,
+				},
+			},
+		},
+	}
+	rbtI := setupLocalRobot(t, ctx, cfg, logger)
+	rbt := rbtI.(*localRobot)
+
+	armGeometryLabels := func() []string {
+		armResource, err := rbt.ResourceByName(arm.Named("myArm"))
+		test.That(t, err, test.ShouldBeNil)
+
+		armComponent, ok := armResource.(arm.Arm)
+		test.That(t, ok, test.ShouldBeTrue)
+
+		geometries, err := armComponent.Geometries(ctx, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		labels := make([]string, 0)
+		for _, geometry := range geometries {
+			labels = append(labels, geometry.Label())
+		}
+		return labels
+	}
+
+	frameSystemGeometryLabels := func() []string {
+		fsCfg, err := rbt.frameSvc.FrameSystemConfig(ctx)
+		test.That(t, err, test.ShouldBeNil)
+
+		frameSystem, err := referenceframe.NewFrameSystem("test", fsCfg.Parts, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		labels := make([]string, 0)
+		for _, frameName := range frameSystem.FrameNames() {
+			frame := frameSystem.Frame(frameName)
+			if frame == nil {
+				continue
+			}
+
+			zeroInputs := make([]referenceframe.Input, len(frame.DoF()))
+			gif, err := frame.Geometries(zeroInputs)
+			test.That(t, err, test.ShouldBeNil)
+
+			for _, geometry := range gif.Geometries() {
+				labels = append(labels, geometry.Label())
+			}
+		}
+		return labels
+	}
+
+	preArmLabels := armGeometryLabels()
+	preFSLabels := frameSystemGeometryLabels()
+	test.That(t, preFSLabels, test.ShouldResemble, preArmLabels)
+
+	cfg.Components[0].Attributes = rutils.AttributeMap{"arm-model": "ur5e"}
+	rbt.Reconfigure(ctx, cfg)
+
+	postArmLabels := armGeometryLabels()
+	test.That(t, postArmLabels, test.ShouldNotResemble, preArmLabels)
+
+	postFSLabels := frameSystemGeometryLabels()
+	test.That(t, postFSLabels, test.ShouldResemble, postArmLabels)
+}

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -390,12 +390,19 @@ func TestModularFramesystemDependency(t *testing.T) {
 	test.That(t, resp["fsCfg"], test.ShouldContainSubstring, "myParentIsFoo")
 }
 
-func TestLite6ArmGeometryLabels(t *testing.T) {
+func TestObserveArmKinematicReconfiguration(t *testing.T) {
+	// RSDK-13983: Arm clients were caching kinematics from remote arm's indefinitely. This led to
+	// problems where a reconfiguration of an arm could change kinematics. In the real world, this
+	// was observed when swapping to simple geometry kinematics to high-resolution URDF meshes. This
+	// test instead opts for changing a fake from from a lite6 to a ur5e and reads out the
+	// geometries from a couple of code paths to assert the frame system's understanding of the arm
+	// kinematics have been updated.
 	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
 
+	// This module is just a wrapper around the existing RDK fake arm. We need modules here because
+	// the affected code is in the client.
 	fakeArmModulePath := rtestutils.BuildTempModule(t, "examples/customresources/demos/fakearmmodule")
-
 	cfg := &config.Config{
 		Modules: []config.Module{
 			{
@@ -418,6 +425,7 @@ func TestLite6ArmGeometryLabels(t *testing.T) {
 	rbtI := setupLocalRobot(t, ctx, cfg, logger)
 	rbt := rbtI.(*localRobot)
 
+	// A helper that pulls out all of the geometry labels from `myArm`.
 	armGeometryLabels := func() []string {
 		armResource, err := rbt.ResourceByName(arm.Named("myArm"))
 		test.That(t, err, test.ShouldBeNil)
@@ -435,6 +443,8 @@ func TestLite6ArmGeometryLabels(t *testing.T) {
 		return labels
 	}
 
+	// A helper that pulls out all of the geometries in the robot frame system. Given the robot only
+	// contains an arm, these should exactly match the geometry labels from the arm.
 	frameSystemGeometryLabels := func() []string {
 		fsCfg, err := rbt.frameSvc.FrameSystemConfig(ctx)
 		test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -394,9 +394,9 @@ func TestObserveArmKinematicReconfiguration(t *testing.T) {
 	// RSDK-13983: Arm clients were caching kinematics from remote arm's indefinitely. This led to
 	// problems where a reconfiguration of an arm could change kinematics. In the real world, this
 	// was observed when swapping to simple geometry kinematics to high-resolution URDF meshes. This
-	// test instead opts for changing a fake from from a lite6 to a ur5e and reads out the
-	// geometries from a couple of code paths to assert the frame system's understanding of the arm
-	// kinematics have been updated.
+	// test instead opts for changing a fake arm from a lite6 to a ur5e and reads out the geometries
+	// from a couple of code paths to assert the frame system's understanding of the arm kinematics
+	// have been updated.
 	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
 


### PR DESCRIPTION
This affects arm, gripper and gantry kinematics.