### PR TITLE
RSDK-13664: surface legitimate cloud config rejections instead of hiding them

### DIFF
--- a/config/reader.go
+++ b/config/reader.go
@@ -654,21 +654,24 @@ func processConfig(unprocessedConfig *Config, fromCloud bool, logger logging.Log
 	return cfg, nil
 }
 
-// cloudConfigErrorKind classifies why a cloud config fetch failed. It determines how
-// getFromCloudOrCache reports the failure when falling back to a cached config.
-type cloudConfigErrorKind int
+// rejectedConfigError wraps an error indicating the cloud responded but rejected this robot's
+// config (e.g. it is malformed), as opposed to a transient failure to reach the cloud. Callers can
+// detect it with IsRejectedConfigError to surface the failure loudly rather than treat it as a
+// routine, retryable error.
+type rejectedConfigError struct {
+	err error
+}
 
-const (
-	// configErrorTransient indicates the cloud could not be reached (connectivity/timeout) or a
-	// local error occurred before the request was answered. Falling back to a cached config is
-	// expected, so it is logged quietly.
-	configErrorTransient cloudConfigErrorKind = iota
-	// configErrorRejected indicates the cloud responded but rejected this robot's config or
-	// returned a config we could not use (e.g. the config is malformed). This is a legitimate,
-	// likely-permanent error: we still fall back to the cache so a previously-good robot keeps
-	// running, but we surface the rejection loudly so it is not silently hidden.
-	configErrorRejected
-)
+func (e rejectedConfigError) Error() string { return e.err.Error() }
+
+func (e rejectedConfigError) Unwrap() error { return e.err }
+
+// IsRejectedConfigError reports whether err indicates the cloud rejected this robot's config
+// (rather than a transient failure to reach the cloud).
+func IsRejectedConfigError(err error) bool {
+	var rejErr rejectedConfigError
+	return errors.As(err, &rejErr)
+}
 
 // getFromCloudOrCache returns the config from the gRPC endpoint. If failures during cloud lookup fallback to the
 // local cache if the error indicates it should.
