### PR TITLE
Surface viam update error from brew

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -4550,7 +4550,11 @@ func addToWindowsUserPATH(cmd *cli.Command, binaryDir string) error {
 	out, err := exec.Command("powershell", "-Command",
 		`[Environment]::GetEnvironmentVariable("Path", "User")`).Output()
 	if err != nil {
-		return errors.Errorf("failed to read user PATH: %v", err)
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return errors.Errorf("failed to read user PATH:\n%s", strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return errors.Wrap(err, "failed to read user PATH")
 	}
 	currentPath := strings.TrimSpace(string(out))
 
@@ -4569,11 +4573,14 @@ func addToWindowsUserPATH(cmd *cli.Command, binaryDir string) error {
 	newPath += cleanDir
 
 	//nolint:gosec
-	if err := exec.Command("powershell", "-Command",
+	setCmd := exec.Command("powershell", "-Command",
 		fmt.Sprintf(`[Environment]::SetEnvironmentVariable("Path", "%s", "User")`,
-			strings.ReplaceAll(newPath, `"`, `\"`)),
-	).Run(); err != nil {
-		return errors.Errorf("failed to update user PATH: %v", err)
+			strings.ReplaceAll(newPath, `"`, `\"`)))
+	if out, err := setCmd.CombinedOutput(); err != nil {
+		if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+			return errors.Errorf("failed to update user PATH:\n%s", trimmed)
+		}
+		return errors.Wrap(err, "failed to update user PATH")
 	}
 
 	infof(cmd.Root().Writer, "Added %s to your user PATH. Restart your terminal to use 'viam' from anywhere.", cleanDir)

--- a/cli/client.go
+++ b/cli/client.go
@@ -4418,7 +4418,11 @@ func isRunningBrewBinary() (bool, error) {
 	}
 	brewPrefixOut, err := exec.Command("brew", "--prefix", "viam").Output()
 	if err != nil {
-		return false, errors.Errorf("failed to get brew prefix for viam: %v", err)
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return false, errors.Errorf("failed to get brew prefix for viam:\n%s", strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return false, errors.Wrap(err, "failed to get brew prefix for viam")
 	}
 	brewBinary := filepath.Join(strings.TrimSpace(string(brewPrefixOut)), "bin", "viam")
 	resolvedBrewBinary, err := filepath.EvalSymlinks(brewBinary)
@@ -4433,7 +4437,10 @@ func isRunningBrewBinary() (bool, error) {
 func tryBrewUpgrade() (brewUpdateResult, error) {
 	out, err := exec.Command("brew", "upgrade", "viam").CombinedOutput()
 	if err != nil {
-		return brewUpdated, errors.Errorf("failed to upgrade CLI via brew: %v", err)
+		if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+			return brewUpdated, errors.Errorf("failed to upgrade CLI via brew:\n%s", trimmed)
+		}
+		return brewUpdated, errors.Wrap(err, "failed to upgrade CLI via brew")
 	}
 	if strings.Contains(string(out), "already installed") {
 		return brewNotAvailable, nil

--- a/cli/client.go
+++ b/cli/client.go
@@ -4550,11 +4550,7 @@ func addToWindowsUserPATH(cmd *cli.Command, binaryDir string) error {
 	out, err := exec.Command("powershell", "-Command",
 		`[Environment]::GetEnvironmentVariable("Path", "User")`).Output()
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
-			return errors.Errorf("failed to read user PATH:\n%s", strings.TrimSpace(string(exitErr.Stderr)))
-		}
-		return errors.Wrap(err, "failed to read user PATH")
+		return errors.Errorf("failed to read user PATH: %v", err)
 	}
 	currentPath := strings.TrimSpace(string(out))
 
@@ -4573,14 +4569,11 @@ func addToWindowsUserPATH(cmd *cli.Command, binaryDir string) error {
 	newPath += cleanDir
 
 	//nolint:gosec
-	setCmd := exec.Command("powershell", "-Command",
+	if err := exec.Command("powershell", "-Command",
 		fmt.Sprintf(`[Environment]::SetEnvironmentVariable("Path", "%s", "User")`,
-			strings.ReplaceAll(newPath, `"`, `\"`)))
-	if out, err := setCmd.CombinedOutput(); err != nil {
-		if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
-			return errors.Errorf("failed to update user PATH:\n%s", trimmed)
-		}
-		return errors.Wrap(err, "failed to update user PATH")
+			strings.ReplaceAll(newPath, `"`, `\"`)),
+	).Run(); err != nil {
+		return errors.Errorf("failed to update user PATH: %v", err)
 	}
 
 	infof(cmd.Root().Writer, "Added %s to your user PATH. Restart your terminal to use 'viam' from anywhere.", cleanDir)


### PR DESCRIPTION
When running into an error on viam update with brew, the error does not surface and users just see a useless "exit error 1"

Now, it looks like:
<img width="727" height="144" alt="Screenshot 2026-06-12 at 11 01 59 AM" src="https://github.com/user-attachments/assets/0c1fea3e-4545-4e7e-907c-f607af8508cc" />

