### PR TITLE
chore: bump claude-ci-workflows to v2.1.2 and re-check approvals on PR reviews

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -5,7 +5,7 @@ name: Check PR Approvals
 # branch-protection rule (or ruleset) that targets `main`.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     branches: [main]
   pull_request_review:
@@ -21,8 +21,8 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'claude/')
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
-      issues: write
+      pull-requests: read   # list reviews + get the PR
+      issues: write         # post/update the "Review Required" comment
     steps:
       # Flaky-test fixes and dependabot bumps only require a single approval;
       # everything else needs two. Title/branch are read via env (never interpolated
@@ -46,12 +46,12 @@ jobs:
             echo "Requiring 2 approvals."
           fi
 
-      # viamrobotics/claude-ci-workflows@v2.1.1
+      # viamrobotics/claude-ci-workflows@v2.1.2
       - name: Checkout claude-ci-workflows for composite action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: viamrobotics/claude-ci-workflows
-          ref: f55f0995718f073950100a1fe030577cdc23adb6
+          ref: 467bc6f62151c399c33fe54073896160bda25b9b
           path: .claude-ci-workflows
           sparse-checkout: |
             .github/actions/check-approvals/

--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -30,8 +30,8 @@ jobs:
         github.event.workflow_run.conclusion == 'failure' &&
         startsWith(github.event.workflow_run.head_branch, 'claude/')
       )
-    # viamrobotics/claude-ci-workflows@v2.1.1
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@f55f0995718f073950100a1fe030577cdc23adb6
+    # viamrobotics/claude-ci-workflows@v2.1.2
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@467bc6f62151c399c33fe54073896160bda25b9b
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       run_id: ${{ github.event.workflow_run.id || inputs.run_id }}

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -58,8 +58,8 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    # viamrobotics/claude-ci-workflows@v2.1.1
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@f55f0995718f073950100a1fe030577cdc23adb6
+    # viamrobotics/claude-ci-workflows@v2.1.2
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@467bc6f62151c399c33fe54073896160bda25b9b
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       ticket_id: ${{ github.event.client_payload.ticket_id || inputs.ticket_id }}

--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -27,8 +27,8 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'pull_request_review' && github.event.review.state != 'approved' && github.event.review.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'claude/'))
       )
-    # viamrobotics/claude-ci-workflows@v2.1.1
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@f55f0995718f073950100a1fe030577cdc23adb6
+    # viamrobotics/claude-ci-workflows@v2.1.2
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@467bc6f62151c399c33fe54073896160bda25b9b
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       install_command: make tool-install


### PR DESCRIPTION
## Summary
Bumps `viamrobotics/claude-ci-workflows` pins from **v2.1.1** to **v2.1.2** (`467bc6f`) across all four caller workflows, and tightens the approvals gate.

Release: https://github.com/viamrobotics/claude-ci-workflows/releases/tag/v2.1.2

## Changes (v2.1.1 → v2.1.2)
- **v2.1.2** (#113) — derive the PR branch from git HEAD when the `branch_name` output is empty. Internal to the reusable workflows; **no `workflow_call` input/secret changes**.

## check-approvals.yml
- **Re-check on reviews & PR lifecycle.** Switched the PR trigger from `pull_request_target` to `pull_request` with `[opened, reopened, synchronize, ready_for_review]`, alongside the existing `pull_request_review: [submitted, dismissed, edited]`. So the approval count is re-evaluated when reviews are added/dismissed and on PR open/reopen/update/ready. `claude/**` PRs are always same-repo (never forks), so `pull_request` still grants the write token the gate needs to comment.
- **Documented job permissions:**
  ```yaml
  permissions:
    pull-requests: read   # list reviews + get the PR
    issues: write         # post/update the "Review Required" comment
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)