### PR TITLE
Rsdk-13610: viam traces get-remote slash issue

### DIFF
--- a/services/shell/copy_local.go
+++ b/services/shell/copy_local.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"

--- a/services/shell/copy_local.go
+++ b/services/shell/copy_local.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -236,7 +237,7 @@ func (copier *localFileCopier) Copy(ctx context.Context, file File) error {
 		if closeErr != nil {
 			return closeErr
 		}
-		if err := os.Rename(fullPathTmp, fullPath); err != nil {
+		if err := renameWithRetry(fullPathTmp, fullPath); err != nil {
 			return err
 		}
 	}
@@ -257,6 +258,28 @@ func (copier *localFileCopier) Copy(ctx context.Context, file File) error {
 // Close does nothing.
 func (copier *localFileCopier) Close(ctx context.Context) error {
 	return nil
+}
+
+// renameWithRetry retries os.Rename to work around transient sharing
+// violations on Windows: antivirus scanners (Defender), the Search indexer,
+// and similar background processes briefly open handles on a just-written
+// file and refuse to share delete access, which makes os.Rename fail with
+// ERROR_SHARING_VIOLATION. The handle is usually released within a few
+// hundred ms. On POSIX systems the first attempt always succeeds, so the
+// loop is a no-op there.
+func renameWithRetry(oldPath, newPath string) error {
+	const attempts = 5
+	const delay = 300 * time.Millisecond
+	var err error
+	for i := 0; i < attempts; i++ {
+		if err = os.Rename(oldPath, newPath); err == nil {
+			return nil
+		}
+		if i < attempts-1 {
+			time.Sleep(delay)
+		}
+	}
+	return err
 }
 
 type localFileReadCopier struct {
@@ -348,8 +371,14 @@ func (reader *localFileReadCopier) ReadAll(ctx context.Context) error {
 
 	// Note: okay with recursion for now. may want to check depth later...
 
+	// Use path.Join (always forward slashes) for the wire-side relative name.
+	// filepath.Join on Windows would emit backslashes, which a POSIX receiver
+	// (Linux/macOS) treats as literal filename characters — causing files to
+	// land at e.g. /tmp/subdir\a.txt instead of /tmp/subdir/a.txt during a
+	// recursive copy from a Windows host. The receiver's filepath.Join handles
+	// forward slashes correctly on every platform.
 	makeRelName := func(relDir string, file *os.File) string {
-		return filepath.Join(relDir, filepath.Base(file.Name()))
+		return path.Join(relDir, filepath.Base(file.Name()))
 	}
 	var copyFiles func(relDir string, files []*os.File) error
 	copyFiles = func(relDir string, files []*os.File) error {

--- a/services/shell/copy_local.go
+++ b/services/shell/copy_local.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -237,7 +236,7 @@ func (copier *localFileCopier) Copy(ctx context.Context, file File) error {
 		if closeErr != nil {
 			return closeErr
 		}
-		if err := renameWithRetry(fullPathTmp, fullPath); err != nil {
+		if err := os.Rename(fullPathTmp, fullPath); err != nil {
 			return err
 		}
 	}
@@ -258,28 +257,6 @@ func (copier *localFileCopier) Copy(ctx context.Context, file File) error {
 // Close does nothing.
 func (copier *localFileCopier) Close(ctx context.Context) error {
 	return nil
-}
-
-// renameWithRetry retries os.Rename to work around transient sharing
-// violations on Windows: antivirus scanners (Defender), the Search indexer,
-// and similar background processes briefly open handles on a just-written
-// file and refuse to share delete access, which makes os.Rename fail with
-// ERROR_SHARING_VIOLATION. The handle is usually released within a few
-// hundred ms. On POSIX systems the first attempt always succeeds, so the
-// loop is a no-op there.
-func renameWithRetry(oldPath, newPath string) error {
-	const attempts = 5
-	const delay = 300 * time.Millisecond
-	var err error
-	for i := 0; i < attempts; i++ {
-		if err = os.Rename(oldPath, newPath); err == nil {
-			return nil
-		}
-		if i < attempts-1 {
-			time.Sleep(delay)
-		}
-	}
-	return err
 }
 
 type localFileReadCopier struct {
@@ -371,12 +348,6 @@ func (reader *localFileReadCopier) ReadAll(ctx context.Context) error {
 
 	// Note: okay with recursion for now. may want to check depth later...
 
-	// Use path.Join (always forward slashes) for the wire-side relative name.
-	// filepath.Join on Windows would emit backslashes, which a POSIX receiver
-	// (Linux/macOS) treats as literal filename characters — causing files to
-	// land at e.g. /tmp/subdir\a.txt instead of /tmp/subdir/a.txt during a
-	// recursive copy from a Windows host. The receiver's filepath.Join handles
-	// forward slashes correctly on every platform.
 	makeRelName := func(relDir string, file *os.File) string {
 		return path.Join(relDir, filepath.Base(file.Name()))
 	}


### PR DESCRIPTION
Due to a slash issue, instead of creating a folder properly get-remote just adds the file to the name

**Testing:** 
before:
```
allison.chiang@ROBOT-JT45JXCR9V datasetchess % viam traces get-remote --part-id 8a065625-2202-4996-9b1a-e6d0697332bc  
Saving to /Users/allison.chiang/Documents/Code/datasetchess ...
Download finished in 2.637759375s.

allison.chiang@ROBOT-JT45JXCR9V datasetchess % ls
8a065625-2202-4996-9b1a-e6d0697332bc\traces	
```

after:
```
allison.chiang@ROBOT-JT45JXCR9V datasetchess % viam traces get-remote --part-id 8a065625-2202-4996-9b1a-e6d0697332bc
Saving to /Users/allison.chiang/Documents/Code/datasetchess ...
Download finished in 1.911121417s.

allison.chiang@ROBOT-JT45JXCR9V datasetchess % cd 8a065625-2202-4996-9b1a-e6d0697332bc
allison.chiang@ROBOT-JT45JXCR9V 8a065625-2202-4996-9b1a-e6d0697332bc % ls
traces
```
