### PR TITLE
[APP-16363] Sign viam-server Windows binary

### DIFF
--- a/.github/workflows/staticbuild-build.yml
+++ b/.github/workflows/staticbuild-build.yml
@@ -48,9 +48,7 @@ jobs:
       - /tmp/node20:/__e/node20
     timeout-minutes: 15
     # id-token: write enables Workload Identity Federation for the windows-only signing step.
-    # The rest of this workflow still uses the GCP_CREDENTIALS SA key for GCS uploads; WIF is
-    # scoped to signing only because the EV code-signing key has a much larger blast radius
-    # than bucket upload. Migrating the upload path to WIF is tracked separately.
+    # The rest of this workflow still uses the GCP_CREDENTIALS SA key for GCS uploads.
     permissions:
       id-token: write
       contents: read
@@ -92,8 +90,6 @@ jobs:
         credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
     - name: Authorize signing (windows)
-      # Separate WIF-based auth so the signing access token is minted via OIDC for this repo,
-      # not derived from the long-lived GCP_CREDENTIALS SA key. Matches the viam_vnc setup.
       if: matrix.target == 'static-release-win'
       id: signing-auth
       uses: google-github-actions/auth@v3
@@ -117,13 +113,10 @@ jobs:
         SIGNING_CERT: ${{ steps.signing-cert.outputs.cert }}
         GCP_ACCESS_TOKEN: ${{ steps.signing-auth.outputs.access_token }}
       run: |
-        apt-get update
-        # jsign 7 needs Java 11+; antique2's apt may not have 17, so fall back if needed.
-        apt-get install -y openjdk-17-jre-headless || apt-get install -y openjdk-11-jre-headless
+        apt-get install -y openjdk-17-jre-headless
         curl -fsSL -o /tmp/jsign.jar https://github.com/ebourg/jsign/releases/download/7.1/jsign-7.1.jar
         printf '%s' "$SIGNING_CERT" > /tmp/cert.pem
         printf '%s' "$GCP_ACCESS_TOKEN" > /tmp/gcp-access-token
-        # testbot (the build user) must be able to read the cert/token and execute the helper.
         chmod 644 /tmp/cert.pem /tmp/gcp-access-token /tmp/jsign.jar
         cat > /tmp/sign-binary.sh <<'EOF'
         #!/bin/bash

--- a/.github/workflows/staticbuild-build.yml
+++ b/.github/workflows/staticbuild-build.yml
@@ -51,7 +51,12 @@ jobs:
       - /tmp/node20:/__e/node20
     timeout-minutes: 15
     permissions:
+      # Lets us mint an OIDC token for the WIF login used by the Windows
+      # code signing step. GCS uploads uses a stored SA key instead.
       id-token: write
+      # Job-level permissions replace workflow-level ones and any not
+      # explicitly granted are disallowed, so we need to re-grant this
+      # for actions/checkout to check out the code and build from it.
       contents: read
     outputs:
       date: ${{ steps.build_date.outputs.date }}

--- a/.github/workflows/staticbuild-build.yml
+++ b/.github/workflows/staticbuild-build.yml
@@ -50,8 +50,6 @@ jobs:
       # otherwise we get a 'read-only filesystem' error when symlinking over this
       - /tmp/node20:/__e/node20
     timeout-minutes: 15
-    # id-token: write enables Workload Identity Federation for the windows-only signing step.
-    # The rest of this workflow still uses the GCP_CREDENTIALS SA key for GCS uploads.
     permissions:
       id-token: write
       contents: read
@@ -114,7 +112,7 @@ jobs:
         apt-get install -y openjdk-17-jre-headless jq
         curl -fsSL -o /tmp/jsign.jar https://github.com/ebourg/jsign/releases/download/7.1/jsign-7.1.jar
         # Fetch cert directly via Secret Manager REST: the get-secretmanager-secrets
-        # action needs Node 18+ (Headers), but antique2 ships Node 16.
+        # action needs Node 18+, but antique2 ships Node 16.
         curl -fsSL -H "Authorization: Bearer $GCP_ACCESS_TOKEN" \
           "https://secretmanager.googleapis.com/v1/projects/385154741571/secrets/ev-code-signing-public-key/versions/latest:access" \
           | jq -r '.payload.data' | base64 -d > /tmp/cert.pem

