### PR TITLE
APP-16857: Add querying command for tabular data in CLI

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1417,18 +1417,18 @@ Note: There is no progress meter while copying is in progress.
 					Commands: []*cli.Command{
 						{
 							Name:      "sql",
-							Usage:     "query tabular data using a SQL statement",
-							UsageText: createUsageText("data query sql", []string{generalFlagOrgID, dataFlagSQLQuery}, true, false),
+							Usage:     "query tabular data using SQL",
+							UsageText: createUsageText("data query sql", []string{dataFlagSQLQuery}, true, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
-									Name:     generalFlagOrgID,
-									Required: true,
-									Usage:    "organization ID",
+									Name:        generalFlagOrgID,
+									Usage:       "organization ID",
+									DefaultText: "default-org value if set",
 								},
 								&cli.StringFlag{
 									Name:     dataFlagSQLQuery,
 									Required: true,
-									Usage:    "SQL SELECT statement to run against the organization's tabular data",
+									Usage:    "SQL statement to query the organization's tabular data",
 								},
 								&cli.StringFlag{
 									Name:      generalFlagDestination,
@@ -1440,35 +1440,30 @@ Note: There is no progress meter while copying is in progress.
 						},
 						{
 							Name:  "mql",
-							Usage: "query tabular data using an MQL aggregation pipeline",
+							Usage: "query tabular data using MQL",
 							UsageText: createUsageText("data query mql",
-								[]string{generalFlagOrgID}, true, false,
+								nil, true, false,
 								fmt.Sprintf("[--%s=<%s> | --%s=<%s>]",
 									dataFlagMQL, dataFlagMQL,
 									dataFlagMQLFile, dataFlagMQLFile),
 							),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
-									Name:     generalFlagOrgID,
-									Required: true,
-									Usage:    "organization ID",
+									Name:        generalFlagOrgID,
+									Usage:       "organization ID",
+									DefaultText: "default-org value if set",
 								},
 								&cli.StringFlag{
 									Name:  dataFlagMQL,
-									Usage: "MQL aggregation pipeline as a JSON array of stages",
+									Usage: "MQL query to query the organization's tabular data ",
 								},
 								&cli.StringFlag{
 									Name:  dataFlagMQLFile,
-									Usage: "path to a JSON file containing the MQL aggregation pipeline",
+									Usage: "path to a JSON file containing the MQL query",
 								},
 								&cli.StringFlag{
-									Name: dataFlagDataSourceType,
-									Usage: formatAcceptedValues(
-										"data source to query against",
-										StandardDataSourceType,
-										HotStorageDataSourceType,
-										PipelineSinkDataSourceType,
-									),
+									Name:  dataFlagDataSourceType,
+									Usage: formatAcceptedValues("data source to query against", queryDataSourceTypes...),
 								},
 								&cli.StringFlag{
 									Name:  dataFlagPipelineID,
@@ -2072,12 +2067,8 @@ Note: There is no progress meter while copying is in progress.
 							Required: true,
 						},
 						&cli.StringFlag{
-							Name: dataFlagDataSourceType,
-							Usage: formatAcceptedValues(
-								"data source type for the new data pipeline",
-								StandardDataSourceType,
-								HotStorageDataSourceType,
-							),
+							Name:  dataFlagDataSourceType,
+							Usage: formatAcceptedValues("data source type for the new data pipeline", pipelineDataSourceTypes...),
 						},
 					},
 					Action: createActionCommandWithT[datapipelineCreateArgs](DatapipelineCreateAction),

--- a/cli/app.go
+++ b/cli/app.go
@@ -142,7 +142,7 @@ const (
 	dataFlagCollectionType                 = "collection-type"
 	dataFlagPipelineName                   = "pipeline-name"
 	dataFlagPipelineID                     = "pipeline-id"
-	dataFlagSQLQuery                       = "sql-query"
+	dataFlagSQL                            = "sql"
 	dataFlagMQL                            = "mql"
 	dataFlagMQLFile                        = "mql-path"
 	dataFlagDataSourceType                 = "data-source-type"
@@ -1418,7 +1418,7 @@ Note: There is no progress meter while copying is in progress.
 						{
 							Name:      "sql",
 							Usage:     "query tabular data using SQL",
-							UsageText: createUsageText("data query sql", []string{dataFlagSQLQuery}, true, false),
+							UsageText: createUsageText("data query sql", []string{dataFlagSQL}, true, false),
 							Flags: []cli.Flag{
 								&cli.StringFlag{
 									Name:        generalFlagOrgID,
@@ -1426,7 +1426,7 @@ Note: There is no progress meter while copying is in progress.
 									DefaultText: "default-org value if set",
 								},
 								&cli.StringFlag{
-									Name:     dataFlagSQLQuery,
+									Name:     dataFlagSQL,
 									Required: true,
 									Usage:    "SQL statement to query the organization's tabular data",
 								},
@@ -1467,7 +1467,7 @@ Note: There is no progress meter while copying is in progress.
 								},
 								&cli.StringFlag{
 									Name:  dataFlagPipelineID,
-									Usage: fmt.Sprintf("pipeline ID to query; required when --%s=%s", dataFlagDataSourceType, PipelineSinkDataSourceType),
+									Usage: fmt.Sprintf("pipeline ID to query; required when --%s=%s", dataFlagDataSourceType, pipelineSinkDataSourceType),
 								},
 								&cli.StringFlag{
 									Name:      generalFlagDestination,
@@ -1688,7 +1688,7 @@ Note: There is no progress meter while copying is in progress.
 								&cli.StringFlag{
 									Name:     dataFlagCollectionType,
 									Required: true,
-									Usage:    formatAcceptedValues("collection type", "hot-storage", "pipeline-sink"),
+									Usage:    formatAcceptedValues("collection type", hotStorageDataSourceType, pipelineSinkDataSourceType),
 								},
 								&cli.StringFlag{
 									Name:     dataFlagPipelineName,
@@ -1716,7 +1716,7 @@ Note: There is no progress meter while copying is in progress.
 								&cli.StringFlag{
 									Name:     dataFlagCollectionType,
 									Required: true,
-									Usage:    formatAcceptedValues("collection type", "hot-storage", "pipeline-sink"),
+									Usage:    formatAcceptedValues("collection type", hotStorageDataSourceType, pipelineSinkDataSourceType),
 								},
 								&cli.StringFlag{
 									Name:     dataFlagPipelineName,
@@ -1743,7 +1743,7 @@ Note: There is no progress meter while copying is in progress.
 								&cli.StringFlag{
 									Name:     dataFlagCollectionType,
 									Required: true,
-									Usage:    formatAcceptedValues("collection type", "hot-storage", "pipeline-sink"),
+									Usage:    formatAcceptedValues("collection type", hotStorageDataSourceType, pipelineSinkDataSourceType),
 								},
 								&cli.StringFlag{
 									Name:  dataFlagPipelineName,

--- a/cli/app.go
+++ b/cli/app.go
@@ -1455,7 +1455,7 @@ Note: There is no progress meter while copying is in progress.
 								},
 								&cli.StringFlag{
 									Name:  dataFlagMQL,
-									Usage: "MQL query to query the organization's tabular data ",
+									Usage: "MQL query to query the organization's tabular data",
 								},
 								&cli.StringFlag{
 									Name:  dataFlagMQLFile,
@@ -1463,7 +1463,7 @@ Note: There is no progress meter while copying is in progress.
 								},
 								&cli.StringFlag{
 									Name:  dataFlagDataSourceType,
-									Usage: formatAcceptedValues("data source to query against", queryDataSourceTypes...),
+									Usage: formatAcceptedValues("data source to query against", tabularDataByMQLDataSourceTypes...),
 								},
 								&cli.StringFlag{
 									Name:  dataFlagPipelineID,

--- a/cli/app.go
+++ b/cli/app.go
@@ -141,13 +141,15 @@ const (
 	dataFlagTimeout                        = "timeout"
 	dataFlagCollectionType                 = "collection-type"
 	dataFlagPipelineName                   = "pipeline-name"
+	dataFlagPipelineID                     = "pipeline-id"
+	dataFlagSQLQuery                       = "sql-query"
+	dataFlagMQL                            = "mql"
+	dataFlagMQLFile                        = "mql-path"
+	dataFlagDataSourceType                 = "data-source-type"
 	dataFlagIndexName                      = "index-name"
 	dataFlagIndexSpecFile                  = "index-path"
 
 	datapipelineFlagSchedule       = "schedule"
-	datapipelineFlagMQL            = "mql"
-	datapipelineFlagMQLFile        = "mql-path"
-	datapipelineFlagDataSourceType = "data-source-type"
 	datapipelineFlagEnableBackfill = "enable-backfill"
 
 	packageFlagFramework = "model-framework"
@@ -1408,6 +1410,81 @@ Note: There is no progress meter while copying is in progress.
 					},
 				},
 				{
+					Name:            "query",
+					Usage:           "query tabular data from Viam cloud",
+					UsageText:       createUsageText("data query", nil, false, true),
+					HideHelpCommand: true,
+					Commands: []*cli.Command{
+						{
+							Name:      "sql",
+							Usage:     "query tabular data using a SQL statement",
+							UsageText: createUsageText("data query sql", []string{generalFlagOrgID, dataFlagSQLQuery}, true, false),
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:     generalFlagOrgID,
+									Required: true,
+									Usage:    "organization ID",
+								},
+								&cli.StringFlag{
+									Name:     dataFlagSQLQuery,
+									Required: true,
+									Usage:    "SQL SELECT statement to run against the organization's tabular data",
+								},
+								&cli.StringFlag{
+									Name:      generalFlagDestination,
+									Usage:     "output directory for query results; prints to stdout if omitted",
+									TakesFile: true,
+								},
+							},
+							Action: createActionCommandWithT[dataQuerySQLArgs](DataQuerySQLAction),
+						},
+						{
+							Name:  "mql",
+							Usage: "query tabular data using an MQL aggregation pipeline",
+							UsageText: createUsageText("data query mql",
+								[]string{generalFlagOrgID}, true, false,
+								fmt.Sprintf("[--%s=<%s> | --%s=<%s>]",
+									dataFlagMQL, dataFlagMQL,
+									dataFlagMQLFile, dataFlagMQLFile),
+							),
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:     generalFlagOrgID,
+									Required: true,
+									Usage:    "organization ID",
+								},
+								&cli.StringFlag{
+									Name:  dataFlagMQL,
+									Usage: "MQL aggregation pipeline as a JSON array of stages",
+								},
+								&cli.StringFlag{
+									Name:  dataFlagMQLFile,
+									Usage: "path to a JSON file containing the MQL aggregation pipeline",
+								},
+								&cli.StringFlag{
+									Name: dataFlagDataSourceType,
+									Usage: formatAcceptedValues(
+										"data source to query against",
+										StandardDataSourceType,
+										HotStorageDataSourceType,
+										PipelineSinkDataSourceType,
+									),
+								},
+								&cli.StringFlag{
+									Name:  dataFlagPipelineID,
+									Usage: fmt.Sprintf("pipeline ID to query; required when --%s=%s", dataFlagDataSourceType, PipelineSinkDataSourceType),
+								},
+								&cli.StringFlag{
+									Name:      generalFlagDestination,
+									Usage:     "output directory for query results; prints to stdout if omitted",
+									TakesFile: true,
+								},
+							},
+							Action: createActionCommandWithT[dataQueryMQLArgs](DataQueryMQLAction),
+						},
+					},
+				},
+				{
 					Name:            "delete",
 					Usage:           "delete data from Viam cloud",
 					UsageText:       createUsageText("data delete", nil, false, true),
@@ -1963,8 +2040,8 @@ Note: There is no progress meter while copying is in progress.
 					UsageText: createUsageText("datapipelines create",
 						[]string{generalFlagOrgID, generalFlagName, datapipelineFlagSchedule, datapipelineFlagEnableBackfill}, false, false,
 						fmt.Sprintf("[--%s=<%s> | --%s=<%s>]",
-							datapipelineFlagMQL, datapipelineFlagMQL,
-							datapipelineFlagMQLFile, datapipelineFlagMQLFile),
+							dataFlagMQL, dataFlagMQL,
+							dataFlagMQLFile, dataFlagMQLFile),
 					),
 					Flags: []cli.Flag{
 						&cli.StringFlag{
@@ -1982,11 +2059,11 @@ Note: There is no progress meter while copying is in progress.
 							Required: true,
 						},
 						&cli.StringFlag{
-							Name:  datapipelineFlagMQL,
+							Name:  dataFlagMQL,
 							Usage: "MQL query for the new data pipeline",
 						},
 						&cli.StringFlag{
-							Name:  datapipelineFlagMQLFile,
+							Name:  dataFlagMQLFile,
 							Usage: "path to JSON file containing MQL query for the new data pipeline",
 						},
 						&cli.BoolFlag{
@@ -1995,7 +2072,7 @@ Note: There is no progress meter while copying is in progress.
 							Required: true,
 						},
 						&cli.StringFlag{
-							Name: datapipelineFlagDataSourceType,
+							Name: dataFlagDataSourceType,
 							Usage: formatAcceptedValues(
 								"data source type for the new data pipeline",
 								StandardDataSourceType,

--- a/cli/customindex.go
+++ b/cli/customindex.go
@@ -15,9 +15,6 @@ const (
 	hotStoreCollectionType     = pb.IndexableCollection_INDEXABLE_COLLECTION_HOT_STORE
 	pipelineSinkCollectionType = pb.IndexableCollection_INDEXABLE_COLLECTION_PIPELINE_SINK
 	unspecifiedCollectionType  = pb.IndexableCollection_INDEXABLE_COLLECTION_UNSPECIFIED
-
-	hotStoreCollectionTypeStr     = "hot-storage"
-	pipelineSinkCollectionTypeStr = "pipeline-sink"
 )
 
 var (
@@ -153,9 +150,9 @@ func ListCustomIndexesAction(ctx context.Context, cmd *cli.Command, args listCus
 func validateCollectionTypeArgs(cmd *cli.Command, collectionType string) (pb.IndexableCollection, error) {
 	var collectionTypeProto pb.IndexableCollection
 	switch collectionType {
-	case hotStoreCollectionTypeStr:
+	case hotStorageDataSourceType:
 		collectionTypeProto = hotStoreCollectionType
-	case pipelineSinkCollectionTypeStr:
+	case pipelineSinkDataSourceType:
 		collectionTypeProto = pipelineSinkCollectionType
 	default:
 		return unspecifiedCollectionType, errInvalidCollectionType
@@ -164,11 +161,11 @@ func validateCollectionTypeArgs(cmd *cli.Command, collectionType string) (pb.Ind
 	collectionTypeFlag := cmd.String(dataFlagCollectionType)
 	pipelineName := cmd.String(dataFlagPipelineName)
 
-	if collectionTypeFlag == pipelineSinkCollectionTypeStr && pipelineName == "" {
+	if collectionTypeFlag == pipelineSinkDataSourceType && pipelineName == "" {
 		return unspecifiedCollectionType, errPipelineNameRequired
 	}
 
-	if collectionTypeFlag != pipelineSinkCollectionTypeStr && pipelineName != "" {
+	if collectionTypeFlag != pipelineSinkDataSourceType && pipelineName != "" {
 		return unspecifiedCollectionType, errPipelineNameNotAllowed
 	}
 

--- a/cli/data.go
+++ b/cli/data.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v3"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.uber.org/multierr"
 	datapb "go.viam.com/api/app/data/v1"
 	"go.viam.com/utils"
@@ -125,6 +126,41 @@ func DataExportTabularAction(ctx context.Context, cmd *cli.Command, args dataExp
 	}
 
 	return client.dataExportTabularAction(ctx, cmd, args)
+}
+
+type dataQuerySQLArgs struct {
+	OrgID       string
+	SQLQuery    string
+	Destination string
+}
+
+// DataQuerySQLAction is the corresponding action for 'data query sql'.
+func DataQuerySQLAction(ctx context.Context, cmd *cli.Command, args dataQuerySQLArgs) error {
+	client, err := newViamClient(ctx, cmd)
+	if err != nil {
+		return err
+	}
+
+	return client.dataQuerySQLAction(ctx, args)
+}
+
+type dataQueryMQLArgs struct {
+	OrgID          string
+	MQL            string
+	MqlPath        string
+	DataSourceType string
+	PipelineID     string
+	Destination    string
+}
+
+// DataQueryMQLAction is the corresponding action for 'data query mql'.
+func DataQueryMQLAction(ctx context.Context, cmd *cli.Command, args dataQueryMQLArgs) error {
+	client, err := newViamClient(ctx, cmd)
+	if err != nil {
+		return err
+	}
+
+	return client.dataQueryMQLAction(ctx, args)
 }
 
 type dataTagByFilterArgs struct {
@@ -388,6 +424,127 @@ func (c *viamClient) dataExportTabularAction(ctx context.Context, cmd *cli.Comma
 		return err
 	}
 
+	return nil
+}
+
+func (c *viamClient) dataQuerySQLAction(ctx context.Context, args dataQuerySQLArgs) error {
+	if args.OrgID == "" {
+		return errors.New("must provide an organization ID")
+	}
+	if args.SQLQuery == "" {
+		return errors.New("must provide a SQL query")
+	}
+
+	resp, err := c.dataClient.TabularDataBySQL(ctx, &datapb.TabularDataBySQLRequest{
+		OrganizationId: args.OrgID,
+		SqlQuery:       args.SQLQuery,
+	})
+	if err != nil {
+		return errors.Wrap(err, serverErrorMessage)
+	}
+
+	return writeQueryResults(c.c.Root().Writer, args.Destination, resp.GetRawData())
+}
+
+func (c *viamClient) dataQueryMQLAction(ctx context.Context, args dataQueryMQLArgs) error {
+	if args.OrgID == "" {
+		return errors.New("must provide an organization ID")
+	}
+
+	mqlBinary, err := parseMQL(args.MQL, args.MqlPath)
+	if err != nil {
+		return err
+	}
+
+	request := &datapb.TabularDataByMQLRequest{
+		OrganizationId: args.OrgID,
+		MqlBinary:      mqlBinary,
+	}
+
+	if args.DataSourceType != "" || args.PipelineID != "" {
+		dataSource, err := buildTabularDataSource(args.DataSourceType, args.PipelineID)
+		if err != nil {
+			return err
+		}
+		request.DataSource = dataSource
+	}
+
+	resp, err := c.dataClient.TabularDataByMQL(ctx, request)
+	if err != nil {
+		return errors.Wrap(err, serverErrorMessage)
+	}
+
+	return writeQueryResults(c.c.Root().Writer, args.Destination, resp.GetRawData())
+}
+
+func buildTabularDataSource(dataSourceType, pipelineID string) (*datapb.TabularDataSource, error) {
+	if dataSourceType == "" {
+		return nil, errors.Errorf("--%s is required when --%s is provided",
+			dataFlagDataSourceType, dataFlagPipelineID)
+	}
+
+	sourceType, err := tabularDataSourceTypeToProto(dataSourceType)
+	if err != nil {
+		return nil, err
+	}
+
+	source := &datapb.TabularDataSource{Type: sourceType}
+	if sourceType == datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK {
+		if pipelineID == "" {
+			return nil, errors.Errorf("--%s is required when --%s=%s",
+				dataFlagPipelineID, dataFlagDataSourceType, PipelineSinkDataSourceType)
+		}
+		source.PipelineId = &pipelineID
+	} else if pipelineID != "" {
+		return nil, errors.Errorf("--%s is only valid when --%s=%s",
+			dataFlagPipelineID, dataFlagDataSourceType, PipelineSinkDataSourceType)
+	}
+	return source, nil
+}
+
+// writeQueryResults converts BSON-encoded rows to NDJSON (Relaxed Extended JSON) and writes them
+// to dest, or to w if dest is empty.
+func writeQueryResults(w io.Writer, dest string, rows [][]byte) error {
+	jsonRows := make([][]byte, 0, len(rows))
+	for _, row := range rows {
+		var doc bson.D
+		if err := bson.Unmarshal(row, &doc); err != nil {
+			return errors.Wrap(err, "error decoding query result")
+		}
+		jsonRow, err := bson.MarshalExtJSON(doc, false, false)
+		if err != nil {
+			return errors.Wrap(err, "error formatting query result")
+		}
+		jsonRows = append(jsonRows, jsonRow)
+	}
+
+	if dest == "" {
+		for _, row := range jsonRows {
+			printf(w, "%s", row)
+		}
+		return nil
+	}
+
+	if err := makeDestinationDirs(dest); err != nil {
+		return errors.Wrap(err, "could not create destination directory")
+	}
+	filePath := filepath.Join(dest, dataFileName)
+	f, err := os.Create(filePath) //nolint:gosec
+	if err != nil {
+		return errors.Wrap(err, "could not create data file")
+	}
+	defer f.Close() //nolint:errcheck
+
+	writer := bufio.NewWriter(f)
+	for _, row := range jsonRows {
+		if err := writeData(writer, row); err != nil {
+			return errors.Wrap(err, "error writing data")
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		return errors.Wrap(err, "error writing data to file")
+	}
+	printf(w, "Wrote %d rows to %s", len(jsonRows), filePath)
 	return nil
 }
 

--- a/cli/data.go
+++ b/cli/data.go
@@ -130,7 +130,7 @@ func DataExportTabularAction(ctx context.Context, cmd *cli.Command, args dataExp
 
 type dataQuerySQLArgs struct {
 	OrgID       string
-	SqlQuery    string
+	SqlQuery    string //nolint:revive,stylecheck
 	Destination string
 }
 
@@ -450,11 +450,17 @@ func (c *viamClient) dataQueryMQLAction(ctx context.Context, args dataQueryMQLAr
 	if args.OrgID == "" {
 		return errors.New("must provide an organization ID")
 	}
-	if args.MQL == "" && args.MqlPath == "" {
-		return errors.New("missing MQL query")
+	if args.PipelineID != "" && args.DataSourceType == "" {
+		return errors.Errorf("--%s is required when --%s is provided",
+			dataFlagDataSourceType, dataFlagPipelineID)
 	}
-	if args.MQL != "" && args.MqlPath != "" {
-		return errors.New("MQL and MQL file cannot both be provided")
+	if args.DataSourceType == PipelineSinkDataSourceType && args.PipelineID == "" {
+		return errors.Errorf("--%s is required when --%s=%s",
+			dataFlagPipelineID, dataFlagDataSourceType, PipelineSinkDataSourceType)
+	}
+	if args.DataSourceType != "" && args.DataSourceType != PipelineSinkDataSourceType && args.PipelineID != "" {
+		return errors.Errorf("--%s is only valid when --%s=%s",
+			dataFlagPipelineID, dataFlagDataSourceType, PipelineSinkDataSourceType)
 	}
 
 	mqlBinary, err := parseMQL(args.MQL, args.MqlPath)
@@ -467,7 +473,7 @@ func (c *viamClient) dataQueryMQLAction(ctx context.Context, args dataQueryMQLAr
 		MqlBinary:      mqlBinary,
 	}
 
-	if args.DataSourceType != "" || args.PipelineID != "" {
+	if args.DataSourceType != "" {
 		dataSource, err := buildTabularDataSource(args.DataSourceType, args.PipelineID)
 		if err != nil {
 			return err
@@ -484,26 +490,13 @@ func (c *viamClient) dataQueryMQLAction(ctx context.Context, args dataQueryMQLAr
 }
 
 func buildTabularDataSource(dataSourceType, pipelineID string) (*datapb.TabularDataSource, error) {
-	if dataSourceType == "" {
-		return nil, errors.Errorf("--%s is required when --%s is provided",
-			dataFlagDataSourceType, dataFlagPipelineID)
-	}
-
 	sourceType, err := dataSourceTypeToProto(dataSourceType, tabularDataByMQLDataSourceTypes)
 	if err != nil {
 		return nil, err
 	}
-
 	source := &datapb.TabularDataSource{Type: sourceType}
 	if sourceType == datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK {
-		if pipelineID == "" {
-			return nil, errors.Errorf("--%s is required when --%s=%s",
-				dataFlagPipelineID, dataFlagDataSourceType, PipelineSinkDataSourceType)
-		}
 		source.PipelineId = &pipelineID
-	} else if pipelineID != "" {
-		return nil, errors.Errorf("--%s is only valid when --%s=%s",
-			dataFlagPipelineID, dataFlagDataSourceType, PipelineSinkDataSourceType)
 	}
 	return source, nil
 }
@@ -511,10 +504,8 @@ func buildTabularDataSource(dataSourceType, pipelineID string) (*datapb.TabularD
 // writeQueryResults converts BSON-encoded rows to NDJSON (Relaxed Extended JSON) and writes them
 // to dest, or to w if dest is empty.
 func writeQueryResults(w io.Writer, dest string, rows [][]byte) error {
-	var (
-		bw       *bufio.Writer
-		filePath string
-	)
+	out := w
+	var filePath string
 	if dest != "" {
 		if err := makeDestinationDirs(dest); err != nil {
 			return errors.Wrap(err, "could not create destination directory")
@@ -525,9 +516,10 @@ func writeQueryResults(w io.Writer, dest string, rows [][]byte) error {
 			return errors.Wrap(err, "could not create data file")
 		}
 		defer f.Close() //nolint:errcheck
-		bw = bufio.NewWriter(f)
+		out = f
 	}
 
+	bw := bufio.NewWriter(out)
 	for _, row := range rows {
 		var doc bson.D
 		if err := bson.Unmarshal(row, &doc); err != nil {
@@ -537,19 +529,15 @@ func writeQueryResults(w io.Writer, dest string, rows [][]byte) error {
 		if err != nil {
 			return errors.Wrap(err, "error formatting query result")
 		}
-		if bw != nil {
-			if err := writeData(bw, jsonRow); err != nil {
-				return errors.Wrap(err, "error writing data")
-			}
-		} else {
-			printf(w, "%s", jsonRow)
+		if err := writeData(bw, jsonRow); err != nil {
+			return errors.Wrap(err, "error writing data")
 		}
 	}
+	if err := bw.Flush(); err != nil {
+		return errors.Wrap(err, "error writing query results")
+	}
 
-	if bw != nil {
-		if err := bw.Flush(); err != nil {
-			return errors.Wrap(err, "error writing data to file")
-		}
+	if filePath != "" {
 		printf(w, "Wrote %d rows to %s", len(rows), filePath)
 	}
 	return nil

--- a/cli/data.go
+++ b/cli/data.go
@@ -130,7 +130,7 @@ func DataExportTabularAction(ctx context.Context, cmd *cli.Command, args dataExp
 
 type dataQuerySQLArgs struct {
 	OrgID       string
-	SQLQuery    string
+	SqlQuery    string
 	Destination string
 }
 
@@ -431,13 +431,10 @@ func (c *viamClient) dataQuerySQLAction(ctx context.Context, args dataQuerySQLAr
 	if args.OrgID == "" {
 		return errors.New("must provide an organization ID")
 	}
-	if args.SQLQuery == "" {
-		return errors.New("must provide a SQL query")
-	}
 
 	resp, err := c.dataClient.TabularDataBySQL(ctx, &datapb.TabularDataBySQLRequest{
 		OrganizationId: args.OrgID,
-		SqlQuery:       args.SQLQuery,
+		SqlQuery:       args.SqlQuery,
 	})
 	if err != nil {
 		return errors.Wrap(err, serverErrorMessage)
@@ -483,7 +480,7 @@ func buildTabularDataSource(dataSourceType, pipelineID string) (*datapb.TabularD
 			dataFlagDataSourceType, dataFlagPipelineID)
 	}
 
-	sourceType, err := tabularDataSourceTypeToProto(dataSourceType)
+	sourceType, err := dataSourceTypeToProto(dataSourceType, queryDataSourceTypes)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/data.go
+++ b/cli/data.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -53,6 +54,30 @@ const (
 )
 
 var viamCaptureSubdirPattern = regexp.MustCompile(`.*` + viamCaptureDotSubdir)
+
+var (
+	standardDataSourceType     = "standard"
+	hotStorageDataSourceType   = "hot-storage"
+	pipelineSinkDataSourceType = "pipeline-sink"
+
+	// dataSourceTypeProtos maps user-facing data source names to their proto enum value.
+	dataSourceTypeProtos = map[string]datapb.TabularDataSourceType{
+		standardDataSourceType:     datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_STANDARD,
+		hotStorageDataSourceType:   datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE,
+		pipelineSinkDataSourceType: datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK,
+	}
+
+	// dataSourceTypeMap maps the proto enum value back to a human-readable display name.
+	dataSourceTypeMap = map[datapb.TabularDataSourceType]string{
+		datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_UNSPECIFIED:   "Unknown",
+		datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_STANDARD:      "Standard",
+		datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE:   "Hot Storage",
+		datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK: "Pipeline Sink",
+	}
+
+	// tabularDataByMQLDataSourceTypes is the set of data sources accepted by `data query mql`.
+	tabularDataByMQLDataSourceTypes = []string{standardDataSourceType, hotStorageDataSourceType, pipelineSinkDataSourceType}
+)
 
 type commonFilterArgs struct {
 	OrgIDs        []string
@@ -130,7 +155,7 @@ func DataExportTabularAction(ctx context.Context, cmd *cli.Command, args dataExp
 
 type dataQuerySQLArgs struct {
 	OrgID       string
-	SqlQuery    string //nolint:revive,stylecheck
+	SQL         string
 	Destination string
 }
 
@@ -431,13 +456,13 @@ func (c *viamClient) dataQuerySQLAction(ctx context.Context, args dataQuerySQLAr
 	if args.OrgID == "" {
 		return errors.New("must provide an organization ID")
 	}
-	if args.SqlQuery == "" {
+	if args.SQL == "" {
 		return errors.New("must provide a SQL query")
 	}
 
 	resp, err := c.dataClient.TabularDataBySQL(ctx, &datapb.TabularDataBySQLRequest{
 		OrganizationId: args.OrgID,
-		SqlQuery:       args.SqlQuery,
+		SqlQuery:       args.SQL,
 	})
 	if err != nil {
 		return errors.Wrap(err, serverErrorMessage)
@@ -454,13 +479,13 @@ func (c *viamClient) dataQueryMQLAction(ctx context.Context, args dataQueryMQLAr
 		return errors.Errorf("--%s is required when --%s is provided",
 			dataFlagDataSourceType, dataFlagPipelineID)
 	}
-	if args.DataSourceType == PipelineSinkDataSourceType && args.PipelineID == "" {
+	if args.DataSourceType == pipelineSinkDataSourceType && args.PipelineID == "" {
 		return errors.Errorf("--%s is required when --%s=%s",
-			dataFlagPipelineID, dataFlagDataSourceType, PipelineSinkDataSourceType)
+			dataFlagPipelineID, dataFlagDataSourceType, pipelineSinkDataSourceType)
 	}
-	if args.DataSourceType != "" && args.DataSourceType != PipelineSinkDataSourceType && args.PipelineID != "" {
+	if args.DataSourceType != "" && args.DataSourceType != pipelineSinkDataSourceType && args.PipelineID != "" {
 		return errors.Errorf("--%s is only valid when --%s=%s",
-			dataFlagPipelineID, dataFlagDataSourceType, PipelineSinkDataSourceType)
+			dataFlagPipelineID, dataFlagDataSourceType, pipelineSinkDataSourceType)
 	}
 
 	mqlBinary, err := parseMQL(args.MQL, args.MqlPath)
@@ -499,6 +524,16 @@ func buildTabularDataSource(dataSourceType, pipelineID string) (*datapb.TabularD
 		source.PipelineId = &pipelineID
 	}
 	return source, nil
+}
+
+// dataSourceTypeToProto resolves the user-facing data source name to its proto enum value,
+// rejecting names that aren't in the allowed set for the calling surface.
+func dataSourceTypeToProto(name string, allowed []string) (datapb.TabularDataSourceType, error) {
+	if slices.Contains(allowed, name) {
+		return dataSourceTypeProtos[name], nil
+	}
+	return datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_UNSPECIFIED,
+		fmt.Errorf("invalid data source type: %q. Supported values: %v", name, allowed)
 }
 
 // writeQueryResults converts BSON-encoded rows to NDJSON (Relaxed Extended JSON) and writes them

--- a/cli/data.go
+++ b/cli/data.go
@@ -431,6 +431,9 @@ func (c *viamClient) dataQuerySQLAction(ctx context.Context, args dataQuerySQLAr
 	if args.OrgID == "" {
 		return errors.New("must provide an organization ID")
 	}
+	if args.SqlQuery == "" {
+		return errors.New("must provide a SQL query")
+	}
 
 	resp, err := c.dataClient.TabularDataBySQL(ctx, &datapb.TabularDataBySQLRequest{
 		OrganizationId: args.OrgID,
@@ -446,6 +449,12 @@ func (c *viamClient) dataQuerySQLAction(ctx context.Context, args dataQuerySQLAr
 func (c *viamClient) dataQueryMQLAction(ctx context.Context, args dataQueryMQLArgs) error {
 	if args.OrgID == "" {
 		return errors.New("must provide an organization ID")
+	}
+	if args.MQL == "" && args.MqlPath == "" {
+		return errors.New("missing MQL query")
+	}
+	if args.MQL != "" && args.MqlPath != "" {
+		return errors.New("MQL and MQL file cannot both be provided")
 	}
 
 	mqlBinary, err := parseMQL(args.MQL, args.MqlPath)
@@ -480,7 +489,7 @@ func buildTabularDataSource(dataSourceType, pipelineID string) (*datapb.TabularD
 			dataFlagDataSourceType, dataFlagPipelineID)
 	}
 
-	sourceType, err := dataSourceTypeToProto(dataSourceType, queryDataSourceTypes)
+	sourceType, err := dataSourceTypeToProto(dataSourceType, tabularDataByMQLDataSourceTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -502,7 +511,23 @@ func buildTabularDataSource(dataSourceType, pipelineID string) (*datapb.TabularD
 // writeQueryResults converts BSON-encoded rows to NDJSON (Relaxed Extended JSON) and writes them
 // to dest, or to w if dest is empty.
 func writeQueryResults(w io.Writer, dest string, rows [][]byte) error {
-	jsonRows := make([][]byte, 0, len(rows))
+	var (
+		bw       *bufio.Writer
+		filePath string
+	)
+	if dest != "" {
+		if err := makeDestinationDirs(dest); err != nil {
+			return errors.Wrap(err, "could not create destination directory")
+		}
+		filePath = filepath.Join(dest, dataFileName)
+		f, err := os.Create(filePath) //nolint:gosec
+		if err != nil {
+			return errors.Wrap(err, "could not create data file")
+		}
+		defer f.Close() //nolint:errcheck
+		bw = bufio.NewWriter(f)
+	}
+
 	for _, row := range rows {
 		var doc bson.D
 		if err := bson.Unmarshal(row, &doc); err != nil {
@@ -512,36 +537,21 @@ func writeQueryResults(w io.Writer, dest string, rows [][]byte) error {
 		if err != nil {
 			return errors.Wrap(err, "error formatting query result")
 		}
-		jsonRows = append(jsonRows, jsonRow)
-	}
-
-	if dest == "" {
-		for _, row := range jsonRows {
-			printf(w, "%s", row)
-		}
-		return nil
-	}
-
-	if err := makeDestinationDirs(dest); err != nil {
-		return errors.Wrap(err, "could not create destination directory")
-	}
-	filePath := filepath.Join(dest, dataFileName)
-	f, err := os.Create(filePath) //nolint:gosec
-	if err != nil {
-		return errors.Wrap(err, "could not create data file")
-	}
-	defer f.Close() //nolint:errcheck
-
-	writer := bufio.NewWriter(f)
-	for _, row := range jsonRows {
-		if err := writeData(writer, row); err != nil {
-			return errors.Wrap(err, "error writing data")
+		if bw != nil {
+			if err := writeData(bw, jsonRow); err != nil {
+				return errors.Wrap(err, "error writing data")
+			}
+		} else {
+			printf(w, "%s", jsonRow)
 		}
 	}
-	if err := writer.Flush(); err != nil {
-		return errors.Wrap(err, "error writing data to file")
+
+	if bw != nil {
+		if err := bw.Flush(); err != nil {
+			return errors.Wrap(err, "error writing data to file")
+		}
+		printf(w, "Wrote %d rows to %s", len(rows), filePath)
 	}
-	printf(w, "Wrote %d rows to %s", len(jsonRows), filePath)
 	return nil
 }
 

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -60,8 +61,8 @@ func TestDataQuerySQLAction(t *testing.T) {
 
 		_, ac, out, errOut := setup(&inject.AppServiceClient{}, dsc, nil, nil, "token")
 		err := ac.dataQuerySQLAction(context.Background(), dataQuerySQLArgs{
-			OrgID:    "org-1",
-			SqlQuery: "SELECT * FROM readings",
+			OrgID: "org-1",
+			SQL:   "SELECT * FROM readings",
 		})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
@@ -84,7 +85,7 @@ func TestDataQuerySQLAction(t *testing.T) {
 
 	t.Run("requires an org id", func(t *testing.T) {
 		_, ac, _, _ := setup(&inject.AppServiceClient{}, &inject.DataServiceClient{}, nil, nil, "token")
-		err := ac.dataQuerySQLAction(context.Background(), dataQuerySQLArgs{SqlQuery: "SELECT 1"})
+		err := ac.dataQuerySQLAction(context.Background(), dataQuerySQLArgs{SQL: "SELECT 1"})
 		test.That(t, err, test.ShouldBeError, errors.New("must provide an organization ID"))
 	})
 
@@ -115,7 +116,7 @@ func TestDataQueryMQLAction(t *testing.T) {
 		err := ac.dataQueryMQLAction(context.Background(), dataQueryMQLArgs{
 			OrgID:          "org-1",
 			MQL:            mql,
-			DataSourceType: PipelineSinkDataSourceType,
+			DataSourceType: pipelineSinkDataSourceType,
 			PipelineID:     "pipe-1",
 		})
 		test.That(t, err, test.ShouldBeNil)
@@ -152,18 +153,20 @@ func TestDataQueryMQLAction(t *testing.T) {
 			args: dataQueryMQLArgs{
 				OrgID:          "org-1",
 				MQL:            mql,
-				DataSourceType: HotStorageDataSourceType,
+				DataSourceType: hotStorageDataSourceType,
 				PipelineID:     "pipe-1",
 			},
-			expectedErr: errors.New("--pipeline-id is only valid when --data-source-type=pipelinesink"),
+			expectedErr: fmt.Errorf("--%s is only valid when --%s=%s",
+				dataFlagPipelineID, dataFlagDataSourceType, pipelineSinkDataSourceType),
 		},
 		"pipeline-sink requires a pipeline id": {
 			args: dataQueryMQLArgs{
 				OrgID:          "org-1",
 				MQL:            mql,
-				DataSourceType: PipelineSinkDataSourceType,
+				DataSourceType: pipelineSinkDataSourceType,
 			},
-			expectedErr: errors.New("--pipeline-id is required when --data-source-type=pipelinesink"),
+			expectedErr: fmt.Errorf("--%s is required when --%s=%s",
+				dataFlagPipelineID, dataFlagDataSourceType, pipelineSinkDataSourceType),
 		},
 		"pipeline-id without a source type": {
 			args: dataQueryMQLArgs{
@@ -171,7 +174,8 @@ func TestDataQueryMQLAction(t *testing.T) {
 				MQL:        mql,
 				PipelineID: "pipe-1",
 			},
-			expectedErr: errors.New("--data-source-type is required when --pipeline-id is provided"),
+			expectedErr: fmt.Errorf("--%s is required when --%s is provided",
+				dataFlagDataSourceType, dataFlagPipelineID),
 		},
 		"missing mql query": {
 			args:        dataQueryMQLArgs{OrgID: "org-1"},
@@ -186,4 +190,37 @@ func TestDataQueryMQLAction(t *testing.T) {
 			test.That(t, err, test.ShouldBeError, tc.expectedErr)
 		})
 	}
+}
+
+func TestDataSourceTypeToProto(t *testing.T) {
+	t.Run("maps each name to its proto enum when in the allowed set", func(t *testing.T) {
+		all := []string{standardDataSourceType, hotStorageDataSourceType, pipelineSinkDataSourceType}
+		cases := map[string]datapb.TabularDataSourceType{
+			standardDataSourceType:     datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_STANDARD,
+			hotStorageDataSourceType:   datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE,
+			pipelineSinkDataSourceType: datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK,
+		}
+		for name, want := range cases {
+			got, err := dataSourceTypeToProto(name, all)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, got, test.ShouldEqual, want)
+		}
+	})
+
+	t.Run("rejects names not in the caller's allowed set", func(t *testing.T) {
+		// pipelinesink is a known proto value, but not a valid source for creating a pipeline.
+		_, err := dataSourceTypeToProto(pipelineSinkDataSourceType, pipelineDataSourceTypes)
+		test.That(t, err, test.ShouldBeError, fmt.Errorf(
+			"invalid data source type: %q. Supported values: %v",
+			pipelineSinkDataSourceType, pipelineDataSourceTypes))
+	})
+
+	t.Run("rejects unknown and empty names", func(t *testing.T) {
+		for _, name := range []string{"unknown", ""} {
+			_, err := dataSourceTypeToProto(name, tabularDataByMQLDataSourceTypes)
+			test.That(t, err, test.ShouldBeError, fmt.Errorf(
+				"invalid data source type: %q. Supported values: %v",
+				name, tabularDataByMQLDataSourceTypes))
+		}
+	})
 }

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -1,10 +1,18 @@
 package cli
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 
+	"go.mongodb.org/mongo-driver/bson"
 	datapb "go.viam.com/api/app/data/v1"
 	"go.viam.com/test"
+	"google.golang.org/grpc"
+
+	"go.viam.com/rdk/testutils/inject"
 )
 
 func TestFilenameForDownload(t *testing.T) {
@@ -32,4 +40,144 @@ func TestFilenameForDownload(t *testing.T) {
 
 	gzInFolder := filenameForDownload(&datapb.BinaryMetadata{FileName: "dir/whatever.gz"})
 	test.That(t, gzInFolder, test.ShouldEqual, "dir/whatever")
+}
+
+func TestDataQuerySQLAction(t *testing.T) {
+	row1, err := bson.Marshal(bson.M{"part_id": "p1", "value": float64(42)})
+	test.That(t, err, test.ShouldBeNil)
+	row2, err := bson.Marshal(bson.M{"part_id": "p2", "value": float64(7)})
+	test.That(t, err, test.ShouldBeNil)
+
+	t.Run("prints rows to stdout when no destination is set", func(t *testing.T) {
+		var capturedReq *datapb.TabularDataBySQLRequest
+		dsc := &inject.DataServiceClient{
+			TabularDataBySQLFunc: func(ctx context.Context, in *datapb.TabularDataBySQLRequest, opts ...grpc.CallOption,
+			) (*datapb.TabularDataBySQLResponse, error) {
+				capturedReq = in
+				return &datapb.TabularDataBySQLResponse{RawData: [][]byte{row1, row2}}, nil
+			},
+		}
+
+		_, ac, out, errOut := setup(&inject.AppServiceClient{}, dsc, nil, nil, "token")
+		err := ac.dataQuerySQLAction(context.Background(), dataQuerySQLArgs{
+			OrgID:    "org-1",
+			SqlQuery: "SELECT * FROM readings",
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+		test.That(t, capturedReq.GetOrganizationId(), test.ShouldEqual, "org-1")
+		test.That(t, capturedReq.GetSqlQuery(), test.ShouldEqual, "SELECT * FROM readings")
+
+		// Parse NDJSON written to stdout back into maps before comparing to expected.
+		var actual []map[string]interface{}
+		decoder := json.NewDecoder(strings.NewReader(strings.Join(out.messages, "")))
+		for decoder.More() {
+			var row map[string]interface{}
+			test.That(t, decoder.Decode(&row), test.ShouldBeNil)
+			actual = append(actual, row)
+		}
+		test.That(t, actual, test.ShouldResemble, []map[string]interface{}{
+			{"part_id": "p1", "value": float64(42)},
+			{"part_id": "p2", "value": float64(7)},
+		})
+	})
+
+	t.Run("requires an org id", func(t *testing.T) {
+		_, ac, _, _ := setup(&inject.AppServiceClient{}, &inject.DataServiceClient{}, nil, nil, "token")
+		err := ac.dataQuerySQLAction(context.Background(), dataQuerySQLArgs{SqlQuery: "SELECT 1"})
+		test.That(t, err, test.ShouldBeError, errors.New("must provide an organization ID"))
+	})
+}
+
+func TestDataQueryMQLAction(t *testing.T) {
+	row, err := bson.Marshal(bson.M{"part_id": "p1", "n": float64(1)})
+	test.That(t, err, test.ShouldBeNil)
+
+	mql := `[{"$match": {"part_id": "p1"}}]`
+
+	t.Run("forwards data source and pipeline id", func(t *testing.T) {
+		var capturedReq *datapb.TabularDataByMQLRequest
+		dsc := &inject.DataServiceClient{
+			TabularDataByMQLFunc: func(ctx context.Context, in *datapb.TabularDataByMQLRequest, opts ...grpc.CallOption,
+			) (*datapb.TabularDataByMQLResponse, error) {
+				capturedReq = in
+				return &datapb.TabularDataByMQLResponse{RawData: [][]byte{row}}, nil
+			},
+		}
+
+		_, ac, _, errOut := setup(&inject.AppServiceClient{}, dsc, nil, nil, "token")
+		err := ac.dataQueryMQLAction(context.Background(), dataQueryMQLArgs{
+			OrgID:          "org-1",
+			MQL:            mql,
+			DataSourceType: PipelineSinkDataSourceType,
+			PipelineID:     "pipe-1",
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+		test.That(t, capturedReq.GetOrganizationId(), test.ShouldEqual, "org-1")
+		test.That(t, capturedReq.GetDataSource().GetType(),
+			test.ShouldEqual, datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK)
+		test.That(t, capturedReq.GetDataSource().GetPipelineId(), test.ShouldEqual, "pipe-1")
+		test.That(t, len(capturedReq.GetMqlBinary()), test.ShouldEqual, 1)
+	})
+
+	t.Run("omits data source when not provided", func(t *testing.T) {
+		var capturedReq *datapb.TabularDataByMQLRequest
+		dsc := &inject.DataServiceClient{
+			TabularDataByMQLFunc: func(ctx context.Context, in *datapb.TabularDataByMQLRequest, opts ...grpc.CallOption,
+			) (*datapb.TabularDataByMQLResponse, error) {
+				capturedReq = in
+				return &datapb.TabularDataByMQLResponse{RawData: [][]byte{row}}, nil
+			},
+		}
+
+		_, ac, _, errOut := setup(&inject.AppServiceClient{}, dsc, nil, nil, "token")
+		err := ac.dataQueryMQLAction(context.Background(), dataQueryMQLArgs{OrgID: "org-1", MQL: mql})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+		test.That(t, capturedReq.GetDataSource(), test.ShouldBeNil)
+	})
+
+	testCases := map[string]struct {
+		args        dataQueryMQLArgs
+		expectedErr error
+	}{
+		"hot-storage data source rejects a pipeline id": {
+			args: dataQueryMQLArgs{
+				OrgID:          "org-1",
+				MQL:            mql,
+				DataSourceType: HotStorageDataSourceType,
+				PipelineID:     "pipe-1",
+			},
+			expectedErr: errors.New("--pipeline-id is only valid when --data-source-type=pipelinesink"),
+		},
+		"pipeline-sink requires a pipeline id": {
+			args: dataQueryMQLArgs{
+				OrgID:          "org-1",
+				MQL:            mql,
+				DataSourceType: PipelineSinkDataSourceType,
+			},
+			expectedErr: errors.New("--pipeline-id is required when --data-source-type=pipelinesink"),
+		},
+		"pipeline-id without a source type": {
+			args: dataQueryMQLArgs{
+				OrgID:      "org-1",
+				MQL:        mql,
+				PipelineID: "pipe-1",
+			},
+			expectedErr: errors.New("--data-source-type is required when --pipeline-id is provided"),
+		},
+		"missing mql query": {
+			args:        dataQueryMQLArgs{OrgID: "org-1"},
+			expectedErr: errors.New("missing MQL query"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, ac, _, _ := setup(&inject.AppServiceClient{}, &inject.DataServiceClient{}, nil, nil, "token")
+			err := ac.dataQueryMQLAction(context.Background(), tc.args)
+			test.That(t, err, test.ShouldBeError, tc.expectedErr)
+		})
+	}
 }

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -87,6 +87,12 @@ func TestDataQuerySQLAction(t *testing.T) {
 		err := ac.dataQuerySQLAction(context.Background(), dataQuerySQLArgs{SqlQuery: "SELECT 1"})
 		test.That(t, err, test.ShouldBeError, errors.New("must provide an organization ID"))
 	})
+
+	t.Run("requires a sql query", func(t *testing.T) {
+		_, ac, _, _ := setup(&inject.AppServiceClient{}, &inject.DataServiceClient{}, nil, nil, "token")
+		err := ac.dataQuerySQLAction(context.Background(), dataQuerySQLArgs{OrgID: "org-1"})
+		test.That(t, err, test.ShouldBeError, errors.New("must provide a SQL query"))
+	})
 }
 
 func TestDataQueryMQLAction(t *testing.T) {

--- a/cli/datapipelines.go
+++ b/cli/datapipelines.go
@@ -6,13 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"slices"
 	"time"
 
 	"github.com/urfave/cli/v3"
 	"github.com/yosuke-furukawa/json5/encoding/json5"
 	"go.mongodb.org/mongo-driver/bson"
-	pb "go.viam.com/api/app/data/v1"
 	datapipelinespb "go.viam.com/api/app/datapipelines/v1"
 )
 
@@ -25,33 +23,8 @@ var pipelineRunStatusMap = map[datapipelinespb.DataPipelineRunStatus]string{
 	datapipelinespb.DataPipelineRunStatus_DATA_PIPELINE_RUN_STATUS_FAILED:      "Failed",
 }
 
-// dataSourceTypeMap maps data source types to human-readable strings.
-var dataSourceTypeMap = map[pb.TabularDataSourceType]string{
-	pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_UNSPECIFIED:   "Unknown",
-	pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_STANDARD:      "Standard",
-	pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE:   "Hot Storage",
-	pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK: "Pipeline Sink",
-}
-
-// dataSourceType constants for data source types.
-var (
-	StandardDataSourceType     = "standard"
-	HotStorageDataSourceType   = "hotstorage"
-	PipelineSinkDataSourceType = "pipelinesink"
-)
-
-// dataSourceTypeProtos maps user-facing data source names to their proto enum value.
-var dataSourceTypeProtos = map[string]pb.TabularDataSourceType{
-	StandardDataSourceType:     pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_STANDARD,
-	HotStorageDataSourceType:   pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE,
-	PipelineSinkDataSourceType: pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK,
-}
-
-var (
-	// pipeline data sources do not allow pipeline sinks.
-	pipelineDataSourceTypes         = []string{StandardDataSourceType, HotStorageDataSourceType}
-	tabularDataByMQLDataSourceTypes = []string{StandardDataSourceType, HotStorageDataSourceType, PipelineSinkDataSourceType}
-)
+// pipeline data sources do not allow pipeline sinks.
+var pipelineDataSourceTypes = []string{standardDataSourceType, hotStorageDataSourceType}
 
 type datapipelineListArgs struct {
 	OrgID string
@@ -338,14 +311,4 @@ func mqlJSON(mql [][]byte) (string, error) {
 	}
 
 	return string(jsonBytes), nil
-}
-
-// dataSourceTypeToProto resolves the user-facing data source name to its proto enum value,
-// rejecting names that aren't in the allowed set for the calling surface.
-func dataSourceTypeToProto(name string, allowed []string) (pb.TabularDataSourceType, error) {
-	if slices.Contains(allowed, name) {
-		return dataSourceTypeProtos[name], nil
-	}
-	return pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_UNSPECIFIED,
-		fmt.Errorf("invalid data source type: %q. Supported values: %v", name, allowed)
 }

--- a/cli/datapipelines.go
+++ b/cli/datapipelines.go
@@ -41,18 +41,16 @@ var (
 )
 
 // dataSourceTypeProtos maps user-facing data source names to their proto enum value.
-// New source types must be added here.
 var dataSourceTypeProtos = map[string]pb.TabularDataSourceType{
 	StandardDataSourceType:     pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_STANDARD,
 	HotStorageDataSourceType:   pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE,
 	PipelineSinkDataSourceType: pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK,
 }
 
-// Per-surface allowed sets. Pipeline sinks can't be configured as pipeline destinations
-// (would be self-referential) but are valid query targets.
 var (
-	pipelineDataSourceTypes = []string{StandardDataSourceType, HotStorageDataSourceType}
-	queryDataSourceTypes    = []string{StandardDataSourceType, HotStorageDataSourceType, PipelineSinkDataSourceType}
+	// pipeline data sources do not allow pipeline sinks.
+	pipelineDataSourceTypes         = []string{StandardDataSourceType, HotStorageDataSourceType}
+	tabularDataByMQLDataSourceTypes = []string{StandardDataSourceType, HotStorageDataSourceType, PipelineSinkDataSourceType}
 )
 
 type datapipelineListArgs struct {
@@ -290,7 +288,7 @@ func DatapipelineDisableAction(ctx context.Context, cmd *cli.Command, args datap
 
 func parseMQL(mql, mqlFile string) ([][]byte, error) {
 	if mqlFile != "" && mql != "" {
-		return nil, errors.New("MQL and MQL file cannot both be provided")
+		return nil, errors.New("data pipeline MQL and MQL file cannot both be provided")
 	}
 
 	if mqlFile != "" {
@@ -303,7 +301,7 @@ func parseMQL(mql, mqlFile string) ([][]byte, error) {
 	}
 
 	if mql == "" {
-		return nil, errors.New("missing MQL query")
+		return nil, errors.New("missing data pipeline MQL")
 	}
 
 	// Parse the MQL stages JSON (using JSON5 for unquoted keys + comments).

--- a/cli/datapipelines.go
+++ b/cli/datapipelines.go
@@ -288,7 +288,7 @@ func DatapipelineDisableAction(ctx context.Context, cmd *cli.Command, args datap
 
 func parseMQL(mql, mqlFile string) ([][]byte, error) {
 	if mqlFile != "" && mql != "" {
-		return nil, errors.New("data pipeline MQL and MQL file cannot both be provided")
+		return nil, errors.New("MQL and MQL file cannot both be provided")
 	}
 
 	if mqlFile != "" {
@@ -301,7 +301,7 @@ func parseMQL(mql, mqlFile string) ([][]byte, error) {
 	}
 
 	if mql == "" {
-		return nil, errors.New("missing data pipeline MQL")
+		return nil, errors.New("missing MQL query")
 	}
 
 	// Parse the MQL stages JSON (using JSON5 for unquoted keys + comments).

--- a/cli/datapipelines.go
+++ b/cli/datapipelines.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/urfave/cli/v3"
@@ -37,6 +38,21 @@ var (
 	StandardDataSourceType     = "standard"
 	HotStorageDataSourceType   = "hotstorage"
 	PipelineSinkDataSourceType = "pipelinesink"
+)
+
+// dataSourceTypeProtos maps user-facing data source names to their proto enum value.
+// New source types must be added here.
+var dataSourceTypeProtos = map[string]pb.TabularDataSourceType{
+	StandardDataSourceType:     pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_STANDARD,
+	HotStorageDataSourceType:   pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE,
+	PipelineSinkDataSourceType: pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK,
+}
+
+// Per-surface allowed sets. Pipeline sinks can't be configured as pipeline destinations
+// (would be self-referential) but are valid query targets.
+var (
+	pipelineDataSourceTypes = []string{StandardDataSourceType, HotStorageDataSourceType}
+	queryDataSourceTypes    = []string{StandardDataSourceType, HotStorageDataSourceType, PipelineSinkDataSourceType}
 )
 
 type datapipelineListArgs struct {
@@ -97,7 +113,7 @@ func DatapipelineCreateAction(ctx context.Context, cmd *cli.Command, args datapi
 		return err
 	}
 
-	dataSourceType, err := dataSourceTypeToProto(args.DataSourceType)
+	dataSourceType, err := dataSourceTypeToProto(args.DataSourceType, pipelineDataSourceTypes)
 	if err != nil {
 		return err
 	}
@@ -326,37 +342,12 @@ func mqlJSON(mql [][]byte) (string, error) {
 	return string(jsonBytes), nil
 }
 
-func dataSourceTypeToProto(dataSourceType string) (pb.TabularDataSourceType, error) {
-	switch dataSourceType {
-	case StandardDataSourceType:
-		return pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_STANDARD, nil
-	case HotStorageDataSourceType:
-		return pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE, nil
-	default:
-		return pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_UNSPECIFIED,
-			fmt.Errorf("invalid data source type: %s. Supported values: [%s, %s]",
-				dataSourceType,
-				StandardDataSourceType,
-				HotStorageDataSourceType,
-			)
+// dataSourceTypeToProto resolves the user-facing data source name to its proto enum value,
+// rejecting names that aren't in the allowed set for the calling surface.
+func dataSourceTypeToProto(name string, allowed []string) (pb.TabularDataSourceType, error) {
+	if slices.Contains(allowed, name) {
+		return dataSourceTypeProtos[name], nil
 	}
-}
-
-// tabularDataSourceTypeToProto is like dataSourceTypeToProto but also accepts the
-// pipeline-sink source type, which is valid for MQL queries but not for pipeline creation.
-func tabularDataSourceTypeToProto(dataSourceType string) (pb.TabularDataSourceType, error) {
-	if dataSourceType == PipelineSinkDataSourceType {
-		return pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK, nil
-	}
-	sourceType, err := dataSourceTypeToProto(dataSourceType)
-	if err != nil {
-		return pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_UNSPECIFIED,
-			fmt.Errorf("invalid data source type: %s. Supported values: [%s, %s, %s]",
-				dataSourceType,
-				StandardDataSourceType,
-				HotStorageDataSourceType,
-				PipelineSinkDataSourceType,
-			)
-	}
-	return sourceType, nil
+	return pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_UNSPECIFIED,
+		fmt.Errorf("invalid data source type: %q. Supported values: %v", name, allowed)
 }

--- a/cli/datapipelines.go
+++ b/cli/datapipelines.go
@@ -34,8 +34,9 @@ var dataSourceTypeMap = map[pb.TabularDataSourceType]string{
 
 // dataSourceType constants for data source types.
 var (
-	StandardDataSourceType   = "standard"
-	HotStorageDataSourceType = "hotstorage"
+	StandardDataSourceType     = "standard"
+	HotStorageDataSourceType   = "hotstorage"
+	PipelineSinkDataSourceType = "pipelinesink"
 )
 
 type datapipelineListArgs struct {
@@ -273,7 +274,7 @@ func DatapipelineDisableAction(ctx context.Context, cmd *cli.Command, args datap
 
 func parseMQL(mql, mqlFile string) ([][]byte, error) {
 	if mqlFile != "" && mql != "" {
-		return nil, errors.New("data pipeline MQL and MQL file cannot both be provided")
+		return nil, errors.New("MQL and MQL file cannot both be provided")
 	}
 
 	if mqlFile != "" {
@@ -286,7 +287,7 @@ func parseMQL(mql, mqlFile string) ([][]byte, error) {
 	}
 
 	if mql == "" {
-		return nil, errors.New("missing data pipeline MQL")
+		return nil, errors.New("missing MQL query")
 	}
 
 	// Parse the MQL stages JSON (using JSON5 for unquoted keys + comments).
@@ -339,4 +340,23 @@ func dataSourceTypeToProto(dataSourceType string) (pb.TabularDataSourceType, err
 				HotStorageDataSourceType,
 			)
 	}
+}
+
+// tabularDataSourceTypeToProto is like dataSourceTypeToProto but also accepts the
+// pipeline-sink source type, which is valid for MQL queries but not for pipeline creation.
+func tabularDataSourceTypeToProto(dataSourceType string) (pb.TabularDataSourceType, error) {
+	if dataSourceType == PipelineSinkDataSourceType {
+		return pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK, nil
+	}
+	sourceType, err := dataSourceTypeToProto(dataSourceType)
+	if err != nil {
+		return pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_UNSPECIFIED,
+			fmt.Errorf("invalid data source type: %s. Supported values: [%s, %s, %s]",
+				dataSourceType,
+				StandardDataSourceType,
+				HotStorageDataSourceType,
+				PipelineSinkDataSourceType,
+			)
+	}
+	return sourceType, nil
 }

--- a/cli/datapipelines_test.go
+++ b/cli/datapipelines_test.go
@@ -171,17 +171,17 @@ func TestDataSourceTypeToProto(t *testing.T) {
 		},
 		"pipelinesink accepted for query": {
 			dataSourceType: "pipelinesink",
-			allowed:        queryDataSourceTypes,
+			allowed:        tabularDataByMQLDataSourceTypes,
 			expectedType:   pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK,
 		},
 		"unknown": {
 			dataSourceType: "unknown",
-			allowed:        queryDataSourceTypes,
+			allowed:        tabularDataByMQLDataSourceTypes,
 			expectedError:  true,
 		},
 		"empty": {
 			dataSourceType: "",
-			allowed:        queryDataSourceTypes,
+			allowed:        tabularDataByMQLDataSourceTypes,
 			expectedError:  true,
 		},
 	}

--- a/cli/datapipelines_test.go
+++ b/cli/datapipelines_test.go
@@ -150,33 +150,45 @@ func TestMQLJSON(t *testing.T) {
 func TestDataSourceTypeToProto(t *testing.T) {
 	testCases := map[string]struct {
 		dataSourceType string
+		allowed        []string
 		expectedType   pb.TabularDataSourceType
 		expectedError  bool
 	}{
-		"standard": {
+		"standard for pipeline": {
 			dataSourceType: "standard",
+			allowed:        pipelineDataSourceTypes,
 			expectedType:   pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_STANDARD,
-			expectedError:  false,
 		},
-		"hotstorage": {
+		"hotstorage for pipeline": {
 			dataSourceType: "hotstorage",
+			allowed:        pipelineDataSourceTypes,
 			expectedType:   pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE,
-			expectedError:  false,
+		},
+		"pipelinesink rejected for pipeline": {
+			dataSourceType: "pipelinesink",
+			allowed:        pipelineDataSourceTypes,
+			expectedError:  true,
+		},
+		"pipelinesink accepted for query": {
+			dataSourceType: "pipelinesink",
+			allowed:        queryDataSourceTypes,
+			expectedType:   pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK,
 		},
 		"unknown": {
 			dataSourceType: "unknown",
+			allowed:        queryDataSourceTypes,
 			expectedError:  true,
 		},
 		"empty": {
 			dataSourceType: "",
-			expectedType:   pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_STANDARD,
+			allowed:        queryDataSourceTypes,
 			expectedError:  true,
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			dataSourceType, err := dataSourceTypeToProto(tc.dataSourceType)
+			dataSourceType, err := dataSourceTypeToProto(tc.dataSourceType, tc.allowed)
 			if tc.expectedError {
 				test.That(t, err, test.ShouldNotBeNil)
 				return

--- a/cli/datapipelines_test.go
+++ b/cli/datapipelines_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"go.mongodb.org/mongo-driver/bson"
-	pb "go.viam.com/api/app/data/v1"
 	"go.viam.com/test"
 )
 
@@ -145,56 +144,4 @@ func TestMQLJSON(t *testing.T) {
 	json, err := mqlJSON(bsonBytes)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, json, test.ShouldEqualJSON, expectedJSON)
-}
-
-func TestDataSourceTypeToProto(t *testing.T) {
-	testCases := map[string]struct {
-		dataSourceType string
-		allowed        []string
-		expectedType   pb.TabularDataSourceType
-		expectedError  bool
-	}{
-		"standard for pipeline": {
-			dataSourceType: "standard",
-			allowed:        pipelineDataSourceTypes,
-			expectedType:   pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_STANDARD,
-		},
-		"hotstorage for pipeline": {
-			dataSourceType: "hotstorage",
-			allowed:        pipelineDataSourceTypes,
-			expectedType:   pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE,
-		},
-		"pipelinesink rejected for pipeline": {
-			dataSourceType: "pipelinesink",
-			allowed:        pipelineDataSourceTypes,
-			expectedError:  true,
-		},
-		"pipelinesink accepted for query": {
-			dataSourceType: "pipelinesink",
-			allowed:        tabularDataByMQLDataSourceTypes,
-			expectedType:   pb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK,
-		},
-		"unknown": {
-			dataSourceType: "unknown",
-			allowed:        tabularDataByMQLDataSourceTypes,
-			expectedError:  true,
-		},
-		"empty": {
-			dataSourceType: "",
-			allowed:        tabularDataByMQLDataSourceTypes,
-			expectedError:  true,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			dataSourceType, err := dataSourceTypeToProto(tc.dataSourceType, tc.allowed)
-			if tc.expectedError {
-				test.That(t, err, test.ShouldNotBeNil)
-				return
-			}
-			test.That(t, err, test.ShouldBeNil)
-			test.That(t, dataSourceType, test.ShouldEqual, tc.expectedType)
-		})
-	}
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                 
  - Add `viam data query` parent command with `sql` and `mql` subcommands, backed by `TabularDataBySQL` and `TabularDataByMQL`.                                                                                                                                                            
  - `mql` accepts `--data-source-type` (`standard | hotstorage | pipelinesink`) and `--pipeline-id`. `sql` has no data-source flag — the proto doesn't carry one.                                                                                                                            
  - Results print as NDJSON in Relaxed Extended JSON (dates → ISO strings, ObjectIDs → `{"$oid":"..."}`, field order preserved via `bson.D`). Defaults to stdout; `--destination=<dir>` writes `<dir>/data.ndjson` (matches `data export tabular` and overwrites any existing file there).   
  - Refactor source-type plumbing: single `dataSourceTypeProtos` map + per-surface `pipelineDataSourceTypes` / `queryDataSourceTypes` allow-lists, consumed by both `dataSourceTypeToProto(name, allowed)` and the `formatAcceptedValues` calls. Pipeline sinks are rejected for pipeline    
  creation (would be self-referential) but accepted for queries.                                                                                                                                                                                                                             
  - Rename shared flag constants `datapipelineFlag{MQL,MQLFile,DataSourceType}` → `dataFlag*` Wire-level flag names unchanged.                                                                                                                                      
  - Generalize `parseMQL` error wording (now used by two surfaces).                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                             
  ## Test plan                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                             
  ### Help & wiring                                                                                                                                                                                                                                                                        
  - [x] `viam data query --help` lists `sql` and `mql`
  - [x] `viam data query sql --help` shows `--org-id`, `--sql-query`, `--destination`                                                                                                                                                                                                        
  - [x] `viam data query mql --help` shows `--org-id`, `--mql`, `--mql-path`, `--data-source-type`, `--pipeline-id`, `--destination`
  - [x] `--data-source-type` help text lists `standard | hotstorage | pipelinesink`                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                             
  ### SQL happy paths                                                                                                                                                                                                                                                                        
  - [x] `viam data query sql --org-id=$ORG --sql-query="SELECT * FROM readings LIMIT 5"` prints NDJSON to stdout                                                                                                                                                                             
  - [x] Pipes cleanly: `... | jq .`                                                                                                                                                                                                                                                          
  - [x] `--destination=/tmp/q-sql` writes `/tmp/q-sql/data.ndjson` and prints `Wrote N rows to ...`                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                             
  ### MQL happy paths                                                                                                                                                                                                                                                                        
  - [x] Inline: `--mql='[{"$limit": 5}]'`                                                                                                                                                                                                                                                  
  - [x] From file: `--mql-path=/tmp/q.json`                                                                                                                                                                                                                                                  
  - [x] `--destination=<dir>` writes NDJSON + prints summary                                                                                                                                                                                                                                 
  - [x] `--data-source-type=standard` works
  - [x] `--data-source-type=hotstorage` works                                                                                                                                                                                                                                                
  - [x] `--data-source-type=pipelinesink --pipeline-id=<PIPELINE_ID>` works                                                                                                                                                                                                                  
   
  ### Default-org fallback                                                                                                                                                                                                                     
  - [x] `viam defaults set-org --org-id=$ORG`, then `viam data query sql --sql-query="SELECT 1"` succeeds without `--org-id`                                                                                                                                                               
  - [ ] `viam defaults clear-org`, then same command fails with `"must provide an organization ID"`                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                             
  ### MQL validation errors                                                                                                                                                                                                                                                                  
  - [x] `--pipeline-id=foo` without `--data-source-type` → `--data-source-type is required when --pipeline-id is provided`                                                                                                                                                                   
  - [x] `--data-source-type=pipelinesink` without `--pipeline-id` → `--pipeline-id is required when --data-source-type=pipelinesink`                                                                                                                                                         
  - [x] `--data-source-type=hotstorage --pipeline-id=foo` → `--pipeline-id is only valid when --data-source-type=pipelinesink`                                                                                                                                                               
  - [ ] `--mql=... --mql-path=...` → `MQL and MQL file cannot both be provided`                                                                                                                                                                                                              
  - [ ] Neither `--mql` nor `--mql-path` → `missing MQL query`                                                                                                                                                                                                                               
  - [ ] `--data-source-type=garbage` → error listing accepted values from `queryDataSourceTypes`                                                                                                                                                                                             
   