### PR TITLE
cli: add --pipeline-name flag to data index list

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1673,6 +1673,10 @@ Note: There is no progress meter while copying is in progress.
 									Required: true,
 									Usage:    formatAcceptedValues("collection type", "hot-storage", "pipeline-sink"),
 								},
+								&cli.StringFlag{
+									Name:  dataFlagPipelineName,
+									Usage: "pipeline name (required when --collection-type is 'pipeline-sink')",
+								},
 							},
 							Action: createActionCommandWithT[listCustomIndexesArgs](ListCustomIndexesAction),
 						},


### PR DESCRIPTION
`--pipeline-name` was registered on `data index create` and `data index delete` but omitted from `data index list`, making it impossible to query `pipeline-sink` collections (validation always returned `errPipelineNameRequired`).

**Testing:** Built CLI locally and was able to retrieve pipeline indexes ✅ 