### PR TITLE
chore: bump claude-ci-workflows to v2.0.4

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -24,12 +24,12 @@ jobs:
       pull-requests: read
       issues: write
     steps:
-      # viamrobotics/claude-ci-workflows@v2.0.0
+      # viamrobotics/claude-ci-workflows@v2.0.4
       - name: Checkout claude-ci-workflows for composite action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: viamrobotics/claude-ci-workflows
-          ref: aa76787c145ed43f8f7b9bae4d978da4f9850001
+          ref: 46b3c2c12d72f19c639608803b565a99df77fcc5
           path: .claude-ci-workflows
           sparse-checkout: |
             .github/actions/check-approvals/

--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -30,8 +30,8 @@ jobs:
         github.event.workflow_run.conclusion == 'failure' &&
         startsWith(github.event.workflow_run.head_branch, 'claude/')
       )
-    # viamrobotics/claude-ci-workflows@v2.0.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@aa76787c145ed43f8f7b9bae4d978da4f9850001
+    # viamrobotics/claude-ci-workflows@v2.0.4
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@46b3c2c12d72f19c639608803b565a99df77fcc5
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       run_id: ${{ github.event.workflow_run.id || inputs.run_id }}

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -58,8 +58,8 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    # viamrobotics/claude-ci-workflows@v2.0.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@aa76787c145ed43f8f7b9bae4d978da4f9850001
+    # viamrobotics/claude-ci-workflows@v2.0.4
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@46b3c2c12d72f19c639608803b565a99df77fcc5
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       ticket_id: ${{ github.event.client_payload.ticket_id || inputs.ticket_id }}

--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -27,8 +27,8 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'pull_request_review' && github.event.review.state != 'approved' && github.event.review.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'claude/'))
       )
-    # viamrobotics/claude-ci-workflows@v2.0.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@aa76787c145ed43f8f7b9bae4d978da4f9850001
+    # viamrobotics/claude-ci-workflows@v2.0.4
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@46b3c2c12d72f19c639608803b565a99df77fcc5
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       install_command: make tool-install


### PR DESCRIPTION
## Summary
Bumps `viamrobotics/claude-ci-workflows` pins (pinned SHA + version comment) from **v2.0.0** to **v2.0.4** (`46b3c2c`).

Release: https://github.com/viamrobotics/claude-ci-workflows/releases/tag/v2.0.4

## Changes in claude-ci-workflows (v2.0.0 → v2.0.4)
- v2.0.1 jira: avoid PR search-index race when locating opened PR
- v2.0.2 dependabot rebase-job: switch nested `uses:` to absolute reference
- v2.0.3 jira: add `contents: read` to the check-pr job
- v2.0.4 jira: match bracketed `[TICKET]` prefix in PR detection

All changes are internal to the reusable workflows — **no `workflow_call` input/secret changes**, so no caller-side edits were required.

Note: `check-approvals.yml` consumes the `check-approvals` **composite action** via `actions/checkout` + sparse-checkout; its `ref:` pin (and version comment) were bumped to v2.0.4 as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)