### PR TITLE
motionplan: honor WorldState.Transforms() in armplanning.PlanMotion

### DIFF
--- a/motionplan/armplanning/api.go
+++ b/motionplan/armplanning/api.go
@@ -4,6 +4,7 @@ package armplanning
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -42,7 +43,19 @@ type PlanRequest struct {
 	// The use case here is that if a particularly difficult path must be planned between two poses, that can be done first to ensure
 	// feasibility, and then other plans can be requested to connect to that returned plan's configurations.
 	StartState *PlanState `json:"start_state"`
-	// The data representation of the robot's environment.
+	// WorldState is the data representation of the robot's environment.
+	//
+	// Its two parts are honored differently by the planner:
+	//   - Obstacles() are resolved to the world frame exactly once, at the start configuration, and
+	//     held static for the entire plan. Use them for fixed environment geometry. An obstacle
+	//     nominally expressed in a moving frame will be frozen at wherever that frame is at the start
+	//     of the move - it will NOT sweep with the arm.
+	//   - Transforms() (LinkInFrames) are merged into FrameSystem before planning (see
+	//     validatePlanRequest), each becoming a real frame parented to the frame it names. Geometry
+	//     carried by a transform parented to a moving frame therefore moves with that frame and is
+	//     collision-checked along the whole trajectory. This is the right way to model a held/attached
+	//     object (e.g. an item in a gripper). FrameSystem is not mutated - the transforms are applied
+	//     to a copy - so a frame system may be reused across plans.
 	WorldState *referenceframe.WorldState `json:"world_state"`
 	// Additional parameters constraining the motion of the robot.
 	Constraints *motionplan.Constraints `json:"constraints"`
@@ -119,6 +132,15 @@ func (req *PlanRequest) validatePlanRequest() error {
 			return err
 		}
 		req.WorldState = newWS
+	}
+
+	// Merge any WorldState transforms (LinkInFrames) into the planning frame system.
+	if transforms := req.WorldState.Transforms(); len(transforms) > 0 {
+		augmentedFS, err := req.FrameSystem.FrameSystemWithTransforms(transforms)
+		if err != nil {
+			return fmt.Errorf("failed to apply WorldState transforms to the planning frame system: %w", err)
+		}
+		req.FrameSystem = augmentedFS
 	}
 
 	// Validate the goals. Each goal with a pose must not also have a configuration specified. The parent frame of the pose must exist.

