### PR TITLE
chore: bump claude-ci-workflows to v2.1.1

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -46,12 +46,12 @@ jobs:
             echo "Requiring 2 approvals."
           fi
 
-      # viamrobotics/claude-ci-workflows@v2.1.0
+      # viamrobotics/claude-ci-workflows@v2.1.1
       - name: Checkout claude-ci-workflows for composite action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: viamrobotics/claude-ci-workflows
-          ref: 97b61edeb3aebf3b9bfc93129ac9beae053e5aab
+          ref: f55f0995718f073950100a1fe030577cdc23adb6
           path: .claude-ci-workflows
           sparse-checkout: |
             .github/actions/check-approvals/

--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -30,8 +30,8 @@ jobs:
         github.event.workflow_run.conclusion == 'failure' &&
         startsWith(github.event.workflow_run.head_branch, 'claude/')
       )
-    # viamrobotics/claude-ci-workflows@v2.1.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@97b61edeb3aebf3b9bfc93129ac9beae053e5aab
+    # viamrobotics/claude-ci-workflows@v2.1.1
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@f55f0995718f073950100a1fe030577cdc23adb6
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       run_id: ${{ github.event.workflow_run.id || inputs.run_id }}

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -58,8 +58,8 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    # viamrobotics/claude-ci-workflows@v2.1.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@97b61edeb3aebf3b9bfc93129ac9beae053e5aab
+    # viamrobotics/claude-ci-workflows@v2.1.1
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@f55f0995718f073950100a1fe030577cdc23adb6
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       ticket_id: ${{ github.event.client_payload.ticket_id || inputs.ticket_id }}

--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -27,8 +27,8 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'pull_request_review' && github.event.review.state != 'approved' && github.event.review.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'claude/'))
       )
-    # viamrobotics/claude-ci-workflows@v2.1.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@97b61edeb3aebf3b9bfc93129ac9beae053e5aab
+    # viamrobotics/claude-ci-workflows@v2.1.1
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@f55f0995718f073950100a1fe030577cdc23adb6
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       install_command: make tool-install


### PR DESCRIPTION
## Summary
Bumps `viamrobotics/claude-ci-workflows` pins (pinned SHA + version comment) from **v2.1.0** to **v2.1.1** (`f55f099`).

Follow-up to the merged v2.1.0 bump. Release: https://github.com/viamrobotics/claude-ci-workflows/releases/tag/v2.1.1

## Changes (v2.1.0 → v2.1.1)
- **v2.1.1** (#111) — open PRs via `github-script` instead of `gh`, so PR creation works in jobs running **inside a container without the gh CLI**. This is directly relevant to rdk, whose `claude-jira` job runs in the `rdk-devenv` container.

Internal change to the reusable workflows — **no `workflow_call` input/secret changes**, so no caller-side edits were required. Also bumps the `check-approvals` composite-action `ref:` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)