### PR TITLE
ci: fix PR labeler crash on non-member sender and allow trusted bots

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -31,7 +31,10 @@ jobs:
             // sender to bypass the membership check.
             const trustedBots = ["viam-ci-org-reader[bot]"];
             const pr = context.payload.pull_request;
-            const isFork = pr.head.repo.full_name !== pr.base.repo.full_name;
+            // Optional chaining keeps this fail-closed: if the head fork repo
+            // was deleted, pr.head.repo is null and isFork becomes true, which
+            // denies the bot path and falls through to the membership check.
+            const isFork = pr.head.repo?.full_name !== pr.base.repo.full_name;
             const sender = context.payload.sender.login;
             let isAuthorized = !isFork && trustedBots.includes(sender);
             if (!isAuthorized) {
@@ -44,7 +47,7 @@ jobs:
               }
             }
             if (isAuthorized) {
-              // order of labeling events must be preserved, so two seperate calls
+              // order of labeling events must be preserved, so two separate calls
               await github.rest.issues.addLabels({owner: "viamrobotics", repo: "rdk", issue_number: prNumber, labels: ["safe to test"]});
               return true;
             }

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -25,8 +25,25 @@ jobs:
             } catch (err) {
               core.info(`Non-fatal error ${err}, while trying to remove 'safe to test' label.`);
             }
-            let orgResp = await github.rest.orgs.checkMembershipForUser({org: "viamrobotics", username: context.payload.sender.login});
-            if (orgResp.status === 204) {
+            // Trusted bots that drive PRs but are not org members, so the
+            // membership API returns 404 for them. Only honored for same-repo
+            // branch PRs (never forks), so an external fork can never use a bot
+            // sender to bypass the membership check.
+            const trustedBots = ["viam-ci-org-reader[bot]"];
+            const pr = context.payload.pull_request;
+            const isFork = pr.head.repo.full_name !== pr.base.repo.full_name;
+            const sender = context.payload.sender.login;
+            let isAuthorized = !isFork && trustedBots.includes(sender);
+            if (!isAuthorized) {
+              try {
+                // checkMembershipForUser returns 204 for members and throws a 404 for non-members.
+                let orgResp = await github.rest.orgs.checkMembershipForUser({org: "viamrobotics", username: sender});
+                isAuthorized = orgResp.status === 204;
+              } catch (err) {
+                core.info(`User ${sender} is not an org member: ${err}`);
+              }
+            }
+            if (isAuthorized) {
               // order of labeling events must be preserved, so two seperate calls
               await github.rest.issues.addLabels({owner: "viamrobotics", repo: "rdk", issue_number: prNumber, labels: ["safe to test"]});
               return true;

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -47,7 +47,6 @@ jobs:
               }
             }
             if (isAuthorized) {
-              // order of labeling events must be preserved, so two separate calls
               await github.rest.issues.addLabels({owner: "viamrobotics", repo: "rdk", issue_number: prNumber, labels: ["safe to test"]});
               return true;
             }


### PR DESCRIPTION
checkMembershipForUser throws a 404 for non-members rather than returning a status, so the membership check crashed the step (e.g. when the sender was viam-ci-org-reader[bot]) instead of falling through to the unsafe-PR comment. Wrap the call in try/catch.

Also allowlist viam-ci-org-reader[bot], gated on the PR being a same-repo branch (never a fork), so an external fork can never use a bot sender to bypass the org membership check.