### PR TITLE
APP-16908: allow querying tabular data by pipeline name

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1466,8 +1466,14 @@ Note: There is no progress meter while copying is in progress.
 									Usage: formatAcceptedValues("data source to query against", tabularDataByMQLDataSourceTypes...),
 								},
 								&cli.StringFlag{
-									Name:  dataFlagPipelineID,
-									Usage: fmt.Sprintf("pipeline ID to query; required when --%s=%s", dataFlagDataSourceType, pipelineSinkDataSourceType),
+									Name: dataFlagPipelineID,
+									Usage: fmt.Sprintf("pipeline ID to query; one of --%s or --%s is required when --%s=%s",
+										dataFlagPipelineID, dataFlagPipelineName, dataFlagDataSourceType, pipelineSinkDataSourceType),
+								},
+								&cli.StringFlag{
+									Name: dataFlagPipelineName,
+									Usage: fmt.Sprintf("pipeline name to query; one of --%s or --%s is required when --%s=%s",
+										dataFlagPipelineID, dataFlagPipelineName, dataFlagDataSourceType, pipelineSinkDataSourceType),
 								},
 								&cli.StringFlag{
 									Name:      generalFlagDestination,

--- a/cli/data.go
+++ b/cli/data.go
@@ -175,6 +175,7 @@ type dataQueryMQLArgs struct {
 	MqlPath        string
 	DataSourceType string
 	PipelineID     string
+	PipelineName   string
 	Destination    string
 }
 
@@ -475,22 +476,36 @@ func (c *viamClient) dataQueryMQLAction(ctx context.Context, args dataQueryMQLAr
 	if args.OrgID == "" {
 		return errors.New("must provide an organization ID")
 	}
-	if args.PipelineID != "" && args.DataSourceType == "" {
-		return errors.Errorf("--%s is required when --%s is provided",
-			dataFlagDataSourceType, dataFlagPipelineID)
+	if args.PipelineID != "" && args.PipelineName != "" {
+		return errors.Errorf("--%s and --%s cannot both be provided",
+			dataFlagPipelineID, dataFlagPipelineName)
 	}
-	if args.DataSourceType == pipelineSinkDataSourceType && args.PipelineID == "" {
-		return errors.Errorf("--%s is required when --%s=%s",
-			dataFlagPipelineID, dataFlagDataSourceType, pipelineSinkDataSourceType)
+	hasPipelineRef := args.PipelineID != "" || args.PipelineName != ""
+	if hasPipelineRef && args.DataSourceType == "" {
+		return errors.Errorf("--%s is required when --%s or --%s is provided",
+			dataFlagDataSourceType, dataFlagPipelineID, dataFlagPipelineName)
 	}
-	if args.DataSourceType != "" && args.DataSourceType != pipelineSinkDataSourceType && args.PipelineID != "" {
-		return errors.Errorf("--%s is only valid when --%s=%s",
-			dataFlagPipelineID, dataFlagDataSourceType, pipelineSinkDataSourceType)
+	if args.DataSourceType == pipelineSinkDataSourceType && !hasPipelineRef {
+		return errors.Errorf("--%s or --%s is required when --%s=%s",
+			dataFlagPipelineID, dataFlagPipelineName, dataFlagDataSourceType, pipelineSinkDataSourceType)
+	}
+	if args.DataSourceType != "" && args.DataSourceType != pipelineSinkDataSourceType && hasPipelineRef {
+		return errors.Errorf("--%s and --%s are only valid when --%s=%s",
+			dataFlagPipelineID, dataFlagPipelineName, dataFlagDataSourceType, pipelineSinkDataSourceType)
 	}
 
 	mqlBinary, err := parseMQL(args.MQL, args.MqlPath)
 	if err != nil {
 		return err
+	}
+
+	pipelineID := args.PipelineID
+	if args.PipelineName != "" {
+		resolved, err := c.resolvePipelineIDByName(ctx, args.OrgID, args.PipelineName)
+		if err != nil {
+			return err
+		}
+		pipelineID = resolved
 	}
 
 	request := &datapb.TabularDataByMQLRequest{
@@ -499,7 +514,7 @@ func (c *viamClient) dataQueryMQLAction(ctx context.Context, args dataQueryMQLAr
 	}
 
 	if args.DataSourceType != "" {
-		dataSource, err := buildTabularDataSource(args.DataSourceType, args.PipelineID)
+		dataSource, err := buildTabularDataSource(args.DataSourceType, pipelineID)
 		if err != nil {
 			return err
 		}

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -231,7 +231,7 @@ func TestDataQueryMQLAction(t *testing.T) {
 			expectedErr: fmt.Errorf("--%s is required when --%s or --%s is provided",
 				dataFlagDataSourceType, dataFlagPipelineID, dataFlagPipelineName),
 		},
-		"pipeline-id and pipeline-name are mutually exclusive": {
+		"pipeline-id and pipeline-name are both provided": {
 			args: dataQueryMQLArgs{
 				OrgID:          "org-1",
 				MQL:            mql,

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -10,6 +10,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	datapb "go.viam.com/api/app/data/v1"
+	datapipelinespb "go.viam.com/api/app/datapipelines/v1"
 	"go.viam.com/test"
 	"google.golang.org/grpc"
 
@@ -128,6 +129,59 @@ func TestDataQueryMQLAction(t *testing.T) {
 		test.That(t, len(capturedReq.GetMqlBinary()), test.ShouldEqual, 1)
 	})
 
+	t.Run("resolves pipeline name to id", func(t *testing.T) {
+		var capturedReq *datapb.TabularDataByMQLRequest
+		dsc := &inject.DataServiceClient{
+			TabularDataByMQLFunc: func(ctx context.Context, in *datapb.TabularDataByMQLRequest, opts ...grpc.CallOption,
+			) (*datapb.TabularDataByMQLResponse, error) {
+				capturedReq = in
+				return &datapb.TabularDataByMQLResponse{RawData: [][]byte{row}}, nil
+			},
+		}
+		dpc := &inject.DataPipelinesServiceClient{
+			ListDataPipelinesFunc: func(ctx context.Context, in *datapipelinespb.ListDataPipelinesRequest, opts ...grpc.CallOption,
+			) (*datapipelinespb.ListDataPipelinesResponse, error) {
+				return &datapipelinespb.ListDataPipelinesResponse{
+					DataPipelines: []*datapipelinespb.DataPipeline{
+						{Id: "pipe-other-id", Name: "other"},
+						{Id: "pipe-matched-id", Name: "my-pipeline"},
+					},
+				}, nil
+			},
+		}
+
+		_, ac, _, _ := setup(&inject.AppServiceClient{}, dsc, nil, nil, "token")
+		ac.datapipelinesClient = dpc
+		err := ac.dataQueryMQLAction(context.Background(), dataQueryMQLArgs{
+			OrgID:          "org-1",
+			MQL:            mql,
+			DataSourceType: pipelineSinkDataSourceType,
+			PipelineName:   "my-pipeline",
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, capturedReq.GetDataSource().GetPipelineId(), test.ShouldEqual, "pipe-matched-id")
+	})
+
+	t.Run("errors when pipeline name has no match", func(t *testing.T) {
+		dpc := &inject.DataPipelinesServiceClient{
+			ListDataPipelinesFunc: func(ctx context.Context, in *datapipelinespb.ListDataPipelinesRequest, opts ...grpc.CallOption,
+			) (*datapipelinespb.ListDataPipelinesResponse, error) {
+				return &datapipelinespb.ListDataPipelinesResponse{
+					DataPipelines: []*datapipelinespb.DataPipeline{{Id: "x", Name: "something-else"}},
+				}, nil
+			},
+		}
+		_, ac, _, _ := setup(&inject.AppServiceClient{}, &inject.DataServiceClient{}, nil, nil, "token")
+		ac.datapipelinesClient = dpc
+		err := ac.dataQueryMQLAction(context.Background(), dataQueryMQLArgs{
+			OrgID:          "org-1",
+			MQL:            mql,
+			DataSourceType: pipelineSinkDataSourceType,
+			PipelineName:   "missing",
+		})
+		test.That(t, err, test.ShouldBeError, fmt.Errorf("no data pipeline found with name %q", "missing"))
+	})
+
 	t.Run("omits data source when not provided", func(t *testing.T) {
 		var capturedReq *datapb.TabularDataByMQLRequest
 		dsc := &inject.DataServiceClient{
@@ -156,17 +210,17 @@ func TestDataQueryMQLAction(t *testing.T) {
 				DataSourceType: hotStorageDataSourceType,
 				PipelineID:     "pipe-1",
 			},
-			expectedErr: fmt.Errorf("--%s is only valid when --%s=%s",
-				dataFlagPipelineID, dataFlagDataSourceType, pipelineSinkDataSourceType),
+			expectedErr: fmt.Errorf("--%s and --%s are only valid when --%s=%s",
+				dataFlagPipelineID, dataFlagPipelineName, dataFlagDataSourceType, pipelineSinkDataSourceType),
 		},
-		"pipeline-sink requires a pipeline id": {
+		"pipeline-sink requires a pipeline id or name": {
 			args: dataQueryMQLArgs{
 				OrgID:          "org-1",
 				MQL:            mql,
 				DataSourceType: pipelineSinkDataSourceType,
 			},
-			expectedErr: fmt.Errorf("--%s is required when --%s=%s",
-				dataFlagPipelineID, dataFlagDataSourceType, pipelineSinkDataSourceType),
+			expectedErr: fmt.Errorf("--%s or --%s is required when --%s=%s",
+				dataFlagPipelineID, dataFlagPipelineName, dataFlagDataSourceType, pipelineSinkDataSourceType),
 		},
 		"pipeline-id without a source type": {
 			args: dataQueryMQLArgs{
@@ -174,8 +228,19 @@ func TestDataQueryMQLAction(t *testing.T) {
 				MQL:        mql,
 				PipelineID: "pipe-1",
 			},
-			expectedErr: fmt.Errorf("--%s is required when --%s is provided",
-				dataFlagDataSourceType, dataFlagPipelineID),
+			expectedErr: fmt.Errorf("--%s is required when --%s or --%s is provided",
+				dataFlagDataSourceType, dataFlagPipelineID, dataFlagPipelineName),
+		},
+		"pipeline-id and pipeline-name are mutually exclusive": {
+			args: dataQueryMQLArgs{
+				OrgID:          "org-1",
+				MQL:            mql,
+				DataSourceType: pipelineSinkDataSourceType,
+				PipelineID:     "pipe-1",
+				PipelineName:   "my-pipeline",
+			},
+			expectedErr: fmt.Errorf("--%s and --%s cannot both be provided",
+				dataFlagPipelineID, dataFlagPipelineName),
 		},
 		"missing mql query": {
 			args:        dataQueryMQLArgs{OrgID: "org-1"},

--- a/cli/datapipelines.go
+++ b/cli/datapipelines.go
@@ -295,6 +295,23 @@ func parseMQL(mql, mqlFile string) ([][]byte, error) {
 	return mqlBinary, nil
 }
 
+// resolvePipelineIDByName looks up a data pipeline by name within the given org and returns its ID.
+// Pipeline names are unique within an org, so the first match is the only match.
+func (c *viamClient) resolvePipelineIDByName(ctx context.Context, orgID, name string) (string, error) {
+	resp, err := c.datapipelinesClient.ListDataPipelines(ctx, &datapipelinespb.ListDataPipelinesRequest{
+		OrganizationId: orgID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list data pipelines: %w", err)
+	}
+	for _, p := range resp.GetDataPipelines() {
+		if p.GetName() == name {
+			return p.GetId(), nil
+		}
+	}
+	return "", fmt.Errorf("no data pipeline found with name %q", name)
+}
+
 func mqlJSON(mql [][]byte) (string, error) {
 	var stages []bson.M
 	for _, bsonBytes := range mql {


### PR DESCRIPTION
                                                                                                                                         
  ## Summary                                                                                                                                
  - Add `--pipeline-name` flag to `viam data query mql`, allowing users to specify a pipeline by name instead of ID when querying a
  `pipeline-sink` data source.                                                                                                              
  - Resolution happens client-side: we call `ListDataPipelines` for the org and find the matching name. Pipeline names are unique within an
  org, so the first match is the only match.                                                                                                
  - `--pipeline-id` and `--pipeline-name` are mutually exclusive — one canonical input per logical thing.
  - Updated existing validation error wording to mention both flags (e.g. `--pipeline-id or --pipeline-name is required when                
  --data-source-type=pipeline-sink`).                                                                                                       
                                                                                                                                                                                                                          
  
  ## Test plan                                                                                                                                                                                                                                                                                                       
  - [x] `viam data query mql --org-id=$ORG --mql='[{"$limit": 1}]' --data-source-type=pipeline-sink --pipeline-name=<NAME>` returns data    
  - [x] Same query with `--pipeline-id=<ID>` (where `<ID>` is the resolved ID) returns data from same pipeline                                                                                                                                
  - [x] `--pipeline-id=X --pipeline-name=Y` → `--pipeline-id and --pipeline-name cannot both be provided`                                   
  - [x] `--pipeline-name=X` without `--data-source-type` → `--data-source-type is required when --pipeline-id or --pipeline-name is         
  provided`                                                                                                                                 
  - [x] `--pipeline-name=X --data-source-type=hot-storage` → `--pipeline-id and --pipeline-name are only valid when                         
  --data-source-type=pipeline-sink`                                                                                                         
  - [x] `--data-source-type=pipeline-sink` with neither flag → `--pipeline-id or --pipeline-name is required when                         
  --data-source-type=pipeline-sink`                                                                                                         
  - [x] `--pipeline-name=<NONEXISTENT>` → `no data pipeline found with name "<NONEXISTENT>"`