### PR TITLE
Fix fake board data sync

### DIFF
--- a/components/board/collectors.go
+++ b/components/board/collectors.go
@@ -77,14 +77,7 @@ func newAnalogCollector(resource interface{}, params data.CollectorParams) (data
 		}
 
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
-		// The app data-ingestion pipeline expects board Analogs tabular data to contain
-		// exactly the "value" field. Its expected schema (newSensorDataFormatFieldsMap in
-		// the app repo) is built from toProto(&board.ReadAnalogReaderResponse{Value: 1}),
-		// which serializes via omitempty to {"value": ...}. Emitting min_range/max_range/
-		// step_size makes the struct fail the app's exact-field-set check
-		// (isNewSensorDataFormat) and get rejected with:
-		//   "no Analogs data found; make sure to correctly set resource configuration".
-		// So we emit only "value" here (always present, even when zero).
+
 		return data.CaptureResult{
 			Timestamps: ts,
 			Type:       data.CaptureTypeTabular,

--- a/components/board/collectors.go
+++ b/components/board/collectors.go
@@ -77,12 +77,23 @@ func newAnalogCollector(resource interface{}, params data.CollectorParams) (data
 		}
 
 		ts := data.Timestamps{TimeRequested: timeRequested, TimeReceived: time.Now()}
-		return data.NewTabularCaptureResult(ts, pb.ReadAnalogReaderResponse{
-			Value:    int32(analogValue.Value),
-			MinRange: analogValue.Min,
-			MaxRange: analogValue.Max,
-			StepSize: analogValue.StepSize,
-		})
+		// The app data-ingestion pipeline expects board Analogs tabular data to contain
+		// exactly the "value" field. Its expected schema (newSensorDataFormatFieldsMap in
+		// the app repo) is built from toProto(&board.ReadAnalogReaderResponse{Value: 1}),
+		// which serializes via omitempty to {"value": ...}. Emitting min_range/max_range/
+		// step_size makes the struct fail the app's exact-field-set check
+		// (isNewSensorDataFormat) and get rejected with:
+		//   "no Analogs data found; make sure to correctly set resource configuration".
+		// So we emit only "value" here (always present, even when zero).
+		return data.CaptureResult{
+			Timestamps: ts,
+			Type:       data.CaptureTypeTabular,
+			TabularData: data.TabularData{Payload: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"value": structpb.NewNumberValue(float64(analogValue.Value)),
+				},
+			}},
+		}, nil
 	})
 	return data.NewCollector(cFunc, params)
 }

--- a/components/board/collectors_test.go
+++ b/components/board/collectors_test.go
@@ -49,11 +49,10 @@ func TestCollectors(t *testing.T) {
 			collector: board.NewAnalogCollector,
 			expected: []*datasyncpb.SensorData{{
 				Metadata: &datasyncpb.SensorMetadata{},
+				// The app data-ingestion pipeline expects board Analogs data to contain
+				// exactly the "value" field; see newAnalogCollector in collectors.go.
 				Data: &datasyncpb.SensorData_Struct{Struct: tu.ToStructPBStruct(t, map[string]any{
-					"value":     1,
-					"min_range": 0,
-					"max_range": 10,
-					"step_size": float64(float32(0.1)),
+					"value": 1,
 				})},
 			}},
 		},


### PR DESCRIPTION
[Jira Ticket 10863: Fix fake board data sync](https://viam.atlassian.net/browse/APP-10863)

**Summary**
Previously, capturing the board Analogs method produced tabular data that the app's data-ingestion pipeline rejected on every sync with InvalidArgument: no Analogs data found; make sure to correctly set resource configuration, and the data manager moved the files to capture/failed/. The root cause is a field-set mismatch between what rdk emits and what the app expects.
The app validates each tabular upload against an expected schema (newSensorDataFormatFieldsMap) using an exact field-set match. The board-analogs entry is built from toProto(&board.ReadAnalogReaderResponse{Value: 1}), which serializes via omitempty to a single {"value": ...} field. rdk's newAnalogCollector, however, emitted the full ReadAnalogReaderResponse through NewTabularCaptureResult, producing four fields: value, min_range, max_range, step_size.The upload failed the new-format check and fell through to the legacy convertBoardAnalogs path, which expects a different {Readings: [...]} shape, found nothing, and rejected the upload.
This change makes the analog collector emit exactly the value field so uploads match the app's expected schema and sync successfully.

**Changes**

- Changed newAnalogCollector in components/board/collectors.go to emit a tabular payload containing only the value field  instead of the full ReadAnalogReaderResponse. Built the CaptureResult directly rather than via NewTabularCaptureResult, because that helper forces all proto fields in via StructToStructPbIgnoreOmitEmpty and cannot produce a clean single-field struct. min_range/max_range/step_size are dropped — the app's stored schema for analogs is {value} only, so no additional data is lost.
- Updated the analog collector test in components/board/collectors_test.go to expect the single-field {"value": 1} struct.

**Testing**

Unit Testing: Updated the analog subtest in TestCollectors to assert the emitted struct is exactly {"value": 1}, matching the app's expected new-format schema. Verified with go test ./components/board/ -run TestCollectors -v, plus make lint-go / make test-go.

Manual Testing: Reproduced end-to-end against the staging environment (app.viam.dev) with a fake board + data manager capturing the Analogs method (reader_name: test-analog). Before the fix, every upload was rejected with no Analogs data found and files accumulated in ~/.viam/capture/failed/; decoding the on-disk capture files (with a small throwaway decoder) confirmed the four-field payload, and I verified the cloud-stored config correctly defined the test-analog reader — ruling out config as the cause. After building viam-server from this branch and rerunning against a cleared capture directory, capture files were captured and synced successfully: nothing landed in failed/, the no Analogs data found warnings stopped, the decoded payload showed the single {"value": N} field, and analog readings appeared in the DATA tab. All temporary diagnostics were removed before merge.