### PR TITLE
Surface PowerShell errors in `viam update` Windows PATH step

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -4543,7 +4543,12 @@ func addToWindowsUserPATH(cmd *cli.Command, binaryDir string) error {
 	out, err := exec.Command("powershell", "-Command",
 		`[Environment]::GetEnvironmentVariable("Path", "User")`).Output()
 	if err != nil {
-		return errors.Errorf("failed to read user PATH: %v", err)
+		// Surface PowerShell's stderr (stashed on the ExitError) instead of just "exit status 1".
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return errors.Errorf("failed to read user PATH:\n%s", strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return errors.Wrap(err, "failed to read user PATH")
 	}
 	currentPath := strings.TrimSpace(string(out))
 
@@ -4562,11 +4567,15 @@ func addToWindowsUserPATH(cmd *cli.Command, binaryDir string) error {
 	newPath += cleanDir
 
 	//nolint:gosec
-	if err := exec.Command("powershell", "-Command",
+	setCmd := exec.Command("powershell", "-Command",
 		fmt.Sprintf(`[Environment]::SetEnvironmentVariable("Path", "%s", "User")`,
-			strings.ReplaceAll(newPath, `"`, `\"`)),
-	).Run(); err != nil {
-		return errors.Errorf("failed to update user PATH: %v", err)
+			strings.ReplaceAll(newPath, `"`, `\"`)))
+	// CombinedOutput (not Run) so PowerShell's error is surfaced instead of just "exit status 1".
+	if out, err := setCmd.CombinedOutput(); err != nil {
+		if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+			return errors.Errorf("failed to update user PATH:\n%s", trimmed)
+		}
+		return errors.Wrap(err, "failed to update user PATH")
 	}
 
 	infof(cmd.Root().Writer, "Added %s to your user PATH. Restart your terminal to use 'viam' from anywhere.", cleanDir)


### PR DESCRIPTION
`addToWindowsUserPATH` (the Windows PATH step of `viam update`) reduced any PowerShell failure to `exit status 1`, hiding the real cause. This surfaces PowerShell's actual output:

- **read path** (`GetEnvironmentVariable`, `.Output()`): include `exitErr.Stderr`
- **write path** (`SetEnvironmentVariable`): switch `.Run()` → `.CombinedOutput()` so there is captured output to show

Same approach as the brew error-surfacing work. The structural swallow is verified, but this is a Windows-only path — **draft until validated on a Windows machine** (a PATH-write failure is rare to trigger naturally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)