### PR TITLE
RSDK-13613 - Fix flaky TestValidationFailure by handling wrapped DeadlineExceeded errors

### DIFF
--- a/examples/customresources/demos/complexmodule/moduletest/module_test.go
+++ b/examples/customresources/demos/complexmodule/moduletest/module_test.go
@@ -297,17 +297,39 @@ func TestComplexModule(t *testing.T) {
 	})
 }
 
+// isDeadlineExceededErr checks whether an error is or wraps a DeadlineExceeded
+// error. This handles cases where gRPC DeadlineExceeded errors are wrapped by
+// fmt.Errorf (e.g., "error updating resources: rpc error: code = DeadlineExceeded ..."),
+// which prevents status.Code from detecting the gRPC status code.
+func isDeadlineExceededErr(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if status.Code(err) == codes.DeadlineExceeded {
+		return true
+	}
+	// Check for wrapped gRPC status errors that status.Code can't detect.
+	wrappedErr := err
+	for wrappedErr != nil {
+		if status.Code(wrappedErr) == codes.DeadlineExceeded {
+			return true
+		}
+		wrappedErr = errors.Unwrap(wrappedErr)
+	}
+	return false
+}
+
 func connect(port int, logger logging.Logger) (robot.Robot, error) {
 	connectCtx, cancelConn := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancelConn()
 	for {
-		dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+		dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Second*2)
 		rc, err := client.New(dialCtx, fmt.Sprintf("localhost:%d", port), logger,
 			client.WithDialOptions(rpc.WithForceDirectGRPC()),
 			client.WithDisableSessions(), // TODO(PRODUCT-343): add session support to modules
 		)
 		dialCancel()
-		if !errors.Is(err, context.DeadlineExceeded) && status.Code(err) != codes.DeadlineExceeded {
+		if !isDeadlineExceededErr(err) {
 			return rc, err
 		}
 		select {

--- a/examples/customresources/demos/multiplemodules/moduletest/module_test.go
+++ b/examples/customresources/demos/multiplemodules/moduletest/module_test.go
@@ -236,17 +236,39 @@ func TestWebRTCSpans(t *testing.T) {
 	})
 }
 
+// isDeadlineExceededErr checks whether an error is or wraps a DeadlineExceeded
+// error. This handles cases where gRPC DeadlineExceeded errors are wrapped by
+// fmt.Errorf (e.g., "error updating resources: rpc error: code = DeadlineExceeded ..."),
+// which prevents status.Code from detecting the gRPC status code.
+func isDeadlineExceededErr(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if status.Code(err) == codes.DeadlineExceeded {
+		return true
+	}
+	// Check for wrapped gRPC status errors that status.Code can't detect.
+	wrappedErr := err
+	for wrappedErr != nil {
+		if status.Code(wrappedErr) == codes.DeadlineExceeded {
+			return true
+		}
+		wrappedErr = errors.Unwrap(wrappedErr)
+	}
+	return false
+}
+
 func connect(port int, logger logging.Logger, dialOpts ...rpc.DialOption) (robot.Robot, error) {
 	connectCtx, cancelConn := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancelConn()
 	for {
-		dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+		dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Second*2)
 		rc, err := client.New(dialCtx, fmt.Sprintf("localhost:%d", port), logger,
 			client.WithDialOptions(dialOpts...),
 			client.WithDisableSessions(), // TODO(PRODUCT-343): add session support to modules
 		)
 		dialCancel()
-		if !errors.Is(err, context.DeadlineExceeded) && status.Code(err) != codes.DeadlineExceeded {
+		if !isDeadlineExceededErr(err) {
 			return rc, err
 		}
 		select {


### PR DESCRIPTION
The connect() retry loop in module integration tests failed to detect DeadlineExceeded errors wrapped by client.New's updateResources (which uses fmt.Errorf). status.Code() cannot extract the gRPC status code from wrapped errors, so the retry loop would return the error instead of retrying. Fix by unwrapping the error chain to check each level, and increase the per-dial timeout from 500ms to 2s to give resource refresh time to complete.