### PR TITLE
ci: grant check-approvals pull-requests:write so it can comment on PRs

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -21,8 +21,9 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'claude/')
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read   # list reviews + get the PR
-      issues: write         # post/update the "Review Required" comment
+      # write (not read) to post the "Review Required" comment: commenting on a
+      # PR needs pull-requests: write; issues: write does not cover PRs.
+      pull-requests: write
     steps:
       # Flaky-test fixes and dependabot bumps only require a single approval;
       # everything else needs two. Title/branch are read via env (never interpolated


### PR DESCRIPTION
The check-approvals job posts a Review Required comment on the PR when approvals are unmet. That comment goes through the issues-comments endpoint, but for a pull request resource the GITHUB_TOKEN needs pull-requests: write -- issues: write does not cover PRs. The job only granted pull-requests: read + issues: write, so the POST returned 403 'Resource not accessible by integration' and crashed the check on every Claude PR at open time (e.g. #6087).

Verified on the same PR: assign-netcode-reviewer (pull-requests: write) edited the PR fine, while check-approvals (issues: write) 403'd -- confirming the scope, not the token/actor, is the issue. Brings this job in line with the other claude/* workflows (claude-pr-assistant, claude-ci-fix, claude-jira), which all already grant pull-requests: write.