### PR TITLE
[APP-16719] add CLI commands to build/publish module in cloud

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -106,6 +106,7 @@ const (
 
 	moduleBuildFlagRef         = "ref"
 	moduleBuildFlagWait        = "wait"
+	moduleBuildFlagFromSource  = "from-source"
 	moduleBuildFlagToken       = "token"
 	moduleBuildFlagWorkdir     = "workdir"
 	moduleBuildFlagPlatforms   = "platforms"
@@ -3831,64 +3832,22 @@ Example:
 							Action: createActionCommandWithT[moduleBuildLocalArgs](ModuleBuildLocalAction),
 						},
 						{
-							Name:  "cloud",
-							Usage: "upload your local source and publish a new version via cloud build",
-							Description: `Upload the contents of a local directory to the cloud builder and publish
-a new registry version of your module from it, without requiring a git push.
+							Name:  "start",
+							Usage: "start a remote build",
+							Description: `Start a cloud build of your module and publish a new registry version.
+
+By default the build is run from a git ref of the repository in your meta.json's
+"url" field (use --ref/--token to control the checkout).
+
+Pass --from-source to instead package your local source directory and upload it to
+the cloud builder, without requiring a git push. The --ref and --token flags are
+ignored in this mode; use --path to point at the source directory to upload.
 
 Example:
-viam module build cloud --version 0.5.0
-viam module build cloud --version 0.5.0 --platforms linux/amd64,linux/arm64 --wait
+viam module build start --version 0.5.0
+viam module build start --version 0.5.0 --from-source --platforms linux/amd64,linux/arm64 --wait
 
-Honors .gitignore when packaging the source directory. Requires a "build" section
-in meta.json (same as 'viam module build start').`,
-							UsageText: createUsageText("module build cloud", []string{generalFlagVersion}, true, false),
-							Flags: []cli.Flag{
-								&cli.StringFlag{
-									Name:      moduleFlagPath,
-									Usage:     "path to meta.json",
-									Value:     "./meta.json",
-									TakesFile: true,
-								},
-								&cli.StringFlag{
-									Name:     generalFlagVersion,
-									Usage:    "version of the module to publish (semver2.0) ex: \"0.1.0\"",
-									Required: true,
-								},
-								&cli.StringFlag{
-									Name:      generalFlagPath,
-									Usage:     "path to the local source directory to upload",
-									Value:     ".",
-									TakesFile: true,
-								},
-								&cli.StringSliceFlag{
-									Name:  moduleBuildFlagPlatforms,
-									Usage: "list of platforms to build, e.g. linux/amd64,linux/arm64 (default: build.arch in meta.json)",
-								},
-								&cli.StringFlag{
-									Name:  moduleBuildFlagWorkdir,
-									Usage: "use this to indicate that your meta.json is in a subdirectory of the uploaded source",
-									Value: ".",
-								},
-								&cli.StringFlag{
-									Name:  moduleBuildFlagBuilder,
-									Usage: formatAcceptedValues("target build service", "default", "viam-cloudbuild-test"),
-									Value: "default",
-								},
-								&cli.BoolFlag{
-									Name:  moduleBuildFlagWait,
-									Usage: "wait for the build to finish; surface failed-platform logs and a non-zero exit code on failure",
-								},
-								&cli.BoolFlag{
-									Name:  generalFlagNoProgress,
-									Usage: "hide the progress spinner",
-								},
-							},
-							Action: createActionCommandWithT[moduleBuildCloudArgs](ModuleBuildCloudAction),
-						},
-						{
-							Name:      "start",
-							Usage:     "start a remote build",
+When using --from-source, .gitignore is honored when packaging the source directory.`,
 							UsageText: createUsageText("module build start", []string{generalFlagVersion}, true, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
@@ -3901,6 +3860,17 @@ in meta.json (same as 'viam module build start').`,
 									Name:     generalFlagVersion,
 									Usage:    "version of the module to upload (semver2.0) ex: \"0.1.0\"",
 									Required: true,
+								},
+								&cli.BoolFlag{
+									Name: moduleBuildFlagFromSource,
+									Usage: "package your local source directory and upload it to the cloud builder " +
+										"instead of building from a git ref",
+								},
+								&cli.StringFlag{
+									Name:      generalFlagPath,
+									Usage:     "(--from-source only) path to the local source directory to upload",
+									Value:     ".",
+									TakesFile: true,
 								},
 								&cli.StringFlag{
 									Name:  moduleBuildFlagRef,
@@ -3925,6 +3895,15 @@ in meta.json (same as 'viam module build start').`,
 									Name:  moduleBuildFlagBuilder,
 									Usage: formatAcceptedValues("target build service", "default", "viam-cloudbuild-test"),
 									Value: "default",
+								},
+								&cli.BoolFlag{
+									Name: moduleBuildFlagWait,
+									Usage: "(--from-source only) wait for the build to finish; surface failed-platform logs " +
+										"and a non-zero exit code on failure",
+								},
+								&cli.BoolFlag{
+									Name:  generalFlagNoProgress,
+									Usage: "(--from-source only) hide the progress spinner",
 								},
 							},
 							Action: createActionCommandWithT[moduleBuildStartArgs](ModuleBuildStartAction),

