### PR TITLE
RSDK-13611: Go SDK: log config type conversion failures

### DIFF
--- a/module/resources.go
+++ b/module/resources.go
@@ -197,7 +197,7 @@ func addConvertedAttributes(cfg *resource.Config) error {
 	if ok && reg.AttributeMapConverter != nil {
 		converted, err := reg.AttributeMapConverter(cfg.Attributes)
 		if err != nil {
-			return fmt.Errorf("error converting attributes for resource")
+			return fmt.Errorf("error converting attributes for resource: %w", err)
 		}
 		cfg.ConvertedAttributes = converted
 	}

--- a/resource/config.go
+++ b/resource/config.go
@@ -372,7 +372,8 @@ func TransformAttributeMap[T any](attributes utils.AttributeMap) (T, error) {
 		return out, err
 	}
 	if err := decoder.Decode(attributes); err != nil {
-		return out, err
+		// strip \n\n from mapstructure library's Decoder.Decode
+		return out, fmt.Errorf("%s", strings.ReplaceAll(err.Error(), "\n\n", " "))
 	}
 	if attributes.Has("attributes") || len(md.Unused) == 0 {
 		return out, nil


### PR DESCRIPTION
New:
`resource/graph_node.go:316	modular resource config validation error: rpc error: code = Unknown desc = unable to convert attributes for validation: error converting attributes for resource: decoding failed due to the following error(s): 'host' expected type 'string', got unconvertible type 'float64'	{"resource":"rdk:component:arm/arm-1","model":"viam:ufactory:lite6"}`

Note the new `decoding failed due to the following error(s): 'host' expected type 'string', got unconvertible type 'float64'`

Old:
`resource/graph_node.go:316   modular resource config validation error: rpc error: code = Unknown desc = unable to convert attributes for validation: error converting attributes for resource   resource rdk:component:arm/lite6  model viam:ufactory:lite6`

Anyone know why this wasn't done in the first place? Oversight or security reasons?