--- a/.github/workflows/staticbuild-build.yml
+++ b/.github/workflows/staticbuild-build.yml
@@ -105,7 +105,6 @@ jobs:
         # Authorize GCP Upload step — the subsequent upload-cloud-storage
         # step needs GCP_CREDENTIALS, not the ev-code-signing SA.
         create_credentials_file: false
-        export_environment_variables: false
 
     - name: Set up Authenticode signing (windows)
       if: matrix.target == 'static-release-win'
@@ -120,7 +119,6 @@ jobs:
           "https://secretmanager.googleapis.com/v1/projects/385154741571/secrets/ev-code-signing-public-key/versions/latest:access" \
           | jq -r '.payload.data' | base64 -d > /tmp/cert.pem
         printf '%s' "$GCP_ACCESS_TOKEN" > /tmp/gcp-access-token
-        chmod 644 /tmp/cert.pem /tmp/gcp-access-token /tmp/jsign.jar
         cat > /tmp/sign-binary.sh <<'EOF'
         #!/bin/bash
         set -euo pipefail

--- a/.github/workflows/staticbuild-build.yml
+++ b/.github/workflows/staticbuild-build.yml
@@ -85,11 +85,6 @@ jobs:
         chown -R testbot:testbot .
         sudo -Hu testbot bash -lc 'make clean-all'
 
-    - name: Authorize GCP Upload
-      uses: google-github-actions/auth@v2
-      with:
-        credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
-
     - name: Authorize signing (windows)
       if: matrix.target == 'static-release-win'
       id: signing-auth
@@ -99,10 +94,6 @@ jobs:
         project_id: 'engineering-tools-310515'
         workload_identity_provider: 'projects/385154741571/locations/global/workloadIdentityPools/ev-signing-id/providers/github-repos-viam-and-labs'
         service_account: 'ev-code-signing@engineering-tools-310515.iam.gserviceaccount.com'
-        # Don't overwrite GOOGLE_APPLICATION_CREDENTIALS from the previous
-        # Authorize GCP Upload step — the subsequent upload-cloud-storage
-        # step needs GCP_CREDENTIALS, not the ev-code-signing SA.
-        create_credentials_file: false
 
     - name: Set up Authenticode signing (windows)
       if: matrix.target == 'static-release-win'
@@ -131,6 +122,11 @@ jobs:
           "$1"
         EOF
         chmod 755 /tmp/sign-binary.sh
+
+    - name: Authorize GCP Upload
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
     - name: Build (Test)
       if: github.event_name == 'workflow_dispatch' && inputs.release_type == 'pr'

--- a/.github/workflows/staticbuild-build.yml
+++ b/.github/workflows/staticbuild-build.yml
@@ -112,7 +112,6 @@ jobs:
       env:
         GCP_ACCESS_TOKEN: ${{ steps.signing-auth.outputs.access_token }}
       run: |
-        apt-get update
         apt-get install -y openjdk-17-jre-headless jq
         curl -fsSL -o /tmp/jsign.jar https://github.com/ebourg/jsign/releases/download/7.1/jsign-7.1.jar
         # Fetch cert directly via Secret Manager REST: the get-secretmanager-secrets

--- a/.github/workflows/staticbuild-build.yml
+++ b/.github/workflows/staticbuild-build.yml
@@ -47,6 +47,13 @@ jobs:
       # otherwise we get a 'read-only filesystem' error when symlinking over this
       - /tmp/node20:/__e/node20
     timeout-minutes: 15
+    # id-token: write enables Workload Identity Federation for the windows-only signing step.
+    # The rest of this workflow still uses the GCP_CREDENTIALS SA key for GCS uploads; WIF is
+    # scoped to signing only because the EV code-signing key has a much larger blast radius
+    # than bucket upload. Migrating the upload path to WIF is tracked separately.
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       date: ${{ steps.build_date.outputs.date }}
       channel: ${{ steps.build_date.outputs.channel }}
@@ -84,15 +91,64 @@ jobs:
       with:
         credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
