### PR TITLE
ci: trust viamrobotics/brews tap before installing formulas

### DIFF
--- a/.github/workflows/staticbuild-build.yml
+++ b/.github/workflows/staticbuild-build.yml
@@ -228,6 +228,7 @@ jobs:
       run: |
         brew update
         brew tap viamrobotics/brews
+        brew trust viamrobotics/brews
         brew install nlopt-static
         brew install x264
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -410,6 +410,7 @@ jobs:
       run: |
         brew update
         brew tap viamrobotics/brews
+        brew trust viamrobotics/brews
         brew install nlopt-static
         brew install x264
         # While it's not a requirement to actually run the viam-server binary, ffmpeg is


### PR DESCRIPTION
Newer Homebrew refuses to install formulas from untrusted third-party taps, breaking the macOS dependency install with:

  Error: Refusing to load formula viamrobotics/brews/nlopt-static from
  untrusted tap viamrobotics/brews.

Run brew trust after tapping so nlopt-static installs again.