--- a/cli/app.go
+++ b/cli/app.go
@@ -3831,6 +3831,62 @@ Example:
 							Action: createActionCommandWithT[moduleBuildLocalArgs](ModuleBuildLocalAction),
 						},
 						{
+							Name:  "cloud",
+							Usage: "upload your local source and publish a new version via cloud build",
+							Description: `Upload the contents of a local directory to the cloud builder and publish
+a new registry version of your module from it, without requiring a git push.
+
+Example:
+viam module build cloud --version 0.5.0
+viam module build cloud --version 0.5.0 --platforms linux/amd64,linux/arm64 --wait
+
+Honors .gitignore when packaging the source directory. Requires a "build" section
+in meta.json (same as 'viam module build start').`,
+							UsageText: createUsageText("module build cloud", []string{generalFlagVersion}, true, false),
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:      moduleFlagPath,
+									Usage:     "path to meta.json",
+									Value:     "./meta.json",
+									TakesFile: true,
+								},
+								&cli.StringFlag{
+									Name:     generalFlagVersion,
+									Usage:    "version of the module to publish (semver2.0) ex: \"0.1.0\"",
+									Required: true,
+								},
+								&cli.StringFlag{
+									Name:      generalFlagPath,
+									Usage:     "path to the local source directory to upload",
+									Value:     ".",
+									TakesFile: true,
+								},
+								&cli.StringSliceFlag{
+									Name:  moduleBuildFlagPlatforms,
+									Usage: "list of platforms to build, e.g. linux/amd64,linux/arm64 (default: build.arch in meta.json)",
+								},
+								&cli.StringFlag{
+									Name:  moduleBuildFlagWorkdir,
+									Usage: "use this to indicate that your meta.json is in a subdirectory of the uploaded source",
+									Value: ".",
+								},
+								&cli.StringFlag{
+									Name:  moduleBuildFlagBuilder,
+									Usage: formatAcceptedValues("target build service", "default", "viam-cloudbuild-test"),
+									Value: "default",
+								},
+								&cli.BoolFlag{
+									Name:  moduleBuildFlagWait,
+									Usage: "wait for the build to finish; surface failed-platform logs and a non-zero exit code on failure",
+								},
+								&cli.BoolFlag{
+									Name:  generalFlagNoProgress,
+									Usage: "hide the progress spinner",
+								},
+							},
+							Action: createActionCommandWithT[moduleBuildCloudArgs](ModuleBuildCloudAction),
+						},
+						{
 							Name:      "start",
 							Usage:     "start a remote build",
 							UsageText: createUsageText("module build start", []string{generalFlagVersion}, true, false),

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -202,13 +202,17 @@ func (c *viamClient) validateRefExists(ctx context.Context, cmd *cli.Command, re
 }
 
 type moduleBuildStartArgs struct {
-	Module    string
-	Version   string
-	Ref       string
-	Token     string
-	Workdir   string
-	Platforms []string
-	Builder   string
+	Module     string
+	Version    string
+	Ref        string
+	Token      string
+	Workdir    string
+	Platforms  []string
+	Builder    string
+	FromSource bool
+	Path       string
+	Wait       bool
+	NoProgress bool
 }
 
 // ModuleBuildStartAction starts a cloud build.
@@ -276,6 +280,10 @@ func (c *viamClient) moduleBuildStartForRepo(
 }
 
 func (c *viamClient) moduleBuildStartAction(ctx context.Context, cmd *cli.Command, args moduleBuildStartArgs) (string, error) {
+	if args.FromSource {
+		return c.moduleBuildStartFromSource(ctx, cmd, args)
+	}
+
 	manifest, err := loadManifest(args.Module)
 	if err != nil {
 		return "", err
@@ -1075,30 +1083,11 @@ func getNextReloadBuildUploadRequest(file *os.File) (*buildpb.StartReloadBuildRe
 	}, byteLen, nil
 }
 
-type moduleBuildCloudArgs struct {
-	Module     string
-	Version    string
-	Path       string
-	Platforms  []string
-	Workdir    string
-	Builder    string
-	Wait       bool
-	NoProgress bool
-}
-
-// ModuleBuildCloudAction uploads the local source directory and starts a cloud
-// build that publishes a new registry version of the module.
-func ModuleBuildCloudAction(ctx context.Context, cmd *cli.Command, args moduleBuildCloudArgs) error {
-	c, err := newViamClient(ctx, cmd)
-	if err != nil {
-		return err
-	}
-	_, err = c.moduleBuildCloudAction(ctx, cmd, args)
-	return err
-}
-
-func (c *viamClient) moduleBuildCloudAction(
-	ctx context.Context, cmd *cli.Command, args moduleBuildCloudArgs,
+// moduleBuildStartFromSource packages the local source directory and starts a
+// cloud build that publishes a new registry version of the module. This backs
+// `viam module build start --from-source`.
+func (c *viamClient) moduleBuildStartFromSource(
+	ctx context.Context, cmd *cli.Command, args moduleBuildStartArgs,
 ) (string, error) {
 	manifest, err := loadManifest(args.Module)
 	if err != nil {
@@ -1250,7 +1239,7 @@ func targetsWindowsPython(manifestPath string, platforms []string) bool {
 	return err == nil
 }
 
-func newModuleBuildCloudProgressManager(args moduleBuildCloudArgs) *ProgressManager {
+func newModuleBuildCloudProgressManager(args moduleBuildStartArgs) *ProgressManager {
 	steps := []*Step{
 		{ID: "prepare", Message: "Preparing for build...", CompletedMsg: "Prepared for build", IndentLevel: 0},
 		{ID: "archive", Message: "Creating source code archive...", CompletedMsg: "Source code archive created", IndentLevel: 1},
@@ -1268,7 +1257,7 @@ func newModuleBuildCloudProgressManager(args moduleBuildCloudArgs) *ProgressMana
 func (c *viamClient) uploadModuleSourceBuild(
 	ctx context.Context,
 	cmd *cli.Command,
-	args moduleBuildCloudArgs,
+	args moduleBuildStartArgs,
 	manifest ModuleManifest,
 	archivePath, orgID string,
 	moduleID moduleID,

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -988,17 +988,6 @@ func (c *viamClient) triggerCloudReloadBuild(
 	archivePath, partID string,
 	reloadUnixTS int64,
 ) (string, error) {
-	stream, err := c.buildClient.StartReloadBuild(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	//nolint:gosec
-	file, err := os.Open(archivePath)
-	if err != nil {
-		return "", err
-	}
-
 	part, err := c.getRobotPart(ctx, partID)
 	if err != nil {
 		return "", err
@@ -1006,21 +995,23 @@ func (c *viamClient) triggerCloudReloadBuild(
 	if part.Part == nil {
 		return "", fmt.Errorf("part with id=%s not found", partID)
 	}
-
 	if part.Part.UserSuppliedInfo == nil {
 		return "", errors.New("unable to determine platform for part")
 	}
 
-	// use the primary org id for the machine as the reload
-	// module org
+	// use the primary org id for the machine as the reload module org
 	orgID, err := c.getOrgIDForPart(ctx, part.Part)
 	if err != nil {
 		return "", err
 	}
 
-	// App expects `BuildInfo` as the first request
+	moduleID, err := parseModuleID(manifest.ModuleID)
+	if err != nil {
+		return "", err
+	}
+
 	platform := part.Part.UserSuppliedInfo.Fields["platform"].GetStringValue()
-	req := &buildpb.StartReloadBuildRequest{
+	buildInfoReq := &buildpb.StartReloadBuildRequest{
 		CloudBuild: &buildpb.StartReloadBuildRequest_BuildInfo{
 			BuildInfo: &buildpb.ReloadBuildInfo{
 				Platform: platform,
@@ -1031,53 +1022,42 @@ func (c *viamClient) triggerCloudReloadBuild(
 		},
 	}
 	if args.Builder != "" && args.Builder != "default" {
-		req.Builder = &args.Builder
-	}
-	if err := stream.Send(req); err != nil {
-		return "", err
+		buildInfoReq.Builder = &args.Builder
 	}
 
-	moduleID, err := parseModuleID(manifest.ModuleID)
+	pkgInfoReq := &buildpb.StartReloadBuildRequest{
+		CloudBuild: &buildpb.StartReloadBuildRequest_Package{
+			Package: &v1.CreatePackageRequest{
+				Package: &v1.CreatePackageRequest_Info{
+					Info: &v1.PackageInfo{
+						OrganizationId: orgID,
+						Name:           moduleID.name,
+						Version:        getReloadVersion(reloadSourceVersionPrefix, partID, reloadUnixTS),
+						Type:           v1.PackageType_PACKAGE_TYPE_MODULE,
+					},
+				},
+			},
+		},
+	}
+
+	stream, err := c.buildClient.StartReloadBuild(ctx)
 	if err != nil {
 		return "", err
 	}
-
-	pkgInfo := v1.PackageInfo{
-		OrganizationId: orgID,
-		Name:           moduleID.name,
-		Version:        getReloadVersion(reloadSourceVersionPrefix, partID, reloadUnixTS),
-		Type:           v1.PackageType_PACKAGE_TYPE_MODULE,
-	}
-	reqInner := &v1.CreatePackageRequest{
-		Package: &v1.CreatePackageRequest_Info{
-			Info: &pkgInfo,
-		},
-	}
-	req = &buildpb.StartReloadBuildRequest{
-		CloudBuild: &buildpb.StartReloadBuildRequest_Package{
-			Package: reqInner,
-		},
-	}
-
-	if err := stream.Send(req); err != nil {
+	resp, err := streamArchiveBuild(
+		ctx,
+		stream,
+		archivePath,
+		[]*buildpb.StartReloadBuildRequest{buildInfoReq, pkgInfoReq},
+		getNextReloadBuildUploadRequest,
+	)
+	if err != nil {
 		return "", err
-	}
-
-	var errs error
-	// Suppress the "Uploading... X%" progress bar output since we have our own spinner
-	if err := sendUploadRequests(
-		ctx, stream, file, io.Discard, getNextReloadBuildUploadRequest); err != nil && !errors.Is(err, io.EOF) {
-		errs = multierr.Combine(errs, errors.Wrapf(err, "could not upload %s", file.Name()))
-	}
-
-	resp, closeErr := stream.CloseAndRecv()
-	if closeErr != nil && !errors.Is(closeErr, io.EOF) {
-		errs = multierr.Combine(errs, closeErr)
 	}
 	if msg := resp.GetBuilderFallbackMessage(); msg != "" {
 		printf(cmd.Root().ErrWriter, "Warning: %s", msg)
 	}
-	return resp.GetBuildId(), errs
+	return resp.GetBuildId(), nil
 }
 
 func getNextReloadBuildUploadRequest(file *os.File) (*buildpb.StartReloadBuildRequest, int, error) {

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -1073,6 +1073,268 @@ func getNextReloadBuildUploadRequest(file *os.File) (*buildpb.StartReloadBuildRe
 	}, byteLen, nil
 }
 
+type moduleBuildCloudArgs struct {
+	Module     string
+	Version    string
+	Path       string
+	Platforms  []string
+	Workdir    string
+	Builder    string
+	Wait       bool
+	NoProgress bool
+}
+
+// ModuleBuildCloudAction uploads the local source directory and starts a cloud
+// build that publishes a new registry version of the module.
+func ModuleBuildCloudAction(ctx context.Context, cmd *cli.Command, args moduleBuildCloudArgs) error {
+	c, err := newViamClient(ctx, cmd)
+	if err != nil {
+		return err
+	}
+	_, err = c.moduleBuildCloudAction(ctx, cmd, args)
+	return err
+}
+
+func (c *viamClient) moduleBuildCloudAction(
+	ctx context.Context, cmd *cli.Command, args moduleBuildCloudArgs,
+) (string, error) {
+	manifest, err := loadManifest(args.Module)
+	if err != nil {
+		return "", err
+	}
+	if manifest.Build == nil || manifest.Build.Build == "" {
+		return "", errors.New(
+			"your meta.json cannot have an empty build step. See 'viam module build --help' for more information")
+	}
+
+	moduleID, err := parseModuleID(manifest.ModuleID)
+	if err != nil {
+		return "", err
+	}
+	org, err := getOrgByModuleIDPrefix(ctx, c, moduleID.prefix)
+	if err != nil {
+		return "", err
+	}
+
+	var platforms []string
+	switch {
+	case len(args.Platforms) > 0:
+		platforms = args.Platforms
+	case len(manifest.Build.Arch) > 0:
+		platforms = manifest.Build.Arch
+	default:
+		platforms = defaultBuildInfo.Arch
+	}
+
+	// Cloud build cannot currently build Python modules for Windows targets.
+	// Check the resolved target platforms — a Windows developer
+	// is free to cloud-build a Python module for linux/darwin, and a macOS/Linux
+	// developer requesting a windows/* target should be caught here regardless.
+	if targetsWindowsPython(args.Module, platforms) {
+		return "", errors.New("cloud build is not currently supported for Windows Python modules.\n" +
+			"Build locally with 'viam module build local' and upload with 'viam module upload'")
+	}
+
+	// Clean the version argument to match github tag conventions, mirroring `module build start`.
+	version := strings.TrimPrefix(args.Version, "v")
+
+	sourcePath := args.Path
+	if sourcePath == "" {
+		sourcePath = "."
+	}
+
+	pm := newModuleBuildCloudProgressManager(args)
+	defer pm.Stop()
+
+	if err := pm.Start("prepare"); err != nil {
+		return "", err
+	}
+	if err := pm.Start("archive"); err != nil {
+		return "", err
+	}
+	archivePath, err := c.createGitArchive(sourcePath)
+	if err != nil {
+		_ = pm.FailWithMessage("archive", "Archive creation failed") //nolint:errcheck
+		_ = pm.FailWithMessage("prepare", "Preparing for build...")  //nolint:errcheck
+		return "", err
+	}
+	defer func() {
+		if removeErr := os.Remove(archivePath); removeErr != nil && !os.IsNotExist(removeErr) {
+			warningf(cmd.Root().ErrWriter, "failed to delete archive at %s", archivePath)
+		}
+	}()
+	if err := pm.Complete("archive"); err != nil {
+		return "", err
+	}
+
+	if err := pm.Start("upload-source"); err != nil {
+		return "", err
+	}
+	buildID, err := c.uploadModuleSourceBuild(
+		ctx, cmd, args, manifest, archivePath, org.GetId(), moduleID, version, platforms,
+	)
+	if err != nil {
+		_ = pm.FailWithMessage("upload-source", "Upload failed")    //nolint:errcheck
+		_ = pm.FailWithMessage("prepare", "Preparing for build...") //nolint:errcheck
+		return "", err
+	}
+	if err := pm.Complete("upload-source"); err != nil {
+		return buildID, err
+	}
+	if err := pm.Complete("prepare"); err != nil {
+		return buildID, err
+	}
+
+	// Match `module build start`: buildID alone on stdout (for scripts/build-action),
+	// follow-up instructions on stderr.
+	printf(cmd.Root().ErrWriter, "Build started, follow the logs with:")
+	printf(cmd.Root().ErrWriter, "	viam module build logs --id %s", buildID)
+	printf(cmd.Root().Writer, buildID)
+
+	if !args.Wait {
+		return buildID, nil
+	}
+
+	if err := pm.Start("build"); err != nil {
+		return buildID, err
+	}
+	if err := pm.Start("build-start"); err != nil {
+		return buildID, err
+	}
+	statuses, err := c.waitForBuildToFinish(ctx, buildID, "", pm)
+	if err != nil {
+		_ = pm.FailWithMessage("build", "Building...") //nolint:errcheck
+		return buildID, err
+	}
+	if buildErr := buildError(statuses); buildErr != nil {
+		_ = pm.FailWithMessage("build", "Building...") //nolint:errcheck
+		// Surface logs for any failed platform so the user can debug without a separate command.
+		var logErrs error
+		for platform, status := range statuses {
+			if status != jobStatusFailed {
+				continue
+			}
+			errorf(cmd.Root().ErrWriter, "Build %q failed on %s. Logs:", buildID, platform)
+			if logErr := c.printModuleBuildLogs(ctx, buildID, platform); logErr != nil {
+				logErrs = multierr.Append(logErrs, logErr)
+			}
+		}
+		return buildID, multierr.Combine(buildErr, logErrs)
+	}
+	if err := pm.Complete("build"); err != nil {
+		return buildID, err
+	}
+	infof(cmd.Root().ErrWriter, "Module version %s published successfully", version)
+	return buildID, nil
+}
+
+// targetsWindowsPython returns true when the module appears to be a Python
+// module (src/main.py exists next to meta.json) AND any of the requested target
+// platforms is windows. The src/main.py marker matches the layout produced by
+// `viam module generate` for Python modules.
+func targetsWindowsPython(manifestPath string, platforms []string) bool {
+	hasWindowsTarget := false
+	for _, p := range platforms {
+		if p == osWindows || strings.HasPrefix(p, osWindows+"/") {
+			hasWindowsTarget = true
+			break
+		}
+	}
+	if !hasWindowsTarget {
+		return false
+	}
+	mainPyPath := filepath.Join(filepath.Dir(manifestPath), "src", "main.py")
+	_, err := os.Stat(mainPyPath)
+	return err == nil
+}
+
+func newModuleBuildCloudProgressManager(args moduleBuildCloudArgs) *ProgressManager {
+	steps := []*Step{
+		{ID: "prepare", Message: "Preparing for build...", CompletedMsg: "Prepared for build", IndentLevel: 0},
+		{ID: "archive", Message: "Creating source code archive...", CompletedMsg: "Source code archive created", IndentLevel: 1},
+		{ID: "upload-source", Message: "Uploading source code...", CompletedMsg: "Source code uploaded", IndentLevel: 1},
+	}
+	if args.Wait {
+		steps = append(steps,
+			&Step{ID: "build", Message: "Building...", CompletedMsg: "Built", IndentLevel: 0},
+			&Step{ID: "build-start", Message: "Starting build...", IndentLevel: 1},
+		)
+	}
+	return NewProgressManager(steps, WithProgressOutput(!args.NoProgress))
+}
+
+func (c *viamClient) uploadModuleSourceBuild(
+	ctx context.Context,
+	cmd *cli.Command,
+	args moduleBuildCloudArgs,
+	manifest ModuleManifest,
+	archivePath, orgID string,
+	moduleID moduleID,
+	version string,
+	platforms []string,
+) (string, error) {
+	buildInfoReq := &buildpb.StartSourceUploadBuildRequest{
+		CloudBuild: &buildpb.StartSourceUploadBuildRequest_BuildInfo{
+			BuildInfo: &buildpb.SourceUploadBuildInfo{
+				Platforms: platforms,
+				Workdir:   &args.Workdir,
+				ModuleId:  manifest.ModuleID,
+				Distro:    &manifest.Build.Distro,
+			},
+		},
+		ModuleVersion: version,
+	}
+	if args.Builder != "" && args.Builder != "default" {
+		buildInfoReq.Builder = &args.Builder
+	}
+
+	pkgInfoReq := &buildpb.StartSourceUploadBuildRequest{
+		CloudBuild: &buildpb.StartSourceUploadBuildRequest_Package{
+			Package: &v1.CreatePackageRequest{
+				Package: &v1.CreatePackageRequest_Info{
+					Info: &v1.PackageInfo{
+						OrganizationId: orgID,
+						Name:           moduleID.name,
+						Version:        version,
+						Type:           v1.PackageType_PACKAGE_TYPE_MODULE,
+					},
+				},
+			},
+		},
+	}
+
+	stream, err := c.buildClient.StartSourceUploadBuild(ctx)
+	if err != nil {
+		return "", err
+	}
+	resp, err := streamArchiveBuild(
+		ctx,
+		stream,
+		archivePath,
+		[]*buildpb.StartSourceUploadBuildRequest{buildInfoReq, pkgInfoReq},
+		getNextSourceUploadBuildRequest,
+	)
+	if err != nil {
+		return "", err
+	}
+	if msg := resp.GetBuilderFallbackMessage(); msg != "" {
+		printf(cmd.Root().ErrWriter, "Warning: %s", msg)
+	}
+	return resp.GetBuildId(), nil
+}
+
+func getNextSourceUploadBuildRequest(file *os.File) (*buildpb.StartSourceUploadBuildRequest, int, error) {
+	packagesRequest, byteLen, err := getNextPackageUploadRequest(file)
+	if err != nil {
+		return nil, 0, err
+	}
+	return &buildpb.StartSourceUploadBuildRequest{
+		CloudBuild: &buildpb.StartSourceUploadBuildRequest_Package{
+			Package: packagesRequest,
+		},
+	}, byteLen, nil
+}
+
 // moduleCloudBuildInfo contains information needed to download a cloud build artifact.
 type moduleCloudBuildInfo struct {
 	ModuleID    string

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -51,6 +51,8 @@ const (
 	jobStatusInProgress jobStatus = "Building"
 	jobStatusFailed     jobStatus = "Failed"
 	jobStatusDone       jobStatus = "Done"
+
+	builderDefault = "default"
 )
 
 var moduleBuildPollingInterval = 2 * time.Second
@@ -255,7 +257,7 @@ func (c *viamClient) moduleBuildStartForRepo(
 		Workdir:       &workdir,
 		Distro:        &manifest.Build.Distro,
 	}
-	if args.Builder != "" && args.Builder != "default" {
+	if args.Builder != "" && args.Builder != builderDefault {
 		req.Builder = &args.Builder
 	}
 	res, err := c.buildClient.StartBuild(ctx, &req)
@@ -1021,7 +1023,7 @@ func (c *viamClient) triggerCloudReloadBuild(
 			},
 		},
 	}
-	if args.Builder != "" && args.Builder != "default" {
+	if args.Builder != "" && args.Builder != builderDefault {
 		buildInfoReq.Builder = &args.Builder
 	}
 
@@ -1284,7 +1286,7 @@ func (c *viamClient) uploadModuleSourceBuild(
 		},
 		ModuleVersion: version,
 	}
-	if args.Builder != "" && args.Builder != "default" {
+	if args.Builder != "" && args.Builder != builderDefault {
 		buildInfoReq.Builder = &args.Builder
 	}
 

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -282,10 +282,10 @@ func TestModuleBuildCloud(t *testing.T) {
 	}
 
 	cCtx, ac, out, errOut := setup(asc, nil, bsc, map[string]any{
-		moduleFlagPath:        manifestPath,
-		generalFlagVersion:    "v1.2.3", // leading "v" should be stripped
-		generalFlagPath:       sourceDir,
-		generalFlagNoProgress: true,
+		moduleFlagPath:         manifestPath,
+		generalFlagVersion:     "v1.2.3", // leading "v" should be stripped
+		generalFlagPath:        sourceDir,
+		generalFlagNoProgress:  true,
 		moduleBuildFlagWorkdir: ".",
 	}, "token")
 

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	v1 "go.viam.com/api/app/build/v1"
+	packagespb "go.viam.com/api/app/packages/v1"
 	apppb "go.viam.com/api/app/v1"
 	"go.viam.com/test"
 	"google.golang.org/grpc"
@@ -217,6 +218,159 @@ func TestStartBuild(t *testing.T) {
 	test.That(t, path, test.ShouldBeEmpty)
 	test.That(t, out.messages, test.ShouldHaveLength, 0)
 	test.That(t, errOut.messages, test.ShouldHaveLength, 0)
+}
+
+// fakeSourceUploadBuildStream is an in-memory test double for the
+// buildpb.BuildService_StartSourceUploadBuildClient streaming RPC. It records
+// every Send call so tests can assert on the request shape, and returns a
+// configurable CloseAndRecv response.
+type fakeSourceUploadBuildStream struct {
+	v1.BuildService_StartSourceUploadBuildClient // embedded for unused methods
+	sends                                        []*v1.StartSourceUploadBuildRequest
+	resp                                         *v1.StartSourceUploadBuildResponse
+}
+
+func (s *fakeSourceUploadBuildStream) Send(req *v1.StartSourceUploadBuildRequest) error {
+	s.sends = append(s.sends, req)
+	return nil
+}
+
+func (s *fakeSourceUploadBuildStream) CloseSend() error { return nil }
+
+func (s *fakeSourceUploadBuildStream) CloseAndRecv() (*v1.StartSourceUploadBuildResponse, error) {
+	return s.resp, nil
+}
+
+func TestModuleBuildCloud(t *testing.T) {
+	// Lay out a source directory with a meta.json and a small "source" file so
+	// createGitArchive has something non-trivial to package up.
+	sourceDir := t.TempDir()
+	manifestPath := filepath.Join(sourceDir, "meta.json")
+	createTestManifest(t, manifestPath, map[string]any{
+		"build": map[string]any{
+			"setup":  "./setup.sh",
+			"build":  "make build",
+			"path":   "module",
+			"arch":   []any{"linux/amd64", "linux/arm64"},
+			"distro": "bookworm",
+		},
+	})
+	err := os.WriteFile(filepath.Join(sourceDir, "hello.go"), []byte("package main\n"), 0o600)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Stub ListOrganizations so getOrgByModuleIDPrefix resolves the "test"
+	// public namespace from the manifest's module_id ("test:test").
+	asc := &inject.AppServiceClient{
+		ListOrganizationsFunc: func(
+			ctx context.Context, in *apppb.ListOrganizationsRequest, opts ...grpc.CallOption,
+		) (*apppb.ListOrganizationsResponse, error) {
+			return &apppb.ListOrganizationsResponse{Organizations: []*apppb.Organization{
+				{Id: "test-org-id", PublicNamespace: "test"},
+			}}, nil
+		},
+	}
+
+	stream := &fakeSourceUploadBuildStream{
+		resp: &v1.StartSourceUploadBuildResponse{BuildId: "build-xyz"},
+	}
+	bsc := &inject.BuildServiceClient{
+		StartSourceUploadBuildFunc: func(
+			ctx context.Context, opts ...grpc.CallOption,
+		) (v1.BuildService_StartSourceUploadBuildClient, error) {
+			return stream, nil
+		},
+	}
+
+	cCtx, ac, out, errOut := setup(asc, nil, bsc, map[string]any{
+		moduleFlagPath:        manifestPath,
+		generalFlagVersion:    "v1.2.3", // leading "v" should be stripped
+		generalFlagPath:       sourceDir,
+		generalFlagNoProgress: true,
+		moduleBuildFlagWorkdir: ".",
+	}, "token")
+
+	buildID, err := ac.moduleBuildCloudAction(
+		context.Background(), cCtx, parseStructFromCtx[moduleBuildCloudArgs](cCtx),
+	)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, buildID, test.ShouldEqual, "build-xyz")
+
+	// At minimum we expect: 1 BuildInfo header + 1 Package_Info header + at
+	// least 1 chunk send (hello.go + meta.json should fit in a single chunk).
+	test.That(t, len(stream.sends), test.ShouldBeGreaterThanOrEqualTo, 3)
+
+	// First send: BuildInfo with platforms / workdir / module_id / distro plus
+	// the top-level ModuleVersion (semver, no leading "v").
+	first := stream.sends[0]
+	test.That(t, first.GetBuildInfo(), test.ShouldNotBeNil)
+	test.That(t, first.GetBuildInfo().GetPlatforms(), test.ShouldResemble, []string{"linux/amd64", "linux/arm64"})
+	test.That(t, first.GetBuildInfo().GetModuleId(), test.ShouldEqual, "test:test")
+	test.That(t, first.GetBuildInfo().GetWorkdir(), test.ShouldEqual, ".")
+	test.That(t, first.GetBuildInfo().GetDistro(), test.ShouldEqual, "bookworm")
+	test.That(t, first.GetModuleVersion(), test.ShouldEqual, "1.2.3")
+
+	// Second send: Package_Info with org/name/version/type. The version on the
+	// package mirrors the top-level ModuleVersion.
+	second := stream.sends[1]
+	test.That(t, second.GetPackage(), test.ShouldNotBeNil)
+	info := second.GetPackage().GetInfo()
+	test.That(t, info, test.ShouldNotBeNil)
+	test.That(t, info.GetOrganizationId(), test.ShouldEqual, "test-org-id")
+	test.That(t, info.GetName(), test.ShouldEqual, "test")
+	test.That(t, info.GetVersion(), test.ShouldEqual, "1.2.3")
+	test.That(t, info.GetType(), test.ShouldEqual, packagespb.PackageType_PACKAGE_TYPE_MODULE)
+
+	// Remaining sends are chunked tarball contents.
+	for _, req := range stream.sends[2:] {
+		pkg := req.GetPackage()
+		test.That(t, pkg, test.ShouldNotBeNil)
+		test.That(t, pkg.GetContents(), test.ShouldNotBeNil)
+	}
+
+	// Stdout: just the buildID (machine-readable). Stderr: human-readable
+	// follow-up instructions matching `module build start`.
+	test.That(t, out.messages, test.ShouldResemble, []string{"build-xyz\n"})
+	test.That(t, errOut.messages, test.ShouldHaveLength, 2)
+	test.That(t, errOut.messages[0], test.ShouldEqual, "Build started, follow the logs with:\n")
+	test.That(t, errOut.messages[1], test.ShouldEqual, "\tviam module build logs --id build-xyz\n")
+}
+
+func TestTargetsWindowsPython(t *testing.T) {
+	withPyDir := func(t *testing.T) string {
+		t.Helper()
+		dir := t.TempDir()
+		test.That(t, os.MkdirAll(filepath.Join(dir, "src"), 0o700), test.ShouldBeNil)
+		test.That(t,
+			os.WriteFile(filepath.Join(dir, "src", "main.py"), []byte("pass\n"), 0o600),
+			test.ShouldBeNil,
+		)
+		return filepath.Join(dir, "meta.json")
+	}
+	withoutPyDir := func(t *testing.T) string {
+		t.Helper()
+		return filepath.Join(t.TempDir(), "meta.json")
+	}
+
+	cases := []struct {
+		name      string
+		manifest  func(*testing.T) string
+		platforms []string
+		want      bool
+	}{
+		{"windows target + python module → block", withPyDir, []string{"windows/amd64"}, true},
+		{"any-arch windows target + python module → block", withPyDir, []string{"windows"}, true},
+		{"windows in mixed targets + python → block", withPyDir, []string{"linux/amd64", "windows/arm64"}, true},
+		{"non-windows targets + python → allow", withPyDir, []string{"linux/amd64", "darwin/arm64"}, false},
+		{"windows target without python module → allow", withoutPyDir, []string{"windows/amd64"}, false},
+		{"non-windows + no python → allow", withoutPyDir, []string{"linux/amd64"}, false},
+		{"linux-prefixed (not 'windows/' prefix) → allow", withPyDir, []string{"linux/any"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := targetsWindowsPython(tc.manifest(t), tc.platforms)
+			test.That(t, got, test.ShouldEqual, tc.want)
+		})
+	}
 }
 
 func TestListBuild(t *testing.T) {

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -241,7 +241,7 @@ func (s *fakeSourceUploadBuildStream) CloseAndRecv() (*v1.StartSourceUploadBuild
 	return s.resp, nil
 }
 
-func TestModuleBuildCloud(t *testing.T) {
+func TestModuleBuildStartFromSource(t *testing.T) {
 	// Lay out a source directory with a meta.json and a small "source" file so
 	// createGitArchive has something non-trivial to package up.
 	sourceDir := t.TempDir()
@@ -282,15 +282,16 @@ func TestModuleBuildCloud(t *testing.T) {
 	}
 
 	cCtx, ac, out, errOut := setup(asc, nil, bsc, map[string]any{
-		moduleFlagPath:         manifestPath,
-		generalFlagVersion:     "v1.2.3", // leading "v" should be stripped
-		generalFlagPath:        sourceDir,
-		generalFlagNoProgress:  true,
-		moduleBuildFlagWorkdir: ".",
+		moduleFlagPath:            manifestPath,
+		generalFlagVersion:        "v1.2.3", // leading "v" should be stripped
+		moduleBuildFlagFromSource: true,
+		generalFlagPath:           sourceDir,
+		generalFlagNoProgress:     true,
+		moduleBuildFlagWorkdir:    ".",
 	}, "token")
 
-	buildID, err := ac.moduleBuildCloudAction(
-		context.Background(), cCtx, parseStructFromCtx[moduleBuildCloudArgs](cCtx),
+	buildID, err := ac.moduleBuildStartAction(
+		context.Background(), cCtx, parseStructFromCtx[moduleBuildStartArgs](cCtx),
 	)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, buildID, test.ShouldEqual, "build-xyz")

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -1059,7 +1059,7 @@ type archiveBuildStream[ReqT any, RespT any] interface {
 // Used by both reload (StartReloadBuild) and source-upload (StartSourceUploadBuild)
 // flows; their differences are confined to the header/chunk constructors the
 // callers pass in.
-func streamArchiveBuild[ReqT any, RespT any, StreamT archiveBuildStream[ReqT, RespT]](
+func streamArchiveBuild[ReqT, RespT any, StreamT archiveBuildStream[ReqT, RespT]](
 	ctx context.Context,
 	stream StreamT,
 	archivePath string,

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -1045,6 +1045,54 @@ type sender[RequestT any] interface {
 	CloseSend() error
 }
 
+// archiveBuildStream is a client-streaming RPC stream that sends N header
+// requests followed by chunked archive bytes and returns a single response on
+// close. Both StartReloadBuild and StartSourceUploadBuild satisfy this shape.
+type archiveBuildStream[ReqT any, RespT any] interface {
+	Send(*ReqT) error
+	CloseSend() error
+	CloseAndRecv() (*RespT, error)
+}
+
+// streamArchiveBuild opens archivePath, sends each header request in order,
+// streams the file contents through chunkReq, and returns the typed response.
+// Used by both reload (StartReloadBuild) and source-upload (StartSourceUploadBuild)
+// flows; their differences are confined to the header/chunk constructors the
+// callers pass in.
+func streamArchiveBuild[ReqT any, RespT any, StreamT archiveBuildStream[ReqT, RespT]](
+	ctx context.Context,
+	stream StreamT,
+	archivePath string,
+	headers []*ReqT,
+	chunkReq func(*os.File) (*ReqT, int, error),
+) (*RespT, error) {
+	//nolint:gosec // archivePath is constructed by createGitArchive / createTarballForUpload
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return nil, err
+	}
+	defer vutils.UncheckedErrorFunc(file.Close)
+
+	for _, header := range headers {
+		if err := stream.Send(header); err != nil {
+			return nil, err
+		}
+	}
+
+	var errs error
+	// Suppress the "Uploading... X%" progress bar from sendUploadRequests; callers
+	// drive their own progress UI (e.g. ProgressManager) around this helper.
+	if err := sendUploadRequests(ctx, stream, file, io.Discard, chunkReq); err != nil && !errors.Is(err, io.EOF) {
+		errs = multierr.Combine(errs, errors.Wrapf(err, "could not upload %s", file.Name()))
+	}
+
+	resp, closeErr := stream.CloseAndRecv()
+	if closeErr != nil && !errors.Is(closeErr, io.EOF) {
+		errs = multierr.Combine(errs, closeErr)
+	}
+	return resp, errs
+}
+
 func sendUploadRequests[RequestT any, StreamT sender[RequestT]](
 	ctx context.Context,
 	stream StreamT,

--- a/go.mod
+++ b/go.mod
@@ -355,3 +355,5 @@ require (
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6
 )
+
+replace go.viam.com/api => github.com/viamrobotics/api v0.1.557-0.20260601174852-e7919fb0d0a9 // gmulitz-start-source-upload-build

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
-	go.viam.com/api v0.1.565
+	go.viam.com/api v0.1.566
 	go.viam.com/test v1.2.4
 	go.viam.com/utils v0.6.6
 	goji.io v2.0.2+incompatible
@@ -355,5 +355,3 @@ require (
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6
 )
-
-replace go.viam.com/api => github.com/viamrobotics/api v0.1.564-0.20260623150732-fab349455f38 // gmulitz-start-source-upload-build

--- a/go.mod
+++ b/go.mod
@@ -356,4 +356,4 @@ require (
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6
 )
 
-replace go.viam.com/api => github.com/viamrobotics/api v0.1.557-0.20260601174852-e7919fb0d0a9 // gmulitz-start-source-upload-build
+replace go.viam.com/api => github.com/viamrobotics/api v0.1.564-0.20260623150732-fab349455f38 // gmulitz-start-source-upload-build

--- a/go.sum
+++ b/go.sum
@@ -1052,8 +1052,8 @@ github.com/viam-labs/go-getter v0.0.0-20251022162721-98d73b852c8a h1:qk5MX36oytF
 github.com/viam-labs/go-getter v0.0.0-20251022162721-98d73b852c8a/go.mod h1:MwPm+Hpd8PZRx+jkOVLGxqHl/bN+Hcsw0dD7ntSpLy0=
 github.com/viam-labs/motion-tools v1.9.0 h1:oUcxVMdrwVS7PXkWVYsUJOXkh0aTydmFlK/rciFcGxw=
 github.com/viam-labs/motion-tools v1.9.0/go.mod h1:unpRaVV4ETuJVoHa/3pzknoTnxqjSpfUMewE1vU27BA=
-github.com/viamrobotics/api v0.1.557-0.20260601174852-e7919fb0d0a9 h1:nHeaVd/rqQLI3cUE6WcUmsf9qpITZJneee67qULqxH8=
-github.com/viamrobotics/api v0.1.557-0.20260601174852-e7919fb0d0a9/go.mod h1:nVe4WXrtc8aupJ8OWXSYx6KhCiOkr3VCbkwxD4D41xQ=
+github.com/viamrobotics/api v0.1.564-0.20260623150732-fab349455f38 h1:AWc25UzlVNxRs3Ni3dgwDpO+xnG5/U4AtwqmW3oYtaE=
+github.com/viamrobotics/api v0.1.564-0.20260623150732-fab349455f38/go.mod h1:nVe4WXrtc8aupJ8OWXSYx6KhCiOkr3VCbkwxD4D41xQ=
 github.com/viamrobotics/evdev v0.1.3 h1:mR4HFafvbc5Wx4Vp1AUJp6/aITfVx9AKyXWx+rWjpfc=
 github.com/viamrobotics/evdev v0.1.3/go.mod h1:N6nuZmPz7HEIpM7esNWwLxbYzqWqLSZkfI/1Sccckqk=
 github.com/viamrobotics/ice/v2 v2.3.40 h1:H9r4ztsKkxWSn42R4fLvYlaPtpBys1Yj7/MERBtZY0k=

--- a/go.sum
+++ b/go.sum
@@ -1052,6 +1052,8 @@ github.com/viam-labs/go-getter v0.0.0-20251022162721-98d73b852c8a h1:qk5MX36oytF
 github.com/viam-labs/go-getter v0.0.0-20251022162721-98d73b852c8a/go.mod h1:MwPm+Hpd8PZRx+jkOVLGxqHl/bN+Hcsw0dD7ntSpLy0=
 github.com/viam-labs/motion-tools v1.9.0 h1:oUcxVMdrwVS7PXkWVYsUJOXkh0aTydmFlK/rciFcGxw=
 github.com/viam-labs/motion-tools v1.9.0/go.mod h1:unpRaVV4ETuJVoHa/3pzknoTnxqjSpfUMewE1vU27BA=
+github.com/viamrobotics/api v0.1.557-0.20260601174852-e7919fb0d0a9 h1:nHeaVd/rqQLI3cUE6WcUmsf9qpITZJneee67qULqxH8=
+github.com/viamrobotics/api v0.1.557-0.20260601174852-e7919fb0d0a9/go.mod h1:nVe4WXrtc8aupJ8OWXSYx6KhCiOkr3VCbkwxD4D41xQ=
 github.com/viamrobotics/evdev v0.1.3 h1:mR4HFafvbc5Wx4Vp1AUJp6/aITfVx9AKyXWx+rWjpfc=
 github.com/viamrobotics/evdev v0.1.3/go.mod h1:N6nuZmPz7HEIpM7esNWwLxbYzqWqLSZkfI/1Sccckqk=
 github.com/viamrobotics/ice/v2 v2.3.40 h1:H9r4ztsKkxWSn42R4fLvYlaPtpBys1Yj7/MERBtZY0k=
@@ -1158,8 +1160,6 @@ go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
 go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
-go.viam.com/api v0.1.565 h1:f4fOM1HFYlwoByIqMlMfjJp9AlZp7w8hLZtVSlFjqT0=
-go.viam.com/api v0.1.565/go.mod h1:nVe4WXrtc8aupJ8OWXSYx6KhCiOkr3VCbkwxD4D41xQ=
 go.viam.com/test v1.2.4 h1:JYgZhsuGAQ8sL9jWkziAXN9VJJiKbjoi9BsO33TW3ug=
 go.viam.com/test v1.2.4/go.mod h1:zI2xzosHdqXAJ/kFqcN+OIF78kQuTV2nIhGZ8EzvaJI=
 go.viam.com/utils v0.6.6 h1:1R+SpKz1McCAIC0JshgkfHy+uDu4okNmDq/AYl9m8iE=

--- a/go.sum
+++ b/go.sum
@@ -1052,8 +1052,6 @@ github.com/viam-labs/go-getter v0.0.0-20251022162721-98d73b852c8a h1:qk5MX36oytF
 github.com/viam-labs/go-getter v0.0.0-20251022162721-98d73b852c8a/go.mod h1:MwPm+Hpd8PZRx+jkOVLGxqHl/bN+Hcsw0dD7ntSpLy0=
 github.com/viam-labs/motion-tools v1.9.0 h1:oUcxVMdrwVS7PXkWVYsUJOXkh0aTydmFlK/rciFcGxw=
 github.com/viam-labs/motion-tools v1.9.0/go.mod h1:unpRaVV4ETuJVoHa/3pzknoTnxqjSpfUMewE1vU27BA=
-github.com/viamrobotics/api v0.1.564-0.20260623150732-fab349455f38 h1:AWc25UzlVNxRs3Ni3dgwDpO+xnG5/U4AtwqmW3oYtaE=
-github.com/viamrobotics/api v0.1.564-0.20260623150732-fab349455f38/go.mod h1:nVe4WXrtc8aupJ8OWXSYx6KhCiOkr3VCbkwxD4D41xQ=
 github.com/viamrobotics/evdev v0.1.3 h1:mR4HFafvbc5Wx4Vp1AUJp6/aITfVx9AKyXWx+rWjpfc=
 github.com/viamrobotics/evdev v0.1.3/go.mod h1:N6nuZmPz7HEIpM7esNWwLxbYzqWqLSZkfI/1Sccckqk=
 github.com/viamrobotics/ice/v2 v2.3.40 h1:H9r4ztsKkxWSn42R4fLvYlaPtpBys1Yj7/MERBtZY0k=
@@ -1160,6 +1158,8 @@ go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
 go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
+go.viam.com/api v0.1.566 h1:o5nWDj6at04Y8nHGC7mZQDA6NIuGdPpwqhNLY+LQtfs=
+go.viam.com/api v0.1.566/go.mod h1:nVe4WXrtc8aupJ8OWXSYx6KhCiOkr3VCbkwxD4D41xQ=
 go.viam.com/test v1.2.4 h1:JYgZhsuGAQ8sL9jWkziAXN9VJJiKbjoi9BsO33TW3ug=
 go.viam.com/test v1.2.4/go.mod h1:zI2xzosHdqXAJ/kFqcN+OIF78kQuTV2nIhGZ8EzvaJI=
 go.viam.com/utils v0.6.6 h1:1R+SpKz1McCAIC0JshgkfHy+uDu4okNmDq/AYl9m8iE=

--- a/testutils/inject/build_service_client.go
+++ b/testutils/inject/build_service_client.go
@@ -12,6 +12,9 @@ type BuildServiceClient struct {
 	buildpb.BuildServiceClient
 	ListJobsFunc   func(ctx context.Context, in *buildpb.ListJobsRequest, opts ...grpc.CallOption) (*buildpb.ListJobsResponse, error)
 	StartBuildFunc func(ctx context.Context, in *buildpb.StartBuildRequest, opts ...grpc.CallOption) (*buildpb.StartBuildResponse, error)
+	StartSourceUploadBuildFunc func(
+		ctx context.Context, opts ...grpc.CallOption,
+	) (buildpb.BuildService_StartSourceUploadBuildClient, error)
 }
 
 // ListJobs calls the injected ListJobsFunc or the real version.
@@ -32,4 +35,15 @@ func (bsc *BuildServiceClient) StartBuild(ctx context.Context, in *buildpb.Start
 		return bsc.StartBuild(ctx, in, opts...)
 	}
 	return bsc.StartBuildFunc(ctx, in, opts...)
+}
+
+// StartSourceUploadBuild calls the injected StartSourceUploadBuildFunc or the
+// real version. Tests can return a fake stream that captures Send calls.
+func (bsc *BuildServiceClient) StartSourceUploadBuild(
+	ctx context.Context, opts ...grpc.CallOption,
+) (buildpb.BuildService_StartSourceUploadBuildClient, error) {
+	if bsc.StartSourceUploadBuildFunc == nil {
+		return bsc.BuildServiceClient.StartSourceUploadBuild(ctx, opts...)
+	}
+	return bsc.StartSourceUploadBuildFunc(ctx, opts...)
 }

--- a/testutils/inject/build_service_client.go
+++ b/testutils/inject/build_service_client.go
@@ -10,8 +10,8 @@ import (
 // BuildServiceClient is an injectable buildpb.BuildServiceClient.
 type BuildServiceClient struct {
 	buildpb.BuildServiceClient
-	ListJobsFunc   func(ctx context.Context, in *buildpb.ListJobsRequest, opts ...grpc.CallOption) (*buildpb.ListJobsResponse, error)
-	StartBuildFunc func(ctx context.Context, in *buildpb.StartBuildRequest, opts ...grpc.CallOption) (*buildpb.StartBuildResponse, error)
+	ListJobsFunc               func(ctx context.Context, in *buildpb.ListJobsRequest, opts ...grpc.CallOption) (*buildpb.ListJobsResponse, error)
+	StartBuildFunc             func(ctx context.Context, in *buildpb.StartBuildRequest, opts ...grpc.CallOption) (*buildpb.StartBuildResponse, error)
 	StartSourceUploadBuildFunc func(
 		ctx context.Context, opts ...grpc.CallOption,
 	) (buildpb.BuildService_StartSourceUploadBuildClient, error)

--- a/testutils/inject/build_service_client.go
+++ b/testutils/inject/build_service_client.go
@@ -10,8 +10,10 @@ import (
 // BuildServiceClient is an injectable buildpb.BuildServiceClient.
 type BuildServiceClient struct {
 	buildpb.BuildServiceClient
-	ListJobsFunc               func(ctx context.Context, in *buildpb.ListJobsRequest, opts ...grpc.CallOption) (*buildpb.ListJobsResponse, error)
-	StartBuildFunc             func(ctx context.Context, in *buildpb.StartBuildRequest, opts ...grpc.CallOption) (*buildpb.StartBuildResponse, error)
+	ListJobsFunc func(ctx context.Context, in *buildpb.ListJobsRequest,
+		opts ...grpc.CallOption) (*buildpb.ListJobsResponse, error)
+	StartBuildFunc func(ctx context.Context, in *buildpb.StartBuildRequest,
+		opts ...grpc.CallOption) (*buildpb.StartBuildResponse, error)
 	StartSourceUploadBuildFunc func(
 		ctx context.Context, opts ...grpc.CallOption,
 	) (buildpb.BuildService_StartSourceUploadBuildClient, error)


### PR DESCRIPTION
Adds the CLI command `viam module build cloud` to trigger a cloud build from source code. Open to suggestions on the command naming, but this command packages the source code for the module and sends it to cloud build (like hot reloading) and then publishes the build to the registry

See app and api PRs for additional context: https://github.com/viamrobotics/app/pull/12217 https://github.com/viamrobotics/api/pull/858#issue-4537499170