### PR TITLE
RSDK-14061 Dynamically allocate ports of TestTunnelE2E tests to avoid collision

### DIFF
--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -28,6 +28,7 @@ import (
 	apppb "go.viam.com/api/app/v1"
 	commonpb "go.viam.com/api/common/v1"
 	"go.viam.com/test"
+	goutils "go.viam.com/utils"
 	"go.viam.com/utils/protoutils"
 	"go.viam.com/utils/rpc"
 	"go.viam.com/utils/testutils"
@@ -1622,28 +1623,33 @@ func TestTunnelE2ECLI(t *testing.T) {
 	// CLI. It is mostly identical to `TestTunnelE2E` in web/server/entrypoint_test.go.
 	// The tunnel is:
 	//
-	// test-process <-> source-listener(localhost:23662) <-> machine(localhost:23661) <-> dest-listener(localhost:23660)
+	// test-process <-> source-listener <-> machine <-> dest-listener
 	//
-	// Ports are kept higher than those used by `TestTunnelE2E` so the two can run in
-	// parallel without colliding.
+	// Ports are reserved dynamically. ReserveRandomPort hands back a live listener
+	// for the dest port so unrelated tests can't race in; the machine bind address
+	// and source port use TryReserveRandomPort since the server and the CLI's
+	// tunnelTraffic open those sockets themselves.
 
 	tunnelMsg := "Hello, World!"
-	destPort := 23660
+
+	destPort, destListener, err := goutils.ReserveRandomPort()
+	test.That(t, err, test.ShouldBeNil)
 	destListenerAddr := net.JoinHostPort("localhost", strconv.Itoa(destPort))
-	machineAddr := net.JoinHostPort("localhost", "23661")
-	sourcePort := 23662
+	defer func() {
+		test.That(t, destListener.Close(), test.ShouldBeNil)
+	}()
+
+	machinePort, err := goutils.TryReserveRandomPort()
+	test.That(t, err, test.ShouldBeNil)
+	machineAddr := net.JoinHostPort("localhost", strconv.Itoa(machinePort))
+
+	sourcePort, err := goutils.TryReserveRandomPort()
+	test.That(t, err, test.ShouldBeNil)
 	sourceListenerAddr := net.JoinHostPort("localhost", strconv.Itoa(sourcePort))
 
 	logger := logging.NewTestLogger(t)
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
-
-	// Start "destination" listener.
-	destListener, err := net.Listen("tcp", destListenerAddr)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, destListener.Close(), test.ShouldBeNil)
-	}()
 
 	wg.Add(1)
 	go func() {

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1622,15 +1622,16 @@ func TestTunnelE2ECLI(t *testing.T) {
 	// CLI. It is mostly identical to `TestTunnelE2E` in web/server/entrypoint_test.go.
 	// The tunnel is:
 	//
-	// test-process <-> source-listener(localhost:23659) <-> machine(localhost:23658) <-> dest-listener(localhost:23657)
-	if runtime.GOOS == osWindows {
-		t.Skip("RSDK-14061")
-	}
+	// test-process <-> source-listener(localhost:23662) <-> machine(localhost:23661) <-> dest-listener(localhost:23660)
+	//
+	// Ports are kept higher than those used by `TestTunnelE2E` so the two can run in
+	// parallel without colliding.
+
 	tunnelMsg := "Hello, World!"
-	destPort := 23657
+	destPort := 23660
 	destListenerAddr := net.JoinHostPort("localhost", strconv.Itoa(destPort))
-	machineAddr := net.JoinHostPort("localhost", "23658")
-	sourcePort := 23659
+	machineAddr := net.JoinHostPort("localhost", "23661")
+	sourcePort := 23662
 	sourceListenerAddr := net.JoinHostPort("localhost", strconv.Itoa(sourcePort))
 
 	logger := logging.NewTestLogger(t)

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1625,10 +1625,7 @@ func TestTunnelE2ECLI(t *testing.T) {
 	//
 	// test-process <-> source-listener <-> machine <-> dest-listener
 	//
-	// Ports are reserved dynamically. ReserveRandomPort hands back a live listener
-	// for the dest port so unrelated tests can't race in; the machine bind address
-	// and source port use TryReserveRandomPort since the server and the CLI's
-	// tunnelTraffic open those sockets themselves.
+	// Ports are reserved dynamically.
 
 	tunnelMsg := "Hello, World!"
 

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -393,35 +393,45 @@ func TestTunnelE2E(t *testing.T) {
 	t.Parallel()
 	// `TestTunnelE2E` attempts to send "Hello, World!" across a tunnel. The tunnel is:
 	//
-	// test-process <-> source-listener(127.0.0.1:23658) <-> machine(127.0.0.1:23657) <-> dest-listener(127.0.0.1:23656)
+	// test-process <-> source-listener <-> machine <-> dest-listener
+	//
+	// Ports are reserved dynamically. ReserveRandomPort hands back a live listener
+	// so unrelated tests can't race in on the dest/source/timeout ports; the
+	// machine bind address uses TryReserveRandomPort since the server itself
+	// opens that socket.
 
 	tunnelMsg := "Hello, World!"
-	destPort := 23656
+
+	destPort, destListener, err := goutils.ReserveRandomPort()
+	test.That(t, err, test.ShouldBeNil)
 	destListenerAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(destPort))
-	machineAddr := net.JoinHostPort("127.0.0.1", "23657")
-	sourceListenerAddr := net.JoinHostPort("127.0.0.1", "23658")
+	defer func() {
+		test.That(t, destListener.Close(), test.ShouldBeNil)
+	}()
+
+	// Mock listener for the timeout endpoint — windows requires a real listener
+	// even though we never accept on it.
+	timeoutDestPort, timeoutDestListener, err := goutils.ReserveRandomPort()
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, timeoutDestListener.Close(), test.ShouldBeNil)
+	}()
+
+	machinePort, err := goutils.TryReserveRandomPort()
+	test.That(t, err, test.ShouldBeNil)
+	machineAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(machinePort))
+
+	sourcePort, sourceListener, err := goutils.ReserveRandomPort()
+	test.That(t, err, test.ShouldBeNil)
+	sourceListenerAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(sourcePort))
+	defer func() {
+		test.That(t, sourceListener.Close(), test.ShouldBeNil)
+	}()
 
 	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
 	runServerCtx, runServerCtxCancel := context.WithCancel(ctx)
 	var wg sync.WaitGroup
