### PR TITLE
RSDK-13583 Clean up logging, logic and docs for maintenance sensors

### DIFF
--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -2070,11 +2070,11 @@ func (r *localRobot) reconfigureAllowed(ctx context.Context, mCfg *config.Mainte
 	}
 	sensorComponent, err := robot.ResourceFromRobot[sensor.Sensor](r, name)
 	if err != nil {
-		return true, fmt.Errorf("could not find sensor named %s: err", mCfg.SensorName)
+		return true, fmt.Errorf("could not find sensor named %s: %w", mCfg.SensorName, err)
 	}
 
 	// If there was any error checking sensor readings on a valid sensor, return false
-	// (reconfigue NOT allowed).
+	// (reconfigure NOT allowed).
 	canReconfigure, err := r.checkMaintenanceSensorReadings(ctx, mCfg.MaintenanceAllowedKey, sensorComponent)
 	if err != nil {
 		return false, fmt.Errorf("failed to check maintenance sensor readings: %w", err)

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1443,12 +1443,10 @@ func (r *localRobot) reconfigure(ctx context.Context, newConfig *config.Config, 
 	}()
 
 	// No need to check whether reconfiguring is allowed if this is initialization.
+	var reconfigureAllowedErr error
 	if !r.initializing.Load() {
-		reconfigureAllowed, err := r.reconfigureAllowed(ctx, newConfig.MaintenanceConfig)
-		if err != nil {
-			r.logger.CWarnw(ctx, "Error checking whether reconfigure is allowed", "error", err.Error())
-		}
-
+		var reconfigureAllowed bool
+		reconfigureAllowed, reconfigureAllowedErr = r.reconfigureAllowed(ctx, newConfig.MaintenanceConfig)
 		if !reconfigureAllowed {
 			// Diff the configs to guess if we are skipping a "meaningful" reconfigure (network
 			// or resources changed), otherwise silently return.
@@ -1458,25 +1456,26 @@ func (r *localRobot) reconfigure(ctx context.Context, newConfig *config.Config, 
 				return
 			}
 			if diff != nil && !diff.NetworkEqual {
-				if err != nil {
+				if reconfigureAllowedErr != nil {
 					r.logger.CInfow(
 						ctx,
-						"Reconfigure NOT allowed due to maintenance sensor error but Cloud/Auth/Network config changes will be applied",
+						"Reconfigure NOT allowed due to error but Cloud/Auth/Network config changes will be applied",
 						"error",
-						err.Error(),
+						reconfigureAllowedErr.Error(),
 					)
 				} else {
-					r.logger.CInfo(
+					r.logger.CInfow(
 						ctx,
 						"Reconfigure NOT allowed by maintenance sensor but Cloud/Auth/Network config changes will be applied",
+						"sensor",
+						newConfig.MaintenanceConfig.SensorName,
 					)
 				}
-			}
-			if diff != nil && !diff.ResourcesEqual {
-				if err != nil {
-					r.logger.CInfow(ctx, "Reconfigure NOT allowed due to maintenance sensor error", "error", err.Error())
+			} else if diff != nil && !diff.ResourcesEqual {
+				if reconfigureAllowedErr != nil {
+					r.logger.CInfow(ctx, "Reconfigure NOT allowed due to error", "error", reconfigureAllowedErr.Error())
 				} else {
-					r.logger.CInfo(ctx, "Reconfigure NOT allowed by maintenance sensor")
+					r.logger.CInfow(ctx, "Reconfigure NOT allowed by maintenance sensor", "sensor", newConfig.MaintenanceConfig.SensorName)
 				}
 			}
 			return
@@ -1679,6 +1678,23 @@ func (r *localRobot) reconfigure(ctx context.Context, newConfig *config.Config, 
 	if !r.initializing.Load() {
 		logVerb = "Reconfigur"
 		logNoun = "reconfiguration"
+		if newConfig.MaintenanceConfig != nil {
+			if reconfigureAllowedErr != nil {
+				r.logger.CInfow(
+					ctx,
+					"Reconfigure allowed despite error while checking",
+					"error",
+					reconfigureAllowedErr.Error(),
+				)
+			} else {
+				r.logger.CInfow(
+					ctx,
+					"Reconfigure allowed by maintenance sensor",
+					"sensor",
+					newConfig.MaintenanceConfig.SensorName,
+				)
+			}
+		}
 	}
 	r.logger.CInfof(ctx, "%ving robot", logVerb)
 
@@ -2097,6 +2113,11 @@ func (r *localRobot) RestartAllowed() bool {
 		return false
 	}
 
+	// The error return is insignificant here; any reconfigureAllowed errors will be logged
+	// in the main reconfigure method. We do not want to log them every time viam-agent hits
+	// the restart_allowed endpoint.
+	//
+	//nolint:errcheck
 	reconfigureAllowed, _ := r.reconfigureAllowed(context.Background(), r.Config().MaintenanceConfig)
 	return reconfigureAllowed
 }

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -2050,18 +2050,18 @@ func (r *localRobot) reconfigureAllowed(ctx context.Context, mCfg *config.Mainte
 	// allowed).
 	name, err := resource.NewFromString(mCfg.SensorName)
 	if err != nil {
-		return true, errors.Errorf("sensor_name %s in maintenance config is not in a supported format", mCfg.SensorName)
+		return true, fmt.Errorf("sensor_name %s in maintenance config is not in a supported format", mCfg.SensorName)
 	}
 	sensorComponent, err := robot.ResourceFromRobot[sensor.Sensor](r, name)
 	if err != nil {
-		return true, errors.Errorf("could not find sensor named %s: err", mCfg.SensorName)
+		return true, fmt.Errorf("could not find sensor named %s: err", mCfg.SensorName)
 	}
 
 	// If there was any error checking sensor readings on a valid sensor, return false
 	// (reconfigue NOT allowed).
 	canReconfigure, err := r.checkMaintenanceSensorReadings(ctx, mCfg.MaintenanceAllowedKey, sensorComponent)
 	if err != nil {
-		return false, errors.Errorf("failed to check maintenance sensor readings: %w", err)
+		return false, fmt.Errorf("failed to check maintenance sensor readings: %w", err)
 	}
 	return canReconfigure, nil
 }
@@ -2075,15 +2075,15 @@ func (r *localRobot) checkMaintenanceSensorReadings(ctx context.Context,
 
 	readings, err := sensor.Readings(ctx, map[string]interface{}{})
 	if err != nil {
-		return false, errors.Errorf("error reading maintenance sensor readings. %s", err.Error())
+		return false, fmt.Errorf("error reading maintenance sensor readings. %s", err.Error())
 	}
 	readingVal, ok := readings[maintenanceAllowedKey]
 	if !ok {
-		return false, errors.Errorf("error getting maintenance_allowed_key %s from sensor reading", maintenanceAllowedKey)
+		return false, fmt.Errorf("error getting maintenance_allowed_key %s from sensor reading", maintenanceAllowedKey)
 	}
 	canReconfigure, ok := readingVal.(bool)
 	if !ok {
-		return false, errors.Errorf("maintenance_allowed_key %s is not a bool value", maintenanceAllowedKey)
+		return false, fmt.Errorf("maintenance_allowed_key %s is not a bool value", maintenanceAllowedKey)
 	}
 
 	return canReconfigure, nil

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -1442,8 +1442,45 @@ func (r *localRobot) reconfigure(ctx context.Context, newConfig *config.Config, 
 		r.initializing.Store(newConfig.Initial)
 	}()
 
-	if !r.reconfigureAllowed(ctx, newConfig, true) {
-		return
+	// No need to check whether reconfiguring is allowed if this is initialization.
+	if !r.initializing.Load() {
+		reconfigureAllowed, err := r.reconfigureAllowed(ctx, newConfig.MaintenanceConfig)
+		if err != nil {
+			r.logger.CWarnw(ctx, "Error checking whether reconfigure is allowed", "error", err.Error())
+		}
+
+		if !reconfigureAllowed {
+			// Diff the configs to guess if we are skipping a "meaningful" reconfigure (network
+			// or resources changed), otherwise silently return.
+			diff, err := config.DiffConfigs(*r.Config(), *newConfig, false)
+			if err != nil {
+				r.logger.CErrorw(ctx, "error diffing the configs", "error", err)
+				return
+			}
+			if diff != nil && !diff.NetworkEqual {
+				if err != nil {
+					r.logger.CInfow(
+						ctx,
+						"Reconfigure NOT allowed due to maintenance sensor error but Cloud/Auth/Network config changes will be applied",
+						"error",
+						err.Error(),
+					)
+				} else {
+					r.logger.CInfo(
+						ctx,
+						"Reconfigure NOT allowed by maintenance sensor but Cloud/Auth/Network config changes will be applied",
+					)
+				}
+			}
+			if diff != nil && !diff.ResourcesEqual {
+				if err != nil {
+					r.logger.CInfow(ctx, "Reconfigure NOT allowed due to maintenance sensor error", "error", err.Error())
+				} else {
+					r.logger.CInfo(ctx, "Reconfigure NOT allowed by maintenance sensor")
+				}
+			}
+			return
+		}
 	}
 
 	// If reconfigure is allowed, assume we are reconfiguring until this function
@@ -2001,75 +2038,43 @@ func (r *localRobot) Version(ctx context.Context) (robot.VersionResponse, error)
 	return robot.Version, nil
 }
 
-// reconfigureAllowed returns whether the local robot can reconfigure.
-func (r *localRobot) reconfigureAllowed(ctx context.Context, cfg *config.Config, log bool) bool {
-	// Hack: if we should not log (allowance of reconfiguration is being checked
-	// from the `/restart_status` endpoint), then use a no-op logger. Otherwise
-	// use robot's logger.
-	logger := r.logger
-	if !log {
-		logger = logging.NewBlankLogger("")
-	}
-
+// reconfigureAllowed returns whether the local robot can reconfigure and any encountered
+// error.
+func (r *localRobot) reconfigureAllowed(ctx context.Context, mCfg *config.MaintenanceConfig) (bool, error) {
 	// Reconfigure is always allowed in the absence of a MaintenanceConfig.
-	if cfg.MaintenanceConfig == nil {
-		return true
+	if mCfg == nil {
+		return true, nil
 	}
 
-	// Maintenance config can be configured to block reconfigure based off of a sensor reading
-	// These sensors can be configured on the main robot, or a remote
-	// In situations where there are conflicting sensor names the following behavior happens
-	// Main robot and remote share sensor name -> main robot sensor is chosen
-	// Only remote has the sensor name -> remote sensor is read
-	// Multiple remotes share a senor name -> conflict error is returned and reconfigure happens
-	// To specify a specific remote sensor use the name format remoteName:sensorName to specify a remote sensor
-	name, err := resource.NewFromString(cfg.MaintenanceConfig.SensorName)
+	// If the sensor name cannot be parsed or found on the machine, return true (reconfigure
+	// allowed).
+	name, err := resource.NewFromString(mCfg.SensorName)
 	if err != nil {
-		logger.Warnf("sensor_name %s in maintenance config is not in a supported format", cfg.MaintenanceConfig.SensorName)
-		return true
+		return true, errors.Errorf("sensor_name %s in maintenance config is not in a supported format", mCfg.SensorName)
 	}
 	sensorComponent, err := robot.ResourceFromRobot[sensor.Sensor](r, name)
 	if err != nil {
-		logger.Warnf("%s, Starting reconfiguration", err.Error())
-		return true
+		return true, errors.Errorf("could not find sensor named %s: err", mCfg.SensorName)
 	}
-	canReconfigure, err := r.checkMaintenanceSensorReadings(ctx, cfg.MaintenanceConfig.MaintenanceAllowedKey, sensorComponent)
-	// The boolean return value of checkMaintenanceSensorReadings
-	// (canReconfigure) is meaningful even when an error is also returned. Check
-	// it first.
-	if !canReconfigure {
-		if err != nil {
-			logger.CErrorw(ctx, "error reading maintenance sensor", "error", err)
-		} else {
-			logger.Info("maintenance_allowed_key found from readings on maintenance sensor. Skipping reconfiguration.")
-		}
-		diff, err := config.DiffConfigs(*r.Config(), *cfg, false)
-		if err != nil {
-			logger.CErrorw(ctx, "error diffing the configs", "error", err)
-		}
-		// NetworkEqual checks if Cloud/Auth/Network are equal between configs
-		if diff != nil && !diff.NetworkEqual {
-			logger.Info("Machine reconfiguration skipped but Cloud/Auth/Network config section contain changes and will be applied.")
-		}
-		return false
-	}
-	logger.Info("maintenance_allowed_key found from readings on maintenance sensor. Starting reconfiguration")
 
-	return true
+	// If there was any error checking sensor readings on a valid sensor, return false
+	// (reconfigue NOT allowed).
+	canReconfigure, err := r.checkMaintenanceSensorReadings(ctx, mCfg.MaintenanceAllowedKey, sensorComponent)
+	if err != nil {
+		return false, errors.Errorf("failed to check maintenance sensor readings: %w", err)
+	}
+	return canReconfigure, nil
 }
 
 // checkMaintenanceSensorReadings ensures that errors from reading a sensor are handled properly.
 func (r *localRobot) checkMaintenanceSensorReadings(ctx context.Context,
 	maintenanceAllowedKey string, sensor resource.Sensor,
 ) (bool, error) {
-	timeout := 5 * time.Second
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	// Context timeouts on this call should be handled by grpc
 	readings, err := sensor.Readings(ctx, map[string]interface{}{})
 	if err != nil {
-		// if the sensor errors or timeouts we return false to block reconfigure
 		return false, errors.Errorf("error reading maintenance sensor readings. %s", err.Error())
 	}
 	readingVal, ok := readings[maintenanceAllowedKey]
@@ -2080,6 +2085,7 @@ func (r *localRobot) checkMaintenanceSensorReadings(ctx context.Context,
 	if !ok {
 		return false, errors.Errorf("maintenance_allowed_key %s is not a bool value", maintenanceAllowedKey)
 	}
+
 	return canReconfigure, nil
 }
 
@@ -2087,12 +2093,12 @@ func (r *localRobot) checkMaintenanceSensorReadings(ctx context.Context,
 // can be safely restarted if the robot is not in the middle of a reconfigure,
 // and a reconfigure would be allowed.
 func (r *localRobot) RestartAllowed() bool {
-	ctx := context.Background()
-
-	if !r.reconfiguring.Load() && r.reconfigureAllowed(ctx, r.Config(), false) {
-		return true
+	if r.reconfiguring.Load() {
+		return false
 	}
-	return false
+
+	reconfigureAllowed, _ := r.reconfigureAllowed(context.Background(), r.Config().MaintenanceConfig)
+	return reconfigureAllowed
 }
 
 // ListTunnels returns information on available traffic tunnels.

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -4994,6 +4994,143 @@ func TestMaintenanceConfig(t *testing.T) {
 	})
 }
 
+func TestMaintenanceConfigLogs(t *testing.T) {
+	ctx := context.Background()
+	model := resource.DefaultModelFamily.WithModel(utils.RandomAlphaString(8))
+	modelErrorSensor := resource.DefaultModelFamily.WithModel(utils.RandomAlphaString(8))
+	resource.RegisterComponent(
+		sensor.API,
+		model,
+		resource.Registration[sensor.Sensor, resource.NoNativeConfig]{Constructor: func(
+			ctx context.Context,
+			deps resource.Dependencies,
+			conf resource.Config,
+			logger logging.Logger,
+		) (sensor.Sensor, error) {
+			return newValidSensor(), nil
+		}})
+	resource.RegisterComponent(
+		sensor.API,
+		modelErrorSensor,
+		resource.Registration[sensor.Sensor, resource.NoNativeConfig]{Constructor: func(
+			ctx context.Context,
+			deps resource.Dependencies,
+			conf resource.Config,
+			logger logging.Logger,
+		) (sensor.Sensor, error) {
+			return newErrorSensor(), nil
+		}})
+	defer func() {
+		resource.Deregister(sensor.API, model)
+		resource.Deregister(sensor.API, modelErrorSensor)
+	}()
+
+	sensor1 := []resource.Config{
+		{Name: "sensor", Model: model, API: sensor.API},
+	}
+	sensor2 := []resource.Config{
+		{Name: "sensor2", Model: model, API: sensor.API},
+	}
+	errorSensor1 := []resource.Config{
+		{Name: "sensor", Model: modelErrorSensor, API: sensor.API},
+	}
+
+	t.Run("sensor allows reconfigure", func(t *testing.T) {
+		logger, logs := logging.NewObservedTestLogger(t)
+		cfg := &config.Config{
+			MaintenanceConfig: &config.MaintenanceConfig{
+				SensorName:            "rdk:component:sensor/sensor",
+				MaintenanceAllowedKey: "ThatsNotMyWallet",
+			},
+			Components: sensor1,
+		}
+		r := setupLocalRobot(t, ctx, cfg, logger)
+
+		cfgWithMore := &config.Config{
+			MaintenanceConfig: &config.MaintenanceConfig{
+				SensorName:            "rdk:component:sensor/sensor",
+				MaintenanceAllowedKey: "ThatsNotMyWallet",
+			},
+			Components: append(sensor1, sensor2...),
+		}
+		r.Reconfigure(ctx, cfgWithMore)
+
+		test.That(t, logs.FilterMessage("Reconfigure allowed by maintenance sensor").Len(), test.ShouldEqual, 1)
+	})
+
+	t.Run("sensor blocks reconfigure", func(t *testing.T) {
+		logger, logs := logging.NewObservedTestLogger(t)
+		cfg := &config.Config{
+			MaintenanceConfig: &config.MaintenanceConfig{
+				SensorName:            "rdk:component:sensor/sensor",
+				MaintenanceAllowedKey: "ThatsMyWallet",
+			},
+			Components: sensor1,
+		}
+		r := setupLocalRobot(t, ctx, cfg, logger)
+
+		cfgBlocked := &config.Config{
+			MaintenanceConfig: &config.MaintenanceConfig{
+				SensorName:            "rdk:component:sensor/sensor",
+				MaintenanceAllowedKey: "ThatsMyWallet",
+			},
+			Components: append(sensor1, sensor2...),
+		}
+		r.Reconfigure(ctx, cfgBlocked)
+
+		test.That(t, logs.FilterMessage("Reconfigure NOT allowed by maintenance sensor").Len(), test.ShouldEqual, 1)
+	})
+
+	t.Run("error sensor", func(t *testing.T) {
+		logger, logs := logging.NewObservedTestLogger(t)
+		cfg := &config.Config{
+			MaintenanceConfig: &config.MaintenanceConfig{
+				SensorName:            "rdk:component:sensor/sensor",
+				MaintenanceAllowedKey: "ThatsMyWallet",
+			},
+			Components: errorSensor1,
+		}
+		r := setupLocalRobot(t, ctx, cfg, logger)
+
+		cfgBlocked := &config.Config{
+			MaintenanceConfig: &config.MaintenanceConfig{
+				SensorName:            "rdk:component:sensor/sensor",
+				MaintenanceAllowedKey: "ThatsMyWallet",
+			},
+			Components: append(errorSensor1, sensor2...),
+		}
+		r.Reconfigure(ctx, cfgBlocked)
+
+		test.That(t, logs.FilterMessage("Reconfigure NOT allowed due to error").Len(), test.ShouldEqual, 1)
+	})
+
+	t.Run("sensor not found", func(t *testing.T) {
+		logger, logs := logging.NewObservedTestLogger(t)
+		cfg := &config.Config{
+			MaintenanceConfig: &config.MaintenanceConfig{
+				SensorName:            "rdk:component:sensor/nonexistent",
+				MaintenanceAllowedKey: "ThatsMyWallet",
+			},
+			Components: sensor1,
+		}
+		r := setupLocalRobot(t, ctx, cfg, logger)
+
+		cfgWithMore := &config.Config{
+			MaintenanceConfig: &config.MaintenanceConfig{
+				SensorName:            "rdk:component:sensor/nonexistent",
+				MaintenanceAllowedKey: "ThatsMyWallet",
+			},
+			Components: append(sensor1, sensor2...),
+		}
+		r.Reconfigure(ctx, cfgWithMore)
+
+		// Construction and reconfiguration should both log here (setupLocalRobot does not go
+		// through the "initializing" state that robot constructed through entrypoint code
+		// does), so expect 2 logs.
+		test.That(t, logs.FilterMessage("Reconfigure allowed despite error while checking").Len(), test.ShouldEqual, 2)
+	})
+}
+
 func TestRemovingOfflineRemote(t *testing.T) {
 	logger, _ := logging.NewObservedTestLogger(t)
 	ctx := context.Background()


### PR DESCRIPTION
RSDK-13583

## What

  - Refactors `reconfigureAllowed` in `local_robot.go` to return `(bool, error)` instead of just bool, separating the concern of error handling from the function itself
  - Moves all maintenance sensor logging out of `reconfigureAllowed` and into reconfigure, where context about what's happening (blocked vs. allowed, network-only changes, etc.) is more readily available
  - Adds structured log fields ("sensor" and "error") to all maintenance-related log lines so users can see which sensor is involved or what went wrong
  - Adds new log lines for the "reconfigure allowed" path so both allow and block decisions are now more observable
  - Removes the log bool hack from `reconfigureAllowed` that suppressed logs when called from `RestartAllowed` by simply ignoring the error return at that callsite with //nolint:errcheck
  - Replaces `errors.Errorf` with `fmt.Errorf` in `checkMaintenanceSensorReadings`

## Why

We _could_ address the ticket by just removing the offending log (it's arguably not critical that users know a maintenance sensor _allowed_ a `reconfigure`), but the logging and logic around maintenance sensors was bothering me, so I attempted a small refactor.

## Testing

  - Adds `TestMaintenanceConfigLogs` in `local_robot_test.go` with four subtests verifying the new log lines are emitted in each code path of `reconfigure`

  [Description generated by Claude 🤖]
