### PR TITLE
[RSDK-14117] config: support archive package type

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1084,10 +1084,12 @@ const (
 	PackageTypeModule PackageType = "module"
 	// PackageTypeSlamMap represents a slam internal state.
 	PackageTypeSlamMap PackageType = "slam_map"
+	// PackageTypeArchive represents a generic archive.
+	PackageTypeArchive PackageType = "archive"
 )
 
 // SupportedPackageTypes is a list of all of the valid package types.
-var SupportedPackageTypes = []PackageType{PackageTypeMlModel, PackageTypeModule, PackageTypeSlamMap}
+var SupportedPackageTypes = []PackageType{PackageTypeMlModel, PackageTypeModule, PackageTypeSlamMap, PackageTypeArchive}
 
 // A PackageConfig describes the configuration of a Package.
 type PackageConfig struct {

--- a/config/placeholder_replacement_test.go
+++ b/config/placeholder_replacement_test.go
@@ -27,6 +27,13 @@ func TestPlaceholderReplacement(t *testing.T) {
 						"mid_string_replace": "Hello ${packages.coolpkg} Friends!",
 						"module_replace":     "${packages.module.coolmod}",
 						"multi_replace":      "${packages.coolpkg} ${packages.module.coolmod}",
+						"archive_replace":    "${packages.archive.cool-archive}",
+						"assets": utils.AttributeMap{
+							"images": []interface{}{
+								"${packages.archive.cool-archive}",
+							},
+							"fonts": []interface{}{},
+						},
 					},
 				},
 			},
@@ -56,12 +63,19 @@ func TestPlaceholderReplacement(t *testing.T) {
 					Type:    "module",
 					Version: "0.5.0",
 				},
+				{
+					Name:    "cool-archive",
+					Package: "orgid/archive",
+					Type:    "archive",
+					Version: "0.6.0",
+				},
 			},
 		}
 		err := cfg.ReplacePlaceholders()
 		test.That(t, err, test.ShouldBeNil)
 		dirForMlModel := cfg.Packages[0].LocalDataDirectory(viamPackagesDir)
 		dirForModule := cfg.Packages[1].LocalDataDirectory(viamPackagesDir)
+		dirForArchive := cfg.Packages[2].LocalDataDirectory(viamPackagesDir)
 		// components
 		attrMap := cfg.Components[0].Attributes
 		test.That(t, attrMap["should_equal_1"], test.ShouldResemble, attrMap["should_equal_2"])
@@ -69,6 +83,12 @@ func TestPlaceholderReplacement(t *testing.T) {
 		test.That(t, attrMap["mid_string_replace"], test.ShouldResemble, fmt.Sprintf("Hello %s Friends!", dirForMlModel))
 		test.That(t, attrMap["module_replace"], test.ShouldResemble, dirForModule)
 		test.That(t, attrMap["multi_replace"], test.ShouldResemble, fmt.Sprintf("%s %s", dirForMlModel, dirForModule))
+		test.That(t, attrMap["archive_replace"], test.ShouldResemble, dirForArchive)
+		assets, ok := attrMap["assets"].(map[string]interface{})
+		test.That(t, ok, test.ShouldBeTrue)
+		images, ok := assets["images"].([]interface{})
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, images[0], test.ShouldResemble, dirForArchive)
 		// services
 		attrMap = cfg.Services[0].Attributes
 		test.That(t, attrMap["apply_to_services_too"], test.ShouldResemble, dirForMlModel)

--- a/config/proto_conversions.go
+++ b/config/proto_conversions.go
@@ -1020,6 +1020,8 @@ func PackageTypeToProto(t PackageType) (*packagespb.PackageType, error) {
 		return packagespb.PackageType_PACKAGE_TYPE_MODULE.Enum(), nil
 	case PackageTypeSlamMap:
 		return packagespb.PackageType_PACKAGE_TYPE_SLAM_MAP.Enum(), nil
+	case PackageTypeArchive:
+		return packagespb.PackageType_PACKAGE_TYPE_ARCHIVE.Enum(), nil
 	default:
 		return packagespb.PackageType_PACKAGE_TYPE_UNSPECIFIED.Enum(), errors.Errorf("unknown package type %q", t)
 	}


