### PR TITLE
RSDK-13737: add --viam-home-dir for downloading traces from machines with non-default VIAM_HOME

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -222,6 +222,13 @@ var commonOtlpFlags = []cli.Flag{
 	},
 }
 
+var commonPathFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:  "viam-home-dir",
+		Usage: "location of the target machine's VIAM_HOME directory",
+	},
+}
+
 // matches all uppercase characters that follow lowercase chars and aren't at the [0] index of a string.
 // This is useful for converting camel case into kabob case when getting values out of a CLI Context
 // based on a flag name, and putting them into a struct with a camel cased field name.
@@ -573,6 +580,7 @@ Note: There is no progress meter while copying is in progress.
 					Flags: lo.Flatten([][]cli.Flag{
 						commonOtlpFlags,
 						commonPartFlags,
+						commonPathFlags,
 					}),
 					Action: createActionCommandWithT(traceImportRemoteAction),
 				},
@@ -592,7 +600,10 @@ In order to use the print-remote command, the machine must have a valid shell ty
 Organization and location are required flags if using name (rather than ID) for the part.
 Note: There is no progress meter while copying is in progress.
 `,
-					Flags:  commonPartFlags,
+					Flags: lo.Flatten([][]cli.Flag{
+						commonPartFlags,
+						commonPathFlags,
+					}),
 					Action: createActionCommandWithT(tracePrintRemoteAction),
 				},
 				{
@@ -606,7 +617,10 @@ Organization and location are required flags if using name (rather than ID) for 
 If [target] is not specified then the traces file will be saved to the current working directory.
 Note: There is no progress meter while copying is in progress.
 `,
