### PR TITLE
RSDK-14035 Fix usages of single op manager in built-in motors and bases

### DIFF
--- a/components/base/sensorcontrolled/movestraight.go
+++ b/components/base/sensorcontrolled/movestraight.go
@@ -27,7 +27,6 @@ const (
 func (sb *sensorBase) MoveStraight(
 	ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{},
 ) error {
-	sb.opMgr.CancelRunning(ctx)
 	ctx, done := sb.opMgr.New(ctx)
 	defer done()
 

--- a/components/base/sensorcontrolled/sensorcontrolled.go
+++ b/components/base/sensorcontrolled/sensorcontrolled.go
@@ -239,7 +239,9 @@ func (sb *sensorBase) Reconfigure(ctx context.Context, deps resource.Dependencie
 func (sb *sensorBase) SetPower(
 	ctx context.Context, linear, angular r3.Vector, extra map[string]interface{},
 ) error {
-	sb.opMgr.CancelRunning(ctx)
+	ctx, finish := sb.opMgr.New(ctx)
+	defer finish()
+
 	if sb.loop != nil {
 		sb.loop.Pause()
 	}
@@ -247,15 +249,17 @@ func (sb *sensorBase) SetPower(
 }
 
 func (sb *sensorBase) Stop(ctx context.Context, extra map[string]interface{}) error {
-	sb.opMgr.CancelRunning(ctx)
+	_, finish := sb.opMgr.New(ctx)
+	defer finish()
+
 	if sb.loop != nil {
 		sb.loop.Pause()
 		// update pid controllers to be an at rest state
-		if err := sb.updateControlConfig(ctx, 0, 0); err != nil {
+		if err := sb.updateControlConfig(context.Background(), 0, 0); err != nil {
 			return err
 		}
 	}
-	return sb.controlledBase.Stop(ctx, extra)
+	return sb.controlledBase.Stop(context.Background(), extra)
 }
 
 func (sb *sensorBase) IsMoving(ctx context.Context) (bool, error) {

--- a/components/base/sensorcontrolled/spin.go
+++ b/components/base/sensorcontrolled/spin.go
@@ -20,7 +20,6 @@ const (
 // any error between the desired degsPerSec and the actual degsPerSec using a PID control loop.
 // Spin also monitors the angleDeg and stops the base when the goal angle is reached.
 func (sb *sensorBase) Spin(ctx context.Context, angleDeg, degsPerSec float64, extra map[string]interface{}) error {
-	sb.opMgr.CancelRunning(ctx)
 	ctx, done := sb.opMgr.New(ctx)
 	defer done()
 

--- a/components/base/sensorcontrolled/velocities.go
+++ b/components/base/sensorcontrolled/velocities.go
@@ -15,7 +15,6 @@ import (
 func (sb *sensorBase) SetVelocity(
 	ctx context.Context, linear, angular r3.Vector, extra map[string]interface{},
 ) error {
-	sb.opMgr.CancelRunning(ctx)
 	ctx, done := sb.opMgr.New(ctx)
 	defer done()
 

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -18,6 +18,7 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/operation"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/utils"
 )
 
 var (
@@ -286,6 +287,9 @@ func checkSpeed(rpm, max float64) (string, error) { //nolint: revive
 // GoFor sets the given direction and an arbitrary power percentage.
 // If rpm is 0, the motor should immediately move to the final position.
 func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
+	ctx, finish := m.OpMgr.New(ctx)
+	defer finish()
+
 	warning, err := checkSpeed(rpm, m.MaxRPM)
 	if warning != "" {
 		m.Logger.CWarn(ctx, warning)
@@ -314,7 +318,7 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 		return err
 	}
 
-	if m.OpMgr.NewTimedWaitOp(ctx, waitDur) {
+	if utils.SelectContextOrWait(ctx, waitDur) {
 		err = m.Stop(ctx, nil)
 		if err != nil {
 			return err
@@ -329,6 +333,9 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 
 // GoTo sets the given direction and an arbitrary power percentage for now.
 func (m *Motor) GoTo(ctx context.Context, rpm, pos float64, extra map[string]interface{}) error {
+	ctx, finish := m.OpMgr.New(ctx)
+	defer finish()
+
 	if m.Encoder == nil {
 		return errors.New("encoder is not defined")
 	}
@@ -359,7 +366,7 @@ func (m *Motor) GoTo(ctx context.Context, rpm, pos float64, extra map[string]int
 		return err
 	}
 
-	if m.OpMgr.NewTimedWaitOp(ctx, waitDur) {
+	if utils.SelectContextOrWait(ctx, waitDur) {
 		err = m.Stop(ctx, nil)
 		if err != nil {
 			return err
@@ -387,6 +394,7 @@ func (m *Motor) SetRPM(ctx context.Context, rpm float64, extra map[string]interf
 
 // Stop has the motor pretend to be off.
 func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
+	m.OpMgr.CancelRunning(ctx)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -394,9 +394,9 @@ func (m *Motor) SetRPM(ctx context.Context, rpm float64, extra map[string]interf
 
 // Stop has the motor pretend to be off.
 func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
-	m.OpMgr.CancelRunning(ctx)
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.OpMgr.CancelRunning(ctx)
 
 	m.Logger.CDebug(ctx, "Motor Stopped")
 	m.setPowerPct(0.0)

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -207,10 +207,15 @@ func (m *Motor) Properties(ctx context.Context, extra map[string]interface{}) (m
 
 // SetPower sets the given power percentage.
 func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+	ctx, finish := m.OpMgr.New(ctx)
+	defer finish()
+	return m.setPower(ctx, powerPct)
+}
+
+func (m *Motor) setPower(ctx context.Context, powerPct float64) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.OpMgr.CancelRunning(ctx)
 	m.Logger.CDebugf(ctx, "Motor SetPower %f", powerPct)
 	m.setPowerPct(powerPct)
 
@@ -313,7 +318,7 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 		finalPos = curPos + dir*math.Abs(revolutions)
 	}
 
-	err = m.SetPower(ctx, powerPct, nil)
+	err = m.setPower(ctx, powerPct)
 	if err != nil {
 		return err
 	}
@@ -361,7 +366,7 @@ func (m *Motor) GoTo(ctx context.Context, rpm, pos float64, extra map[string]int
 
 	powerPct, waitDur, _ := goForMath(m.MaxRPM, math.Abs(rpm), revolutions)
 
-	err = m.SetPower(ctx, powerPct, nil)
+	err = m.setPower(ctx, powerPct)
 	if err != nil {
 		return err
 	}
@@ -394,14 +399,16 @@ func (m *Motor) SetRPM(ctx context.Context, rpm float64, extra map[string]interf
 
 // Stop has the motor pretend to be off.
 func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
+	_, finish := m.OpMgr.New(ctx)
+	defer finish()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.OpMgr.CancelRunning(ctx)
 
 	m.Logger.CDebug(ctx, "Motor Stopped")
 	m.setPowerPct(0.0)
 	if m.Encoder != nil {
-		err := m.Encoder.SetSpeed(ctx, 0.0)
+		err := m.Encoder.SetSpeed(context.Background(), 0.0)
 		if err != nil {
 			return errors.Wrapf(err, "error in Stop from motor (%s)", m.Name())
 		}

--- a/components/motor/fake/motor.go
+++ b/components/motor/fake/motor.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
 	fakeboard "go.viam.com/rdk/components/board/fake"
@@ -18,7 +19,6 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/operation"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/utils"
 )
 
 var (

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -227,18 +227,17 @@ func (m *Motor) setPWM(ctx context.Context, powerPct float64, extra map[string]i
 // SetPower instructs the motor to operate at an rpm, where the sign of the rpm
 // indicates direction.
 func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
-	m.opMgr.CancelRunning(ctx)
-	return m.setPower(ctx, powerPct, extra)
-}
-
-func (m *Motor) setPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
-	if math.Abs(powerPct) <= 0.01 {
-		return m.Stop(ctx, extra)
-	}
-	// Stop locks/unlocks the mutex as well so in the case that the power ~= 0
-	// we want to simply rely on the mutex use in Stop
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.opMgr.CancelRunning(ctx)
+	return m.setPowerInLock(ctx, powerPct, extra)
+}
+
+// setPowerInLock drives the pins for the requested power. Callers MUST hold m.mu.
+func (m *Motor) setPowerInLock(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+	if math.Abs(powerPct) <= 0.01 {
+		return m.stopInLock(ctx, extra)
+	}
 
 	switch m.motorType {
 	case DirectionPwm:
@@ -275,9 +274,6 @@ func (m *Motor) setPower(ctx context.Context, powerPct float64, extra map[string
 // for this so power is determined via a linear relationship with the maxRPM and the distance
 // traveled is a time based estimation based on desired RPM.
 func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
-	ctx, finish := m.opMgr.New(ctx)
-	defer finish()
-
 	if m.maxRPM == 0 {
 		return errors.New("not supported, define max_rpm attribute != 0")
 	}
@@ -295,7 +291,14 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 	}
 
 	powerPct, waitDur := goForMath(m.maxRPM, rpm, revolutions)
-	err = m.setPower(ctx, powerPct, extra)
+
+	// Register the op and drive the pins atomically so an interleaved GoFor/SetPower/Stop
+	// can't slip its pin writes in between our opMgr.New and our setPower.
+	m.mu.Lock()
+	ctx, finish := m.opMgr.New(ctx)
+	defer finish()
+	err = m.setPowerInLock(ctx, powerPct, extra)
+	m.mu.Unlock()
 	if err != nil {
 		return errors.Wrap(err, "error in GoFor")
 	}
@@ -317,6 +320,11 @@ func (m *Motor) IsPowered(ctx context.Context, extra map[string]interface{}) (bo
 func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	return m.stopInLock(ctx, extra)
+}
+
+// stopInLock cancels any running op and drives the motor off. Callers MUST hold m.mu.
+func (m *Motor) stopInLock(ctx context.Context, extra map[string]interface{}) error {
 	m.opMgr.CancelRunning(ctx)
 	return m.setPWM(context.Background(), 0, extra)
 }

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -227,17 +227,20 @@ func (m *Motor) setPWM(ctx context.Context, powerPct float64, extra map[string]i
 // SetPower instructs the motor to operate at an rpm, where the sign of the rpm
 // indicates direction.
 func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.opMgr.CancelRunning(ctx)
-	return m.setPowerInLock(ctx, powerPct, extra)
+	ctx, finish := m.opMgr.New(ctx)
+	defer finish()
+	return m.setPower(ctx, powerPct, extra)
 }
 
-// setPowerInLock drives the pins for the requested power. Callers MUST hold m.mu.
-func (m *Motor) setPowerInLock(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
+// setPower drives the pins for the requested power. m.mu is taken internally to serialize
+// pin writes; ordering against other public motor operations is provided by opMgr.New in
+// each public entrypoint that invokes this method.
+func (m *Motor) setPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
 	if math.Abs(powerPct) <= 0.01 {
-		return m.stopInLock(ctx, extra)
+		return m.Stop(ctx, extra)
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	switch m.motorType {
 	case DirectionPwm:
@@ -292,14 +295,13 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 
 	powerPct, waitDur := goForMath(m.maxRPM, rpm, revolutions)
 
-	// Register the op and drive the pins atomically so an interleaved GoFor/SetPower/Stop
-	// can't slip its pin writes in between our opMgr.New and our setPower.
-	m.mu.Lock()
+	// opMgr.New cancels any prior op and waits for it to finish before registering us as
+	// the current op. That handshake — not m.mu — is what serializes us against concurrent
+	// GoFor / SetPower / Stop calls.
 	ctx, finish := m.opMgr.New(ctx)
 	defer finish()
-	err = m.setPowerInLock(ctx, powerPct, extra)
-	m.mu.Unlock()
-	if err != nil {
+
+	if err := m.setPower(ctx, powerPct, extra); err != nil {
 		return errors.Wrap(err, "error in GoFor")
 	}
 
@@ -318,14 +320,13 @@ func (m *Motor) IsPowered(ctx context.Context, extra map[string]interface{}) (bo
 
 // Stop turns the power to the motor off immediately, without any gradual step down, by setting the appropriate pins to low states.
 func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
+	// Discard the op ctx: Stop's pin writes must fire even if the caller's ctx is canceled
+	// or a concurrent op preempts us, so setPWM uses Background. opMgr.New is here purely
+	// for the cancel-and-wait-and-register handshake.
+	_, finish := m.opMgr.New(ctx)
+	defer finish()
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.stopInLock(ctx, extra)
-}
-
-// stopInLock cancels any running op and drives the motor off. Callers MUST hold m.mu.
-func (m *Motor) stopInLock(ctx context.Context, extra map[string]interface{}) error {
-	m.opMgr.CancelRunning(ctx)
 	return m.setPWM(context.Background(), 0, extra)
 }
 

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
+	"go.viam.com/utils"
 
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/components/motor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/operation"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/utils"
 )
 
 // NewMotor constructs a new GPIO based motor on the given board using the

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -315,9 +315,9 @@ func (m *Motor) IsPowered(ctx context.Context, extra map[string]interface{}) (bo
 
 // Stop turns the power to the motor off immediately, without any gradual step down, by setting the appropriate pins to low states.
 func (m *Motor) Stop(ctx context.Context, extra map[string]interface{}) error {
-	m.opMgr.CancelRunning(ctx)
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.opMgr.CancelRunning(ctx)
 	return m.setPWM(context.Background(), 0, extra)
 }
 

--- a/components/motor/gpio/basic.go
+++ b/components/motor/gpio/basic.go
@@ -13,6 +13,7 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/operation"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/utils"
 )
 
 // NewMotor constructs a new GPIO based motor on the given board using the
@@ -227,6 +228,10 @@ func (m *Motor) setPWM(ctx context.Context, powerPct float64, extra map[string]i
 // indicates direction.
 func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
 	m.opMgr.CancelRunning(ctx)
+	return m.setPower(ctx, powerPct, extra)
+}
+
+func (m *Motor) setPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
 	if math.Abs(powerPct) <= 0.01 {
 		return m.Stop(ctx, extra)
 	}
@@ -270,6 +275,9 @@ func (m *Motor) SetPower(ctx context.Context, powerPct float64, extra map[string
 // for this so power is determined via a linear relationship with the maxRPM and the distance
 // traveled is a time based estimation based on desired RPM.
 func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
+	ctx, finish := m.opMgr.New(ctx)
+	defer finish()
+
 	if m.maxRPM == 0 {
 		return errors.New("not supported, define max_rpm attribute != 0")
 	}
@@ -287,12 +295,12 @@ func (m *Motor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[s
 	}
 
 	powerPct, waitDur := goForMath(m.maxRPM, rpm, revolutions)
-	err = m.SetPower(ctx, powerPct, extra)
+	err = m.setPower(ctx, powerPct, extra)
 	if err != nil {
 		return errors.Wrap(err, "error in GoFor")
 	}
 
-	if m.opMgr.NewTimedWaitOp(ctx, waitDur) {
+	if utils.SelectContextOrWait(ctx, waitDur) {
 		return m.Stop(ctx, extra)
 	}
 	return nil

--- a/components/motor/gpio/controlled.go
+++ b/components/motor/gpio/controlled.go
@@ -188,6 +188,7 @@ func (cm *controlledMotor) IsMoving(ctx context.Context) (bool, error) {
 
 // Stop stops rpmMonitor and stops the real motor.
 func (cm *controlledMotor) Stop(ctx context.Context, extra map[string]interface{}) error {
+	cm.opMgr.CancelRunning(ctx)
 	// after the motor is created, Stop is called, but if the PID controller
 	// is auto-tuning, the loop needs to keep running
 	if cm.loop != nil && !cm.loop.GetTuning(ctx) {
@@ -282,7 +283,6 @@ func (cm *controlledMotor) GoTo(ctx context.Context, rpm, targetPosition float64
 
 // SetRPM instructs the motor to move at the specified RPM indefinitely.
 func (cm *controlledMotor) SetRPM(ctx context.Context, rpm float64, extra map[string]interface{}) error {
-	cm.opMgr.CancelRunning(ctx)
 	ctx, done := cm.opMgr.New(ctx)
 	defer done()
 
@@ -323,7 +323,6 @@ func (cm *controlledMotor) SetRPM(ctx context.Context, rpm float64, extra map[st
 // negative the motor will spin in the forward direction.
 // If revolutions != 0, this will block until the number of revolutions has been completed or another operation comes in.
 func (cm *controlledMotor) GoFor(ctx context.Context, rpm, revolutions float64, extra map[string]interface{}) error {
-	cm.opMgr.CancelRunning(ctx)
 	ctx, done := cm.opMgr.New(ctx)
 	defer done()
 

--- a/components/motor/gpio/controlled.go
+++ b/components/motor/gpio/controlled.go
@@ -168,7 +168,8 @@ type controlledMotor struct {
 // SetPower sets the percentage of power the motor should employ between -1 and 1.
 // Negative power implies a backward directional rotational.
 func (cm *controlledMotor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
-	cm.opMgr.CancelRunning(ctx)
+	ctx, finish := cm.opMgr.New(ctx)
+	defer finish()
 	if cm.loop != nil {
 		cm.loop.Pause()
 	}
@@ -188,22 +189,23 @@ func (cm *controlledMotor) IsMoving(ctx context.Context) (bool, error) {
 
 // Stop stops rpmMonitor and stops the real motor.
 func (cm *controlledMotor) Stop(ctx context.Context, extra map[string]interface{}) error {
-	cm.opMgr.CancelRunning(ctx)
+	_, finish := cm.opMgr.New(ctx)
+	defer finish()
 	// after the motor is created, Stop is called, but if the PID controller
 	// is auto-tuning, the loop needs to keep running
-	if cm.loop != nil && !cm.loop.GetTuning(ctx) {
+	if cm.loop != nil && !cm.loop.GetTuning(context.Background()) {
 		cm.loop.Pause()
 
 		// update pid controller to use the current state as the desired state
-		currentTicks, _, err := cm.enc.Position(ctx, encoder.PositionTypeTicks, extra)
+		currentTicks, _, err := cm.enc.Position(context.Background(), encoder.PositionTypeTicks, extra)
 		if err != nil {
 			return err
 		}
-		if err := cm.updateControlBlock(ctx, currentTicks+cm.offsetInTicks, cm.maxRPM*cm.ticksPerRotation/60); err != nil {
+		if err := cm.updateControlBlock(context.Background(), currentTicks+cm.offsetInTicks, cm.maxRPM*cm.ticksPerRotation/60); err != nil {
 			return err
 		}
 	}
-	return cm.real.Stop(ctx, nil)
+	return cm.real.Stop(context.Background(), nil)
 }
 
 // Close cleanly shuts down the motor.

--- a/components/motor/gpio/encoded.go
+++ b/components/motor/gpio/encoded.go
@@ -233,7 +233,8 @@ func (m *EncodedMotor) calcNewPowerPct(
 // SetPower sets the percentage of power the motor should employ between -1 and 1.
 // Negative power implies a backward directional rotational.
 func (m *EncodedMotor) SetPower(ctx context.Context, powerPct float64, extra map[string]interface{}) error {
-	m.opMgr.CancelRunning(ctx)
+	ctx, finish := m.opMgr.New(ctx)
+	defer finish()
 	if m.makeAdjustmentsDone != nil {
 		m.makeAdjustmentsDone()
 	}
@@ -438,11 +439,12 @@ func (m *EncodedMotor) IsMoving(ctx context.Context) (bool, error) {
 
 // Stop stops makeAdjustments and stops the real motor.
 func (m *EncodedMotor) Stop(ctx context.Context, extra map[string]interface{}) error {
-	m.opMgr.CancelRunning(ctx)
+	_, finish := m.opMgr.New(ctx)
+	defer finish()
 	if m.makeAdjustmentsDone != nil {
 		m.makeAdjustmentsDone()
 	}
-	return m.real.Stop(ctx, nil)
+	return m.real.Stop(context.Background(), nil)
 }
 
 // Close cleanly shuts down the motor.

--- a/components/motor/gpio/encoded.go
+++ b/components/motor/gpio/encoded.go
@@ -438,6 +438,7 @@ func (m *EncodedMotor) IsMoving(ctx context.Context) (bool, error) {
 
 // Stop stops makeAdjustments and stops the real motor.
 func (m *EncodedMotor) Stop(ctx context.Context, extra map[string]interface{}) error {
+	m.opMgr.CancelRunning(ctx)
 	if m.makeAdjustmentsDone != nil {
 		m.makeAdjustmentsDone()
 	}


### PR DESCRIPTION
RSDK-14035

## What

Fixes a race condition in `GoFor`/`GoTo` for several motor and base implementations involving incorrect usage of `SingleOperationManager`.

  - Adds `opMgr.New(ctx)` at the top of `GoFor` and `GoTo` in `fake/motor.go` and `gpio/basic.go`, replacing `NewTimedWaitOp` with `utils.SelectContextOrWait` on the already-registered context
  - Splits `SetPower` in `gpio/basic.go` into a public `SetPower` (calls `CancelRunning`) and a private `setPower` (does not), so `GoFor` can set power without tearing down its own registered operation
  - Adds `opMgr.CancelRunning(ctx)` to `Stop` in `fake/motor.go`, `gpio/controlled.go`, and `gpio/encoded.go` so that a `Stop` call correctly interrupts a `GoFor` blocked in `WaitForSuccess`
  - Removes redundant `opMgr.CancelRunning(ctx)` calls immediately before `opMgr.New(ctx)` in `gpio/controlled.go` (`GoFor`, `SetRPM`) and `sensorcontrolled/` (`Spin`, `MoveStraight`, `SetVelocity`), since `New` already cancels any existing operation

## Why

`NewTimedWaitOp` internally calls `opMgr.New` to register a new operation and then waits. The old pattern in `GoFor` was:

  1. Call `SetPower` → which calls `CancelRunning` (old operation cancelled, no new one registered yet)
  2. Call `NewTimedWaitOp` → registers new operation and blocks for `waitDur`

A `Stop` arriving between steps 1 and 2 would call `CancelRunning`, find no operation registered, and return without effect. `NewTimedWaitOp` would then register a fresh operation and sleep for the full duration regardless. `TestGoForInterruptionDir` demonstrates this failure if a small sleep is added between the two steps (100ms e.g.).

The fix registers the operation at the very start of `GoFor` via `opMgr.New(ctx)`, so any concurrent `Stop` always has a live operation to cancel.

The same type of race existed anywhere `CancelRunning` was called immediately before `New`. Since `New` already cancels any prior operation under the op manager's mutex, the explicit `CancelRunning` beforehand created an unprotected gap between the two calls.

Finally, `EncodedMotor.Stop` and `controlledMotor.Stop` were not calling `opMgr.CancelRunning`, meaning a `GoFor` blocked in WaitForSuccess would not be interrupted by a `Stop` call.

## Testing

  - `TestGoForInterruptionDir` and `TestGoForInterruptionAB` (existing tests in `gpio/`) directly exercise the race condition (with added sleeps) and pass with the fix
  - All tests in `components/motor/gpio/...`, `components/motor/fake/...`, and `components/base/sensorcontrolled/...` pass

[Description generated by Claude 🤖]