### PR DESCRIPTION
Register "archive" as a valid package type so viam-server can validate, download, and resolve placeholder paths for archive packages like other package types.

This was necessary because I was getting the following error message:
```
rdk.package_manager   packages/cloud_package_manager.go:249   package config validation error; skipping   package michael-lee-streamdeck-icons  error Error validating. Path: "" Error: unsupported package type "archive". Must be one of: [ml_model module slam_map]
```

I tested that the static build image in this PR works on a part and I used the bugfix to have a package store custom streamdeck icons and display them with the following config:

```
{
  "agent": {
    "version_control": {
      "viam-server": "https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-pr-6114-aarch64"
    }
  },
  "components": [
    {
      "name": "http-switch",
      "api": "rdk:component:switch",
      "model": "michaellee1019:http-switch:http-switch",
      "attributes": {
        "positions": [
          {
            "url": "http://homeassistant.local:8123/api/webhook/scene_makerroom_high",
            "method": "POST",
            "name": "0) maker lights on"
          },
          {
            "url": "http://homeassistant.local:8123/api/webhook/scene_makerroom_low",
            "method": "POST",
            "name": "1) maker lights off"
          },
          {
            "url": "http://192.168.1.156:5000/api/dpad/rotate-right",
            "method": "POST",
            "name": "2) empty"
          },
          {
            "url": "http://192.168.1.156:5000/api/dpad/up",
            "method": "POST",
            "name": "3) empty"
          },
          {
            "method": "POST",
            "name": "4) empty",
            "url": "http://192.168.1.156:5000/api/dpad/rotate-left"
          },
          {
            "url": "http://homeassistant.local:8123/api/webhook/scene_living_room_high",
            "method": "POST",
            "name": "5) all lights on"
          },
          {
            "name": "6) all lights off",
            "url": "http://homeassistant.local:8123/api/webhook/scene_all_off",
            "method": "POST"
          },
          {
            "url": "http://192.168.1.156:5000/api/dpad/left",
            "method": "POST",
            "name": "7) empty"
          },
          {
            "method": "GET",
            "name": "8) empty",
            "url": "http://192.168.1.156:5000/api/dpad/down"
          },
          {
            "name": "9) empty",
            "url": "http://192.168.1.156:5000/api/dpad/right",
            "method": "GET"
          },
          {
            "method": "POST",
            "headers": {
              "Content-Type": "application/json"
            },
            "body": "{}",
            "name": "10) led grid rainbow",
            "url": "http://homeassistant.local:3000/ledgrid/start/rainbow"
          },
          {
            "method": "POST",
            "headers": {
              "Content-Type": "application/json"
            },
            "body": "{}",
            "name": "11) led grid sparkle",
            "url": "http://192.168.1.156:5000/api/start/sparkle"
          },
          {
            "url": "http://homeassistant.local:3000/ledgrid/start/tetris",
            "method": "POST",
            "headers": {
              "Content-Type": "application/json"
            },
            "body": "{}",
            "name": "12) led grid tetris"
          },
          {
            "body": "{}",
            "name": "13) game double down",
            "url": "http://192.168.1.156:5000/api/dpad/ddown",
            "method": "POST"
          }
        ]
      }
    }
  ],
  "services": [
    {
      "name": "streamdeck",
      "api": "rdk:service:generic",
      "model": "erh:viam-streamdeck:streamdeck-original",
      "attributes": {
        "pages": {
          "main": [
            {
              "method": "set_position",
              "args": [
                5
              ],
              "image": "lights_on.png",
              "key": 5,
              "component": "http-switch"
            },
            {
              "args": [
                6
              ],
              "image": "lights_off.png",
              "key": 6,
              "component": "http-switch",
              "method": "set_position"
            },
        },
        "brightness": 100,
        "assets": {
          "images": [
            "${packages.archive.michael-lee-streamdeck-icons}"
          ],
          "fonts": []
        },
        "initial_page": "main"
      },
      "depends_on": [
        "http-switch"
      ]
    }
  ],
  "packages": [
    {
      "name": "michael-lee-streamdeck-icons",
      "package": "490b556e-1c8e-4597-9ec2-c0a64f2ec6cf/michael-lee-streamdeck-icons",
      "type": "archive",
      "version": "latest"
    }
  ]
}
```