-					Flags:  commonPartFlags,
+					Flags: lo.Flatten([][]cli.Flag{
+						commonPartFlags,
+						commonPathFlags,
+					}),
 					Action: createActionCommandWithT(traceGetRemoteAction),
 				},
 			},

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1680,6 +1680,11 @@ func TestTunnelE2ECLI(t *testing.T) {
 		// Create a temporary config file.
 		tempConfigFile, err := os.CreateTemp(t.TempDir(), "temp_config.json")
 		test.That(t, err, test.ShouldBeNil)
+		// we only use the filename, not the file handle in this test. Close immediately, instead of relying on GC.
+		// On Windows we otherwise may get:
+		// "The process cannot access the file because it is being used by another process."
+		test.That(t, tempConfigFile.Close(), test.ShouldBeNil)
+
 		cfg := &robotconfig.Config{
 			Network: robotconfig.NetworkConfig{
 				NetworkConfigData: robotconfig.NetworkConfigData{

--- a/cli/traces.go
+++ b/cli/traces.go
@@ -23,9 +23,12 @@ import (
 )
 
 // traces are stored at VIAM_HOME/trace/[part-id]/traces
-var tracesRootDir = path.Join("~", ".viam")
-var tracesRelativePath = path.Join("trace")
-var defaultTracesPath = path.Join(tracesRootDir, tracesRelativePath)
+const tracesRelativePath = "trace"
+
+var (
+	tracesRootDir     = path.Join("~", ".viam")
+	defaultTracesPath = path.Join(tracesRootDir, tracesRelativePath)
+)
 
 type traceGetRemoteArgs struct {
 	Organization string

--- a/cli/traces.go
+++ b/cli/traces.go
@@ -22,13 +22,17 @@ import (
 	"go.viam.com/rdk/services/shell"
 )
 
-var tracesPath = path.Join("~", ".viam", "trace")
+// traces are stored at VIAM_HOME/trace/[part-id]/traces
+var tracesRootDir = path.Join("~", ".viam")
+var tracesRelativePath = path.Join("trace")
+var defaultTracesPath = path.Join(tracesRootDir, tracesRelativePath)
 
 type traceGetRemoteArgs struct {
 	Organization string
 	Location     string
 	Machine      string
 	Part         string
+	ViamHomeDir  string
 }
 
 type traceImportRemoteArgs struct {
@@ -100,7 +104,11 @@ func (c *viamClient) tracesGetRemoteAction(
 	// Intentional use of path instead of filepath: Windows understands both / and
 	// \ as path separators, and we don't want a cli running on Windows to send
 	// a path using \ to a *NIX machine.
-	src := path.Join(tracesPath, part.Id)
+	src := path.Join(defaultTracesPath, part.Id)
+	// if target part has a non-default VIAM_HOME, the caller can specify it.
+	if flagArgs.ViamHomeDir != "" {
+		src = path.Join(flagArgs.ViamHomeDir, tracesRelativePath, part.Id)
+	}
 	// if getAll is set then download the entire directory, including rotated
 	// files. Otherwise just get the current file.
 	if !getAll {

--- a/cli/traces_test.go
+++ b/cli/traces_test.go
@@ -88,18 +88,20 @@ func TestTraceGetRemote(t *testing.T) {
 	})
 
 	t.Run("trace data exists", func(t *testing.T) {
-		tmpPartTracePath := filepath.Join(tfs.Root, partID)
-		err := os.Mkdir(tmpPartTracePath, 0o750)
+		tmpPartTracePath := filepath.Join(tfs.Root, tracesRelativePath, partID)
+		err := os.MkdirAll(tmpPartTracePath, 0o750)
 		test.That(t, err, test.ShouldBeNil)
 		t.Cleanup(func() {
 			err = os.RemoveAll(tmpPartTracePath)
+			test.That(t, err, test.ShouldBeNil)
+			err = os.RemoveAll(filepath.Join(tfs.Root, partID))
 			test.That(t, err, test.ShouldBeNil)
 		})
 		testData := []byte("test")
 		err = os.WriteFile(filepath.Join(tmpPartTracePath, "traces"), testData, 0o640)
 		test.That(t, err, test.ShouldBeNil)
 		originalTracePath := defaultTracesPath
-		defaultTracesPath = tfs.Root
+		defaultTracesPath = filepath.Join(tfs.Root, tracesRelativePath)
 		t.Cleanup(func() {
 			defaultTracesPath = originalTracePath
 		})
@@ -136,6 +138,31 @@ func TestTraceGetRemote(t *testing.T) {
 			fileContents, err := os.ReadFile(filepath.Join(output, subdir.Name(), "traces"))
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, fileContents, test.ShouldResemble, testData)
+		})
+
+		t.Run("trace data exists; VIAM_HOME changed", func(t *testing.T) {
+			testFlags := maps.Collect(maps.All(basePartFlags))
+			output := t.TempDir()
+
+			defaultTracesPath = originalTracePath
+			cCtx, viamClient, _, _ := setupWithRunningPart(
+				t, asc, nil, nil, testFlags, "token", partFqdn)
+			flagArgs := parseStructFromCtx[traceGetRemoteArgs](cCtx)
+
+			// checking default traces path -> not found
+			test.That(t,
+				viamClient.tracesGetRemoteAction(context.Background(), cCtx, flagArgs, output, false, true, logger),
+				test.ShouldNotBeNil)
+
+			// specify location of VIAM_HOME
+			flagArgs.ViamHomeDir = tfs.Root
+			test.That(t,
+				viamClient.tracesGetRemoteAction(context.Background(), cCtx, flagArgs, output, false, true, logger),
+				test.ShouldBeNil)
+
+			contents, err := os.ReadFile(filepath.Join(output, "traces"))
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, contents, test.ShouldResemble, testData)
 		})
 	})
 }

--- a/cli/traces_test.go
+++ b/cli/traces_test.go
@@ -70,10 +70,10 @@ func TestTraceGetRemote(t *testing.T) {
 		output := t.TempDir()
 		testPartFlags := maps.Collect(maps.All(basePartFlags))
 
-		originalTracesPath := tracesPath
-		tracesPath = filepath.Join(tfs.Root, "FAKEDIR")
+		originalTracesPath := defaultTracesPath
+		defaultTracesPath = filepath.Join(tfs.Root, "FAKEDIR")
 		t.Cleanup(func() {
-			tracesPath = originalTracesPath
+			defaultTracesPath = originalTracesPath
 		})
 
 		cCtx, viamClient, _, _ := setupWithRunningPart(
@@ -98,10 +98,10 @@ func TestTraceGetRemote(t *testing.T) {
 		testData := []byte("test")
 		err = os.WriteFile(filepath.Join(tmpPartTracePath, "traces"), testData, 0o640)
 		test.That(t, err, test.ShouldBeNil)
-		originalTracePath := tracesPath
-		tracesPath = tfs.Root
+		originalTracePath := defaultTracesPath
+		defaultTracesPath = tfs.Root
 		t.Cleanup(func() {
-			tracesPath = originalTracePath
+			defaultTracesPath = originalTracePath
 		})
 
 		t.Run("only recent", func(t *testing.T) {


### PR DESCRIPTION
Add `--viam-home-dir`  to `viam traces import/print/get-remote`.

If the user has changed their `VIAM_HOME`, e.g. from `~/.viam` to `/tmp/viam`, the cli will still attempt to download traces from `~/.viam`. This change would allow the user to select the right directory to download from.

I tried these and they all worked:
```bash
viam traces print-remote --part=my-part-id --viam-home-dir ~/.viam2
viam traces print-remote --part=my-part-id --viam-home-dir ~/.viam2/
viam traces print-remote --part=my-part-id --viam-home-dir /home/root/.viam2/

viam traces print-remote --part=my-part-id --viam-home-dir D:/.viam
viam traces print-remote --part=my-part-id --viam-home-dir D:/.viam/
viam traces print-remote --part=my-part-id --viam-home-dir D:\\.viam
viam traces print-remote --part=my-part-id --viam-home-dir D:\\.viam\\
```