+    - name: Authorize signing (windows)
+      # Separate WIF-based auth so the signing access token is minted via OIDC for this repo,
+      # not derived from the long-lived GCP_CREDENTIALS SA key. Matches the viam_vnc setup.
+      if: matrix.target == 'static-release-win'
+      id: signing-auth
+      uses: google-github-actions/auth@v3
+      with:
+        token_format: 'access_token'
+        project_id: 'engineering-tools-310515'
+        workload_identity_provider: 'projects/385154741571/locations/global/workloadIdentityPools/ev-signing-id/providers/github-repos-viam-and-labs'
+        service_account: 'ev-code-signing@engineering-tools-310515.iam.gserviceaccount.com'
+
+    - name: Fetch code-signing cert (windows)
+      if: matrix.target == 'static-release-win'
+      id: signing-cert
+      uses: google-github-actions/get-secretmanager-secrets@v2
+      with:
+        secrets: |
+          cert:projects/385154741571/secrets/ev-code-signing-public-key
+
+    - name: Set up Authenticode signing (windows)
+      if: matrix.target == 'static-release-win'
+      env:
+        SIGNING_CERT: ${{ steps.signing-cert.outputs.cert }}
+        GCP_ACCESS_TOKEN: ${{ steps.signing-auth.outputs.access_token }}
+      run: |
+        apt-get update
+        # jsign 7 needs Java 11+; antique2's apt may not have 17, so fall back if needed.
+        apt-get install -y openjdk-17-jre-headless || apt-get install -y openjdk-11-jre-headless
+        curl -fsSL -o /tmp/jsign.jar https://github.com/ebourg/jsign/releases/download/7.1/jsign-7.1.jar
+        printf '%s' "$SIGNING_CERT" > /tmp/cert.pem
+        printf '%s' "$GCP_ACCESS_TOKEN" > /tmp/gcp-access-token
+        # testbot (the build user) must be able to read the cert/token and execute the helper.
+        chmod 644 /tmp/cert.pem /tmp/gcp-access-token /tmp/jsign.jar
+        cat > /tmp/sign-binary.sh <<'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        java -jar /tmp/jsign.jar \
+          --storetype GOOGLECLOUD \
+          --keystore projects/engineering-tools-310515/locations/global/keyRings/release_signing_key \
+          --storepass "$(cat /tmp/gcp-access-token)" \
+          --alias ev-code-signing-key/cryptoKeyVersions/2 \
+          --certfile /tmp/cert.pem \
+          --name "Viam Server" \
+          --tsaurl http://timestamp.digicert.com \
+          "$1"
+        EOF
+        chmod 755 /tmp/sign-binary.sh
+
     - name: Build (Test)
       if: github.event_name == 'workflow_dispatch' && inputs.release_type == 'pr'
       run: |
-        sudo -Hu testbot bash -lc 'make BUILD_CHANNEL="test-$(git rev-parse --short HEAD)" ${{ matrix.target }}'
+        sudo -Hu testbot bash -lc 'make BUILD_CHANNEL="test-$(git rev-parse --short HEAD)" ${{ matrix.target == 'static-release-win' && 'SIGN_CMD=/tmp/sign-binary.sh' || '' }} ${{ matrix.target }}'
 
     - name: Build (PR)
       if: contains(github.event.pull_request.labels.*.name, 'static-build') || contains(github.event.pull_request.labels.*.name, 'static-ignore-tests')
       run: |
-        sudo -Hu testbot bash -lc 'make BUILD_CHANNEL="pr-${{ github.event.pull_request.number }}" ${{ matrix.target }}'
+        sudo -Hu testbot bash -lc 'make BUILD_CHANNEL="pr-${{ github.event.pull_request.number }}" ${{ matrix.target == 'static-release-win' && 'SIGN_CMD=/tmp/sign-binary.sh' || '' }} ${{ matrix.target }}'
 
     - name: Upload Files (PR)
       if: contains(github.event.pull_request.labels.*.name, 'static-build') || contains(github.event.pull_request.labels.*.name, 'static-ignore-tests')
@@ -108,12 +164,12 @@ jobs:
     - name: Build (Latest)
       if: inputs.release_type == 'latest'
       run: |
