### PR TITLE
chore: bump claude CI workflows to v2.2.1

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -46,12 +46,12 @@ jobs:
             echo "Requiring 2 approvals."
           fi
 
-      # viamrobotics/claude-ci-workflows@v2.1.2
+      # viamrobotics/claude-ci-workflows@v2.2.1
       - name: Checkout claude-ci-workflows for composite action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: viamrobotics/claude-ci-workflows
-          ref: 467bc6f62151c399c33fe54073896160bda25b9b
+          ref: 5506bdaf04cc7d1adbd2df0f31f108834b01aea6
           path: .claude-ci-workflows
           sparse-checkout: |
             .github/actions/check-approvals/

--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -30,8 +30,8 @@ jobs:
         github.event.workflow_run.conclusion == 'failure' &&
         startsWith(github.event.workflow_run.head_branch, 'claude/')
       )
-    # viamrobotics/claude-ci-workflows@v2.1.2
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@467bc6f62151c399c33fe54073896160bda25b9b
+    # viamrobotics/claude-ci-workflows@v2.2.1
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@5506bdaf04cc7d1adbd2df0f31f108834b01aea6
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       run_id: ${{ github.event.workflow_run.id || inputs.run_id }}

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -58,8 +58,8 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    # viamrobotics/claude-ci-workflows@v2.1.2
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@467bc6f62151c399c33fe54073896160bda25b9b
+    # viamrobotics/claude-ci-workflows@v2.2.1
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@5506bdaf04cc7d1adbd2df0f31f108834b01aea6
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       ticket_id: ${{ github.event.client_payload.ticket_id || inputs.ticket_id }}

--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -27,8 +27,8 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'pull_request_review' && github.event.review.state != 'approved' && github.event.review.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'claude/'))
       )
-    # viamrobotics/claude-ci-workflows@v2.1.2
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@467bc6f62151c399c33fe54073896160bda25b9b
+    # viamrobotics/claude-ci-workflows@v2.2.1
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@5506bdaf04cc7d1adbd2df0f31f108834b01aea6
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       install_command: make tool-install


### PR DESCRIPTION
Bumps `viamrobotics/claude-ci-workflows` from **v2.1.2 → v2.2.1** across all consumed workflows:

- `claude-jira.yml`
- `claude-pr-assistant.yml`
- `claude-ci-fix.yml`
- `check-approvals.yml` (composite action checkout ref)

Pinned SHA: `467bc6f` → `5506bdaf04cc7d1adbd2df0f31f108834b01aea6`.

## Jira flow changes (v2.2.x)

Both v2.2.x releases are scoped to the Jira flow and are **internal to the reusable workflow**:

- **v2.2.0** — enforce the Jira ticket ID prefix in PR titles. The reusable workflow now auto-prefixes `[RSDK-123] ` to the PR title if the agent omits it.
- **v2.2.1** — mint a fresh GitHub App token for PR creation instead of reusing the Claude action's OIDC token, which could be rejected with a 401 "Bad credentials" after a long agent run.

## Caller-side impact

**No input/secret changes required.** The new token-minting step uses `CI_GITHUB_APP_ID` / `CI_GITHUB_APP_PRIVATE_KEY`, which this repo's `claude-jira` caller already passes. The reusable workflow's `workflow_call` signature (and those of the other consumed workflows) is unchanged between v2.1.2 and v2.2.1 — verified by diffing the tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)