### PR TITLE
Record module language after viam module generate registration

### DIFF
--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -1309,6 +1309,16 @@ func createModuleAndManifest(
 			return "", errors.Wrap(err, "failed to parse module identifier")
 		}
 		registryURL = moduleResponse.GetUrl()
+		if err := c.recordModuleLanguage(
+			ctx,
+			module.OrgID,
+			module.ModuleName,
+			module.Language,
+			"",
+			module.Visibility,
+		); err != nil {
+			warningf(cmd.Root().Writer, "Module registered, but failed to record language: %v", err)
+		}
 	} else {
 		debugf(cmd.Root().Writer, globalArgs.Debug, "Creating a local-only module")
 		moduleID.name = module.ModuleName

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -469,6 +469,50 @@ func (c *viamClient) createModule(ctx context.Context, moduleName, organizationI
 	return c.client.CreateModule(ctx, &req)
 }
 
+func cliLanguageToProto(language string) (apppb.ModuleLanguage, bool) {
+	switch language {
+	case python:
+		return apppb.ModuleLanguage_MODULE_LANGUAGE_PYTHON, true
+	case golang:
+		return apppb.ModuleLanguage_MODULE_LANGUAGE_GOLANG, true
+	case cpp:
+		return apppb.ModuleLanguage_MODULE_LANGUAGE_CPP, true
+	default:
+		return apppb.ModuleLanguage_MODULE_LANGUAGE_UNSPECIFIED, false
+	}
+}
+
+func (c *viamClient) recordModuleLanguage(
+	ctx context.Context,
+	orgID, moduleName, language, description, visibility string,
+) error {
+	langProto, ok := cliLanguageToProto(language)
+	if !ok {
+		return nil
+	}
+
+	visibilityProto, err := visibilityToProto(visibility)
+	if err != nil {
+		return err
+	}
+
+	sourceType := apppb.ModuleSourceType_MODULE_SOURCE_TYPE_EXTERNAL
+	itemID := fmt.Sprintf("%s:%s", orgID, moduleName)
+	_, err = c.client.UpdateRegistryItem(ctx, &apppb.UpdateRegistryItemRequest{
+		ItemId:      itemID,
+		Type:        packagespb.PackageType_PACKAGE_TYPE_MODULE,
+		Description: description,
+		Visibility:  visibilityProto,
+		Metadata: &apppb.UpdateRegistryItemRequest_UpdateModuleMetadata{
+			UpdateModuleMetadata: &apppb.UpdateModuleMetadata{
+				SourceType: &sourceType,
+				Language:   &langProto,
+			},
+		},
+	})
+	return err
+}
+
 func (c *viamClient) getModule(ctx context.Context, moduleID moduleID) (*apppb.GetModuleResponse, error) {
 	req := apppb.GetModuleRequest{
 		ModuleId: moduleID.String(),

--- a/cli/module_registry_test.go
+++ b/cli/module_registry_test.go
@@ -481,3 +481,27 @@ func TestParseMetaJSONWithBrandingFields(t *testing.T) {
 		})
 	}
 }
+
+func TestCliLanguageToProto(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		language string
+		expected v1.ModuleLanguage
+		ok       bool
+	}{
+		{language: python, expected: v1.ModuleLanguage_MODULE_LANGUAGE_PYTHON, ok: true},
+		{language: golang, expected: v1.ModuleLanguage_MODULE_LANGUAGE_GOLANG, ok: true},
+		{language: cpp, expected: v1.ModuleLanguage_MODULE_LANGUAGE_CPP, ok: true},
+		{language: "rust", expected: v1.ModuleLanguage_MODULE_LANGUAGE_UNSPECIFIED, ok: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.language, func(t *testing.T) {
+			t.Parallel()
+			language, ok := cliLanguageToProto(tc.language)
+			test.That(t, ok, test.ShouldEqual, tc.ok)
+			test.That(t, language, test.ShouldEqual, tc.expected)
+		})
+	}
+}

--- a/cli/module_reload.go
+++ b/cli/module_reload.go
@@ -385,10 +385,12 @@ func configureModule(
 	return partResponse.Part, needsRestart, nil
 }
 
-// localizeModuleID converts a module ID to its 'local mode' name.
+// localizeModuleID converts a module ID of the form "<namespace>:<moduleName>"
+// (or "<orgID>:<moduleName>" if no namespace is set) into a name suitable for
+// adding to a robot config, i.e. "<namespace>_<moduleName>" or "<orgID>_<moduleName>".
 // TODO(APP-4019): remove this logic after registry modules can have local ExecPath.
 func localizeModuleID(moduleID string) string {
-	return strings.ReplaceAll(moduleID, ":", "_") + "_from_reload"
+	return strings.ReplaceAll(moduleID, ":", "_")
 }
 
 // mutateModuleConfig edits the modules list to hot-reload with the given manifest.

--- a/cli/module_reload_test.go
+++ b/cli/module_reload_test.go
@@ -397,9 +397,9 @@ func TestMutateModuleConfig(t *testing.T) {
 		JSONManifest: rdkConfig.JSONManifest{Entrypoint: "/bin/mod"},
 		Build:        &manifestBuildInfo{Path: "module.tar.gz"},
 	}
-	expectedName := "viam-labs_test-module_from_reload"
+	expectedName := "viam-labs_test-module"
 	expectedVersion := "latest-with-prerelease"
-	remoteReloadPath := ".viam/packages-local/viam-labs_test-module_from_reload-module.tar.gz"
+	remoteReloadPath := ".viam/packages-local/viam-labs_test-module-module.tar.gz"
 	testUser := "test@viam.com"
 	testReloadUnixTS := time.Date(2024, 3, 18, 12, 0, 0, 0, time.UTC).Unix()
 


### PR DESCRIPTION
## Summary
- After `CreateModule` succeeds in `viam module generate`, call `UpdateRegistryItem` with the selected language (Go, Python, or C++).
- Failures to record language are logged as warnings and do not fail module generation.

## Test plan
- [ ] Run `go test ./cli/... -run TestCliLanguageToProto`
- [ ] Run `viam module generate` with app registration enabled and confirm `module_metadata.language` is set on the registry item


Made with [Cursor](https://cursor.com)