-        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="latest" BUILD_CHANNEL="$(./etc/dev-version.sh)" ${{ matrix.target }}'
+        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="latest" BUILD_CHANNEL="$(./etc/dev-version.sh)" ${{ matrix.target == 'static-release-win' && 'SIGN_CMD=/tmp/sign-binary.sh' || '' }} ${{ matrix.target }}'
 
     - name: Build (Tagged)
       if: inputs.release_type == 'stable' || inputs.release_type == 'rc'
       run: |
-        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="${{ inputs.release_type }}" BUILD_CHANNEL="${{ github.ref_name }}" ${{ matrix.target }}'
+        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="${{ inputs.release_type }}" BUILD_CHANNEL="${{ github.ref_name }}" ${{ matrix.target == 'static-release-win' && 'SIGN_CMD=/tmp/sign-binary.sh' || '' }} ${{ matrix.target }}'
 
     - name: Set Date and Channel
       id: build_date

--- a/.github/workflows/staticbuild-build.yml
+++ b/.github/workflows/staticbuild-build.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Authorize signing (windows)
       if: matrix.target == 'static-release-win'
       id: signing-auth
-      uses: google-github-actions/auth@v3
+      uses: google-github-actions/auth@v3.0.0
       with:
         token_format: 'access_token'
         project_id: 'engineering-tools-310515'
@@ -102,7 +102,7 @@ jobs:
     - name: Fetch code-signing cert (windows)
       if: matrix.target == 'static-release-win'
       id: signing-cert
-      uses: google-github-actions/get-secretmanager-secrets@v2
+      uses: google-github-actions/get-secretmanager-secrets@v3.0.0
       with:
         secrets: |
           cert:projects/385154741571/secrets/ev-code-signing-public-key

--- a/.github/workflows/staticbuild-build.yml
+++ b/.github/workflows/staticbuild-build.yml
@@ -101,6 +101,11 @@ jobs:
         project_id: 'engineering-tools-310515'
         workload_identity_provider: 'projects/385154741571/locations/global/workloadIdentityPools/ev-signing-id/providers/github-repos-viam-and-labs'
         service_account: 'ev-code-signing@engineering-tools-310515.iam.gserviceaccount.com'
+        # Don't overwrite GOOGLE_APPLICATION_CREDENTIALS from the previous
+        # Authorize GCP Upload step — the subsequent upload-cloud-storage
+        # step needs GCP_CREDENTIALS, not the ev-code-signing SA.
+        create_credentials_file: false
+        export_environment_variables: false
 
     - name: Set up Authenticode signing (windows)
       if: matrix.target == 'static-release-win'

--- a/.github/workflows/staticbuild-build.yml
+++ b/.github/workflows/staticbuild-build.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Authorize signing (windows)
       if: matrix.target == 'static-release-win'
       id: signing-auth
-      uses: google-github-actions/auth@v3.0.0
+      uses: google-github-actions/auth@v2
       with:
         token_format: 'access_token'
         project_id: 'engineering-tools-310515'
@@ -105,7 +105,7 @@ jobs:
     - name: Fetch code-signing cert (windows)
       if: matrix.target == 'static-release-win'
       id: signing-cert
-      uses: google-github-actions/get-secretmanager-secrets@v3.0.0
+      uses: google-github-actions/get-secretmanager-secrets@v2
       with:
         secrets: |
           cert:projects/385154741571/secrets/ev-code-signing-public-key

--- a/.github/workflows/staticbuild-build.yml
+++ b/.github/workflows/staticbuild-build.yml
@@ -31,14 +31,17 @@ jobs:
             image: ghcr.io/viamrobotics/antique2:amd64-cache
             platform: linux/amd64
             target: static-release
+            sign_cmd_arg: ''
           - arch: ubuntu-large-arm
             image: ghcr.io/viamrobotics/antique2:arm64-cache
             platform: linux/arm64
             target: static-release
+            sign_cmd_arg: ''
           - arch: ubuntu-large
             image: ghcr.io/viamrobotics/antique2:amd64-cache
             platform: linux/amd64
             target: static-release-win
