### PR TITLE
APP-16267: revert renameProgFilesToCapture — breaks all data capture on reconfigure

### DIFF
--- a/data/capture_buffer_test.go
+++ b/data/capture_buffer_test.go
@@ -782,6 +782,36 @@ func getCaptureFiles(dir string) (dcFiles, progFiles []string) {
 	return dcFiles, progFiles
 }
 
+// TestFlushFailsAfterProgRenamedExternally reproduces the APP-16267 regression:
+// renameProgFilesToCapture() is called during Reconfigure while collectors are still
+// running. On Linux, renaming a file doesn't invalidate open fds, so writes continue
+// normally — but when the collector eventually calls Flush it tries to rename the .prog
+// path which no longer exists, producing ENOENT.
+func TestFlushFailsAfterProgRenamedExternally(t *testing.T) {
+	dir := t.TempDir()
+	md := &v1.DataCaptureMetadata{Type: CaptureTypeTabular.ToProto()}
+	buf := NewCaptureBuffer(dir, md, 1<<20)
+
+	// Write one item so buf.nextFile is set and a .prog file exists on disk.
+	test.That(t, buf.WriteTabular(structSensorData), test.ShouldBeNil)
+
+	// Simulate renameProgFilesToCapture() running mid-capture: rename every .prog → .capture.
+	entries, err := os.ReadDir(dir)
+	test.That(t, err, test.ShouldBeNil)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == InProgressCaptureFileExt {
+			src := filepath.Join(dir, e.Name())
+			dst := src[:len(src)-len(InProgressCaptureFileExt)] + CompletedCaptureFileExt
+			test.That(t, os.Rename(src, dst), test.ShouldBeNil)
+		}
+	}
+
+	// Flush now tries to rename the (gone) .prog path → .capture and should get ENOENT.
+	err = buf.Flush()
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "no such file or directory")
+}
+
 func TestIsBinary(t *testing.T) {
 	test.That(t, IsBinary(nil), test.ShouldBeFalse)
 	test.That(t, IsBinary(&v1.SensorData{Data: &v1.SensorData_Struct{}}), test.ShouldBeFalse)

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -15,9 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
-	"io/fs"
 	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -27,7 +25,6 @@ import (
 	"google.golang.org/grpc"
 
 	"go.viam.com/rdk/components/sensor"
-	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/internal/cloud"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -149,27 +146,6 @@ func (b *builtIn) Close(ctx context.Context) error {
 	return nil
 }
 
-// renameProgFilesToCapture walks dir recursively and renames any .prog files to .capture so
-// that orphaned in-progress files from a previous crash are picked up by the syncer on restart.
-func renameProgFilesToCapture(dir string, logger logging.Logger) {
-	if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
-			//nolint:nilerr
-			return nil
-		}
-		if filepath.Ext(path) != data.InProgressCaptureFileExt {
-			return nil
-		}
-		newPath := path[:len(path)-len(data.InProgressCaptureFileExt)] + data.CompletedCaptureFileExt
-		if renameErr := os.Rename(path, newPath); renameErr != nil {
-			logger.Warnw("failed to rename in-progress capture file on startup", "path", path, "error", renameErr)
-		}
-		return nil
-	}); err != nil {
-		logger.Warnw("failed to walk capture directory on startup", "dir", dir, "error", err)
-	}
-}
-
 // TODO: Determine desired behavior if sync is disabled. Do we want to allow
 // manual syncs, then?
 //       If so, how could a user cancel it?
@@ -231,8 +207,6 @@ func (b *builtIn) Reconfigure(ctx context.Context, deps resource.Dependencies, c
 	if err := os.MkdirAll(captureConfig.CaptureDir, 0o700); err != nil {
 		b.logger.Warnf("failed to create capture directory: %s", captureConfig.CaptureDir)
 	}
-	renameProgFilesToCapture(captureConfig.CaptureDir, b.logger)
-
 	syncSensor, syncSensorEnabled := syncSensorFromDeps(c.SelectiveSyncerName, deps, b.logger)
 	syncConfig := c.syncConfig(syncSensor, syncSensorEnabled, b.logger)
 

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -828,29 +828,6 @@ func TestLookupCollectorConfigsByResource(t *testing.T) {
 	})
 }
 
-func TestRenameProgFilesToCapture(t *testing.T) {
-	logger := logging.NewTestLogger(t)
-	dir := t.TempDir()
-	subdir := filepath.Join(dir, "subdir")
-	test.That(t, os.MkdirAll(subdir, 0o700), test.ShouldBeNil)
-
-	for _, p := range []string{
-		filepath.Join(dir, "file1.prog"),
-		filepath.Join(dir, "other.capture"),
-		filepath.Join(subdir, "file2.prog"),
-	} {
-		test.That(t, os.WriteFile(p, []byte("x"), 0o600), test.ShouldBeNil)
-	}
-
-	renameProgFilesToCapture(dir, logger)
-
-	test.That(t, getAllFilePaths(dir), test.ShouldResemble, []string{
-		filepath.Join(dir, "file1.capture"),
-		filepath.Join(dir, "other.capture"),
-		filepath.Join(subdir, "file2.capture"),
-	})
-}
-
 func builtinWithEmptyConfig(t *testing.T, logger logging.Logger) (datamanager.Service, func()) {
 	mockDeps := mockDeps(nil, nil)
 	b, err := New(


### PR DESCRIPTION
## Summary

Reverts the `renameProgFilesToCapture` function introduced in #5996.

**Root cause:** `renameProgFilesToCapture` was called on every `Reconfigure`, not just at startup. When any config change triggered a mid-run reconfigure, the function walked the capture directory and renamed active `.prog` files (currently open by running collectors) to `.capture`. On Linux, the open fd stays valid after a rename so writes continued — but when the collector eventually called `CaptureFile.Close()`, it tried to rename the now-missing `.prog` path and got `ENOENT`. That error cascaded: `CaptureBuffer.Flush()` never cleared `b.nextFile`, so every subsequent flush failed with `"file already closed"`, `writeCaptureResults` exited, and the collector stopped capturing permanently until process restart.

Affected all machines with data capture that received any reconfigure mid-run (config push, module update, component change). Reported in production starting 0.127.0.

Adds a regression test in `data/capture_buffer_test.go` that directly reproduces the mechanism.

## Test plan

- [ ] `go test ./data/ -run TestFlushFailsAfterProgRenamedExternally` passes (documents the failure mode)
- [ ] `go test ./services/datamanager/builtin/...` passes
- [ ] Verify data capture continues across a reconfigure on a real machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)