--- a/motionplan/armplanning/held_object_test.go
+++ b/motionplan/armplanning/held_object_test.go
@@ -1,0 +1,301 @@
+package armplanning
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/geo/r3"
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/motionplan"
+	frame "go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/rdk/utils"
+)
+
+// heldObjectTestFS builds a frame system with a single 6-DoF arm and returns it
+// along with the arm model frame.
+func heldObjectTestFS(t *testing.T) (*frame.FrameSystem, frame.Frame) {
+	t.Helper()
+	model, err := frame.ParseModelJSONFile(utils.ResolveFile("components/arm/fake/kinematics/xarm6.json"), "arm")
+	test.That(t, err, test.ShouldBeNil)
+	fs := frame.NewEmptyFrameSystem("")
+	test.That(t, fs.AddFrame(model, fs.World()), test.ShouldBeNil)
+	return fs, model
+}
+
+// TestValidatePlanRequestMergesWorldStateTransforms verifies finding #1/#2: a
+// WorldState transform (LinkInFrame) handed to the direct planner is merged into
+// the planning frame system (on a copy, leaving the caller's FS untouched), and a
+// transform that cannot be applied surfaces a loud error instead of being silently
+// dropped.
+func TestValidatePlanRequestMergesWorldStateTransforms(t *testing.T) {
+	fs, model := heldObjectTestFS(t)
+	heldBox, err := spatialmath.NewBox(spatialmath.NewZeroPose(), r3.Vector{X: 60, Y: 60, Z: 60}, "heldObject")
+	test.That(t, err, test.ShouldBeNil)
+
+	goal := frame.NewPoseInFrame(frame.World, spatialmath.NewPoseFromPoint(r3.Vector{X: 400, Z: 200}))
+	newReq := func(ws *frame.WorldState) *PlanRequest {
+		return &PlanRequest{
+			FrameSystem:    fs,
+			Goals:          []*PlanState{{poses: frame.FrameSystemPoses{model.Name(): goal}}},
+			StartState:     &PlanState{structuredConfiguration: frame.NewNeutralFrameSystemInputs(fs)},
+			WorldState:     ws,
+			PlannerOptions: NewBasicPlannerOptions(),
+		}
+	}
+
+	t.Run("transform is merged into a copy of the frame system", func(t *testing.T) {
+		heldLIF := frame.NewLinkInFrame(model.Name(), spatialmath.NewZeroPose(), "heldObject", heldBox)
+		ws, err := frame.NewWorldState(nil, []*frame.LinkInFrame{heldLIF})
+		test.That(t, err, test.ShouldBeNil)
+
+		req := newReq(ws)
+		test.That(t, req.validatePlanRequest(), test.ShouldBeNil)
+
+		// The transform now exists as a real frame in the request's frame system...
+		test.That(t, req.FrameSystem.Frame("heldObject"), test.ShouldNotBeNil)
+		// ...and the original frame system the caller passed in is untouched, so it can be reused.
+		test.That(t, fs.Frame("heldObject"), test.ShouldBeNil)
+	})
+
+	t.Run("a transform with a missing parent fails loudly", func(t *testing.T) {
+		orphan := frame.NewLinkInFrame("noSuchFrame", spatialmath.NewZeroPose(), "orphan", heldBox)
+		ws, err := frame.NewWorldState(nil, []*frame.LinkInFrame{orphan})
+		test.That(t, err, test.ShouldBeNil)
+
+		err = newReq(ws).validatePlanRequest()
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "transform")
+	})
+}
+
+// TestPlanMotionHeldObjectCollisionCheckedAlongTrajectory verifies that a box attached
+// to the moving arm via a WorldState transform is collision-checked at the goal configuration
+// (because it is a real frame that moves with the arm), whereas the same box expressed as a
+// WorldState obstacle in the arm frame is frozen at the start configuration and the
+// goal-configuration collision goes undetected.
+func TestPlanMotionHeldObjectCollisionCheckedAlongTrajectory(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	fs, model := heldObjectTestFS(t)
+
+	startInputs := frame.NewNeutralFrameSystemInputs(fs)
+	// A configuration that swings the arm well away from neutral so the held object's world
+	// location at the goal is far from where it sits at the start.
+	goalInputs := frame.FrameSystemInputs{model.Name(): {1.2, -1.0, -1.4, 0, 0.6, 0}}
+
+	// The held object: a box 200mm beyond the tool tip, attached to the (moving) arm frame.
+	heldOffset := spatialmath.NewPoseFromPoint(r3.Vector{Z: 200})
+	heldDims := r3.Vector{X: 80, Y: 80, Z: 80}
+	heldBox, err := spatialmath.NewBox(spatialmath.NewZeroPose(), heldDims, "heldObject")
+	test.That(t, err, test.ShouldBeNil)
+
+	heldWorldPose := func(inputs frame.FrameSystemInputs) spatialmath.Pose {
+		t.Helper()
+		tf, err := fs.Transform(inputs.ToLinearInputs(), frame.NewPoseInFrame(model.Name(), heldOffset), frame.World)
+		test.That(t, err, test.ShouldBeNil)
+		return tf.(*frame.PoseInFrame).Pose()
+	}
+
+	heldAtStart := heldWorldPose(startInputs)
+	heldAtGoal := heldWorldPose(goalInputs)
+
+	// Sanity-check the fixture: the held object must travel a meaningful distance between start
+	// and goal, otherwise an obstacle placed at the goal would already overlap it at the start and
+	// the test would not distinguish "checked along the trajectory" from "frozen at the start".
+	separation := heldAtStart.Point().Sub(heldAtGoal.Point()).Norm()
+	test.That(t, separation, test.ShouldBeGreaterThan, 300)
+
+	// A static wall placed exactly where the held object ends up at the goal configuration.
+	wall, err := spatialmath.NewBox(heldAtGoal, heldDims, "wall")
+	test.That(t, err, test.ShouldBeNil)
+	wallGIF := frame.NewGeometriesInFrame(frame.World, []spatialmath.Geometry{wall})
+
+	planToGoalConfig := func(ws *frame.WorldState) error {
+		_, _, err := PlanMotion(context.Background(), logger, &PlanRequest{
+			FrameSystem:    fs,
+			Goals:          []*PlanState{{structuredConfiguration: goalInputs}},
+			StartState:     &PlanState{structuredConfiguration: startInputs},
+			WorldState:     ws,
+			PlannerOptions: NewBasicPlannerOptions(),
+		})
+		return err
+	}
+
+	t.Run("bare arm reaches the goal configuration", func(t *testing.T) {
+		// The wall sits beyond the tool tip, in free space, so the arm itself does not hit it.
+		ws, err := frame.NewWorldState([]*frame.GeometriesInFrame{wallGIF}, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, planToGoalConfig(ws), test.ShouldBeNil)
+	})
+
+	t.Run("held object as a transform is collision-checked at the goal", func(t *testing.T) {
+		heldLIF := frame.NewLinkInFrame(model.Name(), heldOffset, "heldObject", heldBox)
+		ws, err := frame.NewWorldState([]*frame.GeometriesInFrame{wallGIF}, []*frame.LinkInFrame{heldLIF})
+		test.That(t, err, test.ShouldBeNil)
+		// The held object collides with the wall at the goal configuration, so the plan must fail.
+		test.That(t, planToGoalConfig(ws), test.ShouldNotBeNil)
+	})
+
+	t.Run("a WorldState obstacle in a moving frame is frozen at the start", func(t *testing.T) {
+		// Contrast with the transform above: expressing the held object as a WorldState obstacle in
+		// the (moving) arm frame does NOT track the arm. The planner resolves WorldState obstacles to
+		// the world frame exactly once, at the start configuration, so the obstacle stays where the
+		// arm was at the start of the move - nowhere near where the real held object ends up.
+		obsBox, err := spatialmath.NewBox(heldOffset, heldDims, "heldAsObstacle")
+		test.That(t, err, test.ShouldBeNil)
+		ws, err := frame.NewWorldState(
+			[]*frame.GeometriesInFrame{frame.NewGeometriesInFrame(model.Name(), []spatialmath.Geometry{obsBox})}, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		// A WorldState obstacle does not track the arm's joint configuration at all: resolving it at
+		// the start and at the goal yields the same world location (the geometry is effectively pinned
+		// to the base, not the moving end-effector). On top of that, the planner only ever resolves
+		// WorldState obstacles once, at the start configuration (see constraint_checker.go). Either way
+		// the obstacle never follows the arm to the goal, which is why a held object cannot be modeled
+		// as a WorldState obstacle and must instead be a transform (as exercised above).
+		atStart, err := ws.ObstaclesInWorldFrame(fs, startInputs)
+		test.That(t, err, test.ShouldBeNil)
+		atGoal, err := ws.ObstaclesInWorldFrame(fs, goalInputs)
+		test.That(t, err, test.ShouldBeNil)
+		startPoint := atStart.Geometries()[0].Pose().Point()
+		goalPoint := atGoal.Geometries()[0].Pose().Point()
+		test.That(t, startPoint.Sub(goalPoint).Norm(), test.ShouldBeLessThan, 1e-6)
+	})
+}
+
+// TestPlanMotionHeldObjectCollidesBetweenEndpoints demonstates that
+// a held object that is collision-free at BOTH the start and the goal configurations, yet collides
+// with the environment partway along the move. This is the case the previous (frozen-at-seed)
+// modeling could never catch and a goal-only check would miss: only a planner that carries the held
+// geometry with the arm and checks it at every state along the trajectory detects it.
+//
+// The fixture is a doorway - two walls with a gap between them. The arm sweeps from one side to the
+// other; the gap is wide enough for the (thin) arm, but the arm is carrying a large box that is too
+// wide to fit through and so strikes the walls midway through the swing.
+func TestPlanMotionHeldObjectCollidesBetweenEndpoints(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	fs, model := heldObjectTestFS(t)
+
+	// A waist sweep with the shoulder pitched forward: the arm (and the box it holds) swings through
+	// an arc, reaching furthest out in +X at the midpoint and tucked back at both endpoints.
+	startInputs := frame.FrameSystemInputs{model.Name(): {-1.3, -1.5, 0, 0, 0, 0}}
+	goalInputs := frame.FrameSystemInputs{model.Name(): {1.3, -1.5, 0, 0, 0, 0}}
+	midInputs := frame.FrameSystemInputs{model.Name(): {0, -1.5, 0, 0, 0, 0}}
+
+	// The held object: a large box carried 200mm beyond the tool tip.
+	heldOffset := spatialmath.NewPoseFromPoint(r3.Vector{Z: 200})
+	heldDims := r3.Vector{X: 220, Y: 220, Z: 220}
+	heldBox, err := spatialmath.NewBox(spatialmath.NewZeroPose(), heldDims, "heldObject")
+	test.That(t, err, test.ShouldBeNil)
+
+	heldGeometryAt := func(inputs frame.FrameSystemInputs) spatialmath.Geometry {
+		t.Helper()
+		tf, err := fs.Transform(inputs.ToLinearInputs(), frame.NewPoseInFrame(model.Name(), heldOffset), frame.World)
+		test.That(t, err, test.ShouldBeNil)
+		g, err := spatialmath.NewBox(tf.(*frame.PoseInFrame).Pose(), heldDims, "heldCheck")
+		test.That(t, err, test.ShouldBeNil)
+		return g
+	}
+
+	// Build the doorway around where the held object passes at the midpoint of the swing.
+	heldMid := heldGeometryAt(midInputs).Pose().Point()
+	wallDims := r3.Vector{X: 120, Y: 200, Z: 400}
+	leftWall, err := spatialmath.NewBox(
+		spatialmath.NewPoseFromPoint(r3.Vector{X: heldMid.X, Y: heldMid.Y + 170, Z: heldMid.Z}), wallDims, "leftWall")
+	test.That(t, err, test.ShouldBeNil)
+	rightWall, err := spatialmath.NewBox(
+		spatialmath.NewPoseFromPoint(r3.Vector{X: heldMid.X, Y: heldMid.Y - 170, Z: heldMid.Z}), wallDims, "rightWall")
+	test.That(t, err, test.ShouldBeNil)
+	walls := []spatialmath.Geometry{leftWall, rightWall}
+	wallsGIF := frame.NewGeometriesInFrame(frame.World, walls)
+
+	// Confirm the fixture really has the shape the test relies on: the held object is clear of both
+	// walls at the start and the goal, but collides with the doorway in the middle of the move.
+	collidesWithAWall := func(g spatialmath.Geometry) bool {
+		t.Helper()
+		for _, w := range walls {
+			collides, _, err := g.CollidesWith(w, 0)
+			test.That(t, err, test.ShouldBeNil)
+			if collides {
+				return true
+			}
+		}
+		return false
+	}
+	test.That(t, collidesWithAWall(heldGeometryAt(startInputs)), test.ShouldBeFalse)
+	test.That(t, collidesWithAWall(heldGeometryAt(goalInputs)), test.ShouldBeFalse)
+	test.That(t, collidesWithAWall(heldGeometryAt(midInputs)), test.ShouldBeTrue)
+
+	t.Run("bare arm passes through the doorway", func(t *testing.T) {
+		// Without the held object the arm is thin enough to swing through the gap, so the move succeeds.
+		ws, err := frame.NewWorldState([]*frame.GeometriesInFrame{wallsGIF}, nil)
+		test.That(t, err, test.ShouldBeNil)
+		_, _, err = PlanMotion(context.Background(), logger, &PlanRequest{
+			FrameSystem:    fs,
+			Goals:          []*PlanState{{structuredConfiguration: goalInputs}},
+			StartState:     &PlanState{structuredConfiguration: startInputs},
+			WorldState:     ws,
+			PlannerOptions: NewBasicPlannerOptions(),
+		})
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("held object is collision-checked between the endpoints", func(t *testing.T) {
+		// Attach the large box to the arm via a WorldState transform and build the plan the way
+		// PlanMotion does: validatePlanRequest merges the transform into the frame system, then we
+		// construct the same constraint checker the planner uses for the start->goal segment.
+		heldLIF := frame.NewLinkInFrame(model.Name(), heldOffset, "heldObject", heldBox)
+		ws, err := frame.NewWorldState([]*frame.GeometriesInFrame{wallsGIF}, []*frame.LinkInFrame{heldLIF})
+		test.That(t, err, test.ShouldBeNil)
+
+		req := &PlanRequest{
+			FrameSystem:    fs,
+			Goals:          []*PlanState{{structuredConfiguration: goalInputs}},
+			StartState:     &PlanState{structuredConfiguration: startInputs},
+			WorldState:     ws,
+			PlannerOptions: NewBasicPlannerOptions(),
+		}
+		test.That(t, req.validatePlanRequest(), test.ShouldBeNil)
+
+		ctx := context.Background()
+		pc, err := NewPlanContext(ctx, logger, req, &PlanMeta{})
+		test.That(t, err, test.ShouldBeNil)
+		goalPoses, err := req.Goals[0].ComputePoses(ctx, req.FrameSystem)
+		test.That(t, err, test.ShouldBeNil)
+		start := req.StartState.LinearConfiguration()
+		goal := req.Goals[0].LinearConfiguration()
+		psc, err := NewPlanSegmentContext(ctx, pc, start, goalPoses)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Each endpoint on its own is collision-free...
+		_, err = psc.Checker.CheckStateFSConstraints(ctx, &motionplan.StateFS{Configuration: start, FS: req.FrameSystem})
+		test.That(t, err, test.ShouldBeNil)
+		_, err = psc.Checker.CheckStateFSConstraints(ctx, &motionplan.StateFS{Configuration: goal, FS: req.FrameSystem})
+		test.That(t, err, test.ShouldBeNil)
+
+		// ...but the path between them is not, because the held object strikes the doorway midway.
+		err = psc.CheckPath(ctx, start, goal, true, nil)
+		test.That(t, err, test.ShouldNotBeNil)
+
+		// Guard against a false positive: with the doorway removed, the very same held-object path is
+		// collision-free. This proves the failure above is caused by the walls mid-trajectory, not by
+		// the held box self-colliding with the arm or anything else along the way.
+		wsNoWalls, err := frame.NewWorldState(nil, []*frame.LinkInFrame{heldLIF})
+		test.That(t, err, test.ShouldBeNil)
+		reqNoWalls := &PlanRequest{
+			FrameSystem:    fs,
+			Goals:          []*PlanState{{structuredConfiguration: goalInputs}},
+			StartState:     &PlanState{structuredConfiguration: startInputs},
+			WorldState:     wsNoWalls,
+			PlannerOptions: NewBasicPlannerOptions(),
+		}
+		test.That(t, reqNoWalls.validatePlanRequest(), test.ShouldBeNil)
+		pcNoWalls, err := NewPlanContext(ctx, logger, reqNoWalls, &PlanMeta{})
+		test.That(t, err, test.ShouldBeNil)
+		pscNoWalls, err := NewPlanSegmentContext(ctx, pcNoWalls, start, goalPoses)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, pscNoWalls.CheckPath(ctx, start, goal, true, nil), test.ShouldBeNil)
+	})
+}

--- a/motionplan/armplanning/held_object_test.go
+++ b/motionplan/armplanning/held_object_test.go
@@ -165,7 +165,7 @@ func TestPlanMotionHeldObjectCollisionCheckedAlongTrajectory(t *testing.T) {
 	})
 }
 