+            sign_cmd_arg: 'SIGN_CMD=/tmp/sign-binary.sh'
     runs-on: ${{ matrix.arch }}
     container:
       image: ${{ matrix.image }}
@@ -136,12 +139,12 @@ jobs:
     - name: Build (Test)
       if: github.event_name == 'workflow_dispatch' && inputs.release_type == 'pr'
       run: |
-        sudo -Hu testbot bash -lc 'make BUILD_CHANNEL="test-$(git rev-parse --short HEAD)" ${{ matrix.target == 'static-release-win' && 'SIGN_CMD=/tmp/sign-binary.sh' || '' }} ${{ matrix.target }}'
+        sudo -Hu testbot bash -lc 'make BUILD_CHANNEL="test-$(git rev-parse --short HEAD)" ${{ matrix.sign_cmd_arg }} ${{ matrix.target }}'
 
     - name: Build (PR)
       if: contains(github.event.pull_request.labels.*.name, 'static-build') || contains(github.event.pull_request.labels.*.name, 'static-ignore-tests')
       run: |
-        sudo -Hu testbot bash -lc 'make BUILD_CHANNEL="pr-${{ github.event.pull_request.number }}" ${{ matrix.target == 'static-release-win' && 'SIGN_CMD=/tmp/sign-binary.sh' || '' }} ${{ matrix.target }}'
+        sudo -Hu testbot bash -lc 'make BUILD_CHANNEL="pr-${{ github.event.pull_request.number }}" ${{ matrix.sign_cmd_arg }} ${{ matrix.target }}'
 
     - name: Upload Files (PR)
       if: contains(github.event.pull_request.labels.*.name, 'static-build') || contains(github.event.pull_request.labels.*.name, 'static-ignore-tests')
@@ -157,12 +160,12 @@ jobs:
     - name: Build (Latest)
       if: inputs.release_type == 'latest'
       run: |
-        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="latest" BUILD_CHANNEL="$(./etc/dev-version.sh)" ${{ matrix.target == 'static-release-win' && 'SIGN_CMD=/tmp/sign-binary.sh' || '' }} ${{ matrix.target }}'
+        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="latest" BUILD_CHANNEL="$(./etc/dev-version.sh)" ${{ matrix.sign_cmd_arg }} ${{ matrix.target }}'
 
     - name: Build (Tagged)
       if: inputs.release_type == 'stable' || inputs.release_type == 'rc'
       run: |
-        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="${{ inputs.release_type }}" BUILD_CHANNEL="${{ github.ref_name }}" ${{ matrix.target == 'static-release-win' && 'SIGN_CMD=/tmp/sign-binary.sh' || '' }} ${{ matrix.target }}'
+        sudo -Hu testbot bash -lc 'make RELEASE_TYPE="${{ inputs.release_type }}" BUILD_CHANNEL="${{ github.ref_name }}" ${{ matrix.sign_cmd_arg }} ${{ matrix.target }}'
 
     - name: Set Date and Channel
       id: build_date

--- a/.github/workflows/staticbuild-build.yml
+++ b/.github/workflows/staticbuild-build.yml
@@ -102,23 +102,19 @@ jobs:
         workload_identity_provider: 'projects/385154741571/locations/global/workloadIdentityPools/ev-signing-id/providers/github-repos-viam-and-labs'
         service_account: 'ev-code-signing@engineering-tools-310515.iam.gserviceaccount.com'
 
-    - name: Fetch code-signing cert (windows)
-      if: matrix.target == 'static-release-win'
-      id: signing-cert
-      uses: google-github-actions/get-secretmanager-secrets@v2
-      with:
-        secrets: |
-          cert:projects/385154741571/secrets/ev-code-signing-public-key
-
     - name: Set up Authenticode signing (windows)
       if: matrix.target == 'static-release-win'
       env:
-        SIGNING_CERT: ${{ steps.signing-cert.outputs.cert }}
         GCP_ACCESS_TOKEN: ${{ steps.signing-auth.outputs.access_token }}
       run: |
-        apt-get install -y openjdk-17-jre-headless
+        apt-get update
+        apt-get install -y openjdk-17-jre-headless jq
         curl -fsSL -o /tmp/jsign.jar https://github.com/ebourg/jsign/releases/download/7.1/jsign-7.1.jar
