### PR TITLE
Fix windows logging tests and guard against runtime panic

### DIFF
--- a/logging/windows_etw_logger.go
+++ b/logging/windows_etw_logger.go
@@ -72,7 +72,6 @@ func RegisterETWLogger(rootLogger Logger, etlDir string, p ETWProvider) (io.Clos
 	if err := sess.Start(startCtx); err != nil {
 		rootLogger.Warnw("ETW session start failed; provider registered but file capture could not start",
 			"err", err, "session", p.SessionName, "outputPath", etlPath)
-		provider.Close()
 		return nopCloser{}, err
 	} else {
 		liveSession = sess
@@ -88,7 +87,7 @@ func RegisterETWLogger(rootLogger Logger, etlDir string, p ETWProvider) (io.Clos
 // listening, near-free when not — no buffering goroutine needed.
 type etwAppender struct {
 	provider *etw.Provider
-	session  sessionController // nil if session start failed
+	session  sessionController
 }
 
 // Write maps the zap entry to a level-tagged ETW event with structured fields.
@@ -142,20 +141,16 @@ func (a *etwAppender) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 
 func (a *etwAppender) Sync() error { return nil }
 
-// Close stops the session before unregistering the provider so any kernel
-// buffer contents are flushed to the .etl file before teardown.
+// stop the session if it still exists when Close() is called.
+// don't touch the provider to avoid a bug in the Close logic of winio
+// the provider is killed by windows when the process dies
 func (a *etwAppender) Close() error {
-	var sessErr error
-	if a.session != nil {
-		stopCtx, cancel := context.WithTimeout(context.Background(), etwLogmanTimeout)
-		defer cancel()
-		sessErr = a.session.Stop(stopCtx)
+	if a.session == nil {
+		return nil
 	}
-	provErr := a.provider.Close()
-	if sessErr != nil {
-		return sessErr
-	}
-	return provErr
+	stopCtx, cancel := context.WithTimeout(context.Background(), etwLogmanTimeout)
+	defer cancel()
+	return a.session.Stop(stopCtx)
 }
 
 func zapToETWLevel(l zapcore.Level) etw.Level {

--- a/logging/windows_logging_test.go
+++ b/logging/windows_logging_test.go
@@ -26,6 +26,7 @@ func TestETWNulls(t *testing.T) {
 	closer, err := RegisterETWLogger(logger, etlDir, ServerETW)
 	test.That(t, closer, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeNil)
+	defer closer.Close()
 
 	logger.Info("message through registered ETW appender")
 	err = logger.Sync()
@@ -58,7 +59,7 @@ func TestETWAppenderLifecycle(t *testing.T) {
 
 	test.That(t, a.Close(), test.ShouldBeNil)
 
-	// Write after close: provider is unregistered, pkg/etw's WriteEvent checks
-	// provider.enabled and no-ops. Must not panic.
+	// Write after close: there's no active session, so the provider is disabled
+	// Must not panic.
 	logger.Info("after close")
 }


### PR DESCRIPTION
Fix for CI failure: https://github.com/viamrobotics/rdk/actions/runs/27287348888/job/80598208096

```
2026-06-10T15:41:09.5634785Z panic: runtime error: invalid memory address or nil pointer dereference
2026-06-10T15:41:09.5635127Z [signal 0xc0000005 code=0x1 addr=0x40 pc=0x7ff7ee2a0f44]
2026-06-10T15:41:09.5635307Z
2026-06-10T15:41:09.5635396Z goroutine 17 [running, locked to thread]:
2026-06-10T15:41:09.5635947Z github.com/Microsoft/go-winio/pkg/etw.providerCallback({0x0, 0x0, 0x0, {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...}}, ...)
2026-06-10T15:41:09.5636595Z 	C:/Users/runneradmin/go/pkg/mod/github.com/!microsoft/go-winio@v0.6.2/pkg/etw/provider.go:84 +0x44
2026-06-10T15:41:09.5637136Z github.com/Microsoft/go-winio/pkg/etw.providerCallbackAdapter(0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
2026-06-10T15:41:09.5637800Z 	C:/Users/runneradmin/go/pkg/mod/github.com/!microsoft/go-winio@v0.6.2/pkg/etw/wrapper_64.go:57 +0x36
```

### Background

ETW logging operates with a provider / session model, where a provider is like a publisher and a session is like a subscriber in a pub/sub model.

viam-server now calls out to `logman` to start a logging session when it opens, and to kill that session before it exits. Provider registration is handled by the `go-winio` library.

There is a bug in the `go-winio` library that can lead to a nil pointer dereference when attempting to close a log provider if a logging session remains active after the provider is closed. This scenario shouldn't even be reached in prod because
- providers are killed by Windows when the process that owns them exits
- viam-server kills its own session when it exits
- viam-server explicitly kills its provider AFTER killing the session, before exiting (ensuring that no sessions should be active when closing a provider)
- when viam-server starts, it checks for existing sessions and kills them before trying to start its own

In CI, multiple logging providers are being created in parallel all with the same name and ID. Multiple loggers are also trying to create logging sessions with the same name, so if test A and test B start in sequence and each test starts a logging provider and a logging session, the session from test B can be active while the provider from test A is being closed.

None of this would be a problem, though, if not for the bug PLUS a quirk of how providers and sessions interact. When a session closes, it sends a notification to all active providers informing them of the state change. This notification is caught by a callback in `go-winio`, and that callback assumes that the provider is non-nil:

```go
func providerCallback(...) {
	provider := providers.getProvider(uint(i)) // returns nil if the provider has already been killed

	switch state {
	case ProviderStateCaptureState:
	case ProviderStateDisable:
		provider.enabled = false // causes nil pointer rereference
	case ProviderStateEnable:
		provider.enabled = true
		provider.level = level
		provider.keywordAny = matchAnyKeyword
		provider.keywordAll = matchAllKeyword
	}

        // nil check happens too late
	if provider.callback != nil {
		provider.callback(sourceID, state, level, matchAnyKeyword, matchAllKeyword, filterData)
	}
}
```
[permalink to `go-winio` code](https://github.com/microsoft/go-winio/blob/3c9576c9346a1892dee136329e7e15309e82fb4f/pkg/etw/provider.go#L84)

So if the callback fires after the provider has already been closed (which makes it `nil`), then we get the nil pointer panic at runtime.

### Fix

The fix (suggested by Claude) seems to be to just never explicitly call `provider.Close`. Windows already unregisters providers on its own, and if we never call `provider.Close` then the provider will never be `nil` when the callback fires.

So this branch just removes the calls to `provider.Close` and also changes the tests a little bit so they don't unnecessarily leak sessions.