### PR TITLE
chore: bump claude-ci-workflows to v2.1.0

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -24,12 +24,12 @@ jobs:
       pull-requests: read
       issues: write
     steps:
-      # viamrobotics/claude-ci-workflows@v2.0.4
+      # viamrobotics/claude-ci-workflows@v2.1.0
       - name: Checkout claude-ci-workflows for composite action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: viamrobotics/claude-ci-workflows
-          ref: 46b3c2c12d72f19c639608803b565a99df77fcc5
+          ref: 97b61edeb3aebf3b9bfc93129ac9beae053e5aab
           path: .claude-ci-workflows
           sparse-checkout: |
             .github/actions/check-approvals/

--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -30,8 +30,8 @@ jobs:
         github.event.workflow_run.conclusion == 'failure' &&
         startsWith(github.event.workflow_run.head_branch, 'claude/')
       )
-    # viamrobotics/claude-ci-workflows@v2.0.4
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@46b3c2c12d72f19c639608803b565a99df77fcc5
+    # viamrobotics/claude-ci-workflows@v2.1.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@97b61edeb3aebf3b9bfc93129ac9beae053e5aab
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       run_id: ${{ github.event.workflow_run.id || inputs.run_id }}

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -58,8 +58,8 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    # viamrobotics/claude-ci-workflows@v2.0.4
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@46b3c2c12d72f19c639608803b565a99df77fcc5
+    # viamrobotics/claude-ci-workflows@v2.1.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@97b61edeb3aebf3b9bfc93129ac9beae053e5aab
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       ticket_id: ${{ github.event.client_payload.ticket_id || inputs.ticket_id }}

--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -27,8 +27,8 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'pull_request_review' && github.event.review.state != 'approved' && github.event.review.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'claude/'))
       )
-    # viamrobotics/claude-ci-workflows@v2.0.4
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@46b3c2c12d72f19c639608803b565a99df77fcc5
+    # viamrobotics/claude-ci-workflows@v2.1.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@97b61edeb3aebf3b9bfc93129ac9beae053e5aab
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       install_command: make tool-install


### PR DESCRIPTION
## Summary
Bumps `viamrobotics/claude-ci-workflows` pins (pinned SHA + version comment) from **v2.0.4** to **v2.1.0** (`97b61ed`).

Follow-up to the merged v2.0.4 bump. Release: https://github.com/viamrobotics/claude-ci-workflows/releases/tag/v2.1.0

## Changes (v2.0.4 → v2.1.0)
- **v2.1.0** — deterministic PR creation and always-on execution-log artifacts (#107, #109)

All changes are internal to the reusable workflows — **no `workflow_call` input/secret changes**, so no caller-side edits were required.

Includes `check-approvals.yml`, which consumes the `check-approvals` composite action via sparse-checkout; its `ref:` pin was bumped to v2.1.0 as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)