-// TestPlanMotionHeldObjectCollidesBetweenEndpoints demonstates that
+// TestPlanMotionHeldObjectCollidesBetweenEndpoints demonstrates that
 // a held object that is collision-free at BOTH the start and the goal configurations, yet collides
 // with the environment partway along the move. This is the case the previous (frozen-at-seed)
 // modeling could never catch and a goal-only check would miss: only a planner that carries the held

--- a/referenceframe/frame_system.go
+++ b/referenceframe/frame_system.go
@@ -501,6 +501,46 @@ func (sfs *FrameSystem) MergeFrameSystem(systemToMerge *FrameSystem, attachTo Fr
 	})
 }
 
+// FrameSystemWithTransforms returns a copy of the frame system augmented with the given
+// LinkInFrame transforms, each added as a static frame parented to the frame named by its
+// Parent(). The receiver is left unmodified, so a cached frame system may be reused across
+// multiple planning calls.
+//
+// An error is returned when a transform cannot be converted into a frame or its parent frame
+// does not exist in the system.
+func (sfs *FrameSystem) FrameSystemWithTransforms(transforms []*LinkInFrame) (*FrameSystem, error) {
+	newFS := NewEmptyFrameSystem(sfs.name)
+	if err := newFS.MergeFrameSystem(sfs, newFS.World()); err != nil {
+		return nil, err
+	}
+	if len(transforms) == 0 {
+		return newFS, nil
+	}
+
+	parts := make([]*FrameSystemPart, 0, len(transforms))
+	for _, tf := range transforms {
+		part, err := LinkInFrameToFrameSystemPart(tf)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert transform %q into a frame: %w", tf.Name(), err)
+		}
+		parts = append(parts, part)
+	}
+
+	// Sort the transforms amongst themselves (a transform may be parented to another transform).
+	// Transforms parented to an existing frame of the base system fall out as "unlinked" here and
+	// are attached by addUnlinkedParts, which looks them up in newFS.
+	sortedParts, unlinkedParts := TopologicallySortParts(parts)
+	for _, part := range sortedParts {
+		if err := addPartToFS(newFS, part); err != nil {
+			return nil, fmt.Errorf("failed to add transform %q to the frame system: %w", part.FrameConfig.Name(), err)
+		}
+	}
+	if err := addUnlinkedParts(newFS, unlinkedParts); err != nil {
+		return nil, err
+	}
+	return newFS, nil
+}
+
 // FrameSystemSubset will take a frame system and a frame in that system, and return a new frame system rooted
 // at the given frame and containing all descendents of it. The original frame system is unchanged.
 //

