### PR TITLE
add gripper static obstacle test

### DIFF
--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -616,16 +616,17 @@ func TestGripperAPIStaticObstacleInFrameSystem(t *testing.T) {
 	}
 
 	robot := setupLocalRobot(t, ctx, &cfg, logger.Sublogger("robot"))
-	fss, err := framesystem.FromProvider(robot)
+
+	fsCfg, err := robot.FrameSystemConfig(ctx)
 	test.That(t, err, test.ShouldBeNil)
 
-	fs, err := framesystem.NewFromService(ctx, fss, nil)
-	test.That(t, err, test.ShouldBeNil)
-
-	frame := fs.Frame("obstacle-frame")
-	test.That(t, frame, test.ShouldNotBeNil)
-
-	gif, err := frame.Geometries([]referenceframe.Input{})
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, gif.Geometries(), test.ShouldHaveLength, 1)
+	var obstaclePart *referenceframe.FrameSystemPart
+	for _, part := range fsCfg.Parts {
+		if part.FrameConfig != nil && part.FrameConfig.Name() == "obstacle-frame" {
+			obstaclePart = part
+			break
+		}
+	}
+	test.That(t, obstaclePart, test.ShouldNotBeNil)
+	test.That(t, obstaclePart.FrameConfig.Geometry(), test.ShouldNotBeNil)
 }

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -539,3 +539,43 @@ func TestResourcesImplementingGeometriesInFrameSystem(t *testing.T) {
 	// system geometry to match the camera's.
 	test.That(t, camGeomFromCam.ToPoints(1), test.ShouldResemble, camGeomFromFS.ToPoints(1))
 }
+
+func TestGripperAPIStaticObstacleInFrameSystem(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+
+	cfg := config.Config{
+		Components: []resource.Config{
+			{
+				Name:  "obstacle",
+				API:   gripper.API,
+				Model: resource.DefaultModelFamily.WithModel("fake"),
+				Frame: &referenceframe.LinkConfig{
+					ID:     "obstacle-frame",
+					Parent: "world",
+					Geometry: &spatialmath.GeometryConfig{
+						Type:  "box",
+						X:     100,
+						Y:     200,
+						Z:     300,
+						Label: "obstacle-geom",
+					},
+				},
+			},
+		},
+	}
+
+	robot := setupLocalRobot(t, ctx, &cfg, logger.Sublogger("robot"))
+	fss, err := framesystem.FromProvider(robot)
+	test.That(t, err, test.ShouldBeNil)
+
+	fs, err := framesystem.NewFromService(ctx, fss, nil)
+	test.That(t, err, test.ShouldBeNil)
+
+	frame := fs.Frame("obstacle-frame")
+	test.That(t, frame, test.ShouldNotBeNil)
+
+	gif, err := frame.Geometries([]referenceframe.Input{})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, gif.Geometries(), test.ShouldHaveLength, 1)
+}

--- a/robot/impl/robot_framesystem_test.go
+++ b/robot/impl/robot_framesystem_test.go
@@ -540,7 +540,57 @@ func TestResourcesImplementingGeometriesInFrameSystem(t *testing.T) {
 	test.That(t, camGeomFromCam.ToPoints(1), test.ShouldResemble, camGeomFromFS.ToPoints(1))
 }
 
+type staticObstacleGripper struct {
+	resource.Named
+	resource.TriviallyCloseable
+	resource.TriviallyReconfigurable
+}
+
+func (g *staticObstacleGripper) Open(context.Context, map[string]interface{}) error {
+	return nil
+}
+
+func (g *staticObstacleGripper) Grab(context.Context, map[string]interface{}) (bool, error) {
+	return false, nil
+}
+
+func (g *staticObstacleGripper) IsHoldingSomething(context.Context, map[string]interface{}) (gripper.HoldingStatus, error) {
+	return gripper.HoldingStatus{}, nil
+}
+
+func (g *staticObstacleGripper) Stop(context.Context, map[string]interface{}) error {
+	return nil
+}
+
+func (g *staticObstacleGripper) IsMoving(context.Context) (bool, error) {
+	return false, nil
+}
+
+func (g *staticObstacleGripper) Geometries(context.Context, map[string]interface{}) ([]spatialmath.Geometry, error) {
+	return nil, nil
+}
+
+func (g *staticObstacleGripper) Kinematics(context.Context) (referenceframe.Model, error) {
+	return referenceframe.NewSimpleModel(g.Name().ShortName()), nil
+}
+
+func (g *staticObstacleGripper) CurrentInputs(context.Context) ([]referenceframe.Input, error) {
+	return nil, nil
+}
+
+func (g *staticObstacleGripper) GoToInputs(context.Context, ...[]referenceframe.Input) error {
+	return nil
+}
+
 func TestGripperAPIStaticObstacleInFrameSystem(t *testing.T) {
+	staticObstacleModel := resource.NewModel("test", "test", "static-obstacle-gripper")
+	resource.RegisterComponent(gripper.API, staticObstacleModel, resource.Registration[gripper.Gripper, resource.NoNativeConfig]{
+		Constructor: func(_ context.Context, _ resource.Dependencies, conf resource.Config, _ logging.Logger) (gripper.Gripper, error) {
+			return &staticObstacleGripper{Named: conf.ResourceName().AsNamed()}, nil
+		},
+	})
+	defer resource.Deregister(gripper.API, staticObstacleModel)
+
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
 
@@ -549,7 +599,7 @@ func TestGripperAPIStaticObstacleInFrameSystem(t *testing.T) {
 			{
 				Name:  "obstacle",
 				API:   gripper.API,
-				Model: resource.DefaultModelFamily.WithModel("fake"),
+				Model: staticObstacleModel,
 				Frame: &referenceframe.LinkConfig{
 					ID:     "obstacle-frame",
 					Parent: "world",


### PR DESCRIPTION
Registers a minimal gripper whose Kinematics() returns referenceframe.NewSimpleModel(name) which doesn't contain a geometry 

That mirrors module resources whose geometry is declared in frame.geometry rather than served through Kinematics()

Expected behavior - geometry exists on the frame
Actual behavior on main - geometry is dropped and the test fails

```
WARN  impl/local_robot.go:1246  An input enabled component erroneously included a geometry. Ignoring the geometry.  {"ResName":"obstacle"}
```