### PR TITLE
RSDK-13386 Allow not emitting logs from `testAppender` if the associated test has completed

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -183,6 +183,26 @@ func NewObservedTestLoggerWithRegistry(tb testing.TB, name string) (Logger, *obs
 	return logger, observedLogs, registry
 }
 
+// NewTestLoggerSilentAfterComplete is like NewTestLogger but drops log writes after the
+// test has completed, preventing races or panics from late-emitting goroutines. It should
+// only be used by tests that _expect_ to have a log emitted after/during test completion.
+// Most tests should use NewTestLogger, so that goroutines logging after test completion
+// can be seen through data race or panic test failures.
+func NewTestLoggerSilentAfterComplete(tb testing.TB) Logger {
+	return &impl{
+		name:  tb.Name(),
+		level: NewAtomicLevelAt(DEBUG),
+		appenders: []Appender{
+			newSilentAfterCompleteTestAppender(tb),
+		},
+		registry:                 newRegistry(),
+		testHelper:               tb.Helper,
+		recentMessageCounts:      make(map[string]int),
+		recentMessageEntries:     make(map[string]LogEntry),
+		recentMessageWindowStart: time.Now(),
+	}
+}
+
 // MemLogger stores test logs in memory. And can write them on request with `OutputLogs`.
 type MemLogger struct {
 	Logger

--- a/logging/testing.go
+++ b/logging/testing.go
@@ -9,9 +9,7 @@ import (
 )
 
 type testAppender struct {
-	tb            testing.TB
-	completedLock sync.RWMutex
-	completed     bool
+	tb testing.TB
 }
 
 // NewTestAppender returns a logger appender that logs to the underlying `testing.TB`
@@ -41,26 +39,12 @@ type testAppender struct {
 //
 //nolint:lll
 func NewTestAppender(tb testing.TB) Appender {
-	tapp := &testAppender{tb: tb}
-	tb.Cleanup(func() {
-		tapp.completedLock.Lock()
-		defer tapp.completedLock.Unlock()
-		tapp.completed = true
-	})
-	return tapp
+	return &testAppender{tb: tb}
 }
 
 // Write outputs the log entry to the underlying test object `Log` method.
 func (tapp *testAppender) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 	tapp.tb.Helper()
-
-	tapp.completedLock.RLock()
-	defer tapp.completedLock.RUnlock()
-	// Do not attempt to log if the test has already completed; doing so can cause a race or
-	// a panic.
-	if tapp.completed {
-		return nil
-	}
 
 	const maxLength = 10
 	toPrint := make([]string, 0, maxLength)
@@ -95,4 +79,34 @@ func (tapp *testAppender) Write(entry zapcore.Entry, fields []zapcore.Field) err
 // Sync is a no-op.
 func (tapp *testAppender) Sync() error {
 	return nil
+}
+
+// silentAfterCompleteTestAppender is like testAppender but silences writes after the test
+// has completed to prevent races or panics from late-emitting goroutines.
+type silentAfterCompleteTestAppender struct {
+	*testAppender
+	completedLock sync.RWMutex
+	completed     bool
+}
+
+func newSilentAfterCompleteTestAppender(tb testing.TB) Appender {
+	stapp := &silentAfterCompleteTestAppender{testAppender: &testAppender{tb: tb}}
+	tb.Cleanup(func() {
+		stapp.completedLock.Lock()
+		defer stapp.completedLock.Unlock()
+		stapp.completed = true
+	})
+	return stapp
+}
+
+// Write checks if the associated test has completed before Writing like a normal test
+// appender.
+func (stapp *silentAfterCompleteTestAppender) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	stapp.completedLock.RLock()
+	defer stapp.completedLock.RUnlock()
+	if stapp.completed {
+		return nil
+	}
+
+	return stapp.testAppender.Write(entry, fields)
 }

--- a/logging/testing.go
+++ b/logging/testing.go
@@ -39,13 +39,12 @@ type testAppender struct {
 //
 //nolint:lll
 func NewTestAppender(tb testing.TB) Appender {
-	return &testAppender{tb: tb}
+	return &testAppender{tb}
 }
 
 // Write outputs the log entry to the underlying test object `Log` method.
 func (tapp *testAppender) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 	tapp.tb.Helper()
-
 	const maxLength = 10
 	toPrint := make([]string, 0, maxLength)
 	toPrint = append(toPrint, entry.Time.Format(DefaultTimeFormatStr))

--- a/logging/testing.go
+++ b/logging/testing.go
@@ -54,14 +54,12 @@ func NewTestAppender(tb testing.TB) Appender {
 func (tapp *testAppender) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 	tapp.tb.Helper()
 
-	log := func(toPrint []string) {
-		// Do not attempt to log if the test has already completed; doing so can cause a race
-		// or a panic.
-		tapp.completedLock.RLock()
-		defer tapp.completedLock.RUnlock()
-		if !tapp.completed {
-			tapp.tb.Log(strings.Join(toPrint, "\t"))
-		}
+	tapp.completedLock.RLock()
+	defer tapp.completedLock.RUnlock()
+	// Do not attempt to log if the test has already completed; doing so can cause a race or
+	// a panic.
+	if tapp.completed {
+		return nil
 	}
 
 	const maxLength = 10
@@ -75,7 +73,7 @@ func (tapp *testAppender) Write(entry zapcore.Entry, fields []zapcore.Field) err
 	}
 	toPrint = append(toPrint, entry.Message)
 	if len(fields) == 0 {
-		log(toPrint)
+		tapp.tb.Log(strings.Join(toPrint, "\t"))
 		return nil
 	}
 
@@ -86,11 +84,11 @@ func (tapp *testAppender) Write(entry zapcore.Entry, fields []zapcore.Field) err
 	buf, err := jsonEncoder.EncodeEntry(zapcore.Entry{}, fields)
 	if err != nil {
 		// Log what we have and return the error.
-		log(toPrint)
+		tapp.tb.Log(strings.Join(toPrint, "\t"))
 		return err
 	}
 	toPrint = append(toPrint, string(buf.Bytes()))
-	log(toPrint)
+	tapp.tb.Log(strings.Join(toPrint, "\t"))
 	return nil
 }
 

--- a/logging/testing.go
+++ b/logging/testing.go
@@ -2,13 +2,16 @@ package logging
 
 import (
 	"strings"
+	"sync"
 	"testing"
 
 	"go.uber.org/zap/zapcore"
 )
 
 type testAppender struct {
-	tb testing.TB
+	tb            testing.TB
+	completedLock sync.RWMutex
+	completed     bool
 }
 
 // NewTestAppender returns a logger appender that logs to the underlying `testing.TB`
@@ -38,12 +41,29 @@ type testAppender struct {
 //
 //nolint:lll
 func NewTestAppender(tb testing.TB) Appender {
-	return &testAppender{tb}
+	tapp := &testAppender{tb: tb}
+	tb.Cleanup(func() {
+		tapp.completedLock.Lock()
+		defer tapp.completedLock.Unlock()
+		tapp.completed = true
+	})
+	return tapp
 }
 
 // Write outputs the log entry to the underlying test object `Log` method.
 func (tapp *testAppender) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 	tapp.tb.Helper()
+
+	log := func(toPrint []string) {
+		// Do not attempt to log if the test has already completed; doing so can cause a race
+		// or a panic.
+		tapp.completedLock.RLock()
+		defer tapp.completedLock.RUnlock()
+		if !tapp.completed {
+			tapp.tb.Log(strings.Join(toPrint, "\t"))
+		}
+	}
+
 	const maxLength = 10
 	toPrint := make([]string, 0, maxLength)
 	toPrint = append(toPrint, entry.Time.Format(DefaultTimeFormatStr))
@@ -55,7 +75,7 @@ func (tapp *testAppender) Write(entry zapcore.Entry, fields []zapcore.Field) err
 	}
 	toPrint = append(toPrint, entry.Message)
 	if len(fields) == 0 {
-		tapp.tb.Log(strings.Join(toPrint, "\t"))
+		log(toPrint)
 		return nil
 	}
 
@@ -66,11 +86,11 @@ func (tapp *testAppender) Write(entry zapcore.Entry, fields []zapcore.Field) err
 	buf, err := jsonEncoder.EncodeEntry(zapcore.Entry{}, fields)
 	if err != nil {
 		// Log what we have and return the error.
-		tapp.tb.Log(strings.Join(toPrint, "\t"))
+		log(toPrint)
 		return err
 	}
 	toPrint = append(toPrint, string(buf.Bytes()))
-	tapp.tb.Log(strings.Join(toPrint, "\t"))
+	log(toPrint)
 	return nil
 }
 

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -936,11 +936,9 @@ func (mgr *Manager) newOnUnexpectedExitHandler(ctx context.Context, mod *module)
 			// waiting on the lock. Check for a context cancellation to avoid double
 			// starting and/or leaking a module process.
 			if err := ctx.Err(); err != nil {
-				mod.logger.Infow("Restart context canceled, abandoning restart attempt", "err", err)
 				return
 			}
 			if err := oueCtx.Err(); err != nil {
-				mod.logger.Infow("pexec context canceled, abandoning restart attempt", "err", err)
 				return
 			}
 

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -936,9 +936,11 @@ func (mgr *Manager) newOnUnexpectedExitHandler(ctx context.Context, mod *module)
 			// waiting on the lock. Check for a context cancellation to avoid double
 			// starting and/or leaking a module process.
 			if err := ctx.Err(); err != nil {
+				mod.logger.Infow("Restart context canceled, abandoning restart attempt", "err", err)
 				return
 			}
 			if err := oueCtx.Err(); err != nil {
+				mod.logger.Infow("pexec context canceled, abandoning restart attempt", "err", err)
 				return
 			}
 

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -121,7 +121,10 @@ func TestCrashShortCircuit(t *testing.T) {
 	for _, mode := range []string{"unix", "tcp"} {
 		t.Run(mode, func(t *testing.T) {
 			ctx := context.Background()
-			logger := logging.NewTestLogger(t)
+			// This test is known to have an OUE that logs after the test completes ("Restart
+			// context canceled; abandoning restart attempt"). We want a "silent after complete"
+			// logger here.
+			logger := logging.NewTestLoggerSilentAfterComplete(t)
 
 			if mode == "tcp" {
 				os.Setenv("VIAM_TCP_SOCKETS", "yes")

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -806,15 +806,19 @@ func TestModuleReloading(t *testing.T) {
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			test.That(tb, logs.FilterMessageSnippet("Restart context canceled, abandoning restart attempt").Len(),
+			test.That(tb, logs.FilterMessageSnippet("Module has unexpectedly exited").Len(),
 				test.ShouldEqual, 1)
 		})
 
 		ok = mgr.IsModularResource(rNameMyHelper)
 		test.That(t, ok, test.ShouldBeTrue)
-		_, err = h.DoCommand(ctx, map[string]interface{}{"command": "echo"})
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "connection refused")
+		// Wait for connection to be refused; this confirms the module is dead and no restart occurred.
+		testutils.WaitForAssertion(t, func(tb testing.TB) {
+			tb.Helper()
+			_, cmdErr := h.DoCommand(ctx, map[string]interface{}{"command": "echo"})
+			test.That(tb, cmdErr, test.ShouldNotBeNil)
+			test.That(tb, cmdErr.Error(), test.ShouldContainSubstring, "connection refused")
+		})
 
 		// Assert that logs reflect that test-module crashed and was not
 		// restarted.
@@ -822,8 +826,8 @@ func TestModuleReloading(t *testing.T) {
 			test.ShouldEqual, 1)
 		test.That(t, logs.FilterMessageSnippet("Module successfully restarted").Len(),
 			test.ShouldEqual, 0)
-		test.That(t, logs.FilterMessageSnippet("Restart context canceled, abandoning restart attempt").Len(),
-			test.ShouldEqual, 1)
+		// Module should remain in failed state since restart was abandoned due to canceled context.
+		test.That(t, mgr.FailedModules(), test.ShouldContain, modCfg.Name)
 		// Call Stop on the module's ManagedProcess here to absorb the error from
 		// the non-zero exit, otherwise it will end up in the return of mgr.Close
 		// and fail the test during cleanup.
@@ -893,15 +897,23 @@ func TestModuleReloading(t *testing.T) {
 		_, err = h.DoCommand(ctx, map[string]interface{}{"command": "echo"})
 		test.That(t, err, test.ShouldNotBeNil)
 
-		// Stop the module managed process manually and make sure the OUE handler
-		// stops trying to restart it.
-		err = modProc.Stop()
-		test.That(t, err, test.ShouldBeNil)
+		// Wait for at least one failed restart attempt (binary was removed, so
+		// restart cannot succeed). This confirms the OUE handler entered its
+		// restart loop before we stop the process.
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			matching := logs.FilterMessageSnippet("pexec context canceled, abandoning restart attempt").Len()
-			test.That(tb, matching, test.ShouldEqual, 1)
+			test.That(tb, logs.FilterMessageSnippet("Error while restarting crashed module").Len(),
+				test.ShouldBeGreaterThanOrEqualTo, 1)
 		})
+
+		// Stop the module managed process manually to cancel the pexec context,
+		// causing the OUE handler to exit its restart loop.
+		err = modProc.Stop()
+		test.That(t, err, test.ShouldBeNil)
+
+		// Assert that restart was never successful.
+		test.That(t, logs.FilterMessageSnippet("Module successfully restarted").Len(),
+			test.ShouldEqual, 0)
 	})
 	t.Run("timed out module process is stopped", func(t *testing.T) {
 		logger, logs := logging.NewObservedTestLogger(t)

--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -806,19 +806,15 @@ func TestModuleReloading(t *testing.T) {
 
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			test.That(tb, logs.FilterMessageSnippet("Module has unexpectedly exited").Len(),
+			test.That(tb, logs.FilterMessageSnippet("Restart context canceled, abandoning restart attempt").Len(),
 				test.ShouldEqual, 1)
 		})
 
 		ok = mgr.IsModularResource(rNameMyHelper)
 		test.That(t, ok, test.ShouldBeTrue)
-		// Wait for connection to be refused; this confirms the module is dead and no restart occurred.
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			tb.Helper()
-			_, cmdErr := h.DoCommand(ctx, map[string]interface{}{"command": "echo"})
-			test.That(tb, cmdErr, test.ShouldNotBeNil)
-			test.That(tb, cmdErr.Error(), test.ShouldContainSubstring, "connection refused")
-		})
+		_, err = h.DoCommand(ctx, map[string]interface{}{"command": "echo"})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "connection refused")
 
 		// Assert that logs reflect that test-module crashed and was not
 		// restarted.
@@ -826,8 +822,8 @@ func TestModuleReloading(t *testing.T) {
 			test.ShouldEqual, 1)
 		test.That(t, logs.FilterMessageSnippet("Module successfully restarted").Len(),
 			test.ShouldEqual, 0)
-		// Module should remain in failed state since restart was abandoned due to canceled context.
-		test.That(t, mgr.FailedModules(), test.ShouldContain, modCfg.Name)
+		test.That(t, logs.FilterMessageSnippet("Restart context canceled, abandoning restart attempt").Len(),
+			test.ShouldEqual, 1)
 		// Call Stop on the module's ManagedProcess here to absorb the error from
 		// the non-zero exit, otherwise it will end up in the return of mgr.Close
 		// and fail the test during cleanup.
@@ -897,23 +893,15 @@ func TestModuleReloading(t *testing.T) {
 		_, err = h.DoCommand(ctx, map[string]interface{}{"command": "echo"})
 		test.That(t, err, test.ShouldNotBeNil)
 
-		// Wait for at least one failed restart attempt (binary was removed, so
-		// restart cannot succeed). This confirms the OUE handler entered its
-		// restart loop before we stop the process.
-		testutils.WaitForAssertion(t, func(tb testing.TB) {
-			tb.Helper()
-			test.That(tb, logs.FilterMessageSnippet("Error while restarting crashed module").Len(),
-				test.ShouldBeGreaterThanOrEqualTo, 1)
-		})
-
-		// Stop the module managed process manually to cancel the pexec context,
-		// causing the OUE handler to exit its restart loop.
+		// Stop the module managed process manually and make sure the OUE handler
+		// stops trying to restart it.
 		err = modProc.Stop()
 		test.That(t, err, test.ShouldBeNil)
-
-		// Assert that restart was never successful.
-		test.That(t, logs.FilterMessageSnippet("Module successfully restarted").Len(),
-			test.ShouldEqual, 0)
+		testutils.WaitForAssertion(t, func(tb testing.TB) {
+			tb.Helper()
+			matching := logs.FilterMessageSnippet("pexec context canceled, abandoning restart attempt").Len()
+			test.That(tb, matching, test.ShouldEqual, 1)
+		})
 	})
 	t.Run("timed out module process is stopped", func(t *testing.T) {
 		logger, logs := logging.NewObservedTestLogger(t)


### PR DESCRIPTION
RSDK-13386

## What

Adds a `NewTestLoggerSilentAfterComplete` functions that creates a testing logger that does not emit logs if the associated test has already completed.

## Why 

Logs could emit after tests have already completed, causing data races like the following:

```
WARNING: DATA RACE
Read at 0x00c0000f300b by goroutine 116:
  testing.(*common).destination()
      /home/testbot/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-arm64/src/testing/testing.go:1055 +0x17c
  testing.(*common).log()
      /home/testbot/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-arm64/src/testing/testing.go:1027 +0x98
  testing.(*common).Log()
      /home/testbot/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-arm64/src/testing/testing.go:1180 +0x6c
  go.viam.com/rdk/logging.(*testAppender).Write()
      /__w/rdk/rdk/logging/testing.go:73 +0x534
  go.viam.com/rdk/logging.(*impl).Write()
      /__w/rdk/rdk/logging/impl.go:313 +0x44c
  go.viam.com/rdk/logging.(*impl).Infow()
      /__w/rdk/rdk/logging/impl.go:483 +0x98
  go.viam.com/rdk/module/modmanager.(*Manager).startModule.(*Manager).newOnUnexpectedExitHandler.func2()
      /__w/rdk/rdk/module/modmanager/manager.go:939 +0x628
  go.viam.com/utils/pexec.(*managedProcess).manage.func3()
      /home/testbot/go/pkg/mod/go.viam.com/utils@v0.4.19/pexec/managed_process.go:351 +0xfc

Previous write at 0x00c0000f300b by goroutine 27:
  testing.tRunner.func1()
      /home/testbot/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-arm64/src/testing/testing.go:1921 +0x5e8
  runtime.deferreturn()
      /home/testbot/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-arm64/src/runtime/panic.go:589 +0x5c
  testing.(*T).Run.gowrap1()
      /home/testbot/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-arm64/src/testing/testing.go:1997 +0x3c

Goroutine 116 (running) created at:
  go.viam.com/utils/pexec.(*managedProcess).manage()
      /home/testbot/go/pkg/mod/go.viam.com/utils@v0.4.19/pexec/managed_process.go:348 +0x2bc
  go.viam.com/utils/pexec.(*managedProcess).start.func1()
      /home/testbot/go/pkg/mod/go.viam.com/utils@v0.4.19/pexec/managed_process.go:288 +0x54
  go.viam.com/utils.ManagedGo.func1()
      /home/testbot/go/pkg/mod/go.viam.com/utils@v0.4.19/runtime.go:184 +0x34
  go.viam.com/utils.PanicCapturingGoWithCallback.func1()
      /home/testbot/go/pkg/mod/go.viam.com/utils@v0.4.19/runtime.go:176 +0x6c

Goroutine 27 (finished) created at:
  testing.(*T).Run()
      /home/testbot/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-arm64/src/testing/testing.go:1997 +0x6e0
  testing.runTests.func1()
      /home/testbot/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-arm64/src/testing/testing.go:2477 +0x74
  testing.tRunner()
      /home/testbot/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-arm64/src/testing/testing.go:1934 +0x164
  testing.runTests()
      /home/testbot/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-arm64/src/testing/testing.go:2475 +0x734
  testing.(*M).Run()
      /home/testbot/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-arm64/src/testing/testing.go:2337 +0xaf4
  main.main()
      _testmain.go:73 +0x100
==================
```

That data race is complaining about the fact that a reader is trying to check if the testing object is `done` while the testing object is writing `done` to be `true`. In other words, a test is logging at manager.go:939 after the test has finished.

We should allow a test to opt-in to _not_ emitting logs after test completion if there is a known goroutine that leaks during/after test completion. Not all tests should have this behavior so we can still have knowledge of tests that log during or after test completion as a "leak."

## Testing

Verified that if I put a `time.Sleep(20 * time.Millisecond)` before the `Restart context canceled` log and run `go test -v -count=100 ./module/modmanager -run TestCrashShortCircuit -race`, I get a race like the one shown above (_or_ a panic complaining about a test logging after the test completes). I do not get the same race when running with my changes.