--- a/referenceframe/frame_system_test.go
+++ b/referenceframe/frame_system_test.go
@@ -379,6 +379,85 @@ func TestFrameSystemGeometries(t *testing.T) {
 	}
 }
 
+func TestFrameSystemWithTransforms(t *testing.T) {
+	// Build a base frame system with a moving arm model carrying geometry.
+	jsonData, err := os.ReadFile(rdkutils.ResolveFile("config/data/model_frame_geoms.json"))
+	test.That(t, err, test.ShouldBeNil)
+	model, err := UnmarshalModelJSON(jsonData, "arm")
+	test.That(t, err, test.ShouldBeNil)
+	baseFS := NewEmptyFrameSystem("base")
+	test.That(t, baseFS.AddFrame(model, baseFS.World()), test.ShouldBeNil)
+
+	heldOffset := spatial.NewPoseFromPoint(r3.Vector{X: 0, Y: 0, Z: 150})
+	heldBox, err := spatial.NewBox(spatial.NewZeroPose(), r3.Vector{50, 50, 50}, "heldObject")
+	test.That(t, err, test.ShouldBeNil)
+	// A transform parented to the moving arm frame (a held object), plus one parented to World.
+	heldLIF := NewLinkInFrame(model.Name(), heldOffset, "heldObject", heldBox)
+	staticBox, err := spatial.NewBox(spatial.NewZeroPose(), r3.Vector{10, 10, 10}, "staticObject")
+	test.That(t, err, test.ShouldBeNil)
+	staticLIF := NewLinkInFrame(World, spatial.NewPoseFromPoint(r3.Vector{X: 100}), "staticObject", staticBox)
+
+	t.Run("transforms are merged into a copy, leaving the receiver unmodified", func(t *testing.T) {
+		augmented, err := baseFS.FrameSystemWithTransforms([]*LinkInFrame{heldLIF, staticLIF})
+		test.That(t, err, test.ShouldBeNil)
+
+		// The new frames exist in the augmented system...
+		test.That(t, augmented.Frame("heldObject"), test.ShouldNotBeNil)
+		test.That(t, augmented.Frame("staticObject"), test.ShouldNotBeNil)
+		// ...but not in the original, which must be safe to reuse across plans.
+		test.That(t, baseFS.Frame("heldObject"), test.ShouldBeNil)
+		test.That(t, baseFS.Frame("staticObject"), test.ShouldBeNil)
+	})
+
+	t.Run("held geometry tracks its moving parent frame", func(t *testing.T) {
+		augmented, err := baseFS.FrameSystemWithTransforms([]*LinkInFrame{heldLIF})
+		test.That(t, err, test.ShouldBeNil)
+
+		// At any configuration, the held geometry's world pose must equal the parent (arm EE)
+		// world pose composed with the held offset. This is what "moves with the arm" means -
+		// and is exactly what a frozen WorldState obstacle does NOT do.
+		heldWorldPoseAt := func(inputs []Input) spatial.Pose {
+			t.Helper()
+			eePose, err := model.Transform(inputs)
+			test.That(t, err, test.ShouldBeNil)
+			fsInputs := FrameSystemInputs{model.Name(): inputs}
+			tf, err := augmented.Transform(fsInputs.ToLinearInputs(), NewPoseInFrame("heldObject", spatial.NewZeroPose()), World)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, spatial.PoseAlmostCoincident(
+				tf.(*PoseInFrame).Pose(), spatial.Compose(eePose, heldOffset)), test.ShouldBeTrue)
+			return tf.(*PoseInFrame).Pose()
+		}
+
+		zeroCfg := make([]Input, len(model.DoF()))
+		bentCfg := make([]Input, len(model.DoF()))
+		for i := range bentCfg {
+			bentCfg[i] = 0.5
+		}
+		poseAtZero := heldWorldPoseAt(zeroCfg)
+		poseAtBent := heldWorldPoseAt(bentCfg)
+		// Sanity: a different configuration actually relocates the held geometry.
+		test.That(t, spatial.PoseAlmostCoincident(poseAtZero, poseAtBent), test.ShouldBeFalse)
+	})
+
+	t.Run("a transform with a missing parent fails loudly", func(t *testing.T) {
+		orphan := NewLinkInFrame("doesNotExist", spatial.NewZeroPose(), "orphan", heldBox)
+		_, err := baseFS.FrameSystemWithTransforms([]*LinkInFrame{orphan})
+		test.That(t, err, test.ShouldNotBeNil)
+	})
+
+	t.Run("no transforms returns an independent copy", func(t *testing.T) {
+		augmented, err := baseFS.FrameSystemWithTransforms(nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, augmented, test.ShouldNotEqual, baseFS)
+		test.That(t, len(augmented.FrameNames()), test.ShouldEqual, len(baseFS.FrameNames()))
+		// Mutating the copy must not affect the original.
+		extra, err := NewStaticFrame("extra", spatial.NewZeroPose())
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, augmented.AddFrame(extra, augmented.World()), test.ShouldBeNil)
+		test.That(t, baseFS.Frame("extra"), test.ShouldBeNil)
+	})
+}
+
 func TestReplaceFrame(t *testing.T) {
 	fs := NewEmptyFrameSystem("test")
 	// fill framesystem

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -435,6 +435,15 @@ func (ms *builtIn) getFrameSystem(ctx context.Context, transforms []*referencefr
 	return frameSys, nil
 }
 
+// worldStateWithoutTransforms returns the world state with its transforms removed.
+// Obstacles are preserved unchanged.
+func worldStateWithoutTransforms(ws *referenceframe.WorldState) (*referenceframe.WorldState, error) {
+	if ws == nil || len(ws.Transforms()) == 0 {
+		return ws, nil
+	}
+	return referenceframe.NewWorldState(ws.Obstacles(), nil)
+}
+
 func (ms *builtIn) plan(ctx context.Context, req motion.MoveReq, logger logging.Logger) (motionplan.Plan, error) {
 	frameSys, err := ms.getFrameSystem(ctx, req.WorldState.Transforms())
 	if err != nil {
@@ -499,11 +508,16 @@ func (ms *builtIn) plan(ctx context.Context, req motion.MoveReq, logger logging.
 
 	// the goal is to move the component to goalPose which is specified in coordinates of goalFrameName
 
+	planWorldState, err := worldStateWithoutTransforms(req.WorldState)
+	if err != nil {
+		return nil, err
+	}
+
 	planRequest := &armplanning.PlanRequest{
 		FrameSystem:    frameSys,
 		Goals:          worldWaypoints,
 		StartState:     startState,
-		WorldState:     req.WorldState,
+		WorldState:     planWorldState,
 		Constraints:    req.Constraints,
 		PlannerOptions: planOpts,
 	}
@@ -587,11 +601,20 @@ func (ms *builtIn) planTeleop(
 		return nil, err
 	}
 
+	// WorldState transforms were merged into the planning frame system itself (via getFrameSystem),
+	// so they must not also be handed to armplanning.PlanMotion as the planner merges
+	// WorldState.Transforms() into the frame system as well, and merging the same frames twice would
+	// fail with a duplicate-frame error.
+	planWorldState, err := worldStateWithoutTransforms(req.WorldState)
+	if err != nil {
+		return nil, err
+	}
+
 	planRequest := &armplanning.PlanRequest{
 		FrameSystem:    frameSys,
 		Goals:          worldWaypoints,
 		StartState:     startState,
-		WorldState:     req.WorldState,
+		WorldState:     planWorldState,
 		Constraints:    req.Constraints,
 		PlannerOptions: planOpts,
 	}


### PR DESCRIPTION
## Summary

A `LinkInFrame` added to a `PlanRequest.WorldState` — the idiomatic way to model a held/attached object that moves with a frame (e.g. a cup in a gripper) — was **silently dropped** when calling `armplanning.PlanMotion` directly. Only the builtin motion service merged `WorldState.Transforms()` into the planning frame system; the direct path used the request's frame system verbatim. As a result a held object was either ignored (modeled as a transform) or frozen at the seed configuration (modeled as an obstacle), so it was never collision-checked along the trajectory. This makes the two paths consistent so a held object now sweeps with the arm and is checked at every state of the move.

## Changes

- **referenceframe**: Add `FrameSystem.FrameSystemWithTransforms`, which returns a *copy* of the frame system augmented with the given transforms (mirroring how `NewFrameSystem` merges supplemental transforms). The receiver is left unmodified so a cached frame system can be reused across plans.
- **motionplan/armplanning**: `validatePlanRequest` now merges `WorldState.Transforms()` into a copy of the request's frame system before planning, so transform geometry moves with its parent frame and is collision-checked along the whole trajectory. A transform that cannot be applied (e.g. missing parent frame) now returns a wrapped error instead of being silently dropped.
- **motionplan/armplanning**: Document the obstacle-vs-transform distinction on `PlanRequest.WorldState` (obstacles freeze at the start configuration; transforms move with their parent).
- **services/motion/builtin**: The builtin service already pre-merges transforms into its frame system via `getFrameSystem`, so it now strips them from the `WorldState` it hands to `PlanMotion` (`worldStateWithoutTransforms`) to avoid merging the same frames twice and erroring on duplicates.

## Testing

`go test ./referenceframe/ ./motionplan/armplanning/ ./services/motion/builtin/` — all pass. New tests:

- **referenceframe/frame_system_test.go** `TestFrameSystemWithTransforms`: transform becomes a frame in the copy but not the original; held geometry tracks its moving parent across configurations; missing parent errors loudly; empty input returns an independent copy.
- **motionplan/armplanning/held_object_test.go**:
  - `TestValidatePlanRequestMergesWorldStateTransforms` — the transform is merged into a copy of the request frame system; a bad parent fails loudly.
  - `TestPlanMotionHeldObjectCollisionCheckedAlongTrajectory` — end-to-end: a held box attached via a transform is collision-checked at the goal config (plan fails) while the bare arm reaches it; characterizes that a `WorldState` obstacle in a moving frame does not track the arm.
  - `TestPlanMotionHeldObjectCollidesBetweenEndpoints` — the hard case: a held object that is collision-free at both endpoints but strikes a doorway (two walls + gap) partway through the swing. Verified deterministically at the constraint-checker level (endpoints clear, segment between them blocked) with a false-positive guard showing the same path is clear once the walls are removed.

Regression check: the existing builtin "succeeds with supplemental info in world state" test (which sends transforms and a goal expressed relative to a transform frame through the service) still passes.


🤖 Generated with [Claude Code](https://claude.com/claude-code)