### PR TITLE
RSDK-8254 Unskip TestAudioTrackIsNotCreatedForVideoStream

### DIFF
--- a/robot/web/stream/stream_test.go
+++ b/robot/web/stream/stream_test.go
@@ -56,10 +56,6 @@ func setupRealRobot(t *testing.T, robotConfig *config.Config, logger logging.Log
 // same. This test asserts both paths to adding a camera agree on whether to create WebRTC audio
 // tracks.
 func TestAudioTrackIsNotCreatedForVideoStream(t *testing.T) {
-	// Pion has a bug where `PeerConnection.AddTrack` is non-deterministic w.r.t creating a media
-	// track in the SDP due to races in their renegotiation piggy-backing algorithm. This is easy to
-	// reproduce by runnnig the test in a loop.
-	t.Skip("RSDK-7492")
 	logger := logging.NewTestLogger(t).Sublogger("TestWebReconfigure")
 
 	origCfg := &config.Config{Components: []resource.Config{
@@ -172,7 +168,8 @@ func TestAudioTrackIsNotCreatedForVideoStream(t *testing.T) {
 	// Listing the streams now should return both `origCamera` and `newCamera`.
 	listResp, err = livestreamClient.ListStreams(ctx, &streampb.ListStreamsRequest{})
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, listResp.Names, test.ShouldResemble, []string{"origCamera", "newCamera"})
+	test.That(t, listResp.Names, test.ShouldContain, "origCamera")
+	test.That(t, listResp.Names, test.ShouldContain, "newCamera")
 
 	logger.Info("Adding stream `newCamera`")
 	// Call the `AddStream` endpoint to request that the server start streaming video backed by the


### PR DESCRIPTION
RSDK-8254

## What

  - Unskips `TestAudioTrackIsNotCreatedForVideoStream` in `robot/web/stream/stream_test.go`
  - Replaces the `ShouldResemble` assertion on `listResp.Names` with two separate ShouldContain assertions to avoid order-dependence

## Why

The test was previously skipped under RSDK-7492 due to a Pion bug. That bug was allegedly fixed with [this viamrobotics/webrtc release](https://github.com/viamrobotics/webrtc/releases/tag/v3.99.3) which we're now far past in `rdk`.

## Testing

Ran `TestAudioTrackIsNotCreatedForVideoStream` with the race detector enabled 1000 times with no failure.

Description generated by Claude 🤖