### PR TITLE
RSDK-11617: get-ftdc on windows

### DIFF
--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -984,9 +984,6 @@ func TestMachinesPartHistoryAction(t *testing.T) {
 }
 
 func TestShellFileCopy(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("RSDK-11617")
-	}
 	logger := logging.NewTestLogger(t)
 
 	listOrganizationsFunc := func(ctx context.Context, in *apppb.ListOrganizationsRequest,

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -984,6 +984,20 @@ func TestMachinesPartHistoryAction(t *testing.T) {
 	})
 }
 
+// shellCopyTempDir wraps t.TempDir with a Windows-only post-test sleep
+// (registered as a Cleanup that fires before t.TempDir's own RemoveAll, since
+// Cleanups run in LIFO order). Diagnostic for RSDK-11617 — confirms whether
+// the "file in use" cleanup failures on Windows are timing-related (a kernel
+// or external-process handle that's still being released) versus a hard lock
+// from a leaked handle in our code.
+func shellCopyTempDir(t *testing.T) string {
+	dir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Cleanup(func() { time.Sleep(500 * time.Millisecond) })
+	}
+	return dir
+}
+
 func TestShellFileCopy(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
@@ -1095,7 +1109,7 @@ func TestShellFileCopy(t *testing.T) {
 		})
 
 		t.Run("single directory", func(t *testing.T) {
-			tempDir := t.TempDir()
+			tempDir := shellCopyTempDir(t)
 
 			args := []string{fmt.Sprintf("machine:%s", tfs.Root), tempDir}
 
@@ -1120,7 +1134,7 @@ func TestShellFileCopy(t *testing.T) {
 		})
 
 		t.Run("multiple files", func(t *testing.T) {
-			tempDir := t.TempDir()
+			tempDir := shellCopyTempDir(t)
 
 			args := []string{
 				fmt.Sprintf("machine:%s", tfs.SingleFileNested),
@@ -1158,7 +1172,7 @@ func TestShellFileCopy(t *testing.T) {
 
 			for _, preserve := range []bool{false, true} {
 				t.Run(fmt.Sprintf("preserve=%t", preserve), func(t *testing.T) {
-					tempDir := t.TempDir()
+					tempDir := shellCopyTempDir(t)
 
 					args := []string{fmt.Sprintf("machine:%s", tfs.Root), tempDir}
 
@@ -1224,7 +1238,7 @@ func TestShellFileCopy(t *testing.T) {
 		})
 
 		t.Run("single directory", func(t *testing.T) {
-			tempDir := t.TempDir()
+			tempDir := shellCopyTempDir(t)
 
 			args := []string{tfs.Root, fmt.Sprintf("machine:%s", tempDir)}
 
@@ -1249,7 +1263,7 @@ func TestShellFileCopy(t *testing.T) {
 		})
 
 		t.Run("multiple files", func(t *testing.T) {
-			tempDir := t.TempDir()
+			tempDir := shellCopyTempDir(t)
 
 			args := []string{
 				tfs.SingleFileNested,
@@ -1287,7 +1301,7 @@ func TestShellFileCopy(t *testing.T) {
 
 			for _, preserve := range []bool{false, true} {
 				t.Run(fmt.Sprintf("preserve=%t", preserve), func(t *testing.T) {
-					tempDir := t.TempDir()
+					tempDir := shellCopyTempDir(t)
 
 					args := []string{tfs.Root, fmt.Sprintf("machine:%s", tempDir)}
 

--- a/services/shell/copy_local.go
+++ b/services/shell/copy_local.go
@@ -142,7 +142,6 @@ type localFileCopier struct {
 }
 
 func (copier *localFileCopier) Copy(ctx context.Context, file File) error {
-
 	fileName := file.RelativeName
 	if copier.overrideName != "" {
 		// only change the first part of the file name for directory

--- a/services/shell/copy_local.go
+++ b/services/shell/copy_local.go
@@ -142,9 +142,6 @@ type localFileCopier struct {
 }
 
 func (copier *localFileCopier) Copy(ctx context.Context, file File) error {
-	defer func() {
-		utils.UncheckedError(file.Data.Close())
-	}()
 
 	fileName := file.RelativeName
 	if copier.overrideName != "" {
@@ -386,7 +383,10 @@ func (reader *localFileReadCopier) ReadAll(ctx context.Context) error {
 					filesInDir = append(filesInDir, entryFile)
 				}
 
-				if err := copyFiles(makeRelName(relDir, f), filesInDir); err != nil {
+				err = copyFiles(makeRelName(relDir, f), filesInDir)
+					utils.UncheckedError(f.Close())
+				}
+				if err != nil {
 					return err
 				}
 			}

--- a/services/shell/copy_local.go
+++ b/services/shell/copy_local.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -349,7 +350,11 @@ func (reader *localFileReadCopier) ReadAll(ctx context.Context) error {
 	// Note: okay with recursion for now. may want to check depth later...
 
 	makeRelName := func(relDir string, file *os.File) string {
-		return filepath.Join(relDir, filepath.Base(file.Name()))
+		// Intentional use of path instead of filepath so the wire format
+		// uses forward slashes regardless of sender OS — otherwise a Windows
+		// sender emits backslashes that *NIX receivers treat as literal
+		// filename characters rather than path separators.
+		return path.Join(relDir, filepath.Base(file.Name()))
 	}
 	var copyFiles func(relDir string, files []*os.File) error
 	copyFiles = func(relDir string, files []*os.File) error {

--- a/services/shell/copy_local.go
+++ b/services/shell/copy_local.go
@@ -384,6 +384,7 @@ func (reader *localFileReadCopier) ReadAll(ctx context.Context) error {
 				}
 
 				err = copyFiles(makeRelName(relDir, f), filesInDir)
+				for _, f := range filesInDir {
 					utils.UncheckedError(f.Close())
 				}
 				if err != nil {

--- a/services/shell/copy_rpc.go
+++ b/services/shell/copy_rpc.go
@@ -416,9 +416,6 @@ func (writer *shellFileCopyWriter) Copy(ctx context.Context, file File) error {
 	writer.singleWriterMu.Lock()
 	defer writer.singleWriterMu.Unlock()
 
-	defer func() {
-		utils.UncheckedError(file.Data.Close())
-	}()
 	fileInfo, err := file.Data.Stat()
 	if err != nil {
 		return err


### PR DESCRIPTION
I'm enabling this test because copy works on windows - I believe [this PR ](https://github.com/viamrobotics/rdk/pull/6092)fixes it. I'm updating the test so it properly closes its testing files and works on windows. 

Testing:
Mac -> Windows:
```
viam machine part get-ftdc --part-id **
Saving to /Users/(longer path) ...
Done in 4.972409667s.
```

Windows -> Mac:
```
viam machine part get-ftdc --part-id ***
(cwd: D:\a\_temp\adhoc)

Saving to D:\a\_temp\adhoc/*** ...
Done in 28.8642402s.

=== Exit code: 0 ===

=== Files written to cwd ===
  [dir]  ***
  [file] ***\viam-server-2026-04-22T21-34-17Z.ftdc (1474 bytes)
  [file] ***\viam-server-2026-04-22T21-38-16Z.ftdc (101487 bytes)
  [file] ***\viam-server-2026-04-27T19-59-15Z.ftdc (59094 bytes)
  [file] ***\viam-server-2026-04-27T20-35-04Z.ftdc (1912197 bytes)
  [file] ***\viam-server-2026-05-04T15-04-20Z.ftdc (9338362 bytes)
  [file] ***\viam-server-2026-06-08T19-12-56Z.ftdc (13985 bytes)
```