-
-	// Start "destination" listener.
-	destListener, err := net.Listen("tcp", destListenerAddr)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, destListener.Close(), test.ShouldBeNil)
-	}()
-
-	// Start mock "destination" listener, even if we don't intend on actually accepting any messages.
-	// This is because windows doesn't seem to allow for dialing to ports there aren't listeners on.
-	timeoutDestPort := 65534
-	timeoutDestListenerAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(timeoutDestPort))
-	timeoutDestListener, err := net.Listen("tcp", timeoutDestListenerAddr)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, timeoutDestListener.Close(), test.ShouldBeNil)
-	}()
 
 	wg.Add(1)
 	go func() {
@@ -511,11 +521,6 @@ func TestTunnelE2E(t *testing.T) {
 	}
 
 	// Start "source" listener (a `RobotClient` running `Tunnel`.)
-	sourceListener, err := net.Listen("tcp", sourceListenerAddr)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, sourceListener.Close(), test.ShouldBeNil)
-	}()
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -395,10 +395,7 @@ func TestTunnelE2E(t *testing.T) {
 	//
 	// test-process <-> source-listener <-> machine <-> dest-listener
 	//
-	// Ports are reserved dynamically. ReserveRandomPort hands back a live listener
-	// so unrelated tests can't race in on the dest/source/timeout ports; the
-	// machine bind address uses TryReserveRandomPort since the server itself
-	// opens that socket.
+	// Ports are reserved dynamically.
 
 	tunnelMsg := "Hello, World!"
 


### PR DESCRIPTION
RSDK-14061

## What
  
Replaces hardcoded port numbers in `TestTunnelE2E` (`web/server/entrypoint_test.go`) and `TestTunnelE2ECLI` (`cli/client_test.go`) with dynamic port reservation via `goutils.ReserveRandomPort` and `goutils.TryReserveRandomPort`. Also drops the Windows-only `t.Skip("RSDK-14061")` from `TestTunnelE2ECLI`.

## Why

Both tests use `t.Parallel()`, and the original hardcoded ports (23656–23659) collided between them. An earlier change in this branch bumped `TestTunnelE2ECLI` to 23660–23662 to clear that direct collision, but the underlying problem — that any other test using `net.Listen(":0")` to grab a random port could land on those same numbers and cause a flake — was still there.

`goutils.ReserveRandomPort` returns a live listener, so the dest, source, and Windows-mock listeners are held against unrelated tests for the full lifetime of the test. `goutils.TryReserveRandomPort` is used only for the machine bind address (and for `TestTunnelE2ECLI`'s source port, which the CLI's `tunnelTraffic` opens itself) since the server reopens those sockets after the test reserves the port. The `runtime.GOOS == osWindows` skip for TestTunnelE2ECLI is no longer needed now that the test isn't claiming a fixed port range.

## Testing

  - Ran both tests backgrounded against each other in the same shell
  - Will see if Windows tests pass in this PR and rerun them once or twice

  [Description generated by Claude 🤖]
