### PR TITLE
RSDK-14002 - use default baseURL if config is empty

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -149,8 +149,7 @@ func (c *viamClient) loginAction(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	if _, isAPIKey := c.conf.Auth.(*apiKey); isAPIKey {
-		warningf(c.c.Root().ErrWriter, "was logged in with an api-key. logging out")
-		utils.UncheckedError(c.logout())
+		warningf(c.c.Root().ErrWriter, "was logged in with an api-key. re-authenticating via user credentials")
 	}
 	currentToken, _ := c.conf.Auth.(*token) // currentToken can be nil
 	if currentToken != nil && !currentToken.isExpired() {

--- a/cli/config.go
+++ b/cli/config.go
@@ -160,7 +160,11 @@ func (conf *Config) tryUnmarshallWithAPIKey(configBytes []byte) error {
 
 // DialOptions constructs an rpc.DialOption slice from config.
 func (conf *Config) DialOptions() ([]rpc.DialOption, error) {
-	_, opts, err := rutils.ParseBaseURL(conf.BaseURL, true)
+	baseURL := conf.BaseURL
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	_, opts, err := rutils.ParseBaseURL(baseURL, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Addresses bug encountered in sanding repo where an empty URL was interpreted as being `https` scheme and so a `:443` was appended, thus resulting in attempts to dial to `:443`, which of course failed.