-        printf '%s' "$SIGNING_CERT" > /tmp/cert.pem
+        # Fetch cert directly via Secret Manager REST: the get-secretmanager-secrets
+        # action needs Node 18+ (Headers), but antique2 ships Node 16.
+        curl -fsSL -H "Authorization: Bearer $GCP_ACCESS_TOKEN" \
+          "https://secretmanager.googleapis.com/v1/projects/385154741571/secrets/ev-code-signing-public-key/versions/latest:access" \
+          | jq -r '.payload.data' | base64 -d > /tmp/cert.pem
         printf '%s' "$GCP_ACCESS_TOKEN" > /tmp/gcp-access-token
         chmod 644 /tmp/cert.pem /tmp/gcp-access-token /tmp/jsign.jar
         cat > /tmp/sign-binary.sh <<'EOF'

--- a/packaging.make
+++ b/packaging.make
@@ -50,10 +50,10 @@ static-release-win:
 	rm -f bin/static/viam-server-windows.exe
 	GOOS=windows GOARCH=amd64 go build -tags no_cgo,osusergo,netgo -ldflags="-extldflags=-static $(COMMON_LDFLAGS)" -o bin/static/viam-server-windows.exe ./web/cmd/server
 	upx --best --lzma bin/static/viam-server-windows.exe
-	# SIGN_CMD invoked against the unpacked viam-server-windows.exe to add an Authenticode signature. 
-	# CI sets this in the release workflow; local builds leave it empty and skips signing. Must run 
-	# before the deploy copies + subsystem_manifest step so  the manifest hashes the SIGNED binary.
-	test -z "$(SIGN_CMD)" || $(SIGN_CMD) bin/static/viam-server-windows.exe√
+	# SIGN_CMD invoked against the unpacked viam-server-windows.exe to add an Authenticode signature.
+	# CI sets this in the release workflow; local builds leave it empty, skipping signing. Must run
+	# before the deploy copies + subsystem_manifest step so the manifest hashes the SIGNED binary.
+	test -z "$(SIGN_CMD)" || $(SIGN_CMD) bin/static/viam-server-windows.exe
 
 	rm -rf etc/packaging/static/deploy/
 	mkdir -p etc/packaging/static/deploy/

--- a/packaging.make
+++ b/packaging.make
@@ -50,6 +50,11 @@ static-release-win:
 	rm -f bin/static/viam-server-windows.exe
 	GOOS=windows GOARCH=amd64 go build -tags no_cgo,osusergo,netgo -ldflags="-extldflags=-static $(COMMON_LDFLAGS)" -o bin/static/viam-server-windows.exe ./web/cmd/server
 	upx --best --lzma bin/static/viam-server-windows.exe
+	# SIGN_CMD is an optional command (with no trailing binary argument) that is invoked against
+	# the unpacked viam-server-windows.exe to add an Authenticode signature. CI sets this in the
+	# release workflow; local builds leave it empty and skip signing. Must run before the deploy
+	# copies + subsystem_manifest step so the manifest hashes the SIGNED binary.
+	test -z "$(SIGN_CMD)" || $(SIGN_CMD) bin/static/viam-server-windows.exe
 
 	rm -rf etc/packaging/static/deploy/
 	mkdir -p etc/packaging/static/deploy/

--- a/packaging.make
+++ b/packaging.make
@@ -50,8 +50,6 @@ static-release-win:
 	rm -f bin/static/viam-server-windows.exe
 	GOOS=windows GOARCH=amd64 go build -tags no_cgo,osusergo,netgo -ldflags="-extldflags=-static $(COMMON_LDFLAGS)" -o bin/static/viam-server-windows.exe ./web/cmd/server
 	upx --best --lzma bin/static/viam-server-windows.exe
-	# Sign before the deploy copy so the subsystem manifest hashes the signed binary.
-	# Empty SIGN_CMD (local builds) is a no-op.
 	test -z "$(SIGN_CMD)" || $(SIGN_CMD) bin/static/viam-server-windows.exe
 
 	rm -rf etc/packaging/static/deploy/

