### PR TITLE
RSDK-14088 Use "rdk.NetAppender" for net appender internal logs instead of "NetAppender"

### DIFF
--- a/logging/net_appender.go
+++ b/logging/net_appender.go
@@ -218,7 +218,7 @@ func newInternalLogEntry(level zapcore.Level, message string) zapcore.Entry {
 	return zapcore.Entry{
 		Level:      level,
 		Time:       time.Now(),
-		LoggerName: "NetAppender",
+		LoggerName: "rdk.NetAppender",
 		Message:    message,
 		Caller:     zapcore.EntryCaller{},
 		Stack:      "",


### PR DESCRIPTION
RSDK-14088

## What

Changes logs like the following:

```
6/8/2026, 7:00:29 PM info NetAppender     error logging to network: rpc error: code = DeadlineExceeded desc = context deadline exceeded
```

to have an "rdk"-prefixed logger name:

```

6/10/2026, 1:54:25 PM info rdk.NetAppender     error logging to network: rpc error: code = DeadlineExceeded desc = not connected
```

## Why

We [want to mark these logs as diagnostic](https://github.com/viamrobotics/app/pull/12326). Currently, diagnostic logger names must be of the form "foo.bar". This rename also better differentiates the `viam-agent`'s `*NetAppender` instance from `viam-server`'s ("viam-agent.NetAppender" vs. "rdk.NetAppender").