### PR TITLE
App 16856: Implement UploadDataFromPath using builtin data manager logic

### DIFF
--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -3262,7 +3262,7 @@ func TestUploadDataFromPath(t *testing.T) {
 		test.That(t, err.Error(), test.ShouldContainSubstring, "no data manager")
 	})
 
-	t.Run("data manager does not support upload", func(t *testing.T) {
+	t.Run("data manager configured but not connected to cloud", func(t *testing.T) {
 		cfg := &config.Config{
 			Services: []resource.Config{
 				{
@@ -3277,7 +3277,7 @@ func TestUploadDataFromPath(t *testing.T) {
 		r := setupLocalRobot(t, ctx, cfg, logger)
 		_, _, _, _, _, err := r.UploadDataFromPath(ctx, "/tmp/whatever", nil)
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "does not support")
+		test.That(t, err.Error(), test.ShouldContainSubstring, "not connected to the cloud")
 	})
 }
 

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -483,6 +483,17 @@ func (b *builtIn) UploadImageToDatasets(ctx context.Context,
 	return b.sync.UploadBinaryDataToDatasets(ctx, imgBytes, datasetIDs, tags, mimeType)
 }
 
+// UploadDataFromPath uploads a file or directory from the robot to the cloud.
+func (b *builtIn) UploadDataFromPath(ctx context.Context, path string, uploadMetadata *v1.UploadMetadata) (
+	uint64, uint64, uint64, uint64, []string, error,
+) {
+	b.logger.Debug("UploadDataFromPath START")
+	defer b.logger.Debug("UploadDataFromPath END")
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.sync.UploadDataFromPath(ctx, path, uploadMetadata)
+}
+
 type dataManagerStats struct {
 	SyncPaths               syncPathsSummary
 	DiskUsage               diskUsageSummary

--- a/services/datamanager/builtin/sync/sync.go
+++ b/services/datamanager/builtin/sync/sync.go
@@ -534,15 +534,17 @@ func (s *Sync) syncDataCaptureFile(ctx context.Context, f *os.File, captureDir s
 func (s *Sync) syncArbitraryFile(
 	ctx context.Context, f *os.File, tags, datasetIDs []string, fileLastModifiedMillis int,
 	logger logging.Logger, bytesUploadingCounter *atomic.Uint64,
-) error {
+) (string, error) {
+	var uploadedID string
 	retry := newExponentialRetry(ctx, s.clock, s.logger, f.Name(), func(ctx context.Context) (uint64, error) {
 		errMetadata := fmt.Sprintf("error uploading arbitrary file %s", f.Name())
-		bytesUploaded, err := uploadArbitraryFile(
+		bytesUploaded, id, err := uploadArbitraryFile(
 			ctx, f, s.cloudConn, tags, datasetIDs, fileLastModifiedMillis, s.clock, logger, bytesUploadingCounter,
 		)
 		if err != nil {
 			return 0, errors.Wrap(err, errMetadata)
 		}
+		uploadedID = id
 		logger.Debugf("uploadArbitraryFile uploaded: %d bytes", bytesUploaded)
 		return bytesUploaded, nil
 	})
@@ -556,7 +558,7 @@ func (s *Sync) syncArbitraryFile(
 		// if we stopped due to a cancelled context,
 		// return without deleting the file or moving it to the failed directory
 		if errors.Is(err, context.Canceled) {
-			return err
+			return "", err
 		}
 
 		// otherwise we hit a terminal error, and we should move the file to the failed directory
@@ -564,7 +566,7 @@ func (s *Sync) syncArbitraryFile(
 			logger.Error(err.Error())
 		}
 		s.uploadStats.arbitrary.uploadFailedFileCount.Add(1)
-		return err
+		return "", err
 	}
 
 	if err := f.Close(); err != nil {
@@ -576,7 +578,7 @@ func (s *Sync) syncArbitraryFile(
 	}
 	s.uploadStats.arbitrary.uploadedFileCount.Add(1)
 	s.uploadStats.arbitrary.completedUploadBytes.Add(bytesUploaded)
-	return nil
+	return uploadedID, nil
 }
 
 // UploadBinaryDataToDatasets simultaneously uploads binary data and adds it to a dataset.
@@ -663,11 +665,14 @@ func (s *Sync) UploadDataFromPath(ctx context.Context, path string, uploadMetada
 				bytesUploaded += uint64(fi.Size())
 			}
 		} else {
-			if syncErr := s.syncArbitraryFile(ctx, f, tags, datasetIDs, 0, s.logger, nil); syncErr != nil {
+			if id, syncErr := s.syncArbitraryFile(ctx, f, tags, datasetIDs, 0, s.logger, nil); syncErr != nil {
 				filesFailed++
 			} else {
 				filesUploaded++
 				bytesUploaded += uint64(fi.Size())
+				if id != "" {
+					ids = append(ids, id)
+				}
 			}
 		}
 	}

--- a/services/datamanager/builtin/sync/sync.go
+++ b/services/datamanager/builtin/sync/sync.go
@@ -447,7 +447,7 @@ func (s *Sync) syncFile(config Config, filePath string) {
 	}
 
 	if data.IsDataCaptureFile(f) {
-		s.syncDataCaptureFile(s.configCtx, f, config.CaptureDir, s.logger) //nolint:errcheck
+		s.syncDataCaptureFile(f, config.CaptureDir, s.logger)
 	} else {
 		//nolint:errcheck
 		s.syncArbitraryFile(s.configCtx, f, config.Tags, []string{}, config.FileLastModifiedMillis, s.logger,
@@ -455,7 +455,7 @@ func (s *Sync) syncFile(config Config, filePath string) {
 	}
 }
 
-func (s *Sync) syncDataCaptureFile(ctx context.Context, f *os.File, captureDir string, logger logging.Logger) error {
+func (s *Sync) syncDataCaptureFile(f *os.File, captureDir string, logger logging.Logger) {
 	captureFile, err := data.ReadCaptureFile(f)
 	// if you can't read the capture file's metadata field, close & move it to the failed directory
 	if err != nil {
@@ -469,7 +469,7 @@ func (s *Sync) syncDataCaptureFile(ctx context.Context, f *os.File, captureDir s
 			s.logger.Error(err)
 		}
 		s.uploadStats.tabular.uploadFailedFileCount.Add(1)
-		return cause
+		return
 	}
 	isBinary := captureFile.ReadMetadata().GetType() == v1.DataType_DATA_TYPE_BINARY_SENSOR
 
@@ -481,7 +481,7 @@ func (s *Sync) syncDataCaptureFile(ctx context.Context, f *os.File, captureDir s
 	}
 
 	// setup a retry struct that will try to upload the capture file
-	retry := newExponentialRetry(ctx, s.clock, s.logger, f.Name(), func(ctx context.Context) (uint64, error) {
+	retry := newExponentialRetry(s.configCtx, s.clock, s.logger, f.Name(), func(ctx context.Context) (uint64, error) {
 		msg := "error uploading data capture file %s, size: %s, md: %s"
 		errMetadata := fmt.Sprintf(msg, captureFile.GetPath(), data.FormatBytesI64(captureFile.Size()), captureFile.ReadMetadata())
 		bytesUploaded, err := uploadDataCaptureFile(ctx, captureFile, s.cloudConn, logger, uploadingBytesCounter)
@@ -502,7 +502,7 @@ func (s *Sync) syncDataCaptureFile(ctx context.Context, f *os.File, captureDir s
 		// if we stopped due to a cancelled context,
 		// return without deleting the file or moving it to the failed directory
 		if errors.Is(err, context.Canceled) {
-			return err
+			return
 		}
 
 		// otherwise we hit a terminal error, and we should move the file to the failed directory
@@ -514,7 +514,7 @@ func (s *Sync) syncDataCaptureFile(ctx context.Context, f *os.File, captureDir s
 		} else {
 			s.uploadStats.tabular.uploadFailedFileCount.Add(1)
 		}
-		return err
+		return
 	}
 
 	// file was successfully uploaded, delete it and log an error if unable to delete
@@ -528,7 +528,6 @@ func (s *Sync) syncDataCaptureFile(ctx context.Context, f *os.File, captureDir s
 		s.uploadStats.tabular.uploadedFileCount.Add(1)
 		s.uploadStats.tabular.completedUploadBytes.Add(bytesUploaded)
 	}
-	return nil
 }
 
 func (s *Sync) syncArbitraryFile(
@@ -635,10 +634,6 @@ func (s *Sync) UploadDataFromPath(ctx context.Context, path string, uploadMetada
 		return 0, 0, 0, 0, nil, err
 	}
 
-	s.configMu.Lock()
-	captureDir := s.config.CaptureDir
-	s.configMu.Unlock()
-
 	tags := uploadMetadata.GetTags()
 	datasetIDs := uploadMetadata.GetDatasetIds()
 
@@ -657,22 +652,13 @@ func (s *Sync) UploadDataFromPath(ctx context.Context, path string, uploadMetada
 			return
 		}
 
-		if data.IsDataCaptureFile(f) {
-			if syncErr := s.syncDataCaptureFile(ctx, f, captureDir, s.logger); syncErr != nil {
-				filesFailed++
-			} else {
-				filesUploaded++
-				bytesUploaded += uint64(fi.Size())
-			}
+		if id, syncErr := s.syncArbitraryFile(ctx, f, tags, datasetIDs, 0, s.logger, nil); syncErr != nil {
+			filesFailed++
 		} else {
-			if id, syncErr := s.syncArbitraryFile(ctx, f, tags, datasetIDs, 0, s.logger, nil); syncErr != nil {
-				filesFailed++
-			} else {
-				filesUploaded++
-				bytesUploaded += uint64(fi.Size())
-				if id != "" {
-					ids = append(ids, id)
-				}
+			filesUploaded++
+			bytesUploaded += uint64(fi.Size())
+			if id != "" {
+				ids = append(ids, id)
 			}
 		}
 	}

--- a/services/datamanager/builtin/sync/sync.go
+++ b/services/datamanager/builtin/sync/sync.go
@@ -447,13 +447,15 @@ func (s *Sync) syncFile(config Config, filePath string) {
 	}
 
 	if data.IsDataCaptureFile(f) {
-		s.syncDataCaptureFile(f, config.CaptureDir, s.logger)
+		s.syncDataCaptureFile(s.configCtx, f, config.CaptureDir, s.logger) //nolint:errcheck
 	} else {
-		s.syncArbitraryFile(f, config.Tags, []string{}, config.FileLastModifiedMillis, s.logger)
+		//nolint:errcheck
+		s.syncArbitraryFile(s.configCtx, f, config.Tags, []string{}, config.FileLastModifiedMillis, s.logger,
+			&s.uploadStats.arbitrary.uploadingBytes)
 	}
 }
 
-func (s *Sync) syncDataCaptureFile(f *os.File, captureDir string, logger logging.Logger) {
+func (s *Sync) syncDataCaptureFile(ctx context.Context, f *os.File, captureDir string, logger logging.Logger) error {
 	captureFile, err := data.ReadCaptureFile(f)
 	// if you can't read the capture file's metadata field, close & move it to the failed directory
 	if err != nil {
@@ -467,7 +469,7 @@ func (s *Sync) syncDataCaptureFile(f *os.File, captureDir string, logger logging
 			s.logger.Error(err)
 		}
 		s.uploadStats.tabular.uploadFailedFileCount.Add(1)
-		return
+		return cause
 	}
 	isBinary := captureFile.ReadMetadata().GetType() == v1.DataType_DATA_TYPE_BINARY_SENSOR
 
@@ -479,7 +481,7 @@ func (s *Sync) syncDataCaptureFile(f *os.File, captureDir string, logger logging
 	}
 
 	// setup a retry struct that will try to upload the capture file
-	retry := newExponentialRetry(s.configCtx, s.clock, s.logger, f.Name(), func(ctx context.Context) (uint64, error) {
+	retry := newExponentialRetry(ctx, s.clock, s.logger, f.Name(), func(ctx context.Context) (uint64, error) {
 		msg := "error uploading data capture file %s, size: %s, md: %s"
 		errMetadata := fmt.Sprintf(msg, captureFile.GetPath(), data.FormatBytesI64(captureFile.Size()), captureFile.ReadMetadata())
 		bytesUploaded, err := uploadDataCaptureFile(ctx, captureFile, s.cloudConn, logger, uploadingBytesCounter)
@@ -500,7 +502,7 @@ func (s *Sync) syncDataCaptureFile(f *os.File, captureDir string, logger logging
 		// if we stopped due to a cancelled context,
 		// return without deleting the file or moving it to the failed directory
 		if errors.Is(err, context.Canceled) {
-			return
+			return err
 		}
 
 		// otherwise we hit a terminal error, and we should move the file to the failed directory
@@ -512,7 +514,7 @@ func (s *Sync) syncDataCaptureFile(f *os.File, captureDir string, logger logging
 		} else {
 			s.uploadStats.tabular.uploadFailedFileCount.Add(1)
 		}
-		return
+		return err
 	}
 
 	// file was successfully uploaded, delete it and log an error if unable to delete
@@ -526,13 +528,17 @@ func (s *Sync) syncDataCaptureFile(f *os.File, captureDir string, logger logging
 		s.uploadStats.tabular.uploadedFileCount.Add(1)
 		s.uploadStats.tabular.completedUploadBytes.Add(bytesUploaded)
 	}
+	return nil
 }
 
-func (s *Sync) syncArbitraryFile(f *os.File, tags, datasetIDs []string, fileLastModifiedMillis int, logger logging.Logger) {
-	retry := newExponentialRetry(s.configCtx, s.clock, s.logger, f.Name(), func(ctx context.Context) (uint64, error) {
+func (s *Sync) syncArbitraryFile(
+	ctx context.Context, f *os.File, tags, datasetIDs []string, fileLastModifiedMillis int,
+	logger logging.Logger, bytesUploadingCounter *atomic.Uint64,
+) error {
+	retry := newExponentialRetry(ctx, s.clock, s.logger, f.Name(), func(ctx context.Context) (uint64, error) {
 		errMetadata := fmt.Sprintf("error uploading arbitrary file %s", f.Name())
 		bytesUploaded, err := uploadArbitraryFile(
-			ctx, f, s.cloudConn, tags, datasetIDs, fileLastModifiedMillis, s.clock, logger, &s.uploadStats.arbitrary.uploadingBytes,
+			ctx, f, s.cloudConn, tags, datasetIDs, fileLastModifiedMillis, s.clock, logger, bytesUploadingCounter,
 		)
 		if err != nil {
 			return 0, errors.Wrap(err, errMetadata)
@@ -550,7 +556,7 @@ func (s *Sync) syncArbitraryFile(f *os.File, tags, datasetIDs []string, fileLast
 		// if we stopped due to a cancelled context,
 		// return without deleting the file or moving it to the failed directory
 		if errors.Is(err, context.Canceled) {
-			return
+			return err
 		}
 
 		// otherwise we hit a terminal error, and we should move the file to the failed directory
@@ -558,7 +564,7 @@ func (s *Sync) syncArbitraryFile(f *os.File, tags, datasetIDs []string, fileLast
 			logger.Error(err.Error())
 		}
 		s.uploadStats.arbitrary.uploadFailedFileCount.Add(1)
-		return
+		return err
 	}
 
 	if err := f.Close(); err != nil {
@@ -570,6 +576,7 @@ func (s *Sync) syncArbitraryFile(f *os.File, tags, datasetIDs []string, fileLast
 	}
 	s.uploadStats.arbitrary.uploadedFileCount.Add(1)
 	s.uploadStats.arbitrary.completedUploadBytes.Add(bytesUploaded)
+	return nil
 }
 
 // UploadBinaryDataToDatasets simultaneously uploads binary data and adds it to a dataset.
@@ -603,10 +610,82 @@ func (s *Sync) UploadBinaryDataToDatasets(ctx context.Context, binaryData []byte
 		}
 		// Since we wrote to the file, the file last modified time should be 0, indicating we should wait no time
 		// before deciding this file is ready for upload and is not still being written to.
-		s.syncArbitraryFile(f, tags, datasetIDs, 0, s.logger)
+		s.syncArbitraryFile(ctx, f, tags, datasetIDs, 0, s.logger, &s.uploadStats.arbitrary.uploadingBytes) //nolint:errcheck
 	}()
 
 	return <-errChan
+}
+
+// UploadDataFromPath uploads a file or all files in a directory at path to the cloud.
+// For directories, every file is attempted and per-file errors are counted; the call
+// returns aggregate counts of files and bytes uploaded/failed.
+func (s *Sync) UploadDataFromPath(ctx context.Context, path string, uploadMetadata *v1.UploadMetadata) (
+	filesUploaded, filesFailed, bytesUploaded, bytesTotal uint64, ids []string, err error,
+) {
+	select {
+	case <-s.cloudConn.ready:
+	default:
+		return 0, 0, 0, 0, nil, errors.New("not connected to the cloud")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, 0, 0, 0, nil, err
+	}
+
+	s.configMu.Lock()
+	captureDir := s.config.CaptureDir
+	s.configMu.Unlock()
+
+	tags := uploadMetadata.GetTags()
+	datasetIDs := uploadMetadata.GetDatasetIds()
+
+	uploadOne := func(filePath string) {
+		fi, statErr := os.Stat(filePath)
+		if statErr != nil {
+			filesFailed++
+			return
+		}
+		bytesTotal += uint64(fi.Size())
+
+		//nolint:gosec
+		f, openErr := os.Open(filePath)
+		if openErr != nil {
+			filesFailed++
+			return
+		}
+
+		if data.IsDataCaptureFile(f) {
+			if syncErr := s.syncDataCaptureFile(ctx, f, captureDir, s.logger); syncErr != nil {
+				filesFailed++
+			} else {
+				filesUploaded++
+				bytesUploaded += uint64(fi.Size())
+			}
+		} else {
+			if syncErr := s.syncArbitraryFile(ctx, f, tags, datasetIDs, 0, s.logger, nil); syncErr != nil {
+				filesFailed++
+			} else {
+				filesUploaded++
+				bytesUploaded += uint64(fi.Size())
+			}
+		}
+	}
+
+	if info.IsDir() {
+		//nolint:errcheck
+		filepath.Walk(path, func(filePath string, fi os.FileInfo, walkErr error) error {
+			if walkErr != nil || fi.IsDir() {
+				return nil //nolint:nilerr
+			}
+			uploadOne(filePath)
+			return ctx.Err()
+		})
+	} else {
+		uploadOne(path)
+	}
+
+	return filesUploaded, filesFailed, bytesUploaded, bytesTotal, ids, nil
 }
 
 // moveFailedData takes any data that could not be synced in the parentDir and

--- a/services/datamanager/builtin/sync/upload_arbitrary_file.go
+++ b/services/datamanager/builtin/sync/upload_arbitrary_file.go
@@ -41,11 +41,11 @@ func uploadArbitraryFile(
 	clock clock.Clock,
 	logger logging.Logger,
 	bytesUploadingCounter *atomic.Uint64,
-) (uint64, error) {
+) (uint64, string, error) {
 	logger.Debugf("attempting to sync arbitrary file: %s", f.Name())
 	path, err := filepath.Abs(f.Name())
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get absolute path")
+		return 0, "", errors.Wrap(err, "failed to get absolute path")
 	}
 
 	// Only sync non-datacapture files that have not been modified in the last
@@ -53,15 +53,15 @@ func uploadArbitraryFile(
 	// to written to.
 	info, err := os.Stat(path)
 	if err != nil {
-		return 0, errors.Wrap(err, "stat failed")
+		return 0, "", errors.Wrap(err, "stat failed")
 	}
 	if info.Size() == 0 {
-		return 0, errFileEmpty
+		return 0, "", errFileEmpty
 	}
 
 	timeSinceMod := clock.Since(info.ModTime())
 	if timeSinceMod < time.Duration(fileLastModifiedMillis)*time.Millisecond {
-		return 0, errFileModifiedTooRecently
+		return 0, "", errFileModifiedTooRecently
 	}
 
 	// We need to seek to the start of the file as if we have tried to upload this file
@@ -70,23 +70,23 @@ func uploadArbitraryFile(
 	// Fixes https://viam.atlassian.net/browse/DATA-3114
 	pos, err := f.Seek(0, io.SeekStart)
 	if err != nil {
-		return 0, errors.Wrap(err, "error trying to Seek to beginning of file")
+		return 0, "", errors.Wrap(err, "error trying to Seek to beginning of file")
 	}
 
 	if pos != 0 {
-		return 0, fmt.Errorf("error trying to seek to beginning of file %s: expected position 0, instead got to position %d", path, pos)
+		return 0, "", fmt.Errorf("error trying to seek to beginning of file %s: expected position 0, instead got to position %d", path, pos)
 	}
 
 	// Get file timestamps
 	fileTimes, err := utils.GetFileTimes(path)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get file times")
+		return 0, "", errors.Wrap(err, "failed to get file times")
 	}
 
 	logger.Debugf("datasync.FileUpload request started for arbitrary file: %s", path)
 	stream, err := conn.client.FileUpload(ctx)
 	if err != nil {
-		return 0, errors.Wrap(err, "error creating FileUpload client")
+		return 0, "", errors.Wrap(err, "error creating FileUpload client")
 	}
 
 	// Try to infer tags and dataset IDs from the filename query parameters.
@@ -123,18 +123,19 @@ func uploadArbitraryFile(
 			},
 		},
 	}); err != nil {
-		return 0, errors.Wrap(err, "FileUpload failed sending metadata")
+		return 0, "", errors.Wrap(err, "FileUpload failed sending metadata")
 	}
 
 	if err := sendFileUploadRequests(ctx, stream, f, path, logger, bytesUploadingCounter); err != nil {
-		return 0, errors.Wrap(err, "FileUpload failed to sync")
+		return 0, "", errors.Wrap(err, "FileUpload failed to sync")
 	}
 
 	logger.Debugf("datasync.FileUpload closing for arbitrary file: %s", path)
-	if _, err = stream.CloseAndRecv(); err != nil {
-		return 0, errors.Wrap(err, "FileUpload  CloseAndRecv failed")
+	resp, err := stream.CloseAndRecv()
+	if err != nil {
+		return 0, "", errors.Wrap(err, "FileUpload  CloseAndRecv failed")
 	}
-	return uint64(info.Size()), nil
+	return uint64(info.Size()), resp.GetBinaryDataId(), nil
 }
 
 func sendFileUploadRequests(

--- a/services/datamanager/builtin/sync/upload_data_from_path_test.go
+++ b/services/datamanager/builtin/sync/upload_data_from_path_test.go
@@ -1,0 +1,117 @@
+package sync
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/benbjohnson/clock"
+	v1 "go.viam.com/api/app/datasync/v1"
+	"go.viam.com/test"
+	"google.golang.org/grpc"
+
+	"go.viam.com/rdk/logging"
+)
+
+// newTestSync builds a Sync wired to a mock cloud client. If connected is true the
+// cloud connection is marked ready. It is torn down via t.Cleanup.
+func newTestSync(t *testing.T, client v1.DataSyncServiceClient, captureDir string, connected bool) *Sync {
+	t.Helper()
+	s := New(
+		func(grpc.ClientConnInterface) v1.DataSyncServiceClient { return client },
+		func() {}, // flushCollectors no-op
+		clock.New(),
+		logging.NewTestLogger(t),
+	)
+	s.config = Config{CaptureDir: captureDir}
+	s.cloudConn.partID = "my-part-id"
+	s.cloudConn.client = client
+	if connected {
+		close(s.cloudConn.ready)
+	}
+	t.Cleanup(s.Close)
+	return s
+}
+
+func writeTestFile(t *testing.T, dir, name string, contents []byte) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	test.That(t, os.WriteFile(p, contents, 0o600), test.ShouldBeNil)
+	return p
+}
+
+func TestUploadDataFromPath(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("not connected to the cloud", func(t *testing.T) {
+		dir := t.TempDir()
+		s := newTestSync(t, NoOpCloudClientConstructor(nil), dir, false)
+		_, _, _, _, _, err := s.UploadDataFromPath(ctx, writeTestFile(t, dir, "f.txt", []byte("hi")), nil)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "not connected to the cloud")
+	})
+
+	t.Run("single file", func(t *testing.T) {
+		dir := t.TempDir()
+		s := newTestSync(t, NoOpCloudClientConstructor(nil), dir, true)
+		contents := []byte("hello world")
+		fp := writeTestFile(t, dir, "f.txt", contents)
+
+		fu, ff, bu, bt, ids, err := s.UploadDataFromPath(ctx, fp, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, fu, test.ShouldEqual, uint64(1))
+		test.That(t, ff, test.ShouldEqual, uint64(0))
+		test.That(t, bu, test.ShouldEqual, uint64(len(contents)))
+		test.That(t, bt, test.ShouldEqual, uint64(len(contents)))
+		test.That(t, ids, test.ShouldBeEmpty)
+
+		// arbitrary files are deleted after a successful upload
+		_, statErr := os.Stat(fp)
+		test.That(t, os.IsNotExist(statErr), test.ShouldBeTrue)
+	})
+
+	t.Run("directory of files", func(t *testing.T) {
+		dir := t.TempDir()
+		s := newTestSync(t, NoOpCloudClientConstructor(nil), dir, true)
+		uploadDir := filepath.Join(dir, "uploads")
+		test.That(t, os.MkdirAll(uploadDir, 0o700), test.ShouldBeNil)
+		a, b, c := []byte("aaa"), []byte("bbbb"), []byte("ccccc")
+		writeTestFile(t, uploadDir, "a.txt", a)
+		writeTestFile(t, uploadDir, "b.txt", b)
+		writeTestFile(t, uploadDir, "c.txt", c)
+
+		fu, ff, bu, bt, _, err := s.UploadDataFromPath(ctx, uploadDir, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, fu, test.ShouldEqual, uint64(3))
+		test.That(t, ff, test.ShouldEqual, uint64(0))
+		total := uint64(len(a) + len(b) + len(c))
+		test.That(t, bu, test.ShouldEqual, total)
+		test.That(t, bt, test.ShouldEqual, total)
+	})
+
+	t.Run("directory with a partial failure", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("chmod-based unreadable file does not fail for root")
+		}
+		dir := t.TempDir()
+		s := newTestSync(t, NoOpCloudClientConstructor(nil), dir, true)
+		uploadDir := filepath.Join(dir, "uploads")
+		test.That(t, os.MkdirAll(uploadDir, 0o700), test.ShouldBeNil)
+
+		good := []byte("good")
+		bad := []byte("bad!")
+		writeTestFile(t, uploadDir, "good.txt", good)
+		badPath := writeTestFile(t, uploadDir, "bad.txt", bad)
+		// make bad.txt unreadable so os.Open fails (os.Stat still succeeds)
+		test.That(t, os.Chmod(badPath, 0o000), test.ShouldBeNil)
+		t.Cleanup(func() { os.Chmod(badPath, 0o600) })
+
+		fu, ff, bu, bt, _, err := s.UploadDataFromPath(ctx, uploadDir, nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, fu, test.ShouldEqual, uint64(1))
+		test.That(t, ff, test.ShouldEqual, uint64(1))
+		test.That(t, bu, test.ShouldEqual, uint64(len(good)))          // only the good file uploaded
+		test.That(t, bt, test.ShouldEqual, uint64(len(good)+len(bad))) // both discovered
+	})
+}

--- a/services/datamanager/builtin/sync/upload_data_from_path_test.go
+++ b/services/datamanager/builtin/sync/upload_data_from_path_test.go
@@ -41,6 +41,20 @@ func writeTestFile(t *testing.T, dir, name string, contents []byte) string {
 	return p
 }
 
+func fileUploadClientReturningID(t *testing.T, id string) MockDataSyncServiceClient {
+	t.Helper()
+	return MockDataSyncServiceClient{
+		T: t,
+		FileUploadFunc: func(ctx context.Context, opts ...grpc.CallOption) (v1.DataSyncService_FileUploadClient, error) {
+			return &ClientStreamingMock[*v1.FileUploadRequest, *v1.FileUploadResponse]{
+				T:                t,
+				SendFunc:         func(*v1.FileUploadRequest) error { return nil },
+				CloseAndRecvFunc: func() (*v1.FileUploadResponse, error) { return &v1.FileUploadResponse{BinaryDataId: id}, nil },
+			}, nil
+		},
+	}
+}
+
 func TestUploadDataFromPath(t *testing.T) {
 	ctx := context.Background()
 
@@ -54,7 +68,7 @@ func TestUploadDataFromPath(t *testing.T) {
 
 	t.Run("single file", func(t *testing.T) {
 		dir := t.TempDir()
-		s := newTestSync(t, NoOpCloudClientConstructor(nil), dir, true)
+		s := newTestSync(t, fileUploadClientReturningID(t, "bin-1"), dir, true)
 		contents := []byte("hello world")
 		fp := writeTestFile(t, dir, "f.txt", contents)
 
@@ -64,7 +78,7 @@ func TestUploadDataFromPath(t *testing.T) {
 		test.That(t, ff, test.ShouldEqual, uint64(0))
 		test.That(t, bu, test.ShouldEqual, uint64(len(contents)))
 		test.That(t, bt, test.ShouldEqual, uint64(len(contents)))
-		test.That(t, ids, test.ShouldBeEmpty)
+		test.That(t, ids, test.ShouldResemble, []string{"bin-1"})
 
 		// arbitrary files are deleted after a successful upload
 		_, statErr := os.Stat(fp)
@@ -73,7 +87,7 @@ func TestUploadDataFromPath(t *testing.T) {
 
 	t.Run("directory of files", func(t *testing.T) {
 		dir := t.TempDir()
-		s := newTestSync(t, NoOpCloudClientConstructor(nil), dir, true)
+		s := newTestSync(t, fileUploadClientReturningID(t, "bin-1"), dir, true)
 		uploadDir := filepath.Join(dir, "uploads")
 		test.That(t, os.MkdirAll(uploadDir, 0o700), test.ShouldBeNil)
 		a, b, c := []byte("aaa"), []byte("bbbb"), []byte("ccccc")
@@ -81,13 +95,14 @@ func TestUploadDataFromPath(t *testing.T) {
 		writeTestFile(t, uploadDir, "b.txt", b)
 		writeTestFile(t, uploadDir, "c.txt", c)
 
-		fu, ff, bu, bt, _, err := s.UploadDataFromPath(ctx, uploadDir, nil)
+		fu, ff, bu, bt, ids, err := s.UploadDataFromPath(ctx, uploadDir, nil)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, fu, test.ShouldEqual, uint64(3))
 		test.That(t, ff, test.ShouldEqual, uint64(0))
 		total := uint64(len(a) + len(b) + len(c))
 		test.That(t, bu, test.ShouldEqual, total)
 		test.That(t, bt, test.ShouldEqual, total)
+		test.That(t, len(ids), test.ShouldEqual, 3)
 	})
 
 	t.Run("directory with a partial failure", func(t *testing.T) {


### PR DESCRIPTION
[Jira Ticket 16856: Implement UploadDataFromPath using builtin data manager logic](https://viam.atlassian.net/browse/APP-16856)

**Summary**
This implements the core logic behind the UploadDataFromPath API. The previous ticket (wiring PR — base of this branch) plumbed the RPC through RobotService → localRobot → the data manager as a stub that returned "data manager does not support UploadDataFromPath." This PR makes the builtin data manager actually perform the upload: given a file or directory path, it uploads each file to the cloud, deletes the source on success, and returns aggregate counts plus the cloud-assigned binary data ids.
Per discussion, UploadDataFromPath is only expected to be used for arbitrary (3rd-party) files, so every file is uploaded via the existing arbitrary-file FileUpload path (no special-casing of data-capture files). If a .capture file is ever passed, it's uploaded as a plain file rather than parsed into the capture pipeline.
This depends on the api proto PR and is stacked on the wiring branch (base: APP-16855).

**Changes**

- services/datamanager/builtin/builtin.go: added the UploadDataFromPath method on the builtin service, which locks and delegates to the sync layer. This is the method the wiring ticket's interface assertion looks for, so the call now reaches the data manager instead of erroring.
- services/datamanager/builtin/sync/sync.go: implemented Sync.UploadDataFromPath. It guards on the cloud connection, os.Stats the path, and either walks a directory or handles a single file, uploading each via the arbitrary-file path and aggregating files_uploaded / files_failed / bytes_uploaded / bytes_total / ids. For directories, a dropped connection stops the walk mid-way, so partial success is reflected in the counts. Refactored syncArbitraryFile to take a context and return the uploaded file's id (and to accept a per-call byte counter so ad-hoc uploads don't pollute the scheduled-sync stats).
- services/datamanager/builtin/sync/upload_arbitrary_file.go: uploadArbitraryFile now returns the cloud-assigned BinaryDataId from the FileUploadResponse (previously discarded), which is what populates the ids field.
- services/datamanager/builtin/sync/upload_data_from_path_test.go: new unit tests — cloud-not-ready guard, single file, directory aggregation, partial failure, and id population.
- robot/impl/local_robot_test.go: updated the wiring ticket's guard test, which now expects "not connected to the cloud" (since the builtin implements the method).

**Testing**

Unit Tests:

- sync package (TestUploadDataFromPath): asserts the not-connected guard, a single file (counts/bytes/id correct and source deleted), a directory aggregating counts/bytes/ids, and a partial failure where bytes_total counts everything discovered while only successful files contribute to files_uploaded/bytes_uploaded. The mock cloud client returns a known BinaryDataId so id population is verified.
- Confirmed the existing builtin and sync tests still pass against the uploadArbitraryFile/syncArbitraryFile signature changes (go test ./services/datamanager/... ./robot/... -count=1).

Manual Testing: Built a local generic module whose DoCommand calls UploadDataFromPath via the Go SDK client, added it to a cloud machine alongside a builtin data manager, and ran viam-server from this branch. Tested two cases:

- Single file: uploading /tmp/uploadtest/a.txt returned {files_uploaded: 1, files_failed: 0, bytes_uploaded: 12, bytes_total: 12, ids: [<binary-data-id>]}. Confirmed the file appeared in the DATA tab with the applied tag, the returned id matched the binary data id shown in the app, and the source file was deleted after upload.
- Directory: uploading a directory of three files returned files_uploaded: 3, files_failed: 0, with bytes_uploaded == 42 and one id per file. Confirmed all three appeared in the DATA tab with the tag and all source files were deleted.