--- a/packaging.make
+++ b/packaging.make
@@ -50,9 +50,8 @@ static-release-win:
 	rm -f bin/static/viam-server-windows.exe
 	GOOS=windows GOARCH=amd64 go build -tags no_cgo,osusergo,netgo -ldflags="-extldflags=-static $(COMMON_LDFLAGS)" -o bin/static/viam-server-windows.exe ./web/cmd/server
 	upx --best --lzma bin/static/viam-server-windows.exe
-	# SIGN_CMD invoked against the unpacked viam-server-windows.exe to add an Authenticode signature.
-	# CI sets this in the release workflow; local builds leave it empty, skipping signing. Must run
-	# before the deploy copies + subsystem_manifest step so the manifest hashes the SIGNED binary.
+	# Sign before the deploy copy so the subsystem manifest hashes the signed binary.
+	# Empty SIGN_CMD (local builds) is a no-op.
 	test -z "$(SIGN_CMD)" || $(SIGN_CMD) bin/static/viam-server-windows.exe
 
 	rm -rf etc/packaging/static/deploy/

--- a/packaging.make
+++ b/packaging.make
@@ -50,11 +50,10 @@ static-release-win:
 	rm -f bin/static/viam-server-windows.exe
 	GOOS=windows GOARCH=amd64 go build -tags no_cgo,osusergo,netgo -ldflags="-extldflags=-static $(COMMON_LDFLAGS)" -o bin/static/viam-server-windows.exe ./web/cmd/server
 	upx --best --lzma bin/static/viam-server-windows.exe
-	# SIGN_CMD is an optional command (with no trailing binary argument) that is invoked against
-	# the unpacked viam-server-windows.exe to add an Authenticode signature. CI sets this in the
-	# release workflow; local builds leave it empty and skip signing. Must run before the deploy
-	# copies + subsystem_manifest step so the manifest hashes the SIGNED binary.
-	test -z "$(SIGN_CMD)" || $(SIGN_CMD) bin/static/viam-server-windows.exe
+	# SIGN_CMD invoked against the unpacked viam-server-windows.exe to add an Authenticode signature. 
+	# CI sets this in the release workflow; local builds leave it empty and skips signing. Must run 
+	# before the deploy copies + subsystem_manifest step so  the manifest hashes the SIGNED binary.
+	test -z "$(SIGN_CMD)" || $(SIGN_CMD) bin/static/viam-server-windows.exe√
 
 	rm -rf etc/packaging/static/deploy/
 	mkdir -p etc/packaging/static/deploy/


### PR DESCRIPTION
## Summary

[APP-16363](https://viam.atlassian.net/browse/APP-16363) sign windows agent and viam-server

- `viam-server-*-windows-x86_64` built by `static-release-win` is unsigned today, which can cause Windows Defender to flag it as untrusted on download. This PR signs it with the existing Viam EV code-signing cert via jsign (same as `viam_vnc` module).
- `packaging.make`: inject optional `SIGN_CMD` into `static-release-win`, invoked between `upx` and the deploy/manifest steps so the subsystem manifest hashes the signed binary. Empty `SIGN_CMD` is a no-op.

Changes to `.github/workflows/staticbuild-build.yml`'s :
- Adds WIF-based auth scoped to windows binary signing path
- Fetch the EV cert from Secret Manager, downloads OpenJDK + `jsign-7.1.jar`, and threads `SIGN_CMD=/tmp/sign-binary.sh` into the four build steps only on the `static-release-win` matrix entry

## Test plan

- [x] Trigger `main.yml` from this branch with `release_type=pr` + `no_prod_upload=true`; all three `static` matrix entries succeed and a `viam-server-test-<sha>-windows-x86_64` lands in GCS. Signed test artifact: https://storage.googleapis.com/packages.viam.com/apps/viam-server/testing/static/2026-05-18/327919338fb299f886023f255828aa4a317e096a/viam-server-test-327919338-windows-x86_64
- [x] Verify the Authenticode signature on that binary: `osslsigncode verify` on Linux, and Properties → Digital Signatures on Windows shows "Viam Server".

[APP-16363]: https://viam.atlassian.net/browse/APP-16363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