### PR TITLE
RSDK-13417: Skip weak/optional dependency reconfigure when resolved set is unchanged

### DIFF
--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -89,6 +89,15 @@ type GraphNode struct {
 	// prefix is an optional string that will be prepended to the resource name for
 	// the purpose of simple name queries against remote resources.
 	prefix string
+
+	// lastWeakOptionalDepsClocks records the graph logical clock value
+	// (GraphNode.UpdatedAt) of every weak/optional dependency that was visible to
+	// this resource the last time it was constructed or reconfigured via the
+	// weak/optional dependency update path. It lets that update path skip a
+	// reconfigure when the set of weak/optional deps and their last-built
+	// generations are unchanged. A nil map means "not yet recorded"; an empty
+	// non-nil map means "no weak/optional deps were resolvable."
+	lastWeakOptionalDepsClocks map[Name]int64
 }
 
 var (
@@ -468,6 +477,23 @@ func (w *GraphNode) GetPrefix() string {
 	return w.prefix
 }
 
+// LastWeakOptionalDepsClocks returns the snapshot of weak/optional dependency
+// graph-clock values recorded for this node, or nil if none has been recorded.
+// The returned map must not be mutated by callers.
+func (w *GraphNode) LastWeakOptionalDepsClocks() map[Name]int64 {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.lastWeakOptionalDepsClocks
+}
+
+// SetLastWeakOptionalDepsClocks records the snapshot of weak/optional dependency
+// graph-clock values for this node. Passing nil clears the snapshot.
+func (w *GraphNode) SetLastWeakOptionalDepsClocks(clocks map[Name]int64) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.lastWeakOptionalDepsClocks = clocks
+}
+
 // Close closes the underlying resource of this node.
 func (w *GraphNode) Close(ctx context.Context) error {
 	w.mu.Lock()
@@ -509,6 +535,7 @@ func (w *GraphNode) replace(other *GraphNode) error {
 	w.unresolvedDependencies = other.unresolvedDependencies
 	w.needsDependencyResolution = other.needsDependencyResolution
 	w.prefix = other.prefix
+	w.lastWeakOptionalDepsClocks = other.lastWeakOptionalDepsClocks
 
 	w.state = other.state
 	w.transitionedAt = other.transitionedAt
@@ -523,6 +550,7 @@ func (w *GraphNode) replace(other *GraphNode) error {
 	other.lastErr = nil
 	other.unresolvedDependencies = nil
 	other.needsDependencyResolution = false
+	other.lastWeakOptionalDepsClocks = nil
 
 	other.state = NodeStateUnknown
 	other.transitionedAt = time.Time{}

--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -91,12 +91,13 @@ type GraphNode struct {
 	prefix string
 
 	// lastWeakOptionalDepsClocks records the graph logical clock value
-	// (GraphNode.UpdatedAt) of every weak/optional dependency that was visible to
-	// this resource the last time it was constructed or reconfigured via the
-	// weak/optional dependency update path. It lets that update path skip a
-	// reconfigure when the set of weak/optional deps and their last-built
-	// generations are unchanged. A nil map means "not yet recorded"; an empty
-	// non-nil map means "no weak/optional deps were resolvable."
+	// of every weak and optional dependency that was resolved for this
+	// resource the last time it was successfully rebuilt.
+	// updateWeakAndOptionalDependents reads this on each pass and skips
+	// an unnecessary reconfigure when the current set of resolvable weak/optional
+	// dependencies match what this resource was last given. A nil map means
+	// "not yet recorded"; an empty non-nil map means "no weak/optional
+	// dependencies were resolvable at the time."
 	lastWeakOptionalDepsClocks map[Name]int64
 }
 

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -801,11 +801,8 @@ func (r *localRobot) getWeakDependencyMatchers(api resource.API, model resource.
 }
 
 // getOptionalDependenciesAndSnapshot resolves each entry in conf.ImplicitOptionalDependsOn
-// and, for each resolved dep, also records the graph-clock value of its GraphNode at the
-// moment of resolution. Building deps and snapshot in the same pass guarantees they
-// describe the same point-in-time view; a separate snapshot pass could observe sibling
-// resources being SwapResource'd in between and over-claim deps the resource was never
-// actually given.
+// and records its GraphNode.UpdatedAt at the moment of resolution. Resolving and
+// snapshotting in the same pass keeps them consistent.
 func (r *localRobot) getOptionalDependenciesAndSnapshot(
 	conf resource.Config,
 ) (resource.Dependencies, map[resource.Name]int64) {
@@ -883,9 +880,9 @@ func (r *localRobot) getOptionalDependenciesAndSnapshot(
 	return optDeps, snapshot
 }
 
-// weakOptionalDepClocksEqual reports whether two weak/optional dependency snapshots
-// describe the same dep set with the same generations. A nil receiver (no snapshot yet
-// recorded) is never equal to any other snapshot.
+// weakOptionalDepClocksEqual reports whether two weak/optional dependency snapshots have
+// identical key sets and identical clock values. A nil argument (no snapshot yet recorded)
+// is never equal to any other.
 func weakOptionalDepClocksEqual(a, b map[resource.Name]int64) bool {
 	if a == nil || b == nil {
 		return false
@@ -904,9 +901,8 @@ func weakOptionalDepClocksEqual(a, b map[resource.Name]int64) bool {
 
 // getWeakDependenciesAndSnapshot matches all currently-available resources against the
 // caller's weak dependency matchers, returning the resolved dep map alongside a snapshot
-// of each matched dep's GraphNode.UpdatedAt at the moment of resolution. Like
-// getOptionalDependenciesAndSnapshot, building deps and snapshot together makes the pair
-// describe the same point-in-time view.
+// of each matched dep's GraphNode.UpdatedAt at the moment of resolution. Resolving and
+// snapshotting in the same pass keeps them consistent.
 func (r *localRobot) getWeakDependenciesAndSnapshot(
 	resName resource.Name,
 	api resource.API,
@@ -1000,11 +996,8 @@ func (r *localRobot) newResource(
 		r.logger.CDebugw(ctx, "resource successfully constructed but context is done, closing constructed resource")
 		return nil, multierr.Combine(ctx.Err(), res.Close(r.closeContext))
 	}
-	// Record the snapshot of weak/optional dependency logical clock times that were visible
-	// at the moment getDependencies ran. updateWeakAndOptionalDependents compares against
-	// this and skips a reconfigure when the resolved dep set has not changed. Storing here,
-	// before SwapResource, ensures the snapshot reflects what was actually
-	// passed to the constructor.
+	// Record the snapshot before SwapResource so it reflects what the constructor
+	// actually received, not whatever the graph looks like by the time we get here.
 	gNode.SetLastWeakOptionalDepsClocks(weakOptionalSnapshot)
 	return res, nil
 }

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -845,9 +845,9 @@ func (r *localRobot) getOptionalDependenciesAndSnapshot(
 			resolvedOptionalDepName.Name = optionalDepNameString
 		}
 
-		// Resolve via simpleNameCache so the resource and the snapshot entry come from
-		// one lookup; a direct g.nodes lookup misses FQNs that resolve to a
-		// remote-resident node via the short-name fallback.
+		// Resolve via simpleNameCache so the resource and UpdatedAt come from one
+		// lookup. The split (ResourceByName + g.nodes) would miss prefixed remote
+		// names on the g.nodes side.
 		node, err := r.manager.resources.FindBySimpleNameAndAPI(resolvedOptionalDepName.Name, resolvedOptionalDepName.API)
 		if err != nil {
 			r.logger.Infow(
@@ -921,8 +921,9 @@ func (r *localRobot) getWeakDependenciesAndSnapshot(
 		if !(n.API.IsComponent() || n.API.IsService()) || n == resName {
 			continue
 		}
-		// Resolve via simpleNameCache so the resource and the snapshot entry come from
-		// one lookup; a direct g.nodes lookup misses prefixed remote names.
+		// Resolve via simpleNameCache so the resource and UpdatedAt come from one
+		// lookup. The split (ResourceByName + g.nodes) would miss prefixed remote
+		// names on the g.nodes side.
 		node, err := r.manager.resources.FindBySimpleNameAndAPI(n.Name, n.API)
 		if err != nil {
 			if !resource.IsDependencyNotReadyError(err) && !resource.IsNotAvailableError(err) {
@@ -932,6 +933,8 @@ func (r *localRobot) getWeakDependenciesAndSnapshot(
 		}
 		res, err := node.Resource()
 		if err != nil {
+			// Wrap as NotAvailableError to match the prior ResourceByName behavior
+			err = resource.NewNotAvailableError(n, err)
 			if !resource.IsDependencyNotReadyError(err) && !resource.IsNotAvailableError(err) {
 				r.Logger().Debugw("error finding resource while getting weak dependencies", "resource", n, "error", err)
 			}

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -814,11 +814,8 @@ func (r *localRobot) getOptionalDependenciesAndSnapshot(
 		// by simple name.
 		//
 		// Not checking whether the resource actually exists because that is done later in the function.
-		var graphNodeName resource.Name
 		resolvedOptionalDepName, err := resource.NewFromString(optionalDepNameString)
-		if err == nil {
-			graphNodeName = resolvedOptionalDepName
-		} else {
+		if err != nil {
 			matchingResourceNames := r.manager.resources.FindBySimpleName(optionalDepNameString)
 			switch len(matchingResourceNames) {
 			case 0:
@@ -841,18 +838,27 @@ func (r *localRobot) getOptionalDependenciesAndSnapshot(
 				)
 				continue
 			}
-			// matchingResourceNames[0] is the full graph node name (including any
-			// remote prefix). Keep that for the GraphNode lookup below.
-			graphNodeName = matchingResourceNames[0]
-
 			// FindBySimpleName strips the prefix on the return, so set Name to the optionalDepNameString passed in
 			// Pop the remote name off since callers won't be expecting it when accessing it in the resource
 			// dependency map in a resource constructor.
-			resolvedOptionalDepName = graphNodeName.PopRemote()
+			resolvedOptionalDepName = matchingResourceNames[0].PopRemote()
 			resolvedOptionalDepName.Name = optionalDepNameString
 		}
 
-		optionalDep, err := r.ResourceByName(resolvedOptionalDepName)
+		// Resolve via simpleNameCache so the resource and the snapshot entry come from
+		// one lookup; a direct g.nodes lookup misses FQNs that resolve to a
+		// remote-resident node via the short-name fallback.
+		node, err := r.manager.resources.FindBySimpleNameAndAPI(resolvedOptionalDepName.Name, resolvedOptionalDepName.API)
+		if err != nil {
+			r.logger.Infow(
+				"Optional dependency for resource is not available; not passing to constructor or reconfigure yet",
+				"dependency", resolvedOptionalDepName.String(),
+				"resource", conf.ResourceName().String(),
+				"error", err,
+			)
+			continue
+		}
+		optionalDep, err := node.Resource()
 		if err != nil {
 			r.logger.Infow(
 				"Optional dependency for resource is not available; not passing to constructor or reconfigure yet",
@@ -865,9 +871,7 @@ func (r *localRobot) getOptionalDependenciesAndSnapshot(
 
 		optDeps[resolvedOptionalDepName] = optionalDep
 		found = append(found, resolvedOptionalDepName)
-		if node, ok := r.manager.resources.Node(graphNodeName); ok {
-			snapshot[resolvedOptionalDepName] = node.UpdatedAt()
-		}
+		snapshot[resolvedOptionalDepName] = node.UpdatedAt()
 	}
 	if len(conf.ImplicitOptionalDependsOn) > 0 {
 		r.logger.Infow(
@@ -917,7 +921,16 @@ func (r *localRobot) getWeakDependenciesAndSnapshot(
 		if !(n.API.IsComponent() || n.API.IsService()) || n == resName {
 			continue
 		}
-		res, err := r.ResourceByName(n)
+		// Resolve via simpleNameCache so the resource and the snapshot entry come from
+		// one lookup; a direct g.nodes lookup misses prefixed remote names.
+		node, err := r.manager.resources.FindBySimpleNameAndAPI(n.Name, n.API)
+		if err != nil {
+			if !resource.IsDependencyNotReadyError(err) && !resource.IsNotAvailableError(err) {
+				r.Logger().Debugw("error finding resource while getting weak dependencies", "resource", n, "error", err)
+			}
+			continue
+		}
+		res, err := node.Resource()
 		if err != nil {
 			if !resource.IsDependencyNotReadyError(err) && !resource.IsNotAvailableError(err) {
 				r.Logger().Debugw("error finding resource while getting weak dependencies", "resource", n, "error", err)
@@ -930,9 +943,7 @@ func (r *localRobot) getWeakDependenciesAndSnapshot(
 				// dependency map in a resource constructor.
 				popped := n.PopRemote()
 				deps[popped] = res
-				if node, ok := r.manager.resources.Node(n); ok {
-					snapshot[popped] = node.UpdatedAt()
-				}
+				snapshot[popped] = node.UpdatedAt()
 				break
 			}
 		}

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -725,7 +725,7 @@ func (r *localRobot) handleOrphanedResources(ctx context.Context,
 //
 // - Weak dependencies
 //   - Specified at the time of resource registration by a set of `resource.Matcher`s
-//   - Can only be used with both non-modular resources
+//   - Can only be used with non-modular resources
 //   - Allow access to a `resource.Resource` or gRPC client referencing the dependency in
 //     the resource's constructor and reconfigure methods IFF that dependency exists and
 //     has been successfully constructed
@@ -740,17 +740,13 @@ func (r *localRobot) getDependencies(
 	return deps, err
 }
 
-// getDependenciesWithWeakOptionalSnapshot is the same as getDependencies but also returns
-// a snapshot of the graph-clock value (GraphNode.UpdatedAt) of every weak and optional
-// dependency that was resolved into deps. The snapshot is what
-// updateWeakAndOptionalDependents compares against to decide whether a resource actually
-// needs to be reconfigured.
+// getDependenciesWithWeakOptionalSnapshot is the implementation helper of getDependencies
+// but also returns a snapshot of the graph-clock UpdatedAt value of every weak and optional
+// dependency that was resolved into deps. The snapshot is what updateWeakAndOptionalDependents
+// compares against to decide whether a resource actually needs to be reconfigured.
 //
 // Returning the snapshot from the same call that resolves dependencies guarantees the
-// snapshot reflects what was passed to the resource: if a sibling resource is built (and
-// its node SwapResource'd) between dep resolution and the snapshot being recorded,
-// computing the snapshot separately would have over-claimed deps the resource was never
-// actually given.
+// snapshot reflects what was passed to the resource.
 func (r *localRobot) getDependenciesWithWeakOptionalSnapshot(
 	rName resource.Name,
 	gNode *resource.GraphNode,
@@ -759,7 +755,7 @@ func (r *localRobot) getDependenciesWithWeakOptionalSnapshot(
 		return nil, nil, errors.Errorf("resource has unresolved dependencies not found in machine config or connected remotes: %v", deps)
 	}
 	allDeps := make(resource.Dependencies)
-	weakOptionalSnapshot := map[resource.Name]int64{}
+	weakAndOptionalDepsSnapshot := map[resource.Name]int64{}
 
 	for _, dep := range r.manager.resources.GetAllParentsOf(rName) {
 		// Specifically call ResourceByName and not directly to the manager since this
@@ -780,7 +776,7 @@ func (r *localRobot) getDependenciesWithWeakOptionalSnapshot(
 		allDeps[weakDepName] = weakDepRes
 	}
 	for name, clock := range weakSnap {
-		weakOptionalSnapshot[name] = clock
+		weakAndOptionalDepsSnapshot[name] = clock
 	}
 	optDeps, optSnap := r.getOptionalDependenciesAndSnapshot(nodeConf)
 	for optionalDepName, optionalDepRes := range optDeps {
@@ -790,10 +786,10 @@ func (r *localRobot) getDependenciesWithWeakOptionalSnapshot(
 		allDeps[optionalDepName] = optionalDepRes
 	}
 	for name, clock := range optSnap {
-		weakOptionalSnapshot[name] = clock
+		weakAndOptionalDepsSnapshot[name] = clock
 	}
 
-	return allDeps, weakOptionalSnapshot, nil
+	return allDeps, weakAndOptionalDepsSnapshot, nil
 }
 
 func (r *localRobot) getWeakDependencyMatchers(api resource.API, model resource.Model) []resource.Matcher {
@@ -821,10 +817,10 @@ func (r *localRobot) getOptionalDependenciesAndSnapshot(
 		// by simple name.
 		//
 		// Not checking whether the resource actually exists because that is done later in the function.
-		var graphName resource.Name
+		var graphNodeName resource.Name
 		resolvedOptionalDepName, err := resource.NewFromString(optionalDepNameString)
 		if err == nil {
-			graphName = resolvedOptionalDepName
+			graphNodeName = resolvedOptionalDepName
 		} else {
 			matchingResourceNames := r.manager.resources.FindBySimpleName(optionalDepNameString)
 			switch len(matchingResourceNames) {
@@ -850,14 +846,13 @@ func (r *localRobot) getOptionalDependenciesAndSnapshot(
 			}
 			// matchingResourceNames[0] is the full graph node name (including any
 			// remote prefix). Keep that for the GraphNode lookup below.
-			graphName = matchingResourceNames[0]
-			resolvedOptionalDepName = matchingResourceNames[0]
+			graphNodeName = matchingResourceNames[0]
 
 			// FindBySimpleName strips the prefix on the return, so set Name to the optionalDepNameString passed in
 			// Pop the remote name off since callers won't be expecting it when accessing it in the resource
 			// dependency map in a resource constructor.
+			resolvedOptionalDepName = graphNodeName.PopRemote()
 			resolvedOptionalDepName.Name = optionalDepNameString
-			resolvedOptionalDepName = resolvedOptionalDepName.PopRemote()
 		}
 
 		optionalDep, err := r.ResourceByName(resolvedOptionalDepName)
@@ -873,7 +868,7 @@ func (r *localRobot) getOptionalDependenciesAndSnapshot(
 
 		optDeps[resolvedOptionalDepName] = optionalDep
 		found = append(found, resolvedOptionalDepName)
-		if node, ok := r.manager.resources.Node(graphName); ok {
+		if node, ok := r.manager.resources.Node(graphNodeName); ok {
 			snapshot[resolvedOptionalDepName] = node.UpdatedAt()
 		}
 	}
@@ -1005,12 +1000,11 @@ func (r *localRobot) newResource(
 		r.logger.CDebugw(ctx, "resource successfully constructed but context is done, closing constructed resource")
 		return nil, multierr.Combine(ctx.Err(), res.Close(r.closeContext))
 	}
-	// Record the snapshot of weak/optional dep clocks that was visible at the moment
-	// getDependencies ran. updateWeakAndOptionalDependents compares against this on the
-	// next pass and skips a reconfigure when the resolved dep set has not changed.
-	// Storing here, before SwapResource, ensures the snapshot reflects what was actually
-	// passed to the constructor — not the state of the graph after sibling resources may
-	// have been SwapResource'd in.
+	// Record the snapshot of weak/optional dependency logical clock times that were visible
+	// at the moment getDependencies ran. updateWeakAndOptionalDependents compares against
+	// this and skips a reconfigure when the resolved dep set has not changed. Storing here,
+	// before SwapResource, ensures the snapshot reflects what was actually
+	// passed to the constructor.
 	gNode.SetLastWeakOptionalDepsClocks(weakOptionalSnapshot)
 	return res, nil
 }
@@ -1176,19 +1170,12 @@ func (r *localRobot) updateWeakAndOptionalDependents(ctx context.Context) {
 		}
 
 		// Only reconfigure if the resolved weak/optional dependency set has actually
-		// changed since the last time this resource was built or reconfigured. The
-		// snapshot captures both the set of resolvable deps and the graph-clock value
-		// of each, so we detect deps appearing, disappearing, or being rebuilt.
+		// changed or updated since the last time this resource was built or reconfigured.
 		if weakOptionalDepClocksEqual(resNode.LastWeakOptionalDepsClocks(), currentSnap) {
 			return
 		}
 
 		r.Logger().CDebugw(ctx, "handling weak/optional update for resource", "resource", resName)
-
-		// Record the snapshot before reconfiguring so that even if the resource's
-		// Reconfigure errors, we don't retry on the next pass unless the dep set
-		// changes again.
-		resNode.SetLastWeakOptionalDepsClocks(currentSnap)
 
 		// Use the module manager to reconfigure the resource if it's a modular resource. This
 		// would be a modular resource that has optional dependencies.
@@ -1216,7 +1203,10 @@ func (r *localRobot) updateWeakAndOptionalDependents(ctx context.Context) {
 					"resource", resName,
 				)
 			}
+			// Do not advance the stored snapshot on failure so the next pass retries.
+			return
 		}
+		resNode.SetLastWeakOptionalDepsClocks(currentSnap)
 	}
 
 	cfg := r.Config()

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -845,9 +845,8 @@ func (r *localRobot) getOptionalDependenciesAndSnapshot(
 			resolvedOptionalDepName.Name = optionalDepNameString
 		}
 
-		// Resolve via simpleNameCache so the resource and UpdatedAt come from one
-		// lookup. The split (ResourceByName + g.nodes) would miss prefixed remote
-		// names on the g.nodes side.
+		// Resolve through FindBySimpleNameAndAPI so the Resource and its UpdatedAt
+		// come from one *GraphNode, keeping deps and snapshot in lockstep.
 		node, err := r.manager.resources.FindBySimpleNameAndAPI(resolvedOptionalDepName.Name, resolvedOptionalDepName.API)
 		if err != nil {
 			r.logger.Infow(
@@ -921,9 +920,8 @@ func (r *localRobot) getWeakDependenciesAndSnapshot(
 		if !(n.API.IsComponent() || n.API.IsService()) || n == resName {
 			continue
 		}
-		// Resolve via simpleNameCache so the resource and UpdatedAt come from one
-		// lookup. The split (ResourceByName + g.nodes) would miss prefixed remote
-		// names on the g.nodes side.
+		// Resolve through FindBySimpleNameAndAPI so the Resource and its UpdatedAt
+		// come from one *GraphNode, keeping deps and snapshot in lockstep.
 		node, err := r.manager.resources.FindBySimpleNameAndAPI(n.Name, n.API)
 		if err != nil {
 			if !resource.IsDependencyNotReadyError(err) && !resource.IsNotAvailableError(err) {
@@ -1182,7 +1180,7 @@ func (r *localRobot) updateWeakAndOptionalDependents(ctx context.Context) {
 			return
 		}
 
-		r.Logger().CDebugw(ctx, "handling weak/optional update for resource", "resource", resName)
+		r.Logger().CInfow(ctx, "handling weak/optional update for resource", "resource", resName)
 
 		// Use the module manager to reconfigure the resource if it's a modular resource. This
 		// would be a modular resource that has optional dependencies.

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -736,10 +736,30 @@ func (r *localRobot) getDependencies(
 	rName resource.Name,
 	gNode *resource.GraphNode,
 ) (resource.Dependencies, error) {
+	deps, _, err := r.getDependenciesWithWeakOptionalSnapshot(rName, gNode)
+	return deps, err
+}
+
+// getDependenciesWithWeakOptionalSnapshot is the same as getDependencies but also returns
+// a snapshot of the graph-clock value (GraphNode.UpdatedAt) of every weak and optional
+// dependency that was resolved into deps. The snapshot is what
+// updateWeakAndOptionalDependents compares against to decide whether a resource actually
+// needs to be reconfigured.
+//
+// Returning the snapshot from the same call that resolves dependencies guarantees the
+// snapshot reflects what was passed to the resource: if a sibling resource is built (and
+// its node SwapResource'd) between dep resolution and the snapshot being recorded,
+// computing the snapshot separately would have over-claimed deps the resource was never
+// actually given.
+func (r *localRobot) getDependenciesWithWeakOptionalSnapshot(
+	rName resource.Name,
+	gNode *resource.GraphNode,
+) (resource.Dependencies, map[resource.Name]int64, error) {
 	if deps := gNode.UnresolvedDependencies(); len(deps) != 0 {
-		return nil, errors.Errorf("resource has unresolved dependencies not found in machine config or connected remotes: %v", deps)
+		return nil, nil, errors.Errorf("resource has unresolved dependencies not found in machine config or connected remotes: %v", deps)
 	}
 	allDeps := make(resource.Dependencies)
+	weakOptionalSnapshot := map[resource.Name]int64{}
 
 	for _, dep := range r.manager.resources.GetAllParentsOf(rName) {
 		// Specifically call ResourceByName and not directly to the manager since this
@@ -747,25 +767,33 @@ func (r *localRobot) getDependencies(
 		// and no last error).
 		prefixedName, res, err := r.manager.ResourceByName(dep)
 		if err != nil {
-			return nil, &resource.DependencyNotReadyError{Name: dep.Name, Reason: err}
+			return nil, nil, &resource.DependencyNotReadyError{Name: dep.Name, Reason: err}
 		}
 		allDeps[prefixedName] = res
 	}
 	nodeConf := gNode.Config()
-	for weakDepName, weakDepRes := range r.getWeakDependencies(rName, nodeConf.API, nodeConf.Model) {
+	weakDeps, weakSnap := r.getWeakDependenciesAndSnapshot(rName, nodeConf.API, nodeConf.Model)
+	for weakDepName, weakDepRes := range weakDeps {
 		if _, ok := allDeps[weakDepName]; ok {
 			continue
 		}
 		allDeps[weakDepName] = weakDepRes
 	}
-	for optionalDepName, optionalDepRes := range r.getOptionalDependencies(nodeConf) {
+	for name, clock := range weakSnap {
+		weakOptionalSnapshot[name] = clock
+	}
+	optDeps, optSnap := r.getOptionalDependenciesAndSnapshot(nodeConf)
+	for optionalDepName, optionalDepRes := range optDeps {
 		if _, ok := allDeps[optionalDepName]; ok {
 			continue
 		}
 		allDeps[optionalDepName] = optionalDepRes
 	}
+	for name, clock := range optSnap {
+		weakOptionalSnapshot[name] = clock
+	}
 
-	return allDeps, nil
+	return allDeps, weakOptionalSnapshot, nil
 }
 
 func (r *localRobot) getWeakDependencyMatchers(api resource.API, model resource.Model) []resource.Matcher {
@@ -776,16 +804,28 @@ func (r *localRobot) getWeakDependencyMatchers(api resource.API, model resource.
 	return reg.WeakDependencies
 }
 
-func (r *localRobot) getOptionalDependencies(conf resource.Config) resource.Dependencies {
+// getOptionalDependenciesAndSnapshot resolves each entry in conf.ImplicitOptionalDependsOn
+// and, for each resolved dep, also records the graph-clock value of its GraphNode at the
+// moment of resolution. Building deps and snapshot in the same pass guarantees they
+// describe the same point-in-time view; a separate snapshot pass could observe sibling
+// resources being SwapResource'd in between and over-claim deps the resource was never
+// actually given.
+func (r *localRobot) getOptionalDependenciesAndSnapshot(
+	conf resource.Config,
+) (resource.Dependencies, map[resource.Name]int64) {
 	optDeps := make(resource.Dependencies)
+	snapshot := make(map[resource.Name]int64)
 	found := make([]resource.Name, 0)
 	for _, optionalDepNameString := range conf.ImplicitOptionalDependsOn {
 		// If the name string is a fully qualified resource name, skip trying to match
 		// by simple name.
 		//
 		// Not checking whether the resource actually exists because that is done later in the function.
+		var graphName resource.Name
 		resolvedOptionalDepName, err := resource.NewFromString(optionalDepNameString)
-		if err != nil {
+		if err == nil {
+			graphName = resolvedOptionalDepName
+		} else {
 			matchingResourceNames := r.manager.resources.FindBySimpleName(optionalDepNameString)
 			switch len(matchingResourceNames) {
 			case 0:
@@ -808,6 +848,9 @@ func (r *localRobot) getOptionalDependencies(conf resource.Config) resource.Depe
 				)
 				continue
 			}
+			// matchingResourceNames[0] is the full graph node name (including any
+			// remote prefix). Keep that for the GraphNode lookup below.
+			graphName = matchingResourceNames[0]
 			resolvedOptionalDepName = matchingResourceNames[0]
 
 			// FindBySimpleName strips the prefix on the return, so set Name to the optionalDepNameString passed in
@@ -830,6 +873,9 @@ func (r *localRobot) getOptionalDependencies(conf resource.Config) resource.Depe
 
 		optDeps[resolvedOptionalDepName] = optionalDep
 		found = append(found, resolvedOptionalDepName)
+		if node, ok := r.manager.resources.Node(graphName); ok {
+			snapshot[resolvedOptionalDepName] = node.UpdatedAt()
+		}
 	}
 	if len(conf.ImplicitOptionalDependsOn) > 0 {
 		r.logger.Infow(
@@ -839,14 +885,43 @@ func (r *localRobot) getOptionalDependencies(conf resource.Config) resource.Depe
 		)
 	}
 
-	return optDeps
+	return optDeps, snapshot
 }
 
-func (r *localRobot) getWeakDependencies(resName resource.Name, api resource.API, model resource.Model) resource.Dependencies {
+// weakOptionalDepClocksEqual reports whether two weak/optional dependency snapshots
+// describe the same dep set with the same generations. A nil receiver (no snapshot yet
+// recorded) is never equal to any other snapshot.
+func weakOptionalDepClocksEqual(a, b map[resource.Name]int64) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, va := range a {
+		vb, ok := b[k]
+		if !ok || va != vb {
+			return false
+		}
+	}
+	return true
+}
+
+// getWeakDependenciesAndSnapshot matches all currently-available resources against the
+// caller's weak dependency matchers, returning the resolved dep map alongside a snapshot
+// of each matched dep's GraphNode.UpdatedAt at the moment of resolution. Like
+// getOptionalDependenciesAndSnapshot, building deps and snapshot together makes the pair
+// describe the same point-in-time view.
+func (r *localRobot) getWeakDependenciesAndSnapshot(
+	resName resource.Name,
+	api resource.API,
+	model resource.Model,
+) (resource.Dependencies, map[resource.Name]int64) {
 	weakDepMatchers := r.getWeakDependencyMatchers(api, model)
 
 	allNames := r.manager.AllNonCollidingResourceNames()
 	deps := make(resource.Dependencies, len(allNames))
+	snapshot := make(map[resource.Name]int64)
 	for _, n := range allNames {
 		if !(n.API.IsComponent() || n.API.IsService()) || n == resName {
 			continue
@@ -862,11 +937,16 @@ func (r *localRobot) getWeakDependencies(resName resource.Name, api resource.API
 			if matcher.IsMatch(res) {
 				// Pop the remote name off since callers won't be expecting it when accessing it in the resource
 				// dependency map in a resource constructor.
-				deps[n.PopRemote()] = res
+				popped := n.PopRemote()
+				deps[popped] = res
+				if node, ok := r.manager.resources.Node(n); ok {
+					snapshot[popped] = node.UpdatedAt()
+				}
+				break
 			}
 		}
 	}
-	return deps
+	return deps, snapshot
 }
 
 func (r *localRobot) newResource(
@@ -892,7 +972,7 @@ func (r *localRobot) newResource(
 			"%sThere may be no module in config that provides this model", resName.API, conf.Model, modules)
 	}
 
-	deps, err := r.getDependencies(resName, gNode)
+	deps, weakOptionalSnapshot, err := r.getDependenciesWithWeakOptionalSnapshot(resName, gNode)
 	if err != nil {
 		return nil, err
 	}
@@ -925,6 +1005,13 @@ func (r *localRobot) newResource(
 		r.logger.CDebugw(ctx, "resource successfully constructed but context is done, closing constructed resource")
 		return nil, multierr.Combine(ctx.Err(), res.Close(r.closeContext))
 	}
+	// Record the snapshot of weak/optional dep clocks that was visible at the moment
+	// getDependencies ran. updateWeakAndOptionalDependents compares against this on the
+	// next pass and skips a reconfigure when the resolved dep set has not changed.
+	// Storing here, before SwapResource, ensures the snapshot reflects what was actually
+	// passed to the constructor — not the state of the graph after sibling resources may
+	// have been SwapResource'd in.
+	gNode.SetLastWeakOptionalDepsClocks(weakOptionalSnapshot)
 	return res, nil
 }
 
@@ -1074,8 +1161,10 @@ func (r *localRobot) updateWeakAndOptionalDependents(ctx context.Context) {
 			len(conf.ImplicitOptionalDependsOn) == 0 {
 			return
 		}
-		r.Logger().CDebugw(ctx, "handling weak/optional update for resource", "resource", resName)
-		deps, err := r.getDependencies(resName, resNode)
+
+		// Resolve deps and snapshot atomically so the snapshot reflects exactly what
+		// would be passed to Reconfigure right now.
+		deps, currentSnap, err := r.getDependenciesWithWeakOptionalSnapshot(resName, resNode)
 		if err != nil {
 			r.Logger().CErrorw(
 				ctx,
@@ -1085,6 +1174,21 @@ func (r *localRobot) updateWeakAndOptionalDependents(ctx context.Context) {
 			)
 			return
 		}
+
+		// Only reconfigure if the resolved weak/optional dependency set has actually
+		// changed since the last time this resource was built or reconfigured. The
+		// snapshot captures both the set of resolvable deps and the graph-clock value
+		// of each, so we detect deps appearing, disappearing, or being rebuilt.
+		if weakOptionalDepClocksEqual(resNode.LastWeakOptionalDepsClocks(), currentSnap) {
+			return
+		}
+
+		r.Logger().CDebugw(ctx, "handling weak/optional update for resource", "resource", resName)
+
+		// Record the snapshot before reconfiguring so that even if the resource's
+		// Reconfigure errors, we don't retry on the next pass unless the dep set
+		// changes again.
+		resNode.SetLastWeakOptionalDepsClocks(currentSnap)
 
 		// Use the module manager to reconfigure the resource if it's a modular resource. This
 		// would be a modular resource that has optional dependencies.

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -5453,10 +5453,10 @@ func TestWeakDependenciesWithPrefix(t *testing.T) {
 	// This test tests that weak dependencies are properly populated in the dependencies map with the remote prefix
 	// attached to any remote resources.
 	//
-	// In this case, the shell resource will be constructed with the remote resource as a
-	// weak dependency since it will be available at the time of construction. The shell
-	// resource will then also be _reconfigured_ with the weak dependency (a noop).
-	// This redundant reconfigure is not great, but is part of the design of our system.
+	// In this case, the shell resource is constructed with the remote resource as a weak
+	// dependency since it is available at the time of construction. Because the resolved
+	// weak dep set is unchanged afterwards, updateWeakAndOptionalDependents does not
+	// trigger a follow-up reconfigure.
 	t.Parallel()
 	logger, logs := logging.NewObservedTestLogger(t)
 	model := resource.DefaultModelFamily.WithModel(utils.RandomAlphaString(8))
@@ -5551,7 +5551,7 @@ func TestWeakDependenciesWithPrefix(t *testing.T) {
 	testutils.WaitForAssertionWithSleep(t, time.Second, 5, func(tb testing.TB) {
 		tb.Helper()
 		test.That(tb, logs.FilterMessage(successLog).Len(),
-			test.ShouldEqual, 2)
+			test.ShouldEqual, 1)
 	})
 }
 

--- a/robot/impl/optional_dependencies_test.go
+++ b/robot/impl/optional_dependencies_test.go
@@ -2443,7 +2443,6 @@ func TestModularStalePointerAfterWeakOptionalRebuild(t *testing.T) {
 		test.That(t, holderResp["instance_id"], test.ShouldEqual, targetResp["instance_id"])
 	}
 
-
 	// Initial Reconfigure — builds target_v1 and holder_v1, then
 	// updateWeakAndOptionalDependents rebuilds target (to target_v2) and the module's
 	// cascade rebuilds holder (to holder_v2) so it points at target_v2.
@@ -2567,8 +2566,6 @@ func TestModularStalePointerCascadeFanOut(t *testing.T) {
 			test.That(t, holderResp["instance_id"], test.ShouldEqual, wantID)
 		}
 	}
-
-
 	lr.Reconfigure(ctx, &cfg)
 	assertAllHoldersPointToCurrentTarget("initial")
 	targetIDInitial := currentTargetID(ctx, t, lr, targetName)
@@ -2694,7 +2691,6 @@ func TestModularStalePointerCascadeChain(t *testing.T) {
 
 		test.That(t, topResp["instance_id"], test.ShouldEqual, targetResp["instance_id"])
 	}
-
 
 	lr.Reconfigure(ctx, &cfg)
 	assertTopHolderReachesCurrentTarget("initial")

--- a/robot/impl/optional_dependencies_test.go
+++ b/robot/impl/optional_dependencies_test.go
@@ -687,9 +687,10 @@ func TestOptionalDependencyOnBuiltin(t *testing.T) {
 	//
 	// The optional child _might_ get 'builtin' as a dependency as part of its initial
 	// construction (if builtin initializes first), in which case no log will be emitted, or
-	// it _might_ get 'builtin' as a dependency only during the reconfigure triggered by the
-	// unconditional call to `updateWeakAndOptionalDependents`, in which case one log will be
-	// emitted due to the initial construction lacking the 'builtin' dependency.
+	// it _might_ get 'builtin' as a dependency only during the reconfigure triggered by
+	// `updateWeakAndOptionalDependents` detecting that the snapshot changed, in which case
+	// one log will be emitted due to the initial construction lacking the 'builtin'
+	// dependency.
 	//
 	// Optional dependencies are _not_ represented as edges in the resource graph and have no
 	// influence on build order. 0 logs would mean the order was m -> builtin -> oc. 1 log
@@ -906,10 +907,10 @@ func TestModularOptionalDependencyOnRemote(t *testing.T) {
 func TestModularOptionalDependencyOnRemoteWithPrefix(t *testing.T) {
 	// Ensures that a modular resource can optionally depend upon a remote resource on a remote with prefix.
 	//
-	// In this case, the modular resource will be constructed with the remote resource as a
-	// dependency since it will be available at the time of construction. The modular
-	// resource will then also be _reconfigured_ to have the optional resource (a noop).
-	// This redundant reconfigure is not great, but is part of the design of our system.
+	// In this case, the modular resource is constructed with the remote resource as a
+	// dependency since it is available at the time of construction. Because the resolved
+	// set of optional dependencies is unchanged after construction,
+	// updateWeakAndOptionalDependents does not trigger a follow-up reconfigure.
 
 	logger, logs := logging.NewObservedTestLogger(t)
 	ctx := context.Background()

--- a/robot/impl/optional_dependencies_test.go
+++ b/robot/impl/optional_dependencies_test.go
@@ -152,15 +152,14 @@ func TestOptionalDependencies(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// Assert that the optional child reconfigured and logged its inability to get 'm1'
-		// from dependencies _twice_. The first of both is from construction (invokes
-		// `Reconfigure`) of the resource, and the second of both is from reconfiguring of the
-		// resource due to an unconditional call to `updateWeakAndOptionalDependents` directly
-		// after `completeConfig`.
+		// from dependencies exactly once, from construction. updateWeakAndOptionalDependents
+		// skips an unnecessary reconfigure here because the resolved set of optional
+		// dependencies has not changed since construction (m1 still does not exist).
 		oc, err := resource.AsType[*optionalChild](ocRes)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, oc.reconfigCount, test.ShouldEqual, 2)
+		test.That(t, oc.reconfigCount, test.ShouldEqual, 1)
 		msgNum := logs.FilterMessageSnippet("could not get optional motor").Len()
-		test.That(t, msgNum, test.ShouldEqual, 2)
+		test.That(t, msgNum, test.ShouldEqual, 1)
 
 		// Assert that, on the component itself, `requiredMotor` is now set, but `optionalMotor`
 		// is not.
@@ -203,15 +202,15 @@ func TestOptionalDependencies(t *testing.T) {
 		ocRes, err := lr.ResourceByName(ocName)
 		test.That(t, err, test.ShouldBeNil)
 
-		// Assert that the optional child has reconfigured _three_ times. Two from the
-		// previous construction and one from the reconfigure to pass 'm1' in _addition_ to 'm'
-		// as a dependency. Assert that there were no more logs (still 2) about failures to
-		// "get optional motor."
+		// Assert that the optional child has reconfigured _twice_. One from the previous
+		// construction and one from updateWeakAndOptionalDependents picking up that 'm1'
+		// became resolvable. Assert that there were no more logs (still 1) about failures
+		// to "get optional motor" since the reconfigure succeeded in supplying 'm1'.
 		oc, err := resource.AsType[*optionalChild](ocRes)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, oc.reconfigCount, test.ShouldEqual, 3)
+		test.That(t, oc.reconfigCount, test.ShouldEqual, 2)
 		msgNum := logs.FilterMessageSnippet("could not get optional motor").Len()
-		test.That(t, msgNum, test.ShouldEqual, 2)
+		test.That(t, msgNum, test.ShouldEqual, 1)
 
 		// Assert that, on the component itself, `requiredMotor` and `optionalMotor` are now
 		// both set.
@@ -248,15 +247,15 @@ func TestOptionalDependencies(t *testing.T) {
 		ocRes, err := lr.ResourceByName(ocName)
 		test.That(t, err, test.ShouldBeNil)
 
-		// Assert that the optional child has reconfigured four times. Three from the previous
+		// Assert that the optional child has reconfigured three times. Two from the previous
 		// construction and reconfigure, and one from the most recent reconfigure to pass
-		// _only_ 'm' as a dependency (no 'm1'). Assert that there was another log (now 3)
+		// _only_ 'm' as a dependency (no 'm1'). Assert that there was another log (now 2)
 		// about failures to "get optional motor."
 		oc, err := resource.AsType[*optionalChild](ocRes)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, oc.reconfigCount, test.ShouldEqual, 4)
+		test.That(t, oc.reconfigCount, test.ShouldEqual, 3)
 		msgNum := logs.FilterMessageSnippet("could not get optional motor").Len()
-		test.That(t, msgNum, test.ShouldEqual, 3)
+		test.That(t, msgNum, test.ShouldEqual, 2)
 
 		// Assert that, on the component itself, `requiredMotor` is still set but
 		// `optionalMotor` is not.
@@ -323,28 +322,23 @@ func TestOptionalDependencies(t *testing.T) {
 		ocRes, err := lr.ResourceByName(ocName)
 		test.That(t, err, test.ShouldBeNil)
 
-		// Assert that the optional child reconfigured twice. The first is from construction
-		// (invokes `Reconfigure`) of the resource, and the second is from reconfiguring of
-		// the resource due to an unconditional call to `updateWeakAndOptionalDependents`
-		// directly after `completeConfig`.
+		// Assert that the optional child reconfigured either once or twice depending on
+		// build order. If construction already saw 'm1', updateWeakAndOptionalDependents
+		// finds the same snapshot and skips a reconfigure (1 total). If construction did
+		// not see 'm1', the snapshot differs and one reconfigure happens (2 total).
 		oc, err := resource.AsType[*optionalChild](ocRes)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, oc.reconfigCount, test.ShouldEqual, 2)
+		test.That(t, oc.reconfigCount, test.ShouldBeIn, []int{1, 2})
 
-		// Assert that there are either 3 (no new) _or_ 4 logs about an inability to "get
-		// optional motor."
-		//
-		// The optional child _might_ get 'm1' as a dependency as part of its initial
-		// construction, in which case no log will be emitted, or it _might_ get 'm1' as a
-		// dependency as part of the reconfigure triggered by the unconditional call to
-		// `updateWeakAndOptionalDependents`, in which case one log will emitted due to the
-		// initial destruction lacking the 'm1' dependency.
+		// Assert that there are either 2 (no new) _or_ 3 logs about an inability to "get
+		// optional motor." Two carry over from the prior step. A third appears only when
+		// construction order was m -> oc -> m1 (oc constructed without m1).
 		//
 		// Optional dependencies are _not_ represented as edges in the resource graph and have
-		// no influence on build order. 3 logs would mean the order was m -> m1 -> oc or m1 ->
-		// m -> oc. 4 logs would mean the order was m -> oc -> m1.
+		// no influence on build order. 2 logs would mean the order was m -> m1 -> oc or m1 ->
+		// m -> oc. 3 logs would mean the order was m -> oc -> m1.
 		msgNum := logs.FilterMessageSnippet("could not get optional motor").Len()
-		test.That(t, msgNum, test.ShouldBeIn, []int{3, 4})
+		test.That(t, msgNum, test.ShouldBeIn, []int{2, 3})
 
 		// Assert that, on the component itself, `requiredMotor` and `optionalMotor` are now
 		// set.
@@ -407,11 +401,11 @@ func TestModularOptionalDependencies(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// Assert that the foo component logged its inability to get 'm1' from dependencies
-		// _twice_. The first is from construction (invokes `Reconfigure`) of the resource,
-		// and the second is from reconfiguring of the resource due to an unconditional call
-		// to `updateWeakAndOptionalDependents` directly after `completeConfig`.
+		// exactly once, from construction. updateWeakAndOptionalDependents skips an
+		// unnecessary reconfigure here because the resolved set of optional dependencies
+		// has not changed since construction (m1 still does not exist).
 		msgNum := logs.FilterMessageSnippet("could not get optional motor").Len()
-		test.That(t, msgNum, test.ShouldEqual, 2)
+		test.That(t, msgNum, test.ShouldEqual, 1)
 
 		// Assert that 'm' is accessible through the foo component and not moving.
 		doCommandResp, err := fooRes.DoCommand(ctx, map[string]any{"command": "required_motor_state"})
@@ -464,10 +458,10 @@ func TestModularOptionalDependencies(t *testing.T) {
 		fooRes, err := lr.ResourceByName(fooName)
 		test.That(t, err, test.ShouldBeNil)
 
-		// Assert that there were no more logs (still 2) about failures to "get optional
+		// Assert that there were no more logs (still 1) about failures to "get optional
 		// motor."
 		msgNum := logs.FilterMessageSnippet("could not get optional motor").Len()
-		test.That(t, msgNum, test.ShouldEqual, 2)
+		test.That(t, msgNum, test.ShouldEqual, 1)
 
 		// Assert that 'm' is still accessible through the foo component and not moving.
 		doCommandResp, err := fooRes.DoCommand(ctx, map[string]any{"command": "required_motor_state"})
@@ -514,10 +508,11 @@ func TestModularOptionalDependencies(t *testing.T) {
 		fooRes, err := lr.ResourceByName(fooName)
 		test.That(t, err, test.ShouldBeNil)
 
-		// Assert that there was another log (still 3) about a failure to "get optional
-		// motor."
+		// Assert that there was another log (now 2) about a failure to "get optional
+		// motor." Removing 'm1' changes the resolved optional dep set, so foo is
+		// reconfigured and re-emits the missing-optional-motor log.
 		msgNum := logs.FilterMessageSnippet("could not get optional motor").Len()
-		test.That(t, msgNum, test.ShouldEqual, 3)
+		test.That(t, msgNum, test.ShouldEqual, 2)
 
 		// Assert that 'm' is still accessible through the foo component and not moving.
 		doCommandResp, err := fooRes.DoCommand(ctx, map[string]any{"command": "required_motor_state"})
@@ -600,20 +595,17 @@ func TestModularOptionalDependencies(t *testing.T) {
 		fooRes, err := lr.ResourceByName(fooName)
 		test.That(t, err, test.ShouldBeNil)
 
-		// Assert that there are either 3 (no new) _or_ 4 logs about an inability to "get
-		// optional motor."
-		//
-		// The foo component child _might_ get 'm1' as a dependency as part of its initial
-		// construction, in which case no log will be emitted, or it _might_ get 'm1' as a
-		// dependency as part of the reconfigure triggered by the unconditional call to
-		// `updateWeakAndOptionalDependents`, in which case one log will emitted due to the
-		// initial destruction lacking the 'm1' dependency.
+		// Assert that there are either 2 (no new) _or_ 3 logs about an inability to "get
+		// optional motor." Two carry over from the prior steps. A third appears only when
+		// construction order was m -> f -> m1 (f constructed without m1, then
+		// updateWeakAndOptionalDependents reconfigures with m1 — but the initial missing-
+		// m1 log was emitted by construction).
 		//
 		// Optional dependencies are _not_ represented as edges in the resource graph and have
-		// no influence on build order. 3 logs would mean the order was m -> m1 -> f or m1 ->
-		// m -> f. 4 logs would mean the order was m -> f -> m1.
+		// no influence on build order. 2 logs would mean the order was m -> m1 -> f or m1 ->
+		// m -> f. 3 logs would mean the order was m -> f -> m1.
 		msgNum := logs.FilterMessageSnippet("could not get optional motor").Len()
-		test.That(t, msgNum, test.ShouldBeIn, []int{3, 4})
+		test.That(t, msgNum, test.ShouldBeIn, []int{2, 3})
 
 		// Assert that 'm' is accessible through the foo component and not moving.
 		doCommandResp, err := fooRes.DoCommand(ctx, map[string]any{"command": "required_motor_state"})
@@ -683,12 +675,13 @@ func TestOptionalDependencyOnBuiltin(t *testing.T) {
 	ocRes, err := lr.ResourceByName(ocName)
 	test.That(t, err, test.ShouldBeNil)
 
-	// Assert that the optional child reconfigured twice. The first is from construction,
-	// and the second is from reconfiguring of the resource due to a call
-	// to `updateWeakAndOptionalDependents` directly after `completeConfig`.
+	// Assert that the optional child reconfigured either once or twice depending on
+	// build order. If construction already saw "builtin", updateWeakAndOptionalDependents
+	// finds the same snapshot and skips a reconfigure (1 total). Otherwise the snapshot
+	// differs and a single reconfigure happens (2 total).
 	oc, err := resource.AsType[*optionalChild](ocRes)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, oc.reconfigCount, test.ShouldEqual, 2)
+	test.That(t, oc.reconfigCount, test.ShouldBeIn, []int{1, 2})
 
 	// Assert that there is either 0 or 1 log about an inability to "get optional motor."
 	//
@@ -787,9 +780,9 @@ func TestModularOptionalDependencyOnRemote(t *testing.T) {
 	// Ensures that a modular resource can optionally depend upon a remote resource.
 	//
 	// In this case, the modular resource will be constructed with the remote resource as a
-	// dependency since it will be available at the time of construction. The modular
-	// resource will then also be _reconfigured_ to have the optional resource (a noop).
-	// This redundant reconfigure is not great, but is part of the design of our system.
+	// dependency since it will be available at the time of construction. Because the
+	// resolved set of optional dependencies is unchanged after construction,
+	// updateWeakAndOptionalDependents does not trigger a follow-up reconfigure.
 	//
 	// Later, if the remote goes offline, the modular resource will NOT be reconfigured and
 	// instead will just have an unusable gRPC client for the remote resource until the
@@ -858,11 +851,12 @@ func TestModularOptionalDependencyOnRemote(t *testing.T) {
 	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
 	lr := setupLocalRobot(t, ctx, &cfg, logger.Sublogger("local"), WithDisableCompleteConfigWorker())
 
-	// Assert that the foo component built successfully and was also reconfigured. Then
-	// assert that its optional dependency on the remote motor is reachable.
+	// Assert that the foo component built successfully and was not subsequently
+	// reconfigured (its optional dep set was unchanged after construction). Then assert
+	// that its optional dependency on the remote motor is reachable.
 	fooRes, err := lr.ResourceByName(fooName)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, logs.FilterMessageSnippet("Reconfiguring resource for module").Len(), test.ShouldEqual, 1)
+	test.That(t, logs.FilterMessageSnippet("Reconfiguring resource for module").Len(), test.ShouldEqual, 0)
 	doCommandResp, err := fooRes.DoCommand(ctx, map[string]any{"command": "optional_motor_state"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"optional_motor_state": "moving: false"})
@@ -880,9 +874,9 @@ func TestModularOptionalDependencyOnRemote(t *testing.T) {
 		verifyReachableResourceNames(tb, lr, localResourceNames)
 	})
 
-	// Assert that the foo component did NOT reconfigure again but its optional dependency
+	// Assert that the foo component did NOT reconfigure but its optional dependency
 	// on the remote motor is now unreachable.
-	test.That(t, logs.FilterMessageSnippet("Reconfiguring resource for module").Len(), test.ShouldEqual, 1)
+	test.That(t, logs.FilterMessageSnippet("Reconfiguring resource for module").Len(), test.ShouldEqual, 0)
 	doCommandResp, err = fooRes.DoCommand(ctx, map[string]any{"command": "optional_motor_state"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"optional_motor_state": "unreachable"})
@@ -903,7 +897,7 @@ func TestModularOptionalDependencyOnRemote(t *testing.T) {
 
 	// Assert that the foo component did NOT reconfigure, but its optional dependency on the
 	// remote motor is now reachable.
-	test.That(t, logs.FilterMessageSnippet("Reconfiguring resource for module").Len(), test.ShouldEqual, 1)
+	test.That(t, logs.FilterMessageSnippet("Reconfiguring resource for module").Len(), test.ShouldEqual, 0)
 	doCommandResp, err = fooRes.DoCommand(ctx, map[string]any{"command": "optional_motor_state"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"optional_motor_state": "moving: false"})
@@ -977,11 +971,12 @@ func TestModularOptionalDependencyOnRemoteWithPrefix(t *testing.T) {
 	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
 	lr := setupLocalRobot(t, ctx, &cfg, logger.Sublogger("local"), WithDisableCompleteConfigWorker())
 
-	// Assert that the foo component built successfully and was also reconfigured. Then
-	// assert that its optional dependency on the remote motor is reachable.
+	// Assert that the foo component built successfully and was not subsequently
+	// reconfigured (its optional dep set was unchanged after construction). Then assert
+	// that its optional dependency on the remote motor is reachable.
 	fooRes, err := lr.ResourceByName(fooName)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, logs.FilterMessageSnippet("Reconfiguring resource for module").Len(), test.ShouldEqual, 1)
+	test.That(t, logs.FilterMessageSnippet("Reconfiguring resource for module").Len(), test.ShouldEqual, 0)
 	doCommandResp, err := fooRes.DoCommand(ctx, map[string]any{"command": "optional_motor_state"})
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"optional_motor_state": "moving: false"})
@@ -1039,12 +1034,13 @@ func TestModularOptionalDependencyOnFullyQualifiedName(t *testing.T) {
 	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
 	lr.Reconfigure(ctx, &cfg)
 
-	// Assert that the foo component built successfully and that the FQN was resolved:
-	// updateWeakAndOptionalDependents reconfigures foo once after construction because
-	// it correctly identifies m_optional via the fully qualified name.
+	// Assert that the foo component built successfully and that the FQN was resolved.
+	// The reconfigure count is 0 if construction already saw m_optional, or 1 if foo
+	// was built before m_optional and updateWeakAndOptionalDependents had to follow up.
+	// Either way, the FQN must resolve to the same motor as a simple short name would.
 	fooRes, err := lr.ResourceByName(fooName)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, logs.FilterMessageSnippet("Reconfiguring resource for module").Len(), test.ShouldEqual, 1)
+	test.That(t, logs.FilterMessageSnippet("Reconfiguring resource for module").Len(), test.ShouldBeIn, []int{0, 1})
 
 	// Verify foo works and that the optional dependency is reachable.
 	doCommandResp, err := fooRes.DoCommand(ctx, map[string]any{"command": "required_motor_state"})
@@ -1171,15 +1167,14 @@ func TestOptionalDependenciesCycles(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// Assert that the mutual optional child reconfigured and logged its inability to get
-		// 'moc2' from dependencies _twice_. The first of both is from construction (invokes
-		// `Reconfigure`) of the resource, and the second of both is from reconfiguring of the
-		// resource due to an unconditional call to `updateWeakAndOptionalDependents` directly
-		// after `completeConfig`.
+		// 'moc2' from dependencies exactly once, from construction.
+		// updateWeakAndOptionalDependents skips an unnecessary reconfigure because the
+		// resolved optional dep set is unchanged.
 		moc, err := resource.AsType[*mutualOptionalChild](mocRes)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, moc.reconfigCount, test.ShouldEqual, 2)
+		test.That(t, moc.reconfigCount, test.ShouldEqual, 1)
 		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
-		test.That(t, msgNum, test.ShouldEqual, 2)
+		test.That(t, msgNum, test.ShouldEqual, 1)
 
 		// Assert that, on the component itself, `otherMOC` remains unset.
 		test.That(t, moc.otherMOC, test.ShouldBeNil)
@@ -1215,15 +1210,15 @@ func TestOptionalDependenciesCycles(t *testing.T) {
 		mocRes, err := lr.ResourceByName(mocName)
 		test.That(t, err, test.ShouldBeNil)
 
-		// Assert that the 'moc' mutual optional child has reconfigured _three_ times. Two
-		// from the previous construction and one from the reconfigure to pass 'moc2' as a
-		// dependency. Assert that there were no more logs (still 2) about failures to "get
+		// Assert that the 'moc' mutual optional child has reconfigured _twice_. Once from
+		// the previous construction and once from the reconfigure to pass 'moc2' as a
+		// dependency. Assert that there were no more logs (still 1) about failures to "get
 		// other MOC."
 		moc, err := resource.AsType[*mutualOptionalChild](mocRes)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, moc.reconfigCount, test.ShouldEqual, 3)
+		test.That(t, moc.reconfigCount, test.ShouldEqual, 2)
 		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
-		test.That(t, msgNum, test.ShouldEqual, 2)
+		test.That(t, msgNum, test.ShouldEqual, 1)
 
 		// Assert that, on the 'moc' component itself, `otherMOC` is now set.
 		test.That(t, moc.otherMOC, test.ShouldNotBeNil)
@@ -1233,10 +1228,11 @@ func TestOptionalDependenciesCycles(t *testing.T) {
 		mocRes2, err := lr.ResourceByName(mocName2)
 		test.That(t, err, test.ShouldBeNil)
 
-		// Assert that the second mutual optional child has reconfigured _two_ times.
+		// Assert that the second mutual optional child has reconfigured exactly once from
+		// construction; its resolved optional dep set was unchanged afterwards.
 		moc2, err := resource.AsType[*mutualOptionalChild](mocRes2)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, moc2.reconfigCount, test.ShouldEqual, 2)
+		test.That(t, moc2.reconfigCount, test.ShouldEqual, 1)
 
 		// Assert that, on the 'moc2' component itself, `otherMOC` is now set.
 		test.That(t, moc2.otherMOC, test.ShouldNotBeNil)
@@ -1268,15 +1264,15 @@ func TestOptionalDependenciesCycles(t *testing.T) {
 		mocRes2, err := lr.ResourceByName(mocName2)
 		test.That(t, err, test.ShouldBeNil)
 
-		// Assert that the second optional child 'moc2' has reconfigured three times. Two from
-		// the previous construction and reconfigure, and one from the most recent reconfigure
-		// to remove 'moc1' as a dependency. Assert that there was another log (now 3) about
+		// Assert that the second optional child 'moc2' has reconfigured twice. Once from
+		// its construction (when 'moc' was present) and one from the most recent reconfigure
+		// to remove 'moc' as a dependency. Assert that there was another log (now 2) about
 		// failures to "get other MOC."
 		moc2, err := resource.AsType[*mutualOptionalChild](mocRes2)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, moc2.reconfigCount, test.ShouldEqual, 3)
+		test.That(t, moc2.reconfigCount, test.ShouldEqual, 2)
 		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
-		test.That(t, msgNum, test.ShouldEqual, 3)
+		test.That(t, msgNum, test.ShouldEqual, 2)
 
 		// Assert that, on the 'moc2' component itself, `otherMOC` is no longer set.
 		test.That(t, moc2.otherMOC, test.ShouldBeNil)
@@ -1331,11 +1327,10 @@ func TestModularOptionalDependenciesCycles(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// Assert that the mutual optional logged its inability to get 'moc2' from
-		// dependencies _twice_. The first is from construction of the resource, and the
-		// second is from reconstruction of the resource (always rebuild) due to a call to
-		// `updateWeakAndOptionalDependents` directly after `completeConfig`.
+		// dependencies exactly once, from construction. updateWeakAndOptionalDependents
+		// skips a follow-up rebuild because the resolved optional dep set is unchanged.
 		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
-		test.That(t, msgNum, test.ShouldEqual, 2)
+		test.That(t, msgNum, test.ShouldEqual, 1)
 
 		// Assert that, on the component itself, `otherMOC` remains unset.
 		doCommandResp, err := mocRes.DoCommand(ctx, map[string]any{"command": "other_moc_state"})
@@ -1384,9 +1379,9 @@ func TestModularOptionalDependenciesCycles(t *testing.T) {
 		mocRes2, err := lr.ResourceByName(mocName2)
 		test.That(t, err, test.ShouldBeNil)
 
-		// Assert that there were no more logs (still 2) about failures to "get other MOC."
+		// Assert that there were no more logs (still 1) about failures to "get other MOC."
 		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
-		test.That(t, msgNum, test.ShouldEqual, 2)
+		test.That(t, msgNum, test.ShouldEqual, 1)
 
 		currentID := func(res resource.Resource) float64 {
 			resp, err := res.DoCommand(ctx, map[string]any{"command": "instance_id"})
@@ -1445,9 +1440,9 @@ func TestModularOptionalDependenciesCycles(t *testing.T) {
 		mocRes2, err := lr.ResourceByName(mocName2)
 		test.That(t, err, test.ShouldBeNil)
 
-		// Assert that there was another log (now 3) about failures to "get other MOC."
+		// Assert that there was another log (now 2) about failures to "get other MOC."
 		msgNum := logs.FilterMessageSnippet("could not get other MOC").Len()
-		test.That(t, msgNum, test.ShouldEqual, 3)
+		test.That(t, msgNum, test.ShouldEqual, 2)
 
 		// Assert that, on the 'moc2' component itself, `otherMOC` is no longer set.
 		doCommandResp, err := mocRes2.DoCommand(ctx, map[string]any{"command": "other_moc_state"})
@@ -1521,11 +1516,11 @@ func TestOptionalDependencyRepeatedErrors(t *testing.T) {
 	oc, err := resource.AsType[*optionalChild](ocRes)
 	test.That(t, err, test.ShouldBeNil)
 
-	// The optional child should have reconfigured twice:
-	// 1. Initial construction
-	// 2. updateWeakAndOptionalDependents after completeConfig
+	// The optional child reconfigured 1 or 2 times depending on construction order:
+	// 1 if it saw m_optional during construction, 2 if it had to be reconfigured by
+	// updateWeakAndOptionalDependents to pick up m_optional.
 	initialReconfigCount := oc.reconfigCount
-	test.That(t, initialReconfigCount, test.ShouldEqual, 2)
+	test.That(t, initialReconfigCount, test.ShouldBeIn, []int{1, 2})
 
 	initialClockValue := lr.(*localRobot).manager.resources.CurrLogicalClockValue()
 
@@ -1536,8 +1531,9 @@ func TestOptionalDependencyRepeatedErrors(t *testing.T) {
 	logs.TakeAll()
 
 	// Reconfigure with an invalid model for m_unrelated to induce a build error.
-	// This transitions m_unrelated from usable→unusable, increments the clock, and triggers
-	// updateWeakAndOptionalDependents which will reconfigure the optional child once.
+	// This transitions m_unrelated from usable→unusable and increments the clock. The
+	// optional child's resolved optional dep set is unchanged (m_unrelated is unrelated
+	// and m_optional is still present), so updateWeakAndOptionalDependents skips it.
 	nonExistentModel := resource.NewModel("rdk", "builtin", "nonexistent")
 	cfg.Components[3] = resource.Config{
 		Name:  "m_unrelated",
@@ -1570,11 +1566,11 @@ func TestOptionalDependencyRepeatedErrors(t *testing.T) {
 			test.ShouldEqual, clockAfterFirstError)
 	}
 
-	// Verify the optional child reconfigured exactly once from the initial state (triggered by
-	// the first error's clock increment during lr.Reconfigure). The repeated retry calls should
-	// NOT have caused additional reconfigurations.
+	// Verify the optional child was not reconfigured by any of the clock changes. The
+	// failing m_unrelated is unrelated to the optional child, so its optional dep set
+	// (m_optional) is unchanged and updateWeakAndOptionalDependents skips it.
 	reconfigCountAfterAllUpdates := oc.reconfigCount
-	test.That(t, reconfigCountAfterAllUpdates-reconfigCountBeforeError, test.ShouldEqual, 1)
+	test.That(t, reconfigCountAfterAllUpdates-reconfigCountBeforeError, test.ShouldEqual, 0)
 
 	// Verify that m_unrelated failed to build 5 times (one for each retry call).
 	buildErrorLogs := logs.FilterMessageSnippet("resource build error: unknown resource type").Len()
@@ -1679,9 +1675,11 @@ func TestModularOptionalDependencyRepeatedErrors(t *testing.T) {
 	firstErrorLogs := logs.FilterMessageSnippet("resource build error: unknown resource type").Len()
 	test.That(t, firstErrorLogs, test.ShouldEqual, 1)
 
-	// Verify the foo component was reconfigured once due to the first error.
+	// Verify the foo component was NOT reconfigured by the clock change. The failing
+	// m_unrelated is unrelated to foo, so foo's optional dep set is unchanged and
+	// updateWeakAndOptionalDependents skips it.
 	reconfigLogsAfterFirstError := logs.FilterMessageSnippet("Reconfiguring resource for module").Len()
-	test.That(t, reconfigLogsAfterFirstError, test.ShouldEqual, 1)
+	test.That(t, reconfigLogsAfterFirstError, test.ShouldEqual, 0)
 
 	// Clear logs again to isolate just the retry attempts.
 	logs.TakeAll()
@@ -1727,8 +1725,10 @@ func TestModularOptionalDependencyRepeatedErrors(t *testing.T) {
 
 func TestOptionalDependencyUnrelatedResourceRemoval(t *testing.T) {
 	// This test verifies behavior when an unrelated resource is removed from the config.
-	// Currently, removing any resource increments the clock, which triggers
-	// updateWeakAndOptionalDependents for all resources with optional dependencies.
+	// Removing any resource increments the clock, which causes
+	// updateWeakAndOptionalDependents to run. Because the unrelated resource is not
+	// part of any other resource's optional dep set, the per-resource snapshot is
+	// unchanged and no reconfigure is triggered.
 
 	logger, logs := logging.NewObservedTestLogger(t)
 	ctx := context.Background()
@@ -1789,11 +1789,11 @@ func TestOptionalDependencyUnrelatedResourceRemoval(t *testing.T) {
 	oc, err := resource.AsType[*optionalChild](ocRes)
 	test.That(t, err, test.ShouldBeNil)
 
-	// The optional child should have reconfigured twice:
-	// 1. Initial construction
-	// 2. updateWeakAndOptionalDependents after completeConfig
+	// The optional child reconfigured 1 or 2 times depending on construction order:
+	// 1 if it saw m_optional during construction, 2 if it had to be reconfigured by
+	// updateWeakAndOptionalDependents to pick up m_optional.
 	initialReconfigCount := oc.reconfigCount
-	test.That(t, initialReconfigCount, test.ShouldEqual, 2)
+	test.That(t, initialReconfigCount, test.ShouldBeIn, []int{1, 2})
 
 	// Verify both motors are accessible.
 	test.That(t, oc.requiredMotor, test.ShouldNotBeNil)
@@ -1837,20 +1837,22 @@ func TestOptionalDependencyUnrelatedResourceRemoval(t *testing.T) {
 	clockAfterRemoval := lr.(*localRobot).manager.resources.CurrLogicalClockValue()
 	test.That(t, clockAfterRemoval, test.ShouldBeGreaterThan, initialClockValue)
 
-	// Verify the optional child reconfigured once (triggered by clock change from removal).
-	// This is the current behavior - any clock change triggers updateWeakAndOptionalDependents.
-	test.That(t, oc.reconfigCount, test.ShouldEqual, initialReconfigCount+1)
+	// Verify the optional child did NOT reconfigure. updateWeakAndOptionalDependents
+	// ran because the clock advanced, but the optional child's resolved optional dep set
+	// (m_optional) is unchanged so it was skipped.
+	test.That(t, oc.reconfigCount, test.ShouldEqual, initialReconfigCount)
 
-	// Verify both motors are still accessible (the reconfiguration was successful).
+	// Verify both motors are still accessible.
 	test.That(t, oc.requiredMotor, test.ShouldNotBeNil)
 	test.That(t, oc.optionalMotor, test.ShouldNotBeNil)
 }
 
 func TestModularOptionalDependencyUnrelatedResourceRemoval(t *testing.T) {
 	// This test is the modular version of TestOptionalDependencyUnrelatedResourceRemoval.
-	// It verifies behavior when an unrelated resource is removed from the config.
-	// Currently, removing any resource increments the clock, which triggers
-	// updateWeakAndOptionalDependents for all resources with optional dependencies.
+	// Removing any resource increments the clock, which causes
+	// updateWeakAndOptionalDependents to run. Because the unrelated resource is not
+	// part of any other resource's optional dep set, the per-resource snapshot is
+	// unchanged and no reconfigure is triggered.
 
 	logger, logs := logging.NewObservedTestLogger(t)
 	ctx := context.Background()
@@ -1963,10 +1965,11 @@ func TestModularOptionalDependencyUnrelatedResourceRemoval(t *testing.T) {
 	clockAfterRemoval := lr.(*localRobot).manager.resources.CurrLogicalClockValue()
 	test.That(t, clockAfterRemoval, test.ShouldBeGreaterThan, initialClockValue)
 
-	// Verify the foo component reconfigured once (triggered by clock change from removal).
-	// This is the current behavior - any clock change triggers updateWeakAndOptionalDependents.
+	// Verify the foo component did NOT reconfigure. updateWeakAndOptionalDependents
+	// ran because the clock advanced, but foo's resolved optional dep set (m_optional)
+	// is unchanged so it was skipped.
 	reconfigLogsAfterRemoval := logs.FilterMessageSnippet("Reconfiguring resource for module").Len()
-	test.That(t, reconfigLogsAfterRemoval, test.ShouldEqual, 1)
+	test.That(t, reconfigLogsAfterRemoval, test.ShouldEqual, 0)
 
 	// Verify both motors are still accessible through the foo component after reconfiguration.
 	doCommandResp, err = fooRes.DoCommand(ctx, map[string]any{"command": "required_motor_state"})
@@ -1983,8 +1986,9 @@ func TestModularOptionalDependencyModuleNameChange(t *testing.T) {
 	// When a module is renamed:
 	//   1. The old module is shut down, marking its resources for removal (clock +1)
 	//   2. The new module starts up and its resources are added (clock +1)
-	// Each clock increment triggers updateWeakAndOptionalDependents, causing resources with
-	// optional dependencies to reconfigure twice total.
+	// Each clock increment causes updateWeakAndOptionalDependents to run, but
+	// foo's resolved optional dep set is unchanged across both increments so it
+	// is never reconfigured.
 
 	logger, logs := logging.NewObservedTestLogger(t)
 	ctx := context.Background()
@@ -2120,11 +2124,11 @@ func TestModularOptionalDependencyModuleNameChange(t *testing.T) {
 	clockAfterModuleChange := lr.(*localRobot).manager.resources.CurrLogicalClockValue()
 	test.That(t, clockAfterModuleChange, test.ShouldBeGreaterThan, initialClockValue)
 
-	// Verify the foo component reconfigured twice: once when the old module was removed,
-	// and once when the new module's resources were added. Each removal/addition increments
-	// the clock, triggering updateWeakAndOptionalDependents.
+	// Verify the foo component did NOT reconfigure. updateWeakAndOptionalDependents
+	// ran on both clock increments, but foo's resolved optional dep set (m_optional)
+	// is unchanged across both events so it was skipped each time.
 	reconfigLogsAfterModuleChange := logs.FilterMessageSnippet("Reconfiguring resource for module").Len()
-	test.That(t, reconfigLogsAfterModuleChange, test.ShouldEqual, 2)
+	test.That(t, reconfigLogsAfterModuleChange, test.ShouldEqual, 0)
 
 	// Verify both motors are still accessible through the foo component after reconfiguration.
 	doCommandResp, err = fooRes.DoCommand(ctx, map[string]any{"command": "required_motor_state"})
@@ -2144,7 +2148,8 @@ func TestModularOptionalDependencyModuleCrash(t *testing.T) {
 	// During crash-and-retry: resources remain in retry state, so the logical clock does NOT
 	// increment and foo does NOT reconfigure.
 	// After recovery (binary restored): the clock increments when the module restarts and
-	// h_unrelated is re-added, triggering exactly one reconfiguration of foo.
+	// h_unrelated is re-added. updateWeakAndOptionalDependents runs but foo's resolved
+	// optional dep set is unchanged so it is not reconfigured.
 
 	logger, logs := logging.NewObservedTestLogger(t)
 	ctx := context.Background()
@@ -2292,9 +2297,10 @@ func TestModularOptionalDependencyModuleCrash(t *testing.T) {
 	recoveredClockValue := lr.(*localRobot).manager.resources.CurrLogicalClockValue()
 	test.That(t, recoveredClockValue, test.ShouldBeGreaterThan, initialClockValue)
 
-	// The clock increment triggers one reconfiguration of foo.
+	// The clock increment does NOT trigger a reconfiguration of foo because its
+	// resolved optional dep set is unchanged.
 	recoveryReconfigCount := logs.FilterMessageSnippet("Reconfiguring resource for module").Len()
-	test.That(t, recoveryReconfigCount, test.ShouldEqual, 1)
+	test.That(t, recoveryReconfigCount, test.ShouldEqual, 0)
 
 	// Both motors remain accessible through foo after the full crash-recovery cycle.
 	doCommandResp, err = fooRes.DoCommand(ctx, map[string]any{"command": "required_motor_state"})

--- a/robot/impl/optional_dependencies_test.go
+++ b/robot/impl/optional_dependencies_test.go
@@ -19,6 +19,7 @@ import (
 	"go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/robot"
 	"go.viam.com/rdk/testutils"
 	"go.viam.com/rdk/testutils/robottestutils"
 	rutils "go.viam.com/rdk/utils"
@@ -2346,6 +2347,17 @@ func TestModularOptionalDependencyModuleCrash(t *testing.T) {
 	test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"optional_motor_state": "moving: false"})
 }
 
+// currentTargetID reports target's live instance id via a "probe":"id" DoCommand.
+// Comparing the id across a reconfigure tells whether target was rebuilt (changed id)
+// or not.
+func currentTargetID(ctx context.Context, t *testing.T, lr robot.Robot, targetName resource.Name) any {
+	targetRes, err := lr.ResourceByName(targetName)
+	test.That(t, err, test.ShouldBeNil)
+	resp, err := targetRes.DoCommand(ctx, map[string]any{"probe": "id"})
+	test.That(t, err, test.ShouldBeNil)
+	return resp["instance_id"]
+}
+
 func TestModularStalePointerAfterWeakOptionalRebuild(t *testing.T) {
 	// Setup:
 	//   - pointer-target (modular) declares an optional dep. When that dep's availability
@@ -2431,22 +2443,13 @@ func TestModularStalePointerAfterWeakOptionalRebuild(t *testing.T) {
 		test.That(t, holderResp["instance_id"], test.ShouldEqual, targetResp["instance_id"])
 	}
 
-	// currentTargetID returns target's live instance id. A change to that id between two
-	// calls means target was rebuilt; an unchanged id means it was not.
-	currentTargetID := func() any {
-		targetRes, err := lr.ResourceByName(targetName)
-		test.That(t, err, test.ShouldBeNil)
-		resp, err := targetRes.DoCommand(ctx, map[string]any{"probe": "id"})
-		test.That(t, err, test.ShouldBeNil)
-		return resp["instance_id"]
-	}
 
 	// Initial Reconfigure — builds target_v1 and holder_v1, then
 	// updateWeakAndOptionalDependents rebuilds target (to target_v2) and the module's
 	// cascade rebuilds holder (to holder_v2) so it points at target_v2.
 	lr.Reconfigure(ctx, &cfg)
 	assertHolderPointsToCurrentTarget("initial")
-	targetIDInitial := currentTargetID()
+	targetIDInitial := currentTargetID(ctx, t, lr, targetName)
 
 	// Add an unrelated motor to advance the clock and re-trigger
 	// updateWeakAndOptionalDependents.
@@ -2461,7 +2464,7 @@ func TestModularStalePointerAfterWeakOptionalRebuild(t *testing.T) {
 	lr.Reconfigure(ctx, &cfg2)
 	// An unrelated change leaves target's optional-dep snapshot untouched, so
 	// target must NOT be rebuilt — its instance is identical.
-	test.That(t, currentTargetID(), test.ShouldEqual, targetIDInitial)
+	test.That(t, currentTargetID(ctx, t, lr, targetName), test.ShouldEqual, targetIDInitial)
 	assertHolderPointsToCurrentTarget("after-unrelated-change")
 
 	// Reconfigure target's opt-dep (Components[0]) in place. opt-dep stays present,
@@ -2469,7 +2472,7 @@ func TestModularStalePointerAfterWeakOptionalRebuild(t *testing.T) {
 	// target's recorded  optional-dep snapshot, so updateWeakAndOptionalDependents
 	// rebuilds target to a fresh instance, and the module cascade must rebuild holder
 	// to point at it.
-	targetIDBefore := currentTargetID()
+	targetIDBefore := currentTargetID(ctx, t, lr, targetName)
 
 	cfg3 := cfg2
 	cfg3.Components = append([]resource.Config{}, cfg2.Components...)
@@ -2478,7 +2481,7 @@ func TestModularStalePointerAfterWeakOptionalRebuild(t *testing.T) {
 	lr.Reconfigure(ctx, &cfg3)
 
 	// target rebuilt to a new instance because its optional dependency's clock advanced.
-	test.That(t, currentTargetID(), test.ShouldNotEqual, targetIDBefore)
+	test.That(t, currentTargetID(ctx, t, lr, targetName), test.ShouldNotEqual, targetIDBefore)
 
 	// holder was cascaded along with that rebuild, so it points at the new target instance
 	// rather than the closed prior one.
@@ -2565,20 +2568,10 @@ func TestModularStalePointerCascadeFanOut(t *testing.T) {
 		}
 	}
 
-	// currentTargetID returns target's live instance id; comparing it across a reconfigure
-	// tells us whether target was rebuilt. Phrased to survive the upcoming
-	// Reconfigure->rebuild change (identity, not reconfigure counts).
-	currentTargetID := func() any {
-		targetRes, err := lr.ResourceByName(targetName)
-		test.That(t, err, test.ShouldBeNil)
-		resp, err := targetRes.DoCommand(ctx, map[string]any{"probe": "id"})
-		test.That(t, err, test.ShouldBeNil)
-		return resp["instance_id"]
-	}
 
 	lr.Reconfigure(ctx, &cfg)
 	assertAllHoldersPointToCurrentTarget("initial")
-	targetIDInitial := currentTargetID()
+	targetIDInitial := currentTargetID(ctx, t, lr, targetName)
 
 	// Push an unrelated config change to advance the clock and re-trigger
 	// updateWeakAndOptionalDependents.
@@ -2594,13 +2587,13 @@ func TestModularStalePointerCascadeFanOut(t *testing.T) {
 	// Skip held: the unrelated change leaves target's optional-dep snapshot untouched, so
 	// target is not rebuilt and its instance is identical. (Without this, the holder==target
 	// checks below pass even if the skip regressed.)
-	test.That(t, currentTargetID(), test.ShouldEqual, targetIDInitial)
+	test.That(t, currentTargetID(ctx, t, lr, targetName), test.ShouldEqual, targetIDInitial)
 	assertAllHoldersPointToCurrentTarget("after-unrelated-change")
 
 	// Force an actual rebuild: change target's optional dependency (opt-dep, Components[0])
 	// in place so its clock bumps, staling target's snapshot and rebuilding target to a new
 	// instance. Capturing the id beforehand lets us assert the rebuild really fired.
-	targetIDBefore := currentTargetID()
+	targetIDBefore := currentTargetID(ctx, t, lr, targetName)
 
 	cfg3 := cfg2
 	cfg3.Components = append([]resource.Config{}, cfg2.Components...)
@@ -2609,7 +2602,7 @@ func TestModularStalePointerCascadeFanOut(t *testing.T) {
 	lr.Reconfigure(ctx, &cfg3)
 
 	// target rebuilt to a new instance because its optional dependency's clock advanced.
-	test.That(t, currentTargetID(), test.ShouldNotEqual, targetIDBefore)
+	test.That(t, currentTargetID(ctx, t, lr, targetName), test.ShouldNotEqual, targetIDBefore)
 
 	// The fan-out is now meaningfully exercised: all three holders must have cascaded to
 	// the new target instance.
@@ -2702,20 +2695,10 @@ func TestModularStalePointerCascadeChain(t *testing.T) {
 		test.That(t, topResp["instance_id"], test.ShouldEqual, targetResp["instance_id"])
 	}
 
-	// currentTargetID returns target's live instance id; comparing it across a reconfigure
-	// tells us whether target was rebuilt. Phrased to survive the upcoming
-	// Reconfigure->rebuild change (identity, not reconfigure counts).
-	currentTargetID := func() any {
-		targetRes, err := lr.ResourceByName(targetName)
-		test.That(t, err, test.ShouldBeNil)
-		resp, err := targetRes.DoCommand(ctx, map[string]any{"probe": "id"})
-		test.That(t, err, test.ShouldBeNil)
-		return resp["instance_id"]
-	}
 
 	lr.Reconfigure(ctx, &cfg)
 	assertTopHolderReachesCurrentTarget("initial")
-	targetIDInitial := currentTargetID()
+	targetIDInitial := currentTargetID(ctx, t, lr, targetName)
 
 	// Push an unrelated config change to advance the clock and re-trigger the cascade path.
 	cfg2 := cfg
@@ -2729,13 +2712,13 @@ func TestModularStalePointerCascadeChain(t *testing.T) {
 	lr.Reconfigure(ctx, &cfg2)
 	// The unrelated change leaves target's optional-dep snapshot untouched, so
 	// target is not rebuilt and its instance is identical.
-	test.That(t, currentTargetID(), test.ShouldEqual, targetIDInitial)
+	test.That(t, currentTargetID(ctx, t, lr, targetName), test.ShouldEqual, targetIDInitial)
 	assertTopHolderReachesCurrentTarget("after-unrelated-change")
 
 	// Force an actual rebuild: change target's opt-dep (Components[0]) in place so
 	// its clock bumps, staling target's snapshot and rebuilding target to a new
 	// instance.
-	targetIDBefore := currentTargetID()
+	targetIDBefore := currentTargetID(ctx, t, lr, targetName)
 
 	cfg3 := cfg2
 	cfg3.Components = append([]resource.Config{}, cfg2.Components...)
@@ -2744,7 +2727,7 @@ func TestModularStalePointerCascadeChain(t *testing.T) {
 	lr.Reconfigure(ctx, &cfg3)
 
 	// target rebuilt to a new instance because its optional dependency's clock advanced.
-	test.That(t, currentTargetID(), test.ShouldNotEqual, targetIDBefore)
+	test.That(t, currentTargetID(ctx, t, lr, targetName), test.ShouldNotEqual, targetIDBefore)
 
 	// The transitive cascade is now meaningfully exercised: top-holder must reach the new
 	// target instance through the freshly rebuilt mid-holder.

--- a/robot/impl/optional_dependencies_test.go
+++ b/robot/impl/optional_dependencies_test.go
@@ -345,6 +345,39 @@ func TestOptionalDependencies(t *testing.T) {
 		test.That(t, oc.requiredMotor, test.ShouldNotBeNil)
 		test.That(t, oc.optionalMotor, test.ShouldNotBeNil)
 	}
+
+	// Reconfigure 'm1' in place by giving it a config diff so that it remains resolvable
+	// in oc's optional depenency set but its GraphNode clock advances via SwapResource,
+	// so oc's recorded snapshot of m1's clock goes stale. This exercises the clock-value-mismatch
+	// branch of weakOptionalDepClocksEqual — the steps above only add or remove a key,
+	// never bump the clock of a key that stays present.
+	cfg.Components[2].Attributes = rutils.AttributeMap{"version": 1}
+	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
+
+	ocRes, err := lr.ResourceByName(ocName)
+	test.That(t, err, test.ShouldBeNil)
+	oc, err := resource.AsType[*optionalChild](ocRes)
+	test.That(t, err, test.ShouldBeNil)
+	countBeforeInPlace := oc.reconfigCount
+	missingLogsBeforeInPlace := logs.FilterMessageSnippet("could not get optional motor").Len()
+
+	lr.Reconfigure(ctx, &cfg)
+
+	{ // Assertions
+		ocRes, err := lr.ResourceByName(ocName)
+		test.That(t, err, test.ShouldBeNil)
+		oc, err := resource.AsType[*optionalChild](ocRes)
+		test.That(t, err, test.ShouldBeNil)
+
+		// 'm1's in-place reconfigure bumped its clock, so oc reconfigures exactly once.
+		test.That(t, oc.reconfigCount, test.ShouldEqual, countBeforeInPlace+1)
+		// 'm1' stayed resolvable, so no new "could not get optional motor" log.
+		test.That(t, logs.FilterMessageSnippet("could not get optional motor").Len(),
+			test.ShouldEqual, missingLogsBeforeInPlace)
+		// Both motors remain set.
+		test.That(t, oc.requiredMotor, test.ShouldNotBeNil)
+		test.That(t, oc.optionalMotor, test.ShouldNotBeNil)
+	}
 }
 
 func TestModularOptionalDependencies(t *testing.T) {
@@ -2398,14 +2431,25 @@ func TestModularStalePointerAfterWeakOptionalRebuild(t *testing.T) {
 		test.That(t, holderResp["instance_id"], test.ShouldEqual, targetResp["instance_id"])
 	}
 
+	// currentTargetID returns target's live instance id. A change to that id between two
+	// calls means target was rebuilt; an unchanged id means it was not.
+	currentTargetID := func() any {
+		targetRes, err := lr.ResourceByName(targetName)
+		test.That(t, err, test.ShouldBeNil)
+		resp, err := targetRes.DoCommand(ctx, map[string]any{"probe": "id"})
+		test.That(t, err, test.ShouldBeNil)
+		return resp["instance_id"]
+	}
+
 	// Initial Reconfigure — builds target_v1 and holder_v1, then
 	// updateWeakAndOptionalDependents rebuilds target (to target_v2) and the module's
 	// cascade rebuilds holder (to holder_v2) so it points at target_v2.
 	lr.Reconfigure(ctx, &cfg)
 	assertHolderPointsToCurrentTarget("initial")
+	targetIDInitial := currentTargetID()
 
 	// Add an unrelated motor to advance the clock and re-trigger
-	// updateWeakAndOptionalDependents — the second cascade must keep holder fresh.
+	// updateWeakAndOptionalDependents.
 	cfg2 := cfg
 	cfg2.Components = append(append([]resource.Config{}, cfg.Components...), resource.Config{
 		Name:                "unrelated-motor",
@@ -2415,7 +2459,30 @@ func TestModularStalePointerAfterWeakOptionalRebuild(t *testing.T) {
 	})
 	test.That(t, cfg2.Ensure(false, logger), test.ShouldBeNil)
 	lr.Reconfigure(ctx, &cfg2)
+	// An unrelated change leaves target's optional-dep snapshot untouched, so
+	// target must NOT be rebuilt — its instance is identical.
+	test.That(t, currentTargetID(), test.ShouldEqual, targetIDInitial)
 	assertHolderPointsToCurrentTarget("after-unrelated-change")
+
+	// Reconfigure target's opt-dep (Components[0]) in place. opt-dep stays present,
+	// but its config diff makes it reconfigure and bump its graph clock. That stales
+	// target's recorded  optional-dep snapshot, so updateWeakAndOptionalDependents
+	// rebuilds target to a fresh instance, and the module cascade must rebuild holder
+	// to point at it.
+	targetIDBefore := currentTargetID()
+
+	cfg3 := cfg2
+	cfg3.Components = append([]resource.Config{}, cfg2.Components...)
+	cfg3.Components[0].Attributes = rutils.AttributeMap{"version": 1}
+	test.That(t, cfg3.Ensure(false, logger), test.ShouldBeNil)
+	lr.Reconfigure(ctx, &cfg3)
+
+	// target rebuilt to a new instance because its optional dependency's clock advanced.
+	test.That(t, currentTargetID(), test.ShouldNotEqual, targetIDBefore)
+
+	// holder was cascaded along with that rebuild, so it points at the new target instance
+	// rather than the closed prior one.
+	assertHolderPointsToCurrentTarget("after-optdep-change")
 }
 
 func TestModularStalePointerCascadeFanOut(t *testing.T) {
@@ -2498,10 +2565,23 @@ func TestModularStalePointerCascadeFanOut(t *testing.T) {
 		}
 	}
 
+	// currentTargetID returns target's live instance id; comparing it across a reconfigure
+	// tells us whether target was rebuilt. Phrased to survive the upcoming
+	// Reconfigure->rebuild change (identity, not reconfigure counts).
+	currentTargetID := func() any {
+		targetRes, err := lr.ResourceByName(targetName)
+		test.That(t, err, test.ShouldBeNil)
+		resp, err := targetRes.DoCommand(ctx, map[string]any{"probe": "id"})
+		test.That(t, err, test.ShouldBeNil)
+		return resp["instance_id"]
+	}
+
 	lr.Reconfigure(ctx, &cfg)
 	assertAllHoldersPointToCurrentTarget("initial")
+	targetIDInitial := currentTargetID()
 
-	// Push a config change to advance the clock and re-trigger updateWeakAndOptionalDependents.
+	// Push an unrelated config change to advance the clock and re-trigger
+	// updateWeakAndOptionalDependents.
 	cfg2 := cfg
 	cfg2.Components = append(append([]resource.Config{}, cfg.Components...), resource.Config{
 		Name:                "unrelated-motor",
@@ -2511,7 +2591,29 @@ func TestModularStalePointerCascadeFanOut(t *testing.T) {
 	})
 	test.That(t, cfg2.Ensure(false, logger), test.ShouldBeNil)
 	lr.Reconfigure(ctx, &cfg2)
+	// Skip held: the unrelated change leaves target's optional-dep snapshot untouched, so
+	// target is not rebuilt and its instance is identical. (Without this, the holder==target
+	// checks below pass even if the skip regressed.)
+	test.That(t, currentTargetID(), test.ShouldEqual, targetIDInitial)
 	assertAllHoldersPointToCurrentTarget("after-unrelated-change")
+
+	// Force an actual rebuild: change target's optional dependency (opt-dep, Components[0])
+	// in place so its clock bumps, staling target's snapshot and rebuilding target to a new
+	// instance. Capturing the id beforehand lets us assert the rebuild really fired.
+	targetIDBefore := currentTargetID()
+
+	cfg3 := cfg2
+	cfg3.Components = append([]resource.Config{}, cfg2.Components...)
+	cfg3.Components[0].Attributes = rutils.AttributeMap{"version": 1}
+	test.That(t, cfg3.Ensure(false, logger), test.ShouldBeNil)
+	lr.Reconfigure(ctx, &cfg3)
+
+	// target rebuilt to a new instance because its optional dependency's clock advanced.
+	test.That(t, currentTargetID(), test.ShouldNotEqual, targetIDBefore)
+
+	// The fan-out is now meaningfully exercised: all three holders must have cascaded to
+	// the new target instance.
+	assertAllHoldersPointToCurrentTarget("after-optdep-change")
 }
 
 func TestModularStalePointerCascadeChain(t *testing.T) {
@@ -2600,10 +2702,22 @@ func TestModularStalePointerCascadeChain(t *testing.T) {
 		test.That(t, topResp["instance_id"], test.ShouldEqual, targetResp["instance_id"])
 	}
 
+	// currentTargetID returns target's live instance id; comparing it across a reconfigure
+	// tells us whether target was rebuilt. Phrased to survive the upcoming
+	// Reconfigure->rebuild change (identity, not reconfigure counts).
+	currentTargetID := func() any {
+		targetRes, err := lr.ResourceByName(targetName)
+		test.That(t, err, test.ShouldBeNil)
+		resp, err := targetRes.DoCommand(ctx, map[string]any{"probe": "id"})
+		test.That(t, err, test.ShouldBeNil)
+		return resp["instance_id"]
+	}
+
 	lr.Reconfigure(ctx, &cfg)
 	assertTopHolderReachesCurrentTarget("initial")
+	targetIDInitial := currentTargetID()
 
-	// Push a config change to advance the clock and re-trigger the cascade.
+	// Push an unrelated config change to advance the clock and re-trigger the cascade path.
 	cfg2 := cfg
 	cfg2.Components = append(append([]resource.Config{}, cfg.Components...), resource.Config{
 		Name:                "unrelated-motor",
@@ -2613,5 +2727,103 @@ func TestModularStalePointerCascadeChain(t *testing.T) {
 	})
 	test.That(t, cfg2.Ensure(false, logger), test.ShouldBeNil)
 	lr.Reconfigure(ctx, &cfg2)
+	// The unrelated change leaves target's optional-dep snapshot untouched, so
+	// target is not rebuilt and its instance is identical.
+	test.That(t, currentTargetID(), test.ShouldEqual, targetIDInitial)
 	assertTopHolderReachesCurrentTarget("after-unrelated-change")
+
+	// Force an actual rebuild: change target's opt-dep (Components[0]) in place so
+	// its clock bumps, staling target's snapshot and rebuilding target to a new
+	// instance.
+	targetIDBefore := currentTargetID()
+
+	cfg3 := cfg2
+	cfg3.Components = append([]resource.Config{}, cfg2.Components...)
+	cfg3.Components[0].Attributes = rutils.AttributeMap{"version": 1}
+	test.That(t, cfg3.Ensure(false, logger), test.ShouldBeNil)
+	lr.Reconfigure(ctx, &cfg3)
+
+	// target rebuilt to a new instance because its optional dependency's clock advanced.
+	test.That(t, currentTargetID(), test.ShouldNotEqual, targetIDBefore)
+
+	// The transitive cascade is now meaningfully exercised: top-holder must reach the new
+	// target instance through the freshly rebuilt mid-holder.
+	assertTopHolderReachesCurrentTarget("after-optdep-change")
+}
+
+func TestWeakOptionalDepClocksEqual(t *testing.T) {
+	// Unit tests for the snapshot comparison that gates the weak/optional reconfigure skip.
+	// A nil snapshot means "not yet recorded" and must never compare equal (so a freshly
+	// built resource is always considered for a follow-up update); two non-nil snapshots
+	// are equal iff they have identical key sets and identical clock values.
+	m := motor.Named("m")
+	m1 := motor.Named("m1")
+
+	for _, tc := range []struct {
+		name string
+		a, b map[resource.Name]int64
+		want bool
+	}{
+		{
+			name: "both nil are not equal",
+			a:    nil,
+			b:    nil,
+			want: false,
+		},
+		{
+			name: "nil vs empty is not equal",
+			a:    nil,
+			b:    map[resource.Name]int64{},
+			want: false,
+		},
+		{
+			name: "two empty non-nil snapshots are equal",
+			a:    map[resource.Name]int64{},
+			b:    map[resource.Name]int64{},
+			want: true,
+		},
+		{
+			name: "same single key and value is equal",
+			a:    map[resource.Name]int64{m: 1},
+			b:    map[resource.Name]int64{m: 1},
+			want: true,
+		},
+		{
+			name: "same key, different clock value is not equal",
+			a:    map[resource.Name]int64{m: 1},
+			b:    map[resource.Name]int64{m: 2},
+			want: false,
+		},
+		{
+			name: "same length, different key is not equal",
+			a:    map[resource.Name]int64{m: 1},
+			b:    map[resource.Name]int64{m1: 1},
+			want: false,
+		},
+		{
+			name: "differing length (extra key) is not equal",
+			a:    map[resource.Name]int64{m: 1},
+			b:    map[resource.Name]int64{m: 1, m1: 2},
+			want: false,
+		},
+		{
+			name: "multiple identical keys and values is equal",
+			a:    map[resource.Name]int64{m: 1, m1: 2},
+			b:    map[resource.Name]int64{m: 1, m1: 2},
+			want: true,
+		},
+		{
+			name: "multiple keys, one clock value differs is not equal",
+			a:    map[resource.Name]int64{m: 1, m1: 2},
+			b:    map[resource.Name]int64{m: 1, m1: 3},
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			test.That(t, weakOptionalDepClocksEqual(tc.a, tc.b), test.ShouldEqual, tc.want)
+			// The comparison must be symmetric: swapping the arguments must not change the
+			// result.
+			test.That(t, weakOptionalDepClocksEqual(tc.b, tc.a), test.ShouldEqual, tc.want)
+		})
+	}
 }

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -327,6 +327,16 @@ func (manager *resourceManager) updateRemoteResourceNames(
 			}
 		}
 
+		// Call SwapResource to always advance the graph's logical clock.
+		//   - New resource: AddNode above created the node and wired it to the shared logical
+		//     clock, but did not advance the clock. The SwapResource inside
+		//     NewConfiguredGraphNodeWithPrefix ran while the node's clock pointer was still nil,
+		//     so its bump was a no-op.
+		//   - Existing resource: we skipped the block above, so this just swaps in the refreshed
+		//     client and advances the clock.
+		//
+		// The clock advance is what lets a local resource with a weak/optional dependency on this
+		// remote resource be detected as stale by updateWeakAndOptionalDependents.
 		gNode.SwapResource(res, unknownModel, manager.opts.ftdc)
 
 		err = manager.resources.AddChild(resName, remoteName)

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -303,9 +303,7 @@ func (manager *resourceManager) updateRemoteResourceNames(
 			}
 		}
 
-		if nodeAlreadyExists {
-			gNode.SwapResource(res, unknownModel, manager.opts.ftdc)
-		} else {
+		if !nodeAlreadyExists {
 			// Check for a full resource name collision and log an error if there is one.
 			prefixedSimpleName := prefix + resName.Name
 			_, err = manager.resources.FindBySimpleNameAndAPI(prefixedSimpleName, resName.API)
@@ -328,6 +326,8 @@ func (manager *resourceManager) updateRemoteResourceNames(
 				resLogger.CErrorw(ctx, "failed to add remote resource node", "error", err)
 			}
 		}
+
+		gNode.SwapResource(res, unknownModel, manager.opts.ftdc)
 
 		err = manager.resources.AddChild(resName, remoteName)
 		if err != nil {

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -361,6 +361,11 @@ func (manager *resourceManager) updateRemoteResourceNames(
 				"reason", err)
 			continue
 		}
+		// MarkForRemoval bumps the graph's logical clock and transitions the node to
+		// Removing, so any local resource with a weak/optional dependency on this
+		// dropped remote resource is detected as stale by updateWeakAndOptionalDependents
+		// on the next pass. Close then clears `current` and shuts down the gRPC client.
+		gNode.MarkForRemoval()
 		if err := gNode.Close(ctx); err != nil {
 			resLogger.CErrorw(ctx,
 				"failed to close remote resource node",

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -1105,7 +1105,7 @@ func (manager *resourceManager) processResource(
 	}
 
 	resName := conf.ResourceName()
-	deps, err := lr.getDependencies(resName, gNode)
+	deps, weakOptionalSnapshot, err := lr.getDependenciesWithWeakOptionalSnapshot(resName, gNode)
 	if err != nil {
 		manager.logger.CDebugw(ctx,
 			"failed to get dependencies for existing resource during reconfiguration, closing and removing resource from graph node",
@@ -1124,11 +1124,13 @@ func (manager *resourceManager) processResource(
 			}
 			// For modular resources, `currentRes` is a client object. Call reconfigure to clear caches.
 			goutils.UncheckedError(currentRes.Reconfigure(ctx, deps, conf))
+			gNode.SetLastWeakOptionalDepsClocks(weakOptionalSnapshot)
 			return currentRes, false, nil
 		}
 
 		err = currentRes.Reconfigure(ctx, deps, conf)
 		if err == nil {
+			gNode.SetLastWeakOptionalDepsClocks(weakOptionalSnapshot)
 			return currentRes, false, nil
 		}
 

--- a/robot/impl/robot_reconfigure_weak_dependencies_test.go
+++ b/robot/impl/robot_reconfigure_weak_dependencies_test.go
@@ -20,6 +20,7 @@ import (
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
 	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/components/sensor"
+
 	// register fake sensor (model rdk:builtin:fake)
 	_ "go.viam.com/rdk/components/sensor/fake"
 	"go.viam.com/rdk/config"
@@ -767,9 +768,15 @@ func TestWeakReconfigureFailureMarksUnhealthy(t *testing.T) {
 }
 
 // TestOptionalReconfigureFailureAndRecovery exercises the modular path
-// end-to-end with the singleton-sensor module: the first weak/optional
-// rebuild fails on a lock conflict, the framework marks the node
-// Unhealthy, and a subsequent worker tick reconstructs it successfully.
+// end-to-end with the singleton-sensor module: bringing up an optional
+// dependency fires a weak/optional rebuild that fails on a lock conflict,
+// the framework marks the node Unhealthy, and a subsequent worker tick
+// reconstructs it successfully.
+//
+// The robot starts with mysensor alone so its first construction resolves
+// no optional dependency. Adding "opt" in a later reconfigure introduces a
+// genuine delta in mysensor's resolved optional set, which is what drives
+// the weak/optional reconfigure path.
 func TestOptionalReconfigureFailureAndRecovery(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
@@ -780,17 +787,40 @@ func TestOptionalReconfigureFailureAndRecovery(t *testing.T) {
 	singletonModel := resource.NewModel("viam-test", "demo", "singleton-sensor")
 	mySensor := sensor.Named("mysensor")
 
+	mySensorCfg := resource.Config{
+		Name:       mySensor.Name,
+		API:        sensor.API,
+		Model:      singletonModel,
+		Attributes: rutils.AttributeMap{"lock_path": lockPath},
+	}
+
 	cfg := &config.Config{
 		Modules: []config.Module{
 			{Name: "singletonsensor", ExePath: modulePath},
 		},
+		Components: []resource.Config{mySensorCfg},
+	}
+	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
+
+	robot := setupLocalRobot(t, ctx, cfg, logger)
+
+	// With no optional dependency present, the first construction succeeds and
+	// writes the lock file. mysensor's resolved optional set is empty, so the
+	// weak/optional update has nothing to act on yet.
+	_, err := robot.ResourceByName(mySensor)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Bringing up "opt" adds a key to mysensor's resolved optional set. That
+	// delta drives the weak/optional update, which rebuilds mysensor; the
+	// rebuild hits the still-present lock and fails. The "lock present at"
+	// string is singleton-sensor-only, so matching it confirms the failure
+	// came from the rebuild path.
+	cfgWithOpt := &config.Config{
+		Modules: []config.Module{
+			{Name: "singletonsensor", ExePath: modulePath},
+		},
 		Components: []resource.Config{
-			{
-				Name:       mySensor.Name,
-				API:        sensor.API,
-				Model:      singletonModel,
-				Attributes: rutils.AttributeMap{"lock_path": lockPath},
-			},
+			mySensorCfg,
 			{
 				Name:  "opt",
 				API:   sensor.API,
@@ -798,15 +828,10 @@ func TestOptionalReconfigureFailureAndRecovery(t *testing.T) {
 			},
 		},
 	}
-	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
+	test.That(t, cfgWithOpt.Ensure(false, logger), test.ShouldBeNil)
+	robot.Reconfigure(ctx, cfgWithOpt)
 
-	robot := setupLocalRobot(t, ctx, cfg, logger)
-
-	// setupLocalRobot runs the weak/optional update at the end of
-	// completeConfig, which fires the rebuild that fails on the still-
-	// present lock. The "lock present at" string is singleton-sensor-only,
-	// so matching it confirms the failure came from the rebuild path.
-	_, err := robot.ResourceByName(mySensor)
+	_, err = robot.ResourceByName(mySensor)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "lock present at")
 

--- a/robot/impl/robot_reconfigure_weak_dependencies_test.go
+++ b/robot/impl/robot_reconfigure_weak_dependencies_test.go
@@ -26,6 +26,7 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	rtestutils "go.viam.com/rdk/testutils"
+	"go.viam.com/rdk/testutils/robottestutils"
 	rutils "go.viam.com/rdk/utils"
 )
 
@@ -871,4 +872,93 @@ func TestOptionalReconfigureFailureAndRecovery(t *testing.T) {
 		_, err := s.Readings(callCtx, nil)
 		test.That(tb, err, test.ShouldBeNil)
 	})
+}
+
+// TestWeakDependencyOnNewRemoteResource verifies that a local resource with a weak
+// dependency is reconfigured to pick up a resource that appears on a remote after
+// initial construction.
+func TestWeakDependencyOnNewRemoteResource(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	ctx := context.Background()
+
+	// Remote robot starts with no components.
+	remoteCfg := &config.Config{}
+	test.That(t, remoteCfg.Ensure(false, logger), test.ShouldBeNil)
+	remoteRobot := setupLocalRobot(t, ctx, remoteCfg, logger.Sublogger("remote"))
+
+	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
+	test.That(t, remoteRobot.StartWeb(ctx, options), test.ShouldBeNil)
+
+	// Register a weak-dependency resource that weakly depends on every component.
+	weakAPI := resource.NewAPI(uuid.NewString(), "component", "weak")
+	weakModel := resource.DefaultModelFamily.WithModel(utils.RandomAlphaString(5))
+	weak1Name := resource.NewName(weakAPI, "weak1")
+	resource.Register(weakAPI, weakModel,
+		resource.Registration[*someTypeWithWeakAndStrongDeps, *someTypeWithWeakAndStrongDepsConfig]{
+			Constructor: func(_ context.Context, deps resource.Dependencies, conf resource.Config, _ logging.Logger,
+			) (*someTypeWithWeakAndStrongDeps, error) {
+				return &someTypeWithWeakAndStrongDeps{Named: conf.ResourceName().AsNamed(), resources: deps}, nil
+			},
+			WeakDependencies: []resource.Matcher{resource.TypeMatcher{Type: resource.APITypeComponentName}},
+		})
+	defer resource.Deregister(weakAPI, weakModel)
+
+	// Main robot: weak1 plus a connection to the (currently empty) remote.
+	mainCfg := &config.Config{
+		Components: []resource.Config{
+			{
+				Name:                weak1Name.Name,
+				API:                 weakAPI,
+				Model:               weakModel,
+				ConvertedAttributes: &someTypeWithWeakAndStrongDepsConfig{},
+			},
+		},
+		Remotes: []config.Remote{{Name: "foo", Address: addr}},
+	}
+	test.That(t, mainCfg.Ensure(false, logger), test.ShouldBeNil)
+	mainRobot := setupLocalRobot(t, ctx, mainCfg, logger.Sublogger("main"))
+
+	remoteBaseName := base.Named("remotebase")
+
+	// weak1 came up with an empty weak set: the remote has no components yet.
+	res, err := mainRobot.ResourceByName(weak1Name)
+	test.That(t, err, test.ShouldBeNil)
+	weak1, err := resource.AsType[*someTypeWithWeakAndStrongDeps](res)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, weak1.resources, test.ShouldNotContainKey, remoteBaseName)
+
+	// Add a base to the remote after the fact.
+	newRemoteCfg := &config.Config{
+		Components: []resource.Config{
+			{Name: remoteBaseName.Name, API: base.API, Model: fake.Model},
+		},
+	}
+	test.That(t, newRemoteCfg.Ensure(false, logger), test.ShouldBeNil)
+	remoteRobot.Reconfigure(ctx, newRemoteCfg)
+
+	lr := mainRobot.(*localRobot)
+
+	// Wait until the main robot's remote client has discovered the new resource and
+	// added it to the graph, driving the remote-update path each iteration.
+	prefixedName := base.Named("foo:remotebase")
+	testutils.WaitForAssertionWithSleep(t, time.Second, 30, func(tb testing.TB) {
+		tb.Helper()
+		lr.updateRemotesAndRetryResourceConfigure()
+		_, err := mainRobot.ResourceByName(prefixedName)
+		test.That(tb, err, test.ShouldBeNil)
+	})
+
+	// Sanity check: the remote resource is genuinely available on the main robot.
+	_, err = mainRobot.ResourceByName(prefixedName)
+	test.That(t, err, test.ShouldBeNil)
+
+	// The new remote resource matches weak1's component matcher, so a weak/optional
+	// update should reconfigure weak1 to include it. If adding the remote node didn't
+	// bump the clock and the round-counter short-circuited the update, weak1 will not
+	// have picked it up and this assertion fails.
+	res, err = mainRobot.ResourceByName(weak1Name)
+	test.That(t, err, test.ShouldBeNil)
+	weak1, err = resource.AsType[*someTypeWithWeakAndStrongDeps](res)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, weak1.resources, test.ShouldContainKey, remoteBaseName)
 }

--- a/robot/impl/robot_reconfigure_weak_dependencies_test.go
+++ b/robot/impl/robot_reconfigure_weak_dependencies_test.go
@@ -207,9 +207,10 @@ func TestUpdateWeakDependents(t *testing.T) {
 	weakCfg4 := config.Config{
 		Components: []resource.Config{
 			{
-				Name:  weak1Name.Name,
-				API:   weakAPI,
-				Model: weakModel,
+				Name:                weak1Name.Name,
+				API:                 weakAPI,
+				Model:               weakModel,
+				ConvertedAttributes: &someTypeWithWeakAndStrongDepsConfig{},
 			},
 			{
 				Name:  base1Name.Name,

--- a/robot/impl/robot_reconfigure_weak_dependencies_test.go
+++ b/robot/impl/robot_reconfigure_weak_dependencies_test.go
@@ -201,6 +201,37 @@ func TestUpdateWeakDependents(t *testing.T) {
 	// reconfigures it exactly once.
 	test.That(t, weak1.reconfigCount, test.ShouldEqual, prevReconfigCount+1)
 
+	// Reconfigure removing arm1 while weak1 and base1 stay. weak1 survives but its
+	// resolved weak set shrinks back to just base1 so updateWeakAndOptionalDependents
+	// reconfigures weak1 exactly once. This is the subtractive mirror of adding arm1 above.
+	weakCfg4 := config.Config{
+		Components: []resource.Config{
+			{
+				Name:  weak1Name.Name,
+				API:   weakAPI,
+				Model: weakModel,
+			},
+			{
+				Name:  base1Name.Name,
+				API:   base.API,
+				Model: fake.Model,
+			},
+		},
+	}
+	test.That(t, weakCfg4.Ensure(false, logger), test.ShouldBeNil)
+	prevReconfigCount = weak1.reconfigCount
+	robot.Reconfigure(context.Background(), &weakCfg4)
+
+	weakRes, err = robot.ResourceByName(weak1Name)
+	test.That(t, err, test.ShouldBeNil)
+	weak1, err = resource.AsType[*someTypeWithWeakAndStrongDeps](weakRes)
+	test.That(t, err, test.ShouldBeNil)
+	// arm1 dropped out of the resolved weak set; base1 remains.
+	test.That(t, weak1.resources, test.ShouldHaveLength, 1)
+	test.That(t, weak1.resources, test.ShouldContainKey, base1Name)
+	test.That(t, weak1.resources, test.ShouldNotContainKey, arm1Name)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, prevReconfigCount+1)
+
 	base2Name := base.Named("base2")
 	weakCfg5 := config.Config{
 		Components: []resource.Config{

--- a/robot/impl/robot_reconfigure_weak_dependencies_test.go
+++ b/robot/impl/robot_reconfigure_weak_dependencies_test.go
@@ -157,7 +157,10 @@ func TestUpdateWeakDependents(t *testing.T) {
 	// Assert that the weak dependency was tracked.
 	test.That(t, weak1.resources, test.ShouldHaveLength, 1)
 	test.That(t, weak1.resources, test.ShouldContainKey, base1Name)
-	test.That(t, weak1.reconfigCount, test.ShouldEqual, 1)
+	// reconfigCount is 0 if construction already saw base1 (snapshot stable,
+	// updateWeakAndOptionalDependents skips), or 1 if construction did not see base1
+	// and the follow-up reconfigure picked it up.
+	test.That(t, weak1.reconfigCount, test.ShouldBeIn, []int{0, 1})
 
 	// Reconfigure again with a new third `arm` component.
 	arm1Name := arm.Named("arm1")
@@ -193,7 +196,9 @@ func TestUpdateWeakDependents(t *testing.T) {
 	test.That(t, weak1.resources, test.ShouldHaveLength, 2)
 	test.That(t, weak1.resources, test.ShouldContainKey, base1Name)
 	test.That(t, weak1.resources, test.ShouldContainKey, arm1Name)
-	test.That(t, weak1.reconfigCount, test.ShouldEqual, 2)
+	// Adding arm1 changes weak1's resolved weak-dep set, so updateWeakAndOptionalDependents
+	// reconfigures it: previous count + 1.
+	test.That(t, weak1.reconfigCount, test.ShouldBeIn, []int{1, 2})
 
 	base2Name := base.Named("base2")
 	weakCfg5 := config.Config{
@@ -229,7 +234,7 @@ func TestUpdateWeakDependents(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "not initialized")
 	// reconfigCount will not increment as the error happens before Reconfigure is called on the resource.
-	test.That(t, weak1.reconfigCount, test.ShouldEqual, 2)
+	test.That(t, weak1.reconfigCount, test.ShouldBeIn, []int{1, 2})
 
 	weakCfg6 := config.Config{
 		Components: []resource.Config{
@@ -263,8 +268,10 @@ func TestUpdateWeakDependents(t *testing.T) {
 	test.That(t, weak1.resources, test.ShouldHaveLength, 2)
 	test.That(t, weak1.resources, test.ShouldContainKey, base1Name)
 	test.That(t, weak1.resources, test.ShouldContainKey, base2Name)
-	// reconfigCount will reset as the resource was destroyed after the previous configuration failure.
-	test.That(t, weak1.reconfigCount, test.ShouldEqual, 1)
+	// reconfigCount will reset as the resource was destroyed after the previous
+	// configuration failure. The new instance reconfigures 0 times if construction
+	// already saw both bases, or 1 time if it did not.
+	test.That(t, weak1.reconfigCount, test.ShouldBeIn, []int{0, 1})
 
 	weakCfg7 := config.Config{
 		Components: []resource.Config{
@@ -300,7 +307,9 @@ func TestUpdateWeakDependents(t *testing.T) {
 	test.That(t, weak1.resources, test.ShouldHaveLength, 2)
 	test.That(t, weak1.resources, test.ShouldContainKey, base1Name)
 	test.That(t, weak1.resources, test.ShouldContainKey, base2Name)
-	test.That(t, weak1.reconfigCount, test.ShouldEqual, 3)
+	// In-place Reconfigure for the config change adds +1; the subsequent
+	// updateWeakAndOptionalDependents pass sees an unchanged dep set and skips.
+	test.That(t, weak1.reconfigCount, test.ShouldBeIn, []int{1, 2})
 }
 
 func TestWeakDependentsExplicitDependency(t *testing.T) {
@@ -577,7 +586,11 @@ func TestWeakDependentsDependedOn(t *testing.T) {
 	// Assert that the weak dependency was tracked.
 	test.That(t, weak1.resources, test.ShouldHaveLength, 2)
 	test.That(t, weak1.resources, test.ShouldContainKey, base1Name)
-	test.That(t, weak1.reconfigCount, test.ShouldEqual, 2)
+	// updateWeakAndOptionalDependents fires once at the level where base1 (which
+	// explicitly depends on weak1) is built. After that the resolved weak-dep set
+	// includes base1, base2, motion; the post-levels pass sees the same set and skips.
+	// Construction may or may not have seen base2 before that, giving 1 or 2 reconfigures.
+	test.That(t, weak1.reconfigCount, test.ShouldBeIn, []int{1, 2})
 
 	lRobot := robot.(*localRobot)
 	test.That(t, lRobot.lastWeakAndOptionalDependentsRound.Load(), test.ShouldEqual, 3)
@@ -607,6 +620,7 @@ func TestWeakDependentsDependedOn(t *testing.T) {
 	//    will be updated to 5.
 
 	t.Log("Reconfigure base1")
+	prevReconfigCount := weak1.reconfigCount
 	weakCfg.Components[1].Attributes = rutils.AttributeMap{"version": 1}
 	robot.Reconfigure(context.Background(), &weakCfg)
 
@@ -614,7 +628,9 @@ func TestWeakDependentsDependedOn(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	weak1, err = resource.AsType[*someTypeWithWeakAndStrongDeps](weakRes)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, weak1.reconfigCount, test.ShouldEqual, 3)
+	// base1 rebuilds, advancing its graph clock; updateWeakAndOptionalDependents
+	// sees that weak1's snapshot of base1's clock is stale and reconfigures weak1.
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, prevReconfigCount+1)
 
 	test.That(t, lRobot.lastWeakAndOptionalDependentsRound.Load(), test.ShouldEqual, 4)
 
@@ -641,6 +657,7 @@ func TestWeakDependentsDependedOn(t *testing.T) {
 	//    weak1 will be reconfigured (to increase weak1.reconfigCount to 4) and `lastWeakDependentsRound`
 	//    will be updated to 6.
 	t.Log("Reconfigure base2")
+	prevReconfigCount = weak1.reconfigCount
 	weakCfg.Components[2].Attributes = rutils.AttributeMap{"version": 1}
 	robot.Reconfigure(context.Background(), &weakCfg)
 
@@ -648,21 +665,24 @@ func TestWeakDependentsDependedOn(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	weak1, err = resource.AsType[*someTypeWithWeakAndStrongDeps](weakRes)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, weak1.reconfigCount, test.ShouldEqual, 4)
+	// base2 rebuilds, advancing its graph clock; updateWeakAndOptionalDependents
+	// reconfigures weak1 again.
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, prevReconfigCount+1)
 
 	test.That(t, lRobot.lastWeakAndOptionalDependentsRound.Load(), test.ShouldEqual, 5)
 
 	// check that calling getDependencies for either weak1 or base1 does not have side effects
 	// such as calling `updateWeakDependents` and changing weak1.reconfigCount
+	postReconfigCount := weak1.reconfigCount
 	node, ok := lRobot.manager.resources.Node(weak1Name)
 	test.That(t, ok, test.ShouldBeTrue)
 	lRobot.getDependencies(weak1Name, node)
-	test.That(t, weak1.reconfigCount, test.ShouldEqual, 4)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, postReconfigCount)
 
 	node, ok = lRobot.manager.resources.Node(base1Name)
 	test.That(t, ok, test.ShouldBeTrue)
 	lRobot.getDependencies(base1Name, node)
-	test.That(t, weak1.reconfigCount, test.ShouldEqual, 4)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, postReconfigCount)
 }
 
 // TestWeakReconfigureFailureMarksUnhealthy verifies the framework marks a

--- a/robot/impl/robot_reconfigure_weak_dependencies_test.go
+++ b/robot/impl/robot_reconfigure_weak_dependencies_test.go
@@ -186,6 +186,7 @@ func TestUpdateWeakDependents(t *testing.T) {
 		},
 	}
 	test.That(t, weakCfg3.Ensure(false, logger), test.ShouldBeNil)
+	prevReconfigCount := weak1.reconfigCount
 	robot.Reconfigure(context.Background(), &weakCfg3)
 
 	weakRes, err = robot.ResourceByName(weak1Name)
@@ -197,8 +198,8 @@ func TestUpdateWeakDependents(t *testing.T) {
 	test.That(t, weak1.resources, test.ShouldContainKey, base1Name)
 	test.That(t, weak1.resources, test.ShouldContainKey, arm1Name)
 	// Adding arm1 changes weak1's resolved weak-dep set, so updateWeakAndOptionalDependents
-	// reconfigures it: previous count + 1.
-	test.That(t, weak1.reconfigCount, test.ShouldBeIn, []int{1, 2})
+	// reconfigures it exactly once.
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, prevReconfigCount+1)
 
 	base2Name := base.Named("base2")
 	weakCfg5 := config.Config{
@@ -228,13 +229,14 @@ func TestUpdateWeakDependents(t *testing.T) {
 		},
 	}
 	test.That(t, weakCfg5.Ensure(false, logger), test.ShouldBeNil)
+	prevReconfigCount = weak1.reconfigCount
 	robot.Reconfigure(context.Background(), &weakCfg5)
 
 	_, err = robot.ResourceByName(weak1Name)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "not initialized")
-	// reconfigCount will not increment as the error happens before Reconfigure is called on the resource.
-	test.That(t, weak1.reconfigCount, test.ShouldBeIn, []int{1, 2})
+	// reconfigCount does not change: the error happens before Reconfigure is called on the resource.
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, prevReconfigCount)
 
 	weakCfg6 := config.Config{
 		Components: []resource.Config{
@@ -298,6 +300,7 @@ func TestUpdateWeakDependents(t *testing.T) {
 		},
 	}
 	test.That(t, weakCfg7.Ensure(false, logger), test.ShouldBeNil)
+	prevReconfigCount = weak1.reconfigCount
 	robot.Reconfigure(context.Background(), &weakCfg7)
 
 	weakRes, err = robot.ResourceByName(weak1Name)
@@ -307,9 +310,9 @@ func TestUpdateWeakDependents(t *testing.T) {
 	test.That(t, weak1.resources, test.ShouldHaveLength, 2)
 	test.That(t, weak1.resources, test.ShouldContainKey, base1Name)
 	test.That(t, weak1.resources, test.ShouldContainKey, base2Name)
-	// In-place Reconfigure for the config change adds +1; the subsequent
+	// In-place Reconfigure for the config change adds exactly one; the subsequent
 	// updateWeakAndOptionalDependents pass sees an unchanged dep set and skips.
-	test.That(t, weak1.reconfigCount, test.ShouldBeIn, []int{1, 2})
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, prevReconfigCount+1)
 }
 
 func TestWeakDependentsExplicitDependency(t *testing.T) {
@@ -401,7 +404,10 @@ func TestWeakDependentsExplicitDependency(t *testing.T) {
 	// Assert that the weak dependency was tracked.
 	test.That(t, weak1.resources, test.ShouldHaveLength, 2)
 	test.That(t, weak1.resources, test.ShouldContainKey, base1Name)
-	test.That(t, weak1.reconfigCount, test.ShouldEqual, 1)
+	// 0 if construction already saw base1, base2, and motion (snapshot stable so the
+	// post-levels updateWeakAndOptionalDependents skips); 1 if construction did not see
+	// all of them and the follow-up pass picked up the rest.
+	test.That(t, weak1.reconfigCount, test.ShouldBeIn, []int{0, 1})
 
 	lRobot := robot.(*localRobot)
 	test.That(t, lRobot.lastWeakAndOptionalDependentsRound.Load(), test.ShouldEqual, 3)
@@ -436,6 +442,7 @@ func TestWeakDependentsExplicitDependency(t *testing.T) {
 	//    weak1 will be reconfigured (to increase weak1.reconfigCount to 2) and `lastWeakDependentsRound`
 	//    will be updated to 5.
 	t.Log("Reconfigure base1")
+	prevReconfigCount := weak1.reconfigCount
 	weakCfg.Components[1].Attributes = rutils.AttributeMap{"version": 1}
 	robot.Reconfigure(context.Background(), &weakCfg)
 
@@ -443,7 +450,9 @@ func TestWeakDependentsExplicitDependency(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	weak1, err = resource.AsType[*someTypeWithWeakAndStrongDeps](weakRes)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, weak1.reconfigCount, test.ShouldEqual, 2)
+	// base1 rebuilds, advancing its graph clock; updateWeakAndOptionalDependents
+	// sees a stale snapshot for base1 and reconfigures weak1 exactly once.
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, prevReconfigCount+1)
 
 	test.That(t, lRobot.lastWeakAndOptionalDependentsRound.Load(), test.ShouldEqual, 4)
 
@@ -470,6 +479,7 @@ func TestWeakDependentsExplicitDependency(t *testing.T) {
 	//    weak1 will be reconfigured (to increase weak1.reconfigCount to 3) and `lastWeakDependentsRound`
 	//    will be updated to 6.
 	t.Log("Reconfigure base2")
+	prevReconfigCount = weak1.reconfigCount
 	weakCfg.Components[2].Attributes = rutils.AttributeMap{"version": 1}
 	robot.Reconfigure(context.Background(), &weakCfg)
 
@@ -477,21 +487,24 @@ func TestWeakDependentsExplicitDependency(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	weak1, err = resource.AsType[*someTypeWithWeakAndStrongDeps](weakRes)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, weak1.reconfigCount, test.ShouldEqual, 3)
+	// base2 rebuilds, advancing its graph clock; updateWeakAndOptionalDependents
+	// reconfigures weak1 exactly once more.
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, prevReconfigCount+1)
 
 	test.That(t, lRobot.lastWeakAndOptionalDependentsRound.Load(), test.ShouldEqual, 5)
 
 	// check that calling getDependencies for either weak1 or base1 does not have side effects
 	// such as calling `updateWeakDependents` and changing weak1.reconfigCount
+	postReconfigCount := weak1.reconfigCount
 	node, ok := lRobot.manager.resources.Node(weak1Name)
 	test.That(t, ok, test.ShouldBeTrue)
 	lRobot.getDependencies(weak1Name, node)
-	test.That(t, weak1.reconfigCount, test.ShouldEqual, 3)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, postReconfigCount)
 
 	node, ok = lRobot.manager.resources.Node(base1Name)
 	test.That(t, ok, test.ShouldBeTrue)
 	lRobot.getDependencies(base1Name, node)
-	test.That(t, weak1.reconfigCount, test.ShouldEqual, 3)
+	test.That(t, weak1.reconfigCount, test.ShouldEqual, postReconfigCount)
 }
 
 func TestWeakDependentsDependedOn(t *testing.T) {

--- a/robot/impl/robot_reconfigure_weak_dependencies_test.go
+++ b/robot/impl/robot_reconfigure_weak_dependencies_test.go
@@ -948,10 +948,6 @@ func TestWeakDependencyOnNewRemoteResource(t *testing.T) {
 		test.That(tb, err, test.ShouldBeNil)
 	})
 
-	// Sanity check: the remote resource is genuinely available on the main robot.
-	_, err = mainRobot.ResourceByName(prefixedName)
-	test.That(t, err, test.ShouldBeNil)
-
 	// The new remote resource matches weak1's component matcher, so a weak/optional
 	// update should reconfigure weak1 to include it. If adding the remote node didn't
 	// bump the clock and the round-counter short-circuited the update, weak1 will not

--- a/robot/impl/robot_reconfigure_weak_dependencies_test.go
+++ b/robot/impl/robot_reconfigure_weak_dependencies_test.go
@@ -20,7 +20,6 @@ import (
 	// TODO(RSDK-7884): change everything that depends on this import to a mock.
 	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/components/sensor"
-
 	// register fake sensor (model rdk:builtin:fake)
 	_ "go.viam.com/rdk/components/sensor/fake"
 	"go.viam.com/rdk/config"
@@ -751,17 +750,37 @@ func TestWeakReconfigureFailureMarksUnhealthy(t *testing.T) {
 
 	// weak1 has no ConvertedAttributes, so its Reconfigure returns a
 	// NativeConfig error when the weak/optional update fires.
+	//
+	// weak1 starts alone so its construction resolves an empty weak set (weak
+	// dependencies impose no construction ordering, so a config with base1
+	// present from the start would race: if base1 built first, weak1's weak set
+	// would already be stable at construction and the no-delta update would be
+	// skipped). Bringing up base1 in a later reconfigure deterministically adds
+	// a key to weak1's resolved weak set; that delta drives the weak/optional
+	// update, which calls weak1.Reconfigure, fails, and marks weak1 Unhealthy.
+	weak1Cfg := resource.Config{Name: weak1Name.Name, API: weakAPI, Model: weakModel}
 	cfg := config.Config{
-		Components: []resource.Config{
-			{Name: weak1Name.Name, API: weakAPI, Model: weakModel},
-			{Name: "base1", API: base.API, Model: fake.Model},
-		},
+		Components: []resource.Config{weak1Cfg},
 	}
 	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
 
 	robot := setupLocalRobot(t, context.Background(), &cfg, logger)
 
+	// With no other component present, weak1's weak set is empty and its
+	// construction succeeds.
 	_, err := robot.ResourceByName(weak1Name)
+	test.That(t, err, test.ShouldBeNil)
+
+	cfgWithBase := config.Config{
+		Components: []resource.Config{
+			weak1Cfg,
+			{Name: "base1", API: base.API, Model: fake.Model},
+		},
+	}
+	test.That(t, cfgWithBase.Ensure(false, logger), test.ShouldBeNil)
+	robot.Reconfigure(context.Background(), &cfgWithBase)
+
+	_, err = robot.ResourceByName(weak1Name)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring,
 		"failed to reconfigure resource during weak/optional dependencies update")


### PR DESCRIPTION
## Summary

[RSDK-13417](https://viam.atlassian.net/browse/RSDK-13417) call optional dependency update only when the underlying resources have changed

- `updateWeakAndOptionalDependents` would reconfigure every resource with weak or optional dependencies on every graph-clock advance. That meant a resource like an xArm (which optionally depends on the motion service) would rebuild whenever any unrelated resource changed, even though it's dependencies e.g. motion service was untouched (which would similarly always rebuild; now will only rebuild if one of its matcher dependencies has changed). 
- Now we track a per-`GraphNode` snapshot of `{depName -> dep's UpdatedAt}` captured at construction and after each successful reconfigure. On subsequent passes, recompute the snapshot and skip the `updateWeakAndOptionalDependents` call when keys and clock values match.
- The snapshot is built in the same pass as dependency resolution (`getDependenciesWithWeakOptionalSnapshot` / `getOptionalDependenciesAndSnapshot` / `getWeakDependenciesAndSnapshot`), so it reflects exactly what was passed to the resource.

## Correctness
The optimized/skipped weak/optional dependents reconfigure path depends on the following invariant holding true:

 If `foo`'s resolved weak/optional dependency set "meaningfully changes," warranting a reconfigure/rebuild, either (a) some dependencies `GraphNode.UpdatedAt` bumps, or (b) a key appears/disappears in `foo`'s resolved set.

A map of `{ResourceName → UpdatedAt}` allows us to track both (a) and (b), so correctness depends on verifying that (a) holds when a weak/optional dependency set reconfigures/rebuilds/ changes availability and that dependency resolution faithfully tracks the resolved dependency set for (b). 

The code in this PR does not meaningfully change graph logical clock bump sites or dependency resolution logic, so we just need to verify existing behavior is correct. Spurious bumps or dependency resolutions are not ideal, but do not affect correctness since they just result in extra reconfigures. We just need to verify that (1) there are no instances where a resource rebuilds/reconfigures/changes availability and does not bump the clock, and (2) no resources are missed by dependency resolution.

(1)  Graph Logical Clock Updates

There are only 3 `GraphNode` methods that bump the clock: `SwapResource`, `MarkForRemoval`, and `LogAndSetLastError`.  We must verify that other methods that change the underlying resource or access to it eventually bump the clock through these methods. 

A resource is available iff it can be returned from `GraphNode.Resource` implying `State != Removing && lastErr == nil && current != nil`

The `GraphNode` methods that change `current`, `State`, or `lastErr` without bumping the clock in production use cases are: 
1. `UnsetResource` called by `SetNeedsRebuild` and `closeAndUnsetResource`
* `closeAndUnsetResource`
    * `resource_manager.go:1116` —`processResource` failure branch when `getDependenciesWithWeakOptionalSnapshot` errors. Returned to the caller at `resource_manager.go:804` with a non-nil error, which falls through to `gNode.LogAndSetLastError(...)` at `resource_manager.go:815`. Bumps clock. 
    * `resource_manager.go:1152` — rebuild branch when the model changed or `Reconfigure` returned `MustRebuildError`. After `closeAndUnsetResource` the code calls `lr.newResource(ctx, gNode, conf)`. On success, the caller at `resource_manager.go:830` runs `gNode.SwapResource(newRes, ...)`. On failure, control returns to the same caller, which hits `gNode.LogAndSetLastError(...)` at `resource_manager.go:815`. Bumps either way.
* `SetNeedsRebuild`
    *  `markRebuildResources` at `resource_manager.go:1486`. After `SetNeedsRebuild`, the node has `current == nil && state == Configuring`, and the clock is unmoved. The next `completeConfig` pass picks the node up (it's in `Configuring` state) and ends in either `SwapResource` at `resource_manager.go:830` or `LogAndSetLastError` at `:815`. Bumps. If `updateWeakAndOptionalDependents` happens to run between `markRebuildResources` and the rebuild because some other node's clock was bumped in the meantime, `foo`'s snapshot computation will drop the temporarily-unavailable dependency, foo will reconfigure once now, and again when the rebuild bumps. Correct but possible extra reconfigure.
2. `Close`
* `resource_manager.go:298` — inside `updateRemoteResourceNames`. Only reached when `recreateAllClients=true`. After this Close, control falls through to `resource_manager.go:306` where `if nodeAlreadyExists { gNode.SwapResource(res, ...) }` runs unconditionally. Bumps. 
*  `resource_manager.go:364` — when a remote stops advertising a previously-known resource. Now paired with `gNode.MarkForRemoval()` immediately before the Close
* `resource_graph.go:684` — inside `Graph.RemoveMarked`. For each node in the graph that has `MarkedForRemoval() == true` (set earlier by MarkForRemoval, which already bumped the clock), wraps `rNode.Close` in a `CloseOnlyResource` and appends it to `toClose`, which the caller uses to close the resource.
* `resource_manager.go:1459` — inside `markRemoved`. For each removed name, appends `resNode.Close` wrapped in `CloseOnlyResource` to `resourcesToCloseBeforeComplete` and then calls `resNode.MarkForRemoval()`.
3. `replace`
* Only invoked from `addNode` at `resource_graph.go:540`, guarded by `!val.IsUninitialized()` so the replaced node always has `current == nil` before replace runs. Every constructor handed in by production callers is a brand new node. No bump but no resource exists yet.

(2) Dependency Resolution

The snapshot and dependency map are built in lockstep inside `getOptionalDependenciesAndSnapshot` (`local_robot.go:806-881`) and `getWeakDependenciesAndSnapshot` (`local_robot.go:906-941`). We need to show that any name that ends up in `foo`'s dependency map must also end up in `foo`'s snapshot under the same key, and any name that's skipped from dependencies must also be skipped from the snapshot. The three properties that prove this are:

1. One lookup decides inclusion. A single `FindBySimpleNameAndAPI` resolves to either a `*GraphNode` or an error. The error path continues before either map is touched, so both maps are skipped together. The success path falls through to the writes, so both maps are written together.
2. The two writes share the node pointer. `res` and `UpdatedAt()` are read off the same `*GraphNode variable`, under the node's internal lock. They cannot disagree about which node was found because there's only one node value in scope.
3. The key into both maps is the same. `popped` (or `resolvedOptionalDepName` in the optional path) is computed once before the writes; both maps are indexed by it. So presence-in-deps ⇔ presence-in-snapshot.

Together: a name is in weak/opt dependencies iff `FindBySimpleNameAndAPI` resolved and `node.Resource()` succeeded, and the same condition is iff for the snapshot. The two key sets are identical by construction satisfying (b).

## Test plan

- [x] Updated optional-dependency test assertions in `robot/impl/optional_dependencies_test.go` to reflect the new reconfigure counts; verified passing with `-race -count=2`
- [x] Updated weak-dependency test assertions in `robot/impl/robot_reconfigure_weak_dependencies_test.go` and `local_robot_test.go:TestWeakDependenciesWithPrefix`; verified passing with `-count=5`
- [x] Full sweep across `./robot/...`, `./resource/...`, `./config/...` passing
- [x] Deployed to live machine and baked changes to observe and reconfigure irregularities. 

[RSDK-13417]: https://viam.atlassian.net/browse/RSDK-13417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