### PR TITLE
remove _from_reload from module name to avoid confusion

### DIFF
--- a/cli/module_reload.go
+++ b/cli/module_reload.go
@@ -385,10 +385,12 @@ func configureModule(
 	return partResponse.Part, needsRestart, nil
 }
 
-// localizeModuleID converts a module ID to its 'local mode' name.
+// localizeModuleID converts a module ID of the form "<namespace>:<moduleName>"
+// (or "<orgID>:<moduleName>" if no namespace is set) into a name suitable for
+// adding to a robot config, i.e. "<namespace>_<moduleName>" or "<orgID>_<moduleName>".
 // TODO(APP-4019): remove this logic after registry modules can have local ExecPath.
 func localizeModuleID(moduleID string) string {
-	return strings.ReplaceAll(moduleID, ":", "_") + "_from_reload"
+	return strings.ReplaceAll(moduleID, ":", "_")
 }
 
 // mutateModuleConfig edits the modules list to hot-reload with the given manifest.

--- a/cli/module_reload_test.go
+++ b/cli/module_reload_test.go
@@ -397,9 +397,9 @@ func TestMutateModuleConfig(t *testing.T) {
 		JSONManifest: rdkConfig.JSONManifest{Entrypoint: "/bin/mod"},
 		Build:        &manifestBuildInfo{Path: "module.tar.gz"},
 	}
-	expectedName := "viam-labs_test-module_from_reload"
+	expectedName := "viam-labs_test-module"
 	expectedVersion := "latest-with-prerelease"
-	remoteReloadPath := ".viam/packages-local/viam-labs_test-module_from_reload-module.tar.gz"
+	remoteReloadPath := ".viam/packages-local/viam-labs_test-module-module.tar.gz"
 	testUser := "test@viam.com"
 	testReloadUnixTS := time.Date(2024, 3, 18, 12, 0, 0, 0, time.UTC).Unix()
 


### PR DESCRIPTION
I've heard that having the module name be generated with "from_reload" is confusing after hot reloading is turned off. The machine's logs will still reference the module name string after the module has been switched to a registry semver version, making it seem like the module is still running the reloaded version.