@@ -684,14 +687,15 @@ func getFromCloudOrCache(
 	ctxWithTimeout, cancel := contextutils.GetTimeoutCtx(ctx, shouldReadFromCache, cloudCfg.ID, logger)
 	defer cancel()
 
-	cfg, errKind, err := getFromCloudGRPC(ctxWithTimeout, cloudCfg, logger, conn)
+	cfg, err := getFromCloudGRPC(ctxWithTimeout, cloudCfg, logger, conn)
 	if err != nil {
+		rejected := IsRejectedConfigError(err)
 		if shouldReadFromCache {
 			cachedConfig, cacheErr := readFromCache(cloudCfg.ID)
 			if cacheErr != nil {
 				if os.IsNotExist(cacheErr) {
 					// Return original error if failed to load from cache.
-					if errKind == configErrorRejected {
+					if rejected {
 						return nil, cached, errors.Wrap(err, "cloud rejected this robot's config and no cached config exists")
 					}
 					return nil, cached, errors.Wrap(
@@ -708,10 +712,7 @@ func getFromCloudOrCache(
 				// Use logging.DefaultTimeFormatStr since this time will be logged.
 				lastUpdated = fInfo.ModTime().Format(logging.DefaultTimeFormatStr)
 			}
-			// A rejected config is a legitimate, likely-permanent error: the robot keeps running on its
-			// cached config, but we surface the rejection loudly so it is not silently hidden. A transient
-			// connectivity error is expected (e.g. a network blip) and is logged quietly.
-			if errKind == configErrorRejected {
+			if rejected {
 				logger.Errorw(
 					"cloud rejected this robot's config; the new config was NOT applied. continuing on cached config",
 					"config last updated", lastUpdated, "error", err)
@@ -728,38 +729,40 @@ func getFromCloudOrCache(
 	return cfg, cached, nil
 }
 
-// getFromCloudGRPC actually does the fetching of the robot config from the gRPC endpoint.
+// getFromCloudGRPC actually does the fetching of the robot config from the gRPC endpoint. A failure to
+// reach the cloud is returned as a plain error; a response that rejects this robot's config or returns
+// a config we cannot use is returned as a rejectedConfigError so callers surface it rather than hide it.
 func getFromCloudGRPC(
 	ctx context.Context,
 	cloudCfg *Cloud,
 	logger logging.Logger,
 	conn rpc.ClientConn,
-) (*Config, cloudConfigErrorKind, error) {
+) (*Config, error) {
 	agentInfo, err := getAgentInfo(logger)
 	if err != nil {
-		return nil, configErrorTransient, errors.WithMessage(err, "error getting agent info")
+		return nil, errors.WithMessage(err, "error getting agent info")
 	}
 
 	service := apppb.NewRobotServiceClient(conn)
 	res, err := service.Config(ctx, &apppb.ConfigRequest{Id: cloudCfg.ID, AgentInfo: agentInfo})
 	if err != nil {
-		// If the cloud could not be reached (a connectivity or timeout error) the failure is transient and
-		// falling back to a cached config is expected. Any other status code means the cloud responded and
-		// actively rejected this robot's config (e.g. the config is malformed); that is a legitimate,
-		// likely-permanent error that we surface loudly rather than hide behind the cache.
-		errKind := configErrorRejected
-		if code := status.Code(err); code == codes.Unavailable || code == codes.DeadlineExceeded || code == codes.Canceled {
-			errKind = configErrorTransient
+		// A connectivity or timeout error means we never reached the cloud and falling back to a cached
+		// config is expected. Any other status code means the cloud responded and rejected this robot's
+		// config (e.g. it is malformed), which we surface as a rejection.
+		code := status.Code(err)
+		err = errors.WithMessage(err, "error getting config from config endpoint")
+		if code != codes.Unavailable && code != codes.DeadlineExceeded && code != codes.Canceled {
+			return nil, rejectedConfigError{err}
 		}
-		return nil, errKind, errors.WithMessage(err, "error getting config from config endpoint")
+		return nil, err
 	}
 	cfg, err := FromProto(res.Config, logger)
 	if err != nil {
 		// The cloud returned a config we could not use; treat it as a rejection so the failure is surfaced.
-		return nil, configErrorRejected, errors.WithMessage(err, "error converting config from proto")
+		return nil, rejectedConfigError{errors.WithMessage(err, "error converting config from proto")}
 	}
 
-	return cfg, configErrorTransient, nil
+	return cfg, nil
 }
 
 // CreateNewGRPCClient creates a new grpc cloud configured to communicate with the robot service based on the cloud config given.

--- a/config/reader.go
+++ b/config/reader.go
@@ -19,6 +19,8 @@ import (
 	"go.viam.com/utils"
 	"go.viam.com/utils/rpc"
 	"golang.org/x/sys/cpu"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -652,6 +654,22 @@ func processConfig(unprocessedConfig *Config, fromCloud bool, logger logging.Log
 	return cfg, nil
 }
 
+// cloudConfigErrorKind classifies why a cloud config fetch failed. It determines how
+// getFromCloudOrCache reports the failure when falling back to a cached config.
+type cloudConfigErrorKind int
+
+const (
+	// configErrorTransient indicates the cloud could not be reached (connectivity/timeout) or a
+	// local error occurred before the request was answered. Falling back to a cached config is
+	// expected, so it is logged quietly.
+	configErrorTransient cloudConfigErrorKind = iota
+	// configErrorRejected indicates the cloud responded but rejected this robot's config or
+	// returned a config we could not use (e.g. the config is malformed). This is a legitimate,
+	// likely-permanent error: we still fall back to the cache so a previously-good robot keeps
+	// running, but we surface the rejection loudly so it is not silently hidden.
+	configErrorRejected
+)
+
 // getFromCloudOrCache returns the config from the gRPC endpoint. If failures during cloud lookup fallback to the
 // local cache if the error indicates it should.
 func getFromCloudOrCache(
@@ -666,13 +684,16 @@ func getFromCloudOrCache(
 	ctxWithTimeout, cancel := contextutils.GetTimeoutCtx(ctx, shouldReadFromCache, cloudCfg.ID, logger)
 	defer cancel()
 
-	cfg, errorShouldCheckCache, err := getFromCloudGRPC(ctxWithTimeout, cloudCfg, logger, conn)
+	cfg, errKind, err := getFromCloudGRPC(ctxWithTimeout, cloudCfg, logger, conn)
 	if err != nil {
-		if shouldReadFromCache && errorShouldCheckCache {
+		if shouldReadFromCache {
 			cachedConfig, cacheErr := readFromCache(cloudCfg.ID)
 			if cacheErr != nil {
 				if os.IsNotExist(cacheErr) {
-					// Return original http error if failed to load from cache.
+					// Return original error if failed to load from cache.
+					if errKind == configErrorRejected {
+						return nil, cached, errors.Wrap(err, "cloud rejected this robot's config and no cached config exists")
+					}
 					return nil, cached, errors.Wrap(
 						err,
 						"error getting cloud config, cached config does not exist; returning error from cloud config attempt",
@@ -687,7 +708,16 @@ func getFromCloudOrCache(
 				// Use logging.DefaultTimeFormatStr since this time will be logged.
 				lastUpdated = fInfo.ModTime().Format(logging.DefaultTimeFormatStr)
 			}
-			logger.Warnw("unable to get cloud config; using cached version", "config last updated", lastUpdated, "error", err)
+			// A rejected config is a legitimate, likely-permanent error: the robot keeps running on its
+			// cached config, but we surface the rejection loudly so it is not silently hidden. A transient
+			// connectivity error is expected (e.g. a network blip) and is logged quietly.
+			if errKind == configErrorRejected {
+				logger.Errorw(
+					"cloud rejected this robot's config; the new config was NOT applied. continuing on cached config",
+					"config last updated", lastUpdated, "error", err)
+			} else {
+				logger.Warnw("unable to get cloud config; using cached version", "config last updated", lastUpdated, "error", err)
+			}
 			cached = true
 			return cachedConfig, cached, nil
 		}
@@ -699,27 +729,37 @@ func getFromCloudOrCache(
 }
 
 // getFromCloudGRPC actually does the fetching of the robot config from the gRPC endpoint.
-func getFromCloudGRPC(ctx context.Context, cloudCfg *Cloud, logger logging.Logger, conn rpc.ClientConn) (*Config, bool, error) {
-	shouldCheckCacheOnFailure := true
-
+func getFromCloudGRPC(
+	ctx context.Context,
+	cloudCfg *Cloud,
+	logger logging.Logger,
+	conn rpc.ClientConn,
+) (*Config, cloudConfigErrorKind, error) {
 	agentInfo, err := getAgentInfo(logger)
 	if err != nil {
-		return nil, shouldCheckCacheOnFailure, errors.WithMessage(err, "error getting agent info")
+		return nil, configErrorTransient, errors.WithMessage(err, "error getting agent info")
 	}
 
 	service := apppb.NewRobotServiceClient(conn)
 	res, err := service.Config(ctx, &apppb.ConfigRequest{Id: cloudCfg.ID, AgentInfo: agentInfo})
 	if err != nil {
-		// Check cache?
-		return nil, shouldCheckCacheOnFailure, errors.WithMessage(err, "error getting config from config endpoint")
+		// If the cloud could not be reached (a connectivity or timeout error) the failure is transient and
+		// falling back to a cached config is expected. Any other status code means the cloud responded and
+		// actively rejected this robot's config (e.g. the config is malformed); that is a legitimate,
+		// likely-permanent error that we surface loudly rather than hide behind the cache.
+		errKind := configErrorRejected
+		if code := status.Code(err); code == codes.Unavailable || code == codes.DeadlineExceeded || code == codes.Canceled {
+			errKind = configErrorTransient
+		}
+		return nil, errKind, errors.WithMessage(err, "error getting config from config endpoint")
 	}
 	cfg, err := FromProto(res.Config, logger)
 	if err != nil {
-		// Check cache?
-		return nil, shouldCheckCacheOnFailure, errors.WithMessage(err, "error converting config from proto")
+		// The cloud returned a config we could not use; treat it as a rejection so the failure is surfaced.
+		return nil, configErrorRejected, errors.WithMessage(err, "error converting config from proto")
 	}
 
-	return cfg, false, nil
+	return cfg, configErrorTransient, nil
 }
 
 // CreateNewGRPCClient creates a new grpc cloud configured to communicate with the robot service based on the cloud config given.

--- a/config/reader.go
+++ b/config/reader.go
@@ -710,10 +710,7 @@ func getFromCloudOrCache(
 			cachedConfig, cacheErr := readFromCache(cloudCfg.ID)
 			if cacheErr != nil {
 				if os.IsNotExist(cacheErr) {
-					// Return original error if failed to load from cache.
-					if malformed {
-						return nil, cached, errors.Wrap(err, "no cached config exists to fall back to")
-					}
+					// No cache to fall back to, return original error.
 					return nil, cached, errors.Wrap(
 						err,
 						"error getting cloud config, cached config does not exist; returning error from cloud config attempt",
@@ -728,13 +725,15 @@ func getFromCloudOrCache(
 				// Use logging.DefaultTimeFormatStr since this time will be logged.
 				lastUpdated = fInfo.ModTime().Format(logging.DefaultTimeFormatStr)
 			}
+			// A malformed config is logged at Error since it will keep failing,
+			// while a transient failure to reach the cloud stays at Warn. Same
+			// message either way.
+			logFunc := logger.Warnw
 			if malformed {
-				logger.Errorw(
-					"the new config was NOT applied; continuing on cached config",
-					"config last updated", lastUpdated, "error", err)
-			} else {
-				logger.Warnw("unable to get cloud config; using cached version", "config last updated", lastUpdated, "error", err)
+				logFunc = logger.Errorw
 			}
+			logFunc("could not apply new cloud config; using cached version",
+				"config last updated", lastUpdated, "error", err)
 			cached = true
 			return cachedConfig, cached, nil
 		}

--- a/config/reader.go
+++ b/config/reader.go
@@ -193,13 +193,16 @@ func readFromCloud(
 	// process the config
 	cfg, err := processConfigFromCloud(unprocessedConfig, logger)
 	if err != nil {
-		// If we cannot process the config from the cache we should clear it.
 		if cached {
-			// clear cache
+			// We could not process the cached config; clear it so we don't keep reusing a bad cache.
 			logger.Warn("Detected failure to process the cached config, clearing cache.")
 			clearCache(cloudCfg.ID)
+			return nil, err
 		}
-		return nil, err
+		// A freshly fetched cloud config we cannot process is a rejection in all but name: the cloud
+		// served it but this robot cannot apply it, and it will fail identically on every refresh.
+		// Surface it as a rejection so callers log it loudly rather than hiding it at debug.
+		return nil, rejectedConfigError{err}
 	}
 	if cfg.Cloud == nil {
 		return nil, errors.New("expected config to have cloud section")
@@ -654,10 +657,11 @@ func processConfig(unprocessedConfig *Config, fromCloud bool, logger logging.Log
 	return cfg, nil
 }
 
-// rejectedConfigError wraps an error indicating the cloud responded but rejected this robot's
-// config (e.g. it is malformed), as opposed to a transient failure to reach the cloud. Callers can
-// detect it with IsRejectedConfigError to surface the failure loudly rather than treat it as a
-// routine, retryable error.
+// rejectedConfigError wraps an error indicating this robot's config was rejected and cannot be
+// applied — either the cloud responded and rejected it (e.g. it is malformed) or a freshly fetched
+// cloud config failed local processing — as opposed to a transient failure to reach the cloud.
+// Callers can detect it with IsRejectedConfigError to surface the failure loudly rather than treat
+// it as a routine, retryable error.
 type rejectedConfigError struct {
 	err error
 }
@@ -666,11 +670,33 @@ func (e rejectedConfigError) Error() string { return e.err.Error() }
 
 func (e rejectedConfigError) Unwrap() error { return e.err }
 
-// IsRejectedConfigError reports whether err indicates the cloud rejected this robot's config
-// (rather than a transient failure to reach the cloud).
+// IsRejectedConfigError reports whether err indicates this robot's config was rejected and cannot be
+// applied (rather than a transient failure to reach the cloud).
 func IsRejectedConfigError(err error) bool {
 	var rejErr rejectedConfigError
 	return errors.As(err, &rejErr)
+}
+
+// isCloudConfigRejection reports whether a cloud config-fetch error means the cloud responded and
+// rejected this robot's config (e.g. it is malformed), as opposed to a transient failure to reach
+// the cloud. Only a gRPC status returned by the cloud can be a rejection: a non-status error (e.g.
+// the rpc layer's "not connected", or a bare context error) never reached the cloud and is treated
+// as transient. Among status codes, the conversion failure that motivated this surfaces as
+// codes.Unknown, and a validating endpoint may instead use codes.InvalidArgument or
+// codes.FailedPrecondition. Every other code is transient: connectivity/timeout (Unavailable,
+// DeadlineExceeded, Canceled), rate-limiting (ResourceExhausted), auth (Unauthenticated,
+// PermissionDenied), NotFound, and server-side faults (Internal) are not config rejections.
+func isCloudConfigRejection(err error) bool {
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	switch st.Code() {
+	case codes.Unknown, codes.InvalidArgument, codes.FailedPrecondition:
+		return true
+	default:
+		return false
+	}
 }
 
 // getFromCloudOrCache returns the config from the gRPC endpoint. If failures during cloud lookup fallback to the
@@ -696,7 +722,7 @@ func getFromCloudOrCache(
 				if os.IsNotExist(cacheErr) {
 					// Return original error if failed to load from cache.
 					if rejected {
-						return nil, cached, errors.Wrap(err, "cloud rejected this robot's config and no cached config exists")
+						return nil, cached, errors.Wrap(err, "this robot's config was rejected and no cached config exists")
 					}
 					return nil, cached, errors.Wrap(
 						err,
@@ -714,7 +740,7 @@ func getFromCloudOrCache(
 			}
 			if rejected {
 				logger.Errorw(
-					"cloud rejected this robot's config; the new config was NOT applied. continuing on cached config",
+					"this robot's config was rejected; the new config was NOT applied. continuing on cached config",
 					"config last updated", lastUpdated, "error", err)
 			} else {
 				logger.Warnw("unable to get cloud config; using cached version", "config last updated", lastUpdated, "error", err)
@@ -746,12 +772,13 @@ func getFromCloudGRPC(
 	service := apppb.NewRobotServiceClient(conn)
 	res, err := service.Config(ctx, &apppb.ConfigRequest{Id: cloudCfg.ID, AgentInfo: agentInfo})
 	if err != nil {
-		// A connectivity or timeout error means we never reached the cloud and falling back to a cached
-		// config is expected. Any other status code means the cloud responded and rejected this robot's
-		// config (e.g. it is malformed), which we surface as a rejection.
-		code := status.Code(err)
+		// A response that rejects this robot's config (e.g. it is malformed) is surfaced as a rejection
+		// so callers can log it loudly. Anything else (connectivity, timeout, auth, rate-limiting,
+		// server-side faults, or a transport error that never reached the cloud) is transient, so we
+		// fall back to the cached config and retry quietly.
+		rejected := isCloudConfigRejection(err)
 		err = errors.WithMessage(err, "error getting config from config endpoint")
-		if code != codes.Unavailable && code != codes.DeadlineExceeded && code != codes.Canceled {
+		if rejected {
 			return nil, rejectedConfigError{err}
 		}
 		return nil, err

--- a/config/reader.go
+++ b/config/reader.go
@@ -199,9 +199,9 @@ func readFromCloud(
 			clearCache(cloudCfg.ID)
 			return nil, err
 		}
-		// A freshly fetched cloud config we cannot process is a rejection in all but name: the cloud
-		// served it but this robot cannot apply it, and it will fail identically on every refresh.
-		// Surface it as a rejection so callers log it loudly rather than hiding it at debug.
+		// A freshly fetched cloud config we cannot process is a rejection. The robot cannot
+		// apply it, and it will fail identically on every refresh. Surface it as a rejection
+		// so callers log it loudly.
 		return nil, rejectedConfigError{err}
 	}
 	if cfg.Cloud == nil {
@@ -678,14 +678,7 @@ func IsRejectedConfigError(err error) bool {
 }
 
 // isCloudConfigRejection reports whether a cloud config-fetch error means the cloud responded and
-// rejected this robot's config (e.g. it is malformed), as opposed to a transient failure to reach
-// the cloud. Only a gRPC status returned by the cloud can be a rejection: a non-status error (e.g.
-// the rpc layer's "not connected", or a bare context error) never reached the cloud and is treated
-// as transient. Among status codes, the conversion failure that motivated this surfaces as
-// codes.Unknown, and a validating endpoint may instead use codes.InvalidArgument or
-// codes.FailedPrecondition. Every other code is transient: connectivity/timeout (Unavailable,
-// DeadlineExceeded, Canceled), rate-limiting (ResourceExhausted), auth (Unauthenticated,
-// PermissionDenied), NotFound, and server-side faults (Internal) are not config rejections.
+// rejected this robot's config or experienced a transient failure to reach the cloud.
 func isCloudConfigRejection(err error) bool {
 	st, ok := status.FromError(err)
 	if !ok {
@@ -757,7 +750,7 @@ func getFromCloudOrCache(
 
 // getFromCloudGRPC actually does the fetching of the robot config from the gRPC endpoint. A failure to
 // reach the cloud is returned as a plain error; a response that rejects this robot's config or returns
-// a config we cannot use is returned as a rejectedConfigError so callers surface it rather than hide it.
+// a config we cannot use is returned as a rejectedConfigError.
 func getFromCloudGRPC(
 	ctx context.Context,
 	cloudCfg *Cloud,
@@ -772,10 +765,8 @@ func getFromCloudGRPC(
 	service := apppb.NewRobotServiceClient(conn)
 	res, err := service.Config(ctx, &apppb.ConfigRequest{Id: cloudCfg.ID, AgentInfo: agentInfo})
 	if err != nil {
-		// A response that rejects this robot's config (e.g. it is malformed) is surfaced as a rejection
-		// so callers can log it loudly. Anything else (connectivity, timeout, auth, rate-limiting,
-		// server-side faults, or a transport error that never reached the cloud) is transient, so we
-		// fall back to the cached config and retry quietly.
+		// A response that rejects this robot's config is surfaced as a rejection.
+		// Anything else (connectivity, timeout, auth, rate-limiting, etc) is transient.
 		rejected := isCloudConfigRejection(err)
 		err = errors.WithMessage(err, "error getting config from config endpoint")
 		if rejected {
@@ -785,7 +776,7 @@ func getFromCloudGRPC(
 	}
 	cfg, err := FromProto(res.Config, logger)
 	if err != nil {
-		// The cloud returned a config we could not use; treat it as a rejection so the failure is surfaced.
+		// The cloud returned a config we could not use so treat it as a rejection.
 		return nil, rejectedConfigError{errors.WithMessage(err, "error converting config from proto")}
 	}
 

--- a/config/reader.go
+++ b/config/reader.go
@@ -199,10 +199,9 @@ func readFromCloud(
 			clearCache(cloudCfg.ID)
 			return nil, err
 		}
-		// A freshly fetched cloud config we cannot process is a rejection. The robot cannot
-		// apply it, and it will fail identically on every refresh. Surface it as a rejection
-		// so callers log it loudly.
-		return nil, rejectedConfigError{err}
+		// A freshly fetched cloud config we cannot process locally is malformed. The robot cannot
+		// apply it, and it will fail identically on every refresh, so surface it loudly.
+		return nil, malformedConfigError{err}
 	}
 	if cfg.Cloud == nil {
 		return nil, errors.New("expected config to have cloud section")
@@ -657,29 +656,31 @@ func processConfig(unprocessedConfig *Config, fromCloud bool, logger logging.Log
 	return cfg, nil
 }
 
-// rejectedConfigError wraps an error indicating this robot's config was rejected and cannot
-// be applied, as opposed to a transient failure to reach the cloud. Either the cloud responded
-// and rejected it (e.g. it is malformed) or a freshly fetchedcloud config failed local processing.
-// Callers can detect it with IsRejectedConfigError to surface the failure loudly rather than treat
-// it as a retryable error.
-type rejectedConfigError struct {
+// malformedConfigError wraps an error indicating this robot's cloud config could not be applied, as
+// opposed to a transient failure to reach the cloud. This happens either because the cloud served a
+// config this robot could not decode from proto or process locally, or because the cloud responded with
+// a status code indicating it could not produce a usable config for this robot. A malformed config fails
+// identically on every refresh, so surface it loudly rather than retrying quietly.
+type malformedConfigError struct {
 	err error
 }
 
-func (e rejectedConfigError) Error() string { return e.err.Error() }
-
-func (e rejectedConfigError) Unwrap() error { return e.err }
-
-// IsRejectedConfigError reports whether err indicates this robot's config was rejected and cannot be
-// applied.
-func IsRejectedConfigError(err error) bool {
-	var rejErr rejectedConfigError
-	return errors.As(err, &rejErr)
+func (e malformedConfigError) Error() string {
+	return fmt.Sprintf("config was malformed: %s", e.err.Error())
 }
 
-// isCloudConfigRejection reports whether a cloud config-fetch error means the cloud responded and
-// rejected this robot's config or experienced a transient failure to reach the cloud.
-func isCloudConfigRejection(err error) bool {
+func (e malformedConfigError) Unwrap() error { return e.err }
+
+// IsMalformedConfigError reports whether err indicates this robot's cloud config could not be applied
+// because it is malformed.
+func IsMalformedConfigError(err error) bool {
+	var malformedErr malformedConfigError
+	return errors.As(err, &malformedErr)
+}
+
+// isCloudConfigMalformed reports whether a cloud config-fetch error means the cloud responded and
+// could not return a usable config for this robot, as opposed to a transient failure to reach the cloud.
+func isCloudConfigMalformed(err error) bool {
 	st, ok := status.FromError(err)
 	if !ok {
 		return false
@@ -704,14 +705,14 @@ func getFromCloudOrCache(
 
 	cfg, err := getFromCloudGRPC(ctxWithTimeout, cloudCfg, logger, conn)
 	if err != nil {
-		rejected := IsRejectedConfigError(err)
+		malformed := IsMalformedConfigError(err)
 		if shouldReadFromCache {
 			cachedConfig, cacheErr := readFromCache(cloudCfg.ID)
 			if cacheErr != nil {
 				if os.IsNotExist(cacheErr) {
 					// Return original error if failed to load from cache.
-					if rejected {
-						return nil, cached, errors.Wrap(err, "this robot's config was rejected and no cached config exists")
+					if malformed {
+						return nil, cached, errors.Wrap(err, "no cached config exists to fall back to")
 					}
 					return nil, cached, errors.Wrap(
 						err,
@@ -727,9 +728,9 @@ func getFromCloudOrCache(
 				// Use logging.DefaultTimeFormatStr since this time will be logged.
 				lastUpdated = fInfo.ModTime().Format(logging.DefaultTimeFormatStr)
 			}
-			if rejected {
+			if malformed {
 				logger.Errorw(
-					"this robot's config was rejected; the new config was NOT applied. continuing on cached config",
+					"the new config was NOT applied; continuing on cached config",
 					"config last updated", lastUpdated, "error", err)
 			} else {
 				logger.Warnw("unable to get cloud config; using cached version", "config last updated", lastUpdated, "error", err)
@@ -745,8 +746,8 @@ func getFromCloudOrCache(
 }
 
 // getFromCloudGRPC actually does the fetching of the robot config from the gRPC endpoint. A failure to
-// reach the cloud is returned as a plain error; a response that rejects this robot's config or returns
-// a config we cannot use is returned as a rejectedConfigError.
+// reach the cloud is returned as a plain error; a config the cloud could not produce or that we cannot
+// decode is returned as a malformedConfigError.
 func getFromCloudGRPC(
 	ctx context.Context,
 	cloudCfg *Cloud,
@@ -761,19 +762,19 @@ func getFromCloudGRPC(
 	service := apppb.NewRobotServiceClient(conn)
 	res, err := service.Config(ctx, &apppb.ConfigRequest{Id: cloudCfg.ID, AgentInfo: agentInfo})
 	if err != nil {
-		// A response that rejects this robot's config is surfaced as a rejection.
+		// A status code indicating the cloud could not produce a usable config is treated as malformed.
 		// Anything else (connectivity, timeout, auth, rate-limiting, etc) is transient.
-		rejected := isCloudConfigRejection(err)
+		malformed := isCloudConfigMalformed(err)
 		err = errors.WithMessage(err, "error getting config from config endpoint")
-		if rejected {
-			return nil, rejectedConfigError{err}
+		if malformed {
+			return nil, malformedConfigError{err}
 		}
 		return nil, err
 	}
 	cfg, err := FromProto(res.Config, logger)
 	if err != nil {
-		// The cloud returned a config we could not use so treat it as a rejection.
-		return nil, rejectedConfigError{errors.WithMessage(err, "error converting config from proto")}
+		// The cloud served a config we could not decode from proto, so it is malformed.
+		return nil, malformedConfigError{errors.WithMessage(err, "error converting config from proto")}
 	}
 
 	return cfg, nil

--- a/config/reader.go
+++ b/config/reader.go
@@ -657,11 +657,11 @@ func processConfig(unprocessedConfig *Config, fromCloud bool, logger logging.Log
 	return cfg, nil
 }
 
-// rejectedConfigError wraps an error indicating this robot's config was rejected and cannot be
-// applied — either the cloud responded and rejected it (e.g. it is malformed) or a freshly fetched
-// cloud config failed local processing — as opposed to a transient failure to reach the cloud.
+// rejectedConfigError wraps an error indicating this robot's config was rejected and cannot
+// be applied, as opposed to a transient failure to reach the cloud. Either the cloud responded
+// and rejected it (e.g. it is malformed) or a freshly fetchedcloud config failed local processing.
 // Callers can detect it with IsRejectedConfigError to surface the failure loudly rather than treat
-// it as a routine, retryable error.
+// it as a retryable error.
 type rejectedConfigError struct {
 	err error
 }
@@ -671,7 +671,7 @@ func (e rejectedConfigError) Error() string { return e.err.Error() }
 func (e rejectedConfigError) Unwrap() error { return e.err }
 
 // IsRejectedConfigError reports whether err indicates this robot's config was rejected and cannot be
-// applied (rather than a transient failure to reach the cloud).
+// applied.
 func IsRejectedConfigError(err error) bool {
 	var rejErr rejectedConfigError
 	return errors.As(err, &rejErr)
@@ -684,12 +684,8 @@ func isCloudConfigRejection(err error) bool {
 	if !ok {
 		return false
 	}
-	switch st.Code() {
-	case codes.Unknown, codes.InvalidArgument, codes.FailedPrecondition:
-		return true
-	default:
-		return false
-	}
+	code := st.Code()
+	return code == codes.Unknown || code == codes.InvalidArgument || code == codes.FailedPrecondition
 }
 
 // getFromCloudOrCache returns the config from the gRPC endpoint. If failures during cloud lookup fallback to the

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -236,8 +236,10 @@ func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 		test.That(t, cached, test.ShouldBeTrue)
 		test.That(t, cfg, test.ShouldNotBeNil)
 
-		test.That(t, logs.FilterMessageSnippet("unable to get cloud config; using cached version").Len(), test.ShouldEqual, 1)
-		test.That(t, logs.FilterMessageSnippet("the new config was NOT applied").Len(), test.ShouldEqual, 0)
+		// Same message for both cases; a transient failure is distinguished only by its Warn level.
+		quiet := logs.FilterMessageSnippet("could not apply new cloud config; using cached version")
+		test.That(t, quiet.Len(), test.ShouldEqual, 1)
+		test.That(t, quiet.All()[0].Level, test.ShouldEqual, zapcore.WarnLevel)
 	})
 
 	t.Run("malformed config is surfaced loudly and falls back to cache", func(t *testing.T) {
@@ -254,10 +256,10 @@ func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 		test.That(t, cached, test.ShouldBeTrue)
 		test.That(t, cfg, test.ShouldNotBeNil)
 
-		malformed := logs.FilterMessageSnippet("the new config was NOT applied")
-		test.That(t, malformed.Len(), test.ShouldEqual, 1)
-		test.That(t, malformed.All()[0].Level, test.ShouldEqual, zapcore.ErrorLevel)
-		test.That(t, logs.FilterMessageSnippet("unable to get cloud config; using cached version").Len(), test.ShouldEqual, 0)
+		// Same message as the transient case, but a malformed config is surfaced loudly at Error.
+		loud := logs.FilterMessageSnippet("could not apply new cloud config; using cached version")
+		test.That(t, loud.Len(), test.ShouldEqual, 1)
+		test.That(t, loud.All()[0].Level, test.ShouldEqual, zapcore.ErrorLevel)
 	})
 
 	t.Run("malformed config with no cache returns a clear error", func(t *testing.T) {
@@ -271,7 +273,7 @@ func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, IsMalformedConfigError(err), test.ShouldBeTrue)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "config was malformed")
-		test.That(t, err.Error(), test.ShouldContainSubstring, "no cached config exists to fall back to")
+		test.That(t, err.Error(), test.ShouldContainSubstring, "cached config does not exist")
 		test.That(t, err.Error(), test.ShouldContainSubstring, "OrientationVectorDegrees has a normal of 0")
 	})
 

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -189,7 +189,7 @@ func TestFromReader(t *testing.T) {
 
 // TestGetFromCloudOrCacheErrorClassification verifies that when the cloud config endpoint fails
 // and we fall back to a cached config, a connectivity error is logged quietly (Warn) while a
-// config rejection from the cloud is surfaced loudly (Error) so it is not silently hidden.
+// config rejection from the cloud is surfaced loudly (Error).
 func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 	const (
 		robotPartID = "forCachingTest"
@@ -290,9 +290,7 @@ func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 }
 
 // TestIsCloudConfigRejection pins down the classification that decides whether a cloud config-fetch
-// failure is a rejection (surfaced loudly) or a transient failure to reach the cloud (retried
-// quietly). Only a gRPC status with a rejection-class code is a rejection; a non-status error never
-// reached the cloud and is transient even though its implied code is Unknown.
+// failure is a rejection or a transient failure to reach the cloud.
 func TestIsCloudConfigRejection(t *testing.T) {
 	for _, tc := range []struct {
 		name     string

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -11,9 +11,12 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"go.uber.org/zap/zapcore"
 	pb "go.viam.com/api/app/v1"
 	"go.viam.com/test"
 	"go.viam.com/utils/rpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"go.viam.com/rdk/config/testutils"
 	"go.viam.com/rdk/grpc"
@@ -181,6 +184,95 @@ func TestFromReader(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		expectedCloud.AppAddress = ""
 		test.That(t, cachedCfg.Cloud, test.ShouldResemble, &expectedCloud)
+	})
+}
+
+// TestGetFromCloudOrCacheErrorClassification verifies that when the cloud config endpoint fails
+// and we fall back to a cached config, a connectivity error is logged quietly (Warn) while a
+// config rejection from the cloud is surfaced loudly (Error) so it is not silently hidden.
+func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
+	const (
+		robotPartID = "forCachingTest"
+		secret      = testutils.FakeCredentialPayLoad
+	)
+	ctx := context.Background()
+
+	// Seed the cache so the fallback path is exercised in every case.
+	setupCache := func(t *testing.T) {
+		t.Helper()
+		clearCache(robotPartID)
+		cachedConf := &Config{Cloud: &Cloud{ID: robotPartID, Secret: secret, FQDN: "fqdn"}}
+		cfgToCache := &Config{Cloud: &Cloud{ID: robotPartID}}
+		cfgToCache.SetToCache(cachedConf)
+		test.That(t, cfgToCache.StoreToCache(), test.ShouldBeNil)
+	}
+
+	newAppConn := func(t *testing.T, failWith error) (*Cloud, rpc.ClientConn, func()) {
+		t.Helper()
+		logger := logging.NewTestLogger(t)
+		fakeServer, cleanup := testutils.NewFakeCloudServer(t, ctx, logger)
+		fakeServer.FailOnConfigAndCertsWith(failWith)
+		fakeServer.StoreDeviceConfig(robotPartID, nil, nil)
+
+		appAddress := fmt.Sprintf("http://%s", fakeServer.Addr().String())
+		cloudCfg := &Cloud{ID: robotPartID, Secret: secret, AppAddress: appAddress}
+		appConn, err := grpc.NewAppConn(ctx, appAddress, robotPartID, cloudCfg.GetCloudCredsDialOpt(), logger)
+		test.That(t, err, test.ShouldBeNil)
+		return cloudCfg, appConn, func() {
+			test.That(t, appConn.Close(), test.ShouldBeNil)
+			cleanup()
+		}
+	}
+
+	t.Run("connectivity error is logged quietly and falls back to cache", func(t *testing.T) {
+		setupCache(t)
+		defer clearCache(robotPartID)
+
+		cloudCfg, appConn, cleanup := newAppConn(t, status.Error(codes.Unavailable, "cloud is down"))
+		defer cleanup()
+
+		logger, logs := logging.NewObservedTestLogger(t)
+		cfg, cached, err := getFromCloudOrCache(ctx, cloudCfg, true, logger, appConn)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, cached, test.ShouldBeTrue)
+		test.That(t, cfg, test.ShouldNotBeNil)
+
+		test.That(t, logs.FilterMessageSnippet("unable to get cloud config; using cached version").Len(), test.ShouldEqual, 1)
+		test.That(t, logs.FilterMessageSnippet("cloud rejected this robot's config").Len(), test.ShouldEqual, 0)
+	})
+
+	t.Run("rejected config is surfaced loudly and falls back to cache", func(t *testing.T) {
+		setupCache(t)
+		defer clearCache(robotPartID)
+
+		// codes.Unknown is what the real config conversion failure surfaces (a plain error returned by the
+		// cloud config endpoint).
+		cloudCfg, appConn, cleanup := newAppConn(t, status.Error(codes.Unknown, "OrientationVectorDegrees has a normal of 0"))
+		defer cleanup()
+
+		logger, logs := logging.NewObservedTestLogger(t)
+		cfg, cached, err := getFromCloudOrCache(ctx, cloudCfg, true, logger, appConn)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, cached, test.ShouldBeTrue)
+		test.That(t, cfg, test.ShouldNotBeNil)
+
+		rejected := logs.FilterMessageSnippet("cloud rejected this robot's config")
+		test.That(t, rejected.Len(), test.ShouldEqual, 1)
+		test.That(t, rejected.All()[0].Level, test.ShouldEqual, zapcore.ErrorLevel)
+		test.That(t, logs.FilterMessageSnippet("unable to get cloud config; using cached version").Len(), test.ShouldEqual, 0)
+	})
+
+	t.Run("rejected config with no cache returns a clear error", func(t *testing.T) {
+		clearCache(robotPartID)
+
+		cloudCfg, appConn, cleanup := newAppConn(t, status.Error(codes.Unknown, "OrientationVectorDegrees has a normal of 0"))
+		defer cleanup()
+
+		logger := logging.NewTestLogger(t)
+		_, _, err := getFromCloudOrCache(ctx, cloudCfg, true, logger, appConn)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "cloud rejected this robot's config and no cached config exists")
+		test.That(t, err.Error(), test.ShouldContainSubstring, "OrientationVectorDegrees has a normal of 0")
 	})
 }
 

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -237,7 +237,7 @@ func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 		test.That(t, cfg, test.ShouldNotBeNil)
 
 		test.That(t, logs.FilterMessageSnippet("unable to get cloud config; using cached version").Len(), test.ShouldEqual, 1)
-		test.That(t, logs.FilterMessageSnippet("cloud rejected this robot's config").Len(), test.ShouldEqual, 0)
+		test.That(t, logs.FilterMessageSnippet("this robot's config was rejected").Len(), test.ShouldEqual, 0)
 	})
 
 	t.Run("rejected config is surfaced loudly and falls back to cache", func(t *testing.T) {
@@ -254,7 +254,7 @@ func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 		test.That(t, cached, test.ShouldBeTrue)
 		test.That(t, cfg, test.ShouldNotBeNil)
 
-		rejected := logs.FilterMessageSnippet("cloud rejected this robot's config")
+		rejected := logs.FilterMessageSnippet("this robot's config was rejected")
 		test.That(t, rejected.Len(), test.ShouldEqual, 1)
 		test.That(t, rejected.All()[0].Level, test.ShouldEqual, zapcore.ErrorLevel)
 		test.That(t, logs.FilterMessageSnippet("unable to get cloud config; using cached version").Len(), test.ShouldEqual, 0)
@@ -270,7 +270,7 @@ func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 		_, _, err := getFromCloudOrCache(ctx, cloudCfg, true, logger, appConn)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, IsRejectedConfigError(err), test.ShouldBeTrue)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "cloud rejected this robot's config and no cached config exists")
+		test.That(t, err.Error(), test.ShouldContainSubstring, "this robot's config was rejected and no cached config exists")
 		test.That(t, err.Error(), test.ShouldContainSubstring, "OrientationVectorDegrees has a normal of 0")
 	})
 
@@ -285,8 +285,122 @@ func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, IsRejectedConfigError(err), test.ShouldBeFalse)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "cached config does not exist")
-		test.That(t, err.Error(), test.ShouldNotContainSubstring, "cloud rejected this robot's config")
+		test.That(t, err.Error(), test.ShouldNotContainSubstring, "this robot's config was rejected")
 	})
+}
+
+// TestIsCloudConfigRejection pins down the classification that decides whether a cloud config-fetch
+// failure is a rejection (surfaced loudly) or a transient failure to reach the cloud (retried
+// quietly). Only a gRPC status with a rejection-class code is a rejection; a non-status error never
+// reached the cloud and is transient even though its implied code is Unknown.
+func TestIsCloudConfigRejection(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		err      error
+		rejected bool
+	}{
+		// Status codes the cloud uses to reject a config.
+		{"unknown (real conversion failure)", status.Error(codes.Unknown, "boom"), true},
+		{"invalid argument", status.Error(codes.InvalidArgument, "boom"), true},
+		{"failed precondition", status.Error(codes.FailedPrecondition, "boom"), true},
+		// Transient status codes are never a rejection. Internal is the notable one: it was previously
+		// treated as a rejection, but a server-side fault is not a config rejection.
+		{"unavailable", status.Error(codes.Unavailable, "boom"), false},
+		{"deadline exceeded", status.Error(codes.DeadlineExceeded, "boom"), false},
+		{"canceled", status.Error(codes.Canceled, "boom"), false},
+		{"internal", status.Error(codes.Internal, "boom"), false},
+		{"resource exhausted", status.Error(codes.ResourceExhausted, "boom"), false},
+		{"unauthenticated", status.Error(codes.Unauthenticated, "boom"), false},
+		{"permission denied", status.Error(codes.PermissionDenied, "boom"), false},
+		{"not found", status.Error(codes.NotFound, "boom"), false},
+		// Non-status errors never reached the cloud, so they are transient even though status.Code
+		// reports Unknown for them. "not connected" is what the rpc layer returns when the app
+		// connection was never established.
+		{"not connected (no gRPC status)", errors.New("not connected"), false},
+		{"bare context deadline", context.DeadlineExceeded, false},
+		// Wrapping must not hide a real rejection.
+		{"wrapped rejection", errors.WithMessage(status.Error(codes.Unknown, "boom"), "fetching config"), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			test.That(t, isCloudConfigRejection(tc.err), test.ShouldEqual, tc.rejected)
+		})
+	}
+}
+
+// TestGetFromCloudGRPCProtoDecodeFailureIsRejection verifies that a config the cloud serves but that
+// this robot cannot decode from proto is surfaced as a rejection, mirroring the reported
+// orientation-vector failure (here, an auth handler with an unsupported credential type).
+func TestGetFromCloudGRPCProtoDecodeFailureIsRejection(t *testing.T) {
+	const robotPartID = "forProtoDecodeTest"
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+	clearCache(robotPartID)
+	defer clearCache(robotPartID)
+
+	fakeServer, cleanup := testutils.NewFakeCloudServer(t, ctx, logger)
+	defer cleanup()
+
+	cloudResponse := &Cloud{ID: robotPartID, Secret: testutils.FakeCredentialPayLoad, FQDN: "fqdn", SignalingInsecure: true}
+	cloudConfProto, err := CloudConfigToProto(cloudResponse)
+	test.That(t, err, test.ShouldBeNil)
+
+	// An auth handler with an unspecified credential type passes the wire but fails FromProto.
+	protoConfig := &pb.RobotConfig{
+		Cloud: cloudConfProto,
+		Auth:  &pb.AuthConfig{Handlers: []*pb.AuthHandlerConfig{{Type: pb.CredentialsType_CREDENTIALS_TYPE_UNSPECIFIED}}},
+	}
+	fakeServer.StoreDeviceConfig(robotPartID, protoConfig, nil)
+
+	appAddress := fmt.Sprintf("http://%s", fakeServer.Addr().String())
+	cloudCfg := &Cloud{ID: robotPartID, Secret: testutils.FakeCredentialPayLoad, AppAddress: appAddress}
+	appConn, err := grpc.NewAppConn(ctx, appAddress, robotPartID, cloudCfg.GetCloudCredsDialOpt(), logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer appConn.Close()
+
+	cfg, err := getFromCloudGRPC(ctx, cloudCfg, logger, appConn)
+	test.That(t, cfg, test.ShouldBeNil)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, IsRejectedConfigError(err), test.ShouldBeTrue)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "converting config from proto")
+}
+
+// TestReadFromCloudRejectsUnprocessableConfig verifies that a config the cloud serves successfully
+// but that this robot cannot process locally (here, a component with an invalid name) is surfaced as
+// a rejection rather than hidden as a routine, retryable error.
+func TestReadFromCloudRejectsUnprocessableConfig(t *testing.T) {
+	const (
+		robotPartID = "forUnprocessableTest"
+		secret      = testutils.FakeCredentialPayLoad
+	)
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+	clearCache(robotPartID)
+	defer clearCache(robotPartID)
+
+	fakeServer, cleanup := testutils.NewFakeCloudServer(t, ctx, logger)
+	defer cleanup()
+
+	cloudResponse := &Cloud{ID: robotPartID, Secret: secret, FQDN: "fqdn", LocalFQDN: "localFqdn", SignalingInsecure: true}
+	cloudConfProto, err := CloudConfigToProto(cloudResponse)
+	test.That(t, err, test.ShouldBeNil)
+
+	// A bind address with no port passes proto conversion but fails local processing (Network.Validate
+	// in Ensure), mirroring a cloud config the cloud serves but this robot cannot apply.
+	networkConfProto, err := NetworkConfigToProto(&NetworkConfig{NetworkConfigData: NetworkConfigData{BindAddress: "no-port-here"}})
+	test.That(t, err, test.ShouldBeNil)
+
+	protoConfig := &pb.RobotConfig{Cloud: cloudConfProto, Network: networkConfProto}
+	fakeServer.StoreDeviceConfig(robotPartID, protoConfig, &pb.CertificateResponse{})
+
+	appAddress := fmt.Sprintf("http://%s", fakeServer.Addr().String())
+	appConn, err := grpc.NewAppConn(ctx, appAddress, robotPartID, cloudResponse.GetCloudCredsDialOpt(), logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer appConn.Close()
+
+	cfgText := fmt.Sprintf(`{"cloud":{"id":%q,"app_address":%q,"secret":%q}}`, robotPartID, appAddress, secret)
+	_, err = FromReader(ctx, "", strings.NewReader(cfgText), logger, appConn)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, IsRejectedConfigError(err), test.ShouldBeTrue)
 }
 
 func TestStoreToCache(t *testing.T) {

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -327,10 +327,9 @@ func TestIsCloudConfigRejection(t *testing.T) {
 	}
 }
 
-// TestGetFromCloudGRPCProtoDecodeFailureIsRejection verifies that a config the cloud serves but that
-// this robot cannot decode from proto is surfaced as a rejection, mirroring the reported
-// orientation-vector failure (here, an auth handler with an unsupported credential type).
-func TestGetFromCloudGRPCProtoDecodeFailureIsRejection(t *testing.T) {
+// TestGetFromCloudGRPCProtoDecodeFailureIsRejected verifies that a config the cloud serves but that
+// this robot cannot decode from proto is surfaced as a rejection.
+func TestGetFromCloudGRPCProtoDecodeFailureIsRejected(t *testing.T) {
 	const robotPartID = "forProtoDecodeTest"
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
@@ -365,8 +364,8 @@ func TestGetFromCloudGRPCProtoDecodeFailureIsRejection(t *testing.T) {
 }
 
 // TestReadFromCloudRejectsUnprocessableConfig verifies that a config the cloud serves successfully
-// but that this robot cannot process locally (here, a component with an invalid name) is surfaced as
-// a rejection rather than hidden as a routine, retryable error.
+// but that this robot cannot process locally (here, a bind address with no port) is surfaced as a
+// rejection.
 func TestReadFromCloudRejectsUnprocessableConfig(t *testing.T) {
 	const (
 		robotPartID = "forUnprocessableTest"
@@ -398,9 +397,10 @@ func TestReadFromCloudRejectsUnprocessableConfig(t *testing.T) {
 	defer appConn.Close()
 
 	cfgText := fmt.Sprintf(`{"cloud":{"id":%q,"app_address":%q,"secret":%q}}`, robotPartID, appAddress, secret)
-	_, err = FromReader(ctx, "", strings.NewReader(cfgText), logger, appConn)
+	cfg, err := FromReader(ctx, "", strings.NewReader(cfgText), logger, appConn)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, IsRejectedConfigError(err), test.ShouldBeTrue)
+	test.That(t, cfg, test.ShouldBeNil)
 }
 
 func TestStoreToCache(t *testing.T) {

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -189,7 +189,7 @@ func TestFromReader(t *testing.T) {
 
 // TestGetFromCloudOrCacheErrorClassification verifies that when the cloud config endpoint fails
 // and we fall back to a cached config, a connectivity error is logged quietly (Warn) while a
-// config rejection from the cloud is surfaced loudly (Error).
+// malformed config from the cloud is surfaced loudly (Error).
 func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 	const (
 		robotPartID = "forCachingTest"
@@ -237,10 +237,10 @@ func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 		test.That(t, cfg, test.ShouldNotBeNil)
 
 		test.That(t, logs.FilterMessageSnippet("unable to get cloud config; using cached version").Len(), test.ShouldEqual, 1)
-		test.That(t, logs.FilterMessageSnippet("this robot's config was rejected").Len(), test.ShouldEqual, 0)
+		test.That(t, logs.FilterMessageSnippet("the new config was NOT applied").Len(), test.ShouldEqual, 0)
 	})
 
-	t.Run("rejected config is surfaced loudly and falls back to cache", func(t *testing.T) {
+	t.Run("malformed config is surfaced loudly and falls back to cache", func(t *testing.T) {
 		setupCache(t)
 		defer clearCache(robotPartID)
 
@@ -254,13 +254,13 @@ func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 		test.That(t, cached, test.ShouldBeTrue)
 		test.That(t, cfg, test.ShouldNotBeNil)
 
-		rejected := logs.FilterMessageSnippet("this robot's config was rejected")
-		test.That(t, rejected.Len(), test.ShouldEqual, 1)
-		test.That(t, rejected.All()[0].Level, test.ShouldEqual, zapcore.ErrorLevel)
+		malformed := logs.FilterMessageSnippet("the new config was NOT applied")
+		test.That(t, malformed.Len(), test.ShouldEqual, 1)
+		test.That(t, malformed.All()[0].Level, test.ShouldEqual, zapcore.ErrorLevel)
 		test.That(t, logs.FilterMessageSnippet("unable to get cloud config; using cached version").Len(), test.ShouldEqual, 0)
 	})
 
-	t.Run("rejected config with no cache returns a clear error", func(t *testing.T) {
+	t.Run("malformed config with no cache returns a clear error", func(t *testing.T) {
 		clearCache(robotPartID)
 
 		cloudCfg, appConn, cleanup := newAppConn(t, status.Error(codes.Unknown, "OrientationVectorDegrees has a normal of 0"))
@@ -269,12 +269,13 @@ func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 		logger := logging.NewTestLogger(t)
 		_, _, err := getFromCloudOrCache(ctx, cloudCfg, true, logger, appConn)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, IsRejectedConfigError(err), test.ShouldBeTrue)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "this robot's config was rejected and no cached config exists")
+		test.That(t, IsMalformedConfigError(err), test.ShouldBeTrue)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "config was malformed")
+		test.That(t, err.Error(), test.ShouldContainSubstring, "no cached config exists to fall back to")
 		test.That(t, err.Error(), test.ShouldContainSubstring, "OrientationVectorDegrees has a normal of 0")
 	})
 
-	t.Run("connectivity error with no cache returns the original error and is not a rejection", func(t *testing.T) {
+	t.Run("connectivity error with no cache returns the original error and is not malformed", func(t *testing.T) {
 		clearCache(robotPartID)
 
 		cloudCfg, appConn, cleanup := newAppConn(t, status.Error(codes.Unavailable, "cloud is down"))
@@ -283,26 +284,25 @@ func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 		logger := logging.NewTestLogger(t)
 		_, _, err := getFromCloudOrCache(ctx, cloudCfg, true, logger, appConn)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, IsRejectedConfigError(err), test.ShouldBeFalse)
+		test.That(t, IsMalformedConfigError(err), test.ShouldBeFalse)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "cached config does not exist")
-		test.That(t, err.Error(), test.ShouldNotContainSubstring, "this robot's config was rejected")
+		test.That(t, err.Error(), test.ShouldNotContainSubstring, "config was malformed")
 	})
 }
 
-// TestIsCloudConfigRejection pins down the classification that decides whether a cloud config-fetch
-// failure is a rejection or a transient failure to reach the cloud.
-func TestIsCloudConfigRejection(t *testing.T) {
+// TestIsCloudConfigMalformed pins down the classification that decides whether a cloud config-fetch
+// failure means the config is malformed or is a transient failure to reach the cloud.
+func TestIsCloudConfigMalformed(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		err      error
-		rejected bool
+		name      string
+		err       error
+		malformed bool
 	}{
-		// Status codes the cloud uses to reject a config.
+		// Status codes the cloud returns when it cannot produce a usable config.
 		{"unknown (real conversion failure)", status.Error(codes.Unknown, "boom"), true},
 		{"invalid argument", status.Error(codes.InvalidArgument, "boom"), true},
 		{"failed precondition", status.Error(codes.FailedPrecondition, "boom"), true},
-		// Transient status codes are never a rejection. Internal is the notable one: it was previously
-		// treated as a rejection, but a server-side fault is not a config rejection.
+		// Transient status codes should not be treated as if the config is malformed.
 		{"unavailable", status.Error(codes.Unavailable, "boom"), false},
 		{"deadline exceeded", status.Error(codes.DeadlineExceeded, "boom"), false},
 		{"canceled", status.Error(codes.Canceled, "boom"), false},
@@ -316,18 +316,18 @@ func TestIsCloudConfigRejection(t *testing.T) {
 		// connection was never established.
 		{"not connected (no gRPC status)", errors.New("not connected"), false},
 		{"bare context deadline", context.DeadlineExceeded, false},
-		// Wrapping must not hide a real rejection.
-		{"wrapped rejection", errors.WithMessage(status.Error(codes.Unknown, "boom"), "fetching config"), true},
+		// Wrapping must not hide a real malformed-config error.
+		{"wrapped malformed", errors.WithMessage(status.Error(codes.Unknown, "boom"), "fetching config"), true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			test.That(t, isCloudConfigRejection(tc.err), test.ShouldEqual, tc.rejected)
+			test.That(t, isCloudConfigMalformed(tc.err), test.ShouldEqual, tc.malformed)
 		})
 	}
 }
 
-// TestGetFromCloudGRPCProtoDecodeFailureIsRejected verifies that a config the cloud serves but that
-// this robot cannot decode from proto is surfaced as a rejection.
-func TestGetFromCloudGRPCProtoDecodeFailureIsRejected(t *testing.T) {
+// TestGetFromCloudGRPCProtoDecodeFailureIsMalformed verifies that a config the cloud serves but that
+// this robot cannot decode from proto is surfaced as a malformed config.
+func TestGetFromCloudGRPCProtoDecodeFailureIsMalformed(t *testing.T) {
 	const robotPartID = "forProtoDecodeTest"
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
@@ -357,14 +357,15 @@ func TestGetFromCloudGRPCProtoDecodeFailureIsRejected(t *testing.T) {
 	cfg, err := getFromCloudGRPC(ctx, cloudCfg, logger, appConn)
 	test.That(t, cfg, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, IsRejectedConfigError(err), test.ShouldBeTrue)
+	test.That(t, IsMalformedConfigError(err), test.ShouldBeTrue)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "config was malformed")
 	test.That(t, err.Error(), test.ShouldContainSubstring, "converting config from proto")
 }
 
-// TestReadFromCloudRejectsUnprocessableConfig verifies that a config the cloud serves successfully
-// but that this robot cannot process locally (here, a bind address with no port) is surfaced as a
-// rejection.
-func TestReadFromCloudRejectsUnprocessableConfig(t *testing.T) {
+// TestReadFromCloudMarksUnprocessableConfigMalformed verifies that a config the cloud serves
+// successfully but that this robot cannot process locally (here, a bind address with no port) is
+// surfaced as a malformed config.
+func TestReadFromCloudMarksUnprocessableConfigMalformed(t *testing.T) {
 	const (
 		robotPartID = "forUnprocessableTest"
 		secret      = testutils.FakeCredentialPayLoad
@@ -397,7 +398,8 @@ func TestReadFromCloudRejectsUnprocessableConfig(t *testing.T) {
 	cfgText := fmt.Sprintf(`{"cloud":{"id":%q,"app_address":%q,"secret":%q}}`, robotPartID, appAddress, secret)
 	cfg, err := FromReader(ctx, "", strings.NewReader(cfgText), logger, appConn)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, IsRejectedConfigError(err), test.ShouldBeTrue)
+	test.That(t, IsMalformedConfigError(err), test.ShouldBeTrue)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "config was malformed")
 	test.That(t, cfg, test.ShouldBeNil)
 }
 

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -201,10 +201,9 @@ func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 	setupCache := func(t *testing.T) {
 		t.Helper()
 		clearCache(robotPartID)
-		cachedConf := &Config{Cloud: &Cloud{ID: robotPartID, Secret: secret, FQDN: "fqdn"}}
-		cfgToCache := &Config{Cloud: &Cloud{ID: robotPartID}}
-		cfgToCache.SetToCache(cachedConf)
-		test.That(t, cfgToCache.StoreToCache(), test.ShouldBeNil)
+		cached := &Config{Cloud: &Cloud{ID: robotPartID, Secret: secret, FQDN: "fqdn"}}
+		test.That(t, cached.SetToCache(cached), test.ShouldBeNil)
+		test.That(t, cached.StoreToCache(), test.ShouldBeNil)
 	}
 
 	newAppConn := func(t *testing.T, failWith error) (*Cloud, rpc.ClientConn, func()) {
@@ -245,8 +244,7 @@ func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 		setupCache(t)
 		defer clearCache(robotPartID)
 
-		// codes.Unknown is what the real config conversion failure surfaces (a plain error returned by the
-		// cloud config endpoint).
+		// codes.Unknown is what the real config conversion failure surfaces
 		cloudCfg, appConn, cleanup := newAppConn(t, status.Error(codes.Unknown, "OrientationVectorDegrees has a normal of 0"))
 		defer cleanup()
 
@@ -271,8 +269,23 @@ func TestGetFromCloudOrCacheErrorClassification(t *testing.T) {
 		logger := logging.NewTestLogger(t)
 		_, _, err := getFromCloudOrCache(ctx, cloudCfg, true, logger, appConn)
 		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, IsRejectedConfigError(err), test.ShouldBeTrue)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "cloud rejected this robot's config and no cached config exists")
 		test.That(t, err.Error(), test.ShouldContainSubstring, "OrientationVectorDegrees has a normal of 0")
+	})
+
+	t.Run("connectivity error with no cache returns the original error and is not a rejection", func(t *testing.T) {
+		clearCache(robotPartID)
+
+		cloudCfg, appConn, cleanup := newAppConn(t, status.Error(codes.Unavailable, "cloud is down"))
+		defer cleanup()
+
+		logger := logging.NewTestLogger(t)
+		_, _, err := getFromCloudOrCache(ctx, cloudCfg, true, logger, appConn)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, IsRejectedConfigError(err), test.ShouldBeFalse)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "cached config does not exist")
+		test.That(t, err.Error(), test.ShouldNotContainSubstring, "cloud rejected this robot's config")
 	})
 }
 

--- a/config/watcher.go
+++ b/config/watcher.go
@@ -77,12 +77,12 @@ func newCloudWatcher(ctx context.Context, config *Config, logger logging.Logger,
 			}
 			newConfig, err := readFromCloud(cancelCtx, config, prevCfg, false, checkForNewCert, logger, conn)
 			if err != nil {
-				// A rejected config is a legitimate error. The robot keeps running its current config,
-				// but we surface the rejection loudly. A transient failure to reach the cloud stays at
-				// debug since the watcher simply retries.
-				if IsRejectedConfigError(err) {
+				// A malformed config is a legitimate error. The robot keeps running its current config,
+				// but we surface it loudly. A transient failure to reach the cloud stays at debug since
+				// the watcher retries.
+				if IsMalformedConfigError(err) {
 					logger.Errorw(
-						"this robot's config was rejected; the new config was NOT applied. keeping the current config",
+						"the new config was NOT applied; keeping the current config",
 						"error", err)
 				} else {
 					logger.Debugw("error reading cloud config; will try again", "error", err)

--- a/config/watcher.go
+++ b/config/watcher.go
@@ -83,7 +83,7 @@ func newCloudWatcher(ctx context.Context, config *Config, logger logging.Logger,
 				// transient failure to reach the cloud stays at debug since the watcher simply retries.
 				if IsRejectedConfigError(err) {
 					logger.Errorw(
-						"cloud rejected this robot's config; the new config was NOT applied. keeping the current config",
+						"this robot's config was rejected; the new config was NOT applied. keeping the current config",
 						"error", err)
 				} else {
 					logger.Debugw("error reading cloud config; will try again", "error", err)

--- a/config/watcher.go
+++ b/config/watcher.go
@@ -80,13 +80,11 @@ func newCloudWatcher(ctx context.Context, config *Config, logger logging.Logger,
 				// A malformed config is a legitimate error. The robot keeps running its current config,
 				// but we surface it loudly. A transient failure to reach the cloud stays at debug since
 				// the watcher retries.
+				logFunc := logger.Debugw
 				if IsMalformedConfigError(err) {
-					logger.Errorw(
-						"the new config was NOT applied; keeping the current config",
-						"error", err)
-				} else {
-					logger.Debugw("error reading cloud config; will try again", "error", err)
+					logFunc = logger.Errorw
 				}
+				logFunc("could not apply new cloud config; keeping the current config", "error", err)
 				continue
 			}
 			if cp, err := newConfig.CopyOnlyPublicFields(); err == nil {

--- a/config/watcher.go
+++ b/config/watcher.go
@@ -77,10 +77,9 @@ func newCloudWatcher(ctx context.Context, config *Config, logger logging.Logger,
 			}
 			newConfig, err := readFromCloud(cancelCtx, config, prevCfg, false, checkForNewCert, logger, conn)
 			if err != nil {
-				// A rejected config is a legitimate error (e.g. a malformed config edit): the robot keeps
-				// running its current config, but we surface the rejection loudly on every refresh so it is
-				// not silently hidden (the logger deduplicates the repeated message if it becomes noisy). A
-				// transient failure to reach the cloud stays at debug since the watcher simply retries.
+				// A rejected config is a legitimate error. The robot keeps running its current config,
+				// but we surface the rejection loudly. A transient failure to reach the cloud stays at
+				// debug since the watcher simply retries.
 				if IsRejectedConfigError(err) {
 					logger.Errorw(
 						"this robot's config was rejected; the new config was NOT applied. keeping the current config",

--- a/config/watcher.go
+++ b/config/watcher.go
@@ -77,7 +77,17 @@ func newCloudWatcher(ctx context.Context, config *Config, logger logging.Logger,
 			}
 			newConfig, err := readFromCloud(cancelCtx, config, prevCfg, false, checkForNewCert, logger, conn)
 			if err != nil {
-				logger.Debugw("error reading cloud config; will try again", "error", err)
+				// A rejected config is a legitimate error (e.g. a malformed config edit): the robot keeps
+				// running its current config, but we surface the rejection loudly on every refresh so it is
+				// not silently hidden (the logger deduplicates the repeated message if it becomes noisy). A
+				// transient failure to reach the cloud stays at debug since the watcher simply retries.
+				if IsRejectedConfigError(err) {
+					logger.Errorw(
+						"cloud rejected this robot's config; the new config was NOT applied. keeping the current config",
+						"error", err)
+				} else {
+					logger.Debugw("error reading cloud config; will try again", "error", err)
+				}
 				continue
 			}
 			if cp, err := newConfig.CopyOnlyPublicFields(); err == nil {

--- a/config/watcher_test.go
+++ b/config/watcher_test.go
@@ -332,7 +332,7 @@ func TestNewWatcherCloud(t *testing.T) {
 	newConf = <-watcher.Config()
 	test.That(t, newConf, test.ShouldResemble, &confToExpect)
 
-	// fake server will start rejecting the config (codes.Unknown mirrors the real config-conversion
+	// fake server will start returning a malformed config (codes.Unknown mirrors the real config-conversion
 	// failure). no new configs should be emitted to channel until the fake server starts returning again
 	fakeServer.FailOnConfigAndCertsWith(status.Error(codes.Unknown, "OrientationVectorDegrees has a normal of 0"))
 	timer := time.NewTimer(5 * time.Second)
@@ -347,17 +347,17 @@ func TestNewWatcherCloud(t *testing.T) {
 	newConf = <-watcher.Config()
 	test.That(t, newConf, test.ShouldResemble, &confToExpect)
 
-	// The fake server returns codes.Unknown while failing, which is a config rejection.
+	// The fake server returns codes.Unknown while failing, which means the config is malformed.
 	// The watcher should surface that loudly at ERROR on every failing refresh.
-	rejectedLogs := logs.FilterMessageSnippet("the new config was NOT applied")
-	test.That(t, rejectedLogs.Len(), test.ShouldBeGreaterThan, 1)
-	for _, entry := range rejectedLogs.All() {
+	malformedLogs := logs.FilterMessageSnippet("the new config was NOT applied")
+	test.That(t, malformedLogs.Len(), test.ShouldBeGreaterThan, 1)
+	for _, entry := range malformedLogs.All() {
 		test.That(t, entry.Level, test.ShouldEqual, zapcore.ErrorLevel)
 	}
 
-	// A transient connectivity failure must NOT be surfaced as a rejection. The
+	// A transient connectivity failure must NOT be surfaced as a malformed config. The
 	// watcher logs it at debug and keeps retrying.
-	rejectedCountBeforeTransient := rejectedLogs.Len()
+	malformedCountBeforeTransient := malformedLogs.Len()
 	debugRetryBeforeTransient := logs.FilterMessageSnippet("error reading cloud config; will try again").Len()
 	fakeServer.FailOnConfigAndCertsWith(status.Error(codes.Unavailable, "cloud is down"))
 	transientTimer := time.NewTimer(3 * time.Second)
@@ -372,7 +372,7 @@ func TestNewWatcherCloud(t *testing.T) {
 	test.That(t, newConf, test.ShouldResemble, &confToExpect)
 
 	// No new "NOT applied" ERROR logs, but the transient failure was logged at debug.
-	test.That(t, logs.FilterMessageSnippet("the new config was NOT applied").Len(), test.ShouldEqual, rejectedCountBeforeTransient)
+	test.That(t, logs.FilterMessageSnippet("the new config was NOT applied").Len(), test.ShouldEqual, malformedCountBeforeTransient)
 	test.That(t, logs.FilterMessageSnippet("error reading cloud config; will try again").Len(),
 		test.ShouldBeGreaterThan, debugRetryBeforeTransient)
 

--- a/config/watcher_test.go
+++ b/config/watcher_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.uber.org/zap/zapcore"
 	pb "go.viam.com/api/app/v1"
 	"go.viam.com/test"
 	"go.viam.com/utils/pexec"
@@ -182,7 +183,7 @@ func TestNewWatcherFile(t *testing.T) {
 
 func TestNewWatcherCloud(t *testing.T) {
 	t.Parallel()
-	logger := logging.NewTestLogger(t)
+	logger, logs := logging.NewObservedTestLogger(t)
 
 	certsToReturn := config.Cloud{
 		TLSCertificate: "hello",
@@ -343,6 +344,14 @@ func TestNewWatcherCloud(t *testing.T) {
 
 	newConf = <-watcher.Config()
 	test.That(t, newConf, test.ShouldResemble, &confToExpect)
+
+	// The fake server returns codes.Internal while failing, which is a config rejection (not a
+	// connectivity error). The watcher should surface that loudly at ERROR on every failing refresh.
+	rejectedLogs := logs.FilterMessageSnippet("the new config was NOT applied")
+	test.That(t, rejectedLogs.Len(), test.ShouldBeGreaterThan, 1)
+	for _, entry := range rejectedLogs.All() {
+		test.That(t, entry.Level, test.ShouldEqual, zapcore.ErrorLevel)
+	}
 
 	confToReturn = config.Config{
 		Cloud: newCloudConf(),

--- a/config/watcher_test.go
+++ b/config/watcher_test.go
@@ -347,17 +347,16 @@ func TestNewWatcherCloud(t *testing.T) {
 	newConf = <-watcher.Config()
 	test.That(t, newConf, test.ShouldResemble, &confToExpect)
 
-	// The fake server returns codes.Unknown while failing, which is a config rejection (not a
-	// connectivity error). The watcher should surface that loudly at ERROR on every failing refresh.
+	// The fake server returns codes.Unknown while failing, which is a config rejection.
+	// The watcher should surface that loudly at ERROR on every failing refresh.
 	rejectedLogs := logs.FilterMessageSnippet("the new config was NOT applied")
 	test.That(t, rejectedLogs.Len(), test.ShouldBeGreaterThan, 1)
 	for _, entry := range rejectedLogs.All() {
 		test.That(t, entry.Level, test.ShouldEqual, zapcore.ErrorLevel)
 	}
 
-	// A transient connectivity failure (codes.Unavailable) must NOT be surfaced as a rejection: the
-	// watcher logs it at debug and keeps retrying. Guard against a regression that turns every network
-	// blip into an ERROR.
+	// A transient connectivity failure must NOT be surfaced as a rejection. The
+	// watcher logs it at debug and keeps retrying.
 	rejectedCountBeforeTransient := rejectedLogs.Len()
 	debugRetryBeforeTransient := logs.FilterMessageSnippet("error reading cloud config; will try again").Len()
 	fakeServer.FailOnConfigAndCertsWith(status.Error(codes.Unavailable, "cloud is down"))

--- a/config/watcher_test.go
+++ b/config/watcher_test.go
@@ -14,6 +14,8 @@ import (
 	pb "go.viam.com/api/app/v1"
 	"go.viam.com/test"
 	"go.viam.com/utils/pexec"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/config"
@@ -330,9 +332,9 @@ func TestNewWatcherCloud(t *testing.T) {
 	newConf = <-watcher.Config()
 	test.That(t, newConf, test.ShouldResemble, &confToExpect)
 
-	// fake server will start returning 5xx on requests.
-	// no new configs should be emitted to channel until the fake server starts returning again
-	fakeServer.FailOnConfigAndCerts(true)
+	// fake server will start rejecting the config (codes.Unknown mirrors the real config-conversion
+	// failure). no new configs should be emitted to channel until the fake server starts returning again
+	fakeServer.FailOnConfigAndCertsWith(status.Error(codes.Unknown, "OrientationVectorDegrees has a normal of 0"))
 	timer := time.NewTimer(5 * time.Second)
 	defer timer.Stop()
 	select {
@@ -345,13 +347,35 @@ func TestNewWatcherCloud(t *testing.T) {
 	newConf = <-watcher.Config()
 	test.That(t, newConf, test.ShouldResemble, &confToExpect)
 
-	// The fake server returns codes.Internal while failing, which is a config rejection (not a
+	// The fake server returns codes.Unknown while failing, which is a config rejection (not a
 	// connectivity error). The watcher should surface that loudly at ERROR on every failing refresh.
 	rejectedLogs := logs.FilterMessageSnippet("the new config was NOT applied")
 	test.That(t, rejectedLogs.Len(), test.ShouldBeGreaterThan, 1)
 	for _, entry := range rejectedLogs.All() {
 		test.That(t, entry.Level, test.ShouldEqual, zapcore.ErrorLevel)
 	}
+
+	// A transient connectivity failure (codes.Unavailable) must NOT be surfaced as a rejection: the
+	// watcher logs it at debug and keeps retrying. Guard against a regression that turns every network
+	// blip into an ERROR.
+	rejectedCountBeforeTransient := rejectedLogs.Len()
+	debugRetryBeforeTransient := logs.FilterMessageSnippet("error reading cloud config; will try again").Len()
+	fakeServer.FailOnConfigAndCertsWith(status.Error(codes.Unavailable, "cloud is down"))
+	transientTimer := time.NewTimer(3 * time.Second)
+	defer transientTimer.Stop()
+	select {
+	case c := <-watcher.Config():
+		test.That(t, c, test.ShouldBeNil)
+	case <-transientTimer.C:
+	}
+	fakeServer.FailOnConfigAndCerts(false)
+	newConf = <-watcher.Config()
+	test.That(t, newConf, test.ShouldResemble, &confToExpect)
+
+	// No new "NOT applied" ERROR logs, but the transient failure was logged at debug.
+	test.That(t, logs.FilterMessageSnippet("the new config was NOT applied").Len(), test.ShouldEqual, rejectedCountBeforeTransient)
+	test.That(t, logs.FilterMessageSnippet("error reading cloud config; will try again").Len(),
+		test.ShouldBeGreaterThan, debugRetryBeforeTransient)
 
 	confToReturn = config.Config{
 		Cloud: newCloudConf(),

--- a/config/watcher_test.go
+++ b/config/watcher_test.go
@@ -347,18 +347,17 @@ func TestNewWatcherCloud(t *testing.T) {
 	newConf = <-watcher.Config()
 	test.That(t, newConf, test.ShouldResemble, &confToExpect)
 
-	// The fake server returns codes.Unknown while failing, which means the config is malformed.
-	// The watcher should surface that loudly at ERROR on every failing refresh.
-	malformedLogs := logs.FilterMessageSnippet("the new config was NOT applied")
+	// The fake server returns codes.Unknown while failing, which means the config is malformed. The
+	// watcher logs the same message either way, so we distinguish the malformed case from the
+	// transient case by log level: a malformed config is surfaced at ERROR on every failing refresh.
+	const notAppliedMsg = "could not apply new cloud config; keeping the current config"
+	malformedLogs := logs.FilterMessageSnippet(notAppliedMsg).FilterLevelExact(zapcore.ErrorLevel)
 	test.That(t, malformedLogs.Len(), test.ShouldBeGreaterThan, 1)
-	for _, entry := range malformedLogs.All() {
-		test.That(t, entry.Level, test.ShouldEqual, zapcore.ErrorLevel)
-	}
 
-	// A transient connectivity failure must NOT be surfaced as a malformed config. The
-	// watcher logs it at debug and keeps retrying.
+	// A transient connectivity failure must NOT be surfaced loudly. The watcher logs the same message
+	// at DEBUG and keeps retrying.
 	malformedCountBeforeTransient := malformedLogs.Len()
-	debugRetryBeforeTransient := logs.FilterMessageSnippet("error reading cloud config; will try again").Len()
+	debugRetryBeforeTransient := logs.FilterMessageSnippet(notAppliedMsg).FilterLevelExact(zapcore.DebugLevel).Len()
 	fakeServer.FailOnConfigAndCertsWith(status.Error(codes.Unavailable, "cloud is down"))
 	transientTimer := time.NewTimer(3 * time.Second)
 	defer transientTimer.Stop()
@@ -371,9 +370,10 @@ func TestNewWatcherCloud(t *testing.T) {
 	newConf = <-watcher.Config()
 	test.That(t, newConf, test.ShouldResemble, &confToExpect)
 
-	// No new "NOT applied" ERROR logs, but the transient failure was logged at debug.
-	test.That(t, logs.FilterMessageSnippet("the new config was NOT applied").Len(), test.ShouldEqual, malformedCountBeforeTransient)
-	test.That(t, logs.FilterMessageSnippet("error reading cloud config; will try again").Len(),
+	// No new ERROR logs, but the transient failure added DEBUG logs.
+	test.That(t, logs.FilterMessageSnippet(notAppliedMsg).FilterLevelExact(zapcore.ErrorLevel).Len(),
+		test.ShouldEqual, malformedCountBeforeTransient)
+	test.That(t, logs.FilterMessageSnippet(notAppliedMsg).FilterLevelExact(zapcore.DebugLevel).Len(),
 		test.ShouldBeGreaterThan, debugRetryBeforeTransient)
 
 	confToReturn = config.Config{


### PR DESCRIPTION
## Description

`viam-server` fetches its config from the cloud's `Config` endpoint. Previously every failure of that fetch was treated identically: log `Warn: unable to get cloud config; using cached version` and fall back to the cached config. However, this masked the distinction between a transient failure to reach the cloud and the cloud responding and rejecting this robot's config. When the cloud rejected a config, a robot with a cache silently kept running stale config with only a quiet warning, and a robot without a cache crash-looped behind a confusing `cached config does not exist` that buried the real cause.

This PR classifies cloud config failures as transient vs rejection and surfaces rejections loudly at ERROR, while keeping the cache-fallback resilience.

A failure is treated as a rejection only when:
- the cloud responds with a gRPC status whose code indicates rejection: `Unknown` (what we see in practice), `InvalidArgument`, or `FailedPrecondition`; or
- the served config cannot be decoded from proto (`FromProto`); or
- the served config cannot be processed locally (`Ensure` / validation).

Everything else is **transient** and keeps the existing logging + cache fallback:

On a rejection a robot with a cache keeps running its previous good config but logs at `ERROR`; with no cache the returned error names the real cause instead of leading with `cached config does not exist`.

## Testing

- `TestIsCloudConfigRejection` — table over the classification rule
- `TestGetFromCloudGRPCProtoDecodeFailureIsRejection` — a config the cloud serves successfully but that fails `FromProto` is surfaced as a rejection.
- `TestReadFromCloudRejectsUnprocessableConfig` — a config the cloud serves successfully but that fails local processing (e.g. a bind address with no port) is surfaced as a rejection.
- `TestGetFromCloudOrCacheErrorClassification` — with a cache present: a connectivity error (`Unavailable`) logs quietly (`Warn`) and falls back to cache; a rejection (`Unknown`) logs at ERROR and falls back to cache. With no cache: a rejection returns a clear error naming the cause; a connectivity error returns the original error and is not classified as a rejection.
- `TestNewWatcherCloud` — extended to assert that a cloud rejection on refresh is surfaced at `ERROR: the new config was NOT applied...`, while a transient connectivity error on refresh stays at `DEBUG` and the watcher recovers once the cloud is healthy again.
- Brought up a real robot and observed logging behavior when starting with a bad config with no cache, starting with a bad config with cache,  swapping to a bad config with cache (`ERROR` logs) then pointed to a bogus app address with and without a cache to simulate transient network issues (`WARN` logs)