### PR TITLE
APP-16078: Add `data query binary` command to the CLI

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -1426,94 +1426,110 @@ Note: There is no progress meter while copying is in progress.
 				},
 				{
 					Name:            "query",
-					Usage:           "query tabular data from Viam cloud",
+					Usage:           "query data from Viam cloud",
 					UsageText:       createUsageText("data query", nil, false, true),
 					HideHelpCommand: true,
 					Commands: []*cli.Command{
 						{
-							Name:      "sql",
-							Usage:     "query tabular data using SQL",
-							UsageText: createUsageText("data query sql", []string{dataFlagSQL}, true, false),
-							Flags: []cli.Flag{
-								&cli.StringFlag{
-									Name:        generalFlagOrgID,
-									Usage:       "organization ID",
-									DefaultText: "default-org value if set",
+							Name:            "tabular",
+							Usage:           "query tabular data using SQL or MQL",
+							UsageText:       createUsageText("data query tabular", nil, false, true),
+							HideHelpCommand: true,
+							Commands: []*cli.Command{
+								{
+									Name:      "sql",
+									Usage:     "query tabular data using SQL",
+									UsageText: createUsageText("data query tabular sql", []string{dataFlagSQL}, true, false),
+									Flags: []cli.Flag{
+										&cli.StringFlag{
+											Name:        generalFlagOrgID,
+											Usage:       "organization ID",
+											DefaultText: "default-org value if set",
+										},
+										&cli.StringFlag{
+											Name:     dataFlagSQL,
+											Required: true,
+											Usage:    "SQL statement to query the organization's tabular data",
+										},
+										&cli.StringFlag{
+											Name:      generalFlagDestination,
+											Usage:     "output directory for query results; prints to stdout if omitted",
+											TakesFile: true,
+										},
+									},
+									Action: createActionCommandWithT[dataQuerySQLArgs](DataQuerySQLAction),
 								},
-								&cli.StringFlag{
-									Name:     dataFlagSQL,
-									Required: true,
-									Usage:    "SQL statement to query the organization's tabular data",
-								},
-								&cli.StringFlag{
-									Name:      generalFlagDestination,
-									Usage:     "output directory for query results; prints to stdout if omitted",
-									TakesFile: true,
+								{
+									Name:  "mql",
+									Usage: "query tabular data using MQL",
+									UsageText: createUsageText("data query tabular mql",
+										nil, true, false,
+										fmt.Sprintf("[--%s=<%s> | --%s=<%s>]",
+											dataFlagMQL, dataFlagMQL,
+											dataFlagMQLFile, dataFlagMQLFile),
+									),
+									Flags: []cli.Flag{
+										&cli.StringFlag{
+											Name:        generalFlagOrgID,
+											Usage:       "organization ID",
+											DefaultText: "default-org value if set",
+										},
+										&cli.StringFlag{
+											Name:  dataFlagMQL,
+											Usage: "MQL query to query the organization's tabular data",
+										},
+										&cli.StringFlag{
+											Name:  dataFlagMQLFile,
+											Usage: "path to a JSON file containing the MQL query",
+										},
+										&cli.StringFlag{
+											Name:  dataFlagDataSourceType,
+											Usage: formatAcceptedValues("data source to query against", tabularDataByMQLDataSourceTypes...),
+										},
+										&cli.StringFlag{
+											Name: dataFlagPipelineID,
+											Usage: fmt.Sprintf("pipeline ID to query; one of --%s or --%s is required when --%s=%s",
+												dataFlagPipelineID, dataFlagPipelineName, dataFlagDataSourceType, pipelineSinkDataSourceType),
+										},
+										&cli.StringFlag{
+											Name: dataFlagPipelineName,
+											Usage: fmt.Sprintf("pipeline name to query; one of --%s or --%s is required when --%s=%s",
+												dataFlagPipelineID, dataFlagPipelineName, dataFlagDataSourceType, pipelineSinkDataSourceType),
+										},
+										&cli.StringFlag{
+											Name:      generalFlagDestination,
+											Usage:     "output directory for query results; prints to stdout if omitted",
+											TakesFile: true,
+										},
+									},
+									Action: createActionCommandWithT[dataQueryMQLArgs](DataQueryMQLAction),
 								},
 							},
-							Action: createActionCommandWithT[dataQuerySQLArgs](DataQuerySQLAction),
 						},
 						{
-							Name:  "mql",
-							Usage: "query tabular data using MQL",
-							UsageText: createUsageText("data query mql",
-								nil, true, false,
-								fmt.Sprintf("[--%s=<%s> | --%s=<%s>]",
-									dataFlagMQL, dataFlagMQL,
-									dataFlagMQLFile, dataFlagMQLFile),
-							),
-							Flags: []cli.Flag{
-								&cli.StringFlag{
-									Name:        generalFlagOrgID,
-									Usage:       "organization ID",
-									DefaultText: "default-org value if set",
-								},
-								&cli.StringFlag{
-									Name:  dataFlagMQL,
-									Usage: "MQL query to query the organization's tabular data",
-								},
-								&cli.StringFlag{
-									Name:  dataFlagMQLFile,
-									Usage: "path to a JSON file containing the MQL query",
-								},
-								&cli.StringFlag{
-									Name:  dataFlagDataSourceType,
-									Usage: formatAcceptedValues("data source to query against", tabularDataByMQLDataSourceTypes...),
-								},
-								&cli.StringFlag{
-									Name: dataFlagPipelineID,
-									Usage: fmt.Sprintf("pipeline ID to query; one of --%s or --%s is required when --%s=%s",
-										dataFlagPipelineID, dataFlagPipelineName, dataFlagDataSourceType, pipelineSinkDataSourceType),
-								},
-								&cli.StringFlag{
-									Name: dataFlagPipelineName,
-									Usage: fmt.Sprintf("pipeline name to query; one of --%s or --%s is required when --%s=%s",
-										dataFlagPipelineID, dataFlagPipelineName, dataFlagDataSourceType, pipelineSinkDataSourceType),
-								},
-								&cli.StringFlag{
-									Name:      generalFlagDestination,
-									Usage:     "output directory for query results; prints to stdout if omitted",
-									TakesFile: true,
+							Name:            "binary",
+							Usage:           "query binary data",
+							UsageText:       createUsageText("data query binary", nil, false, true),
+							HideHelpCommand: true,
+							Commands: []*cli.Command{
+								{
+									Name:      "filter",
+									Usage:     "query binary data metadata using filters",
+									UsageText: createUsageText("data query binary filter", nil, true, false),
+									Flags: append([]cli.Flag{
+										&cli.StringFlag{
+											Name:      generalFlagDestination,
+											Usage:     "output directory for query results; prints to stdout if omitted",
+											TakesFile: true,
+										},
+										&cli.UintFlag{
+											Name:  dataFlagLimit,
+											Usage: "maximum number of results to return; 0 returns all matches",
+										},
+									}, commonFilterFlags...),
+									Action: createActionCommandWithT[dataQueryBinaryArgs](DataQueryBinaryAction),
 								},
 							},
-							Action: createActionCommandWithT[dataQueryMQLArgs](DataQueryMQLAction),
-						},
-						{
-							Name:      "binary",
-							Usage:     "query binary data metadata by filter",
-							UsageText: createUsageText("data query binary", nil, true, false),
-							Flags: append([]cli.Flag{
-								&cli.StringFlag{
-									Name:      generalFlagDestination,
-									Usage:     "output directory for query results; prints to stdout if omitted",
-									TakesFile: true,
-								},
-								&cli.UintFlag{
-									Name:  dataFlagLimit,
-									Usage: "maximum number of results to return; 0 returns all matches",
-								},
-							}, commonFilterFlags...),
-							Action: createActionCommandWithT[dataQueryBinaryArgs](DataQueryBinaryAction),
 						},
 					},
 				},

--- a/cli/app.go
+++ b/cli/app.go
@@ -1514,7 +1514,7 @@ Note: There is no progress meter while copying is in progress.
 							Commands: []*cli.Command{
 								{
 									Name:      "filter",
-									Usage:     "query binary data metadata using filters",
+									Usage:     "query binary data by filter (returns metadata only)",
 									UsageText: createUsageText("data query binary filter", nil, true, false),
 									Flags: append([]cli.Flag{
 										&cli.StringFlag{

--- a/cli/app.go
+++ b/cli/app.go
@@ -148,6 +148,8 @@ const (
 	dataFlagDataSourceType                 = "data-source-type"
 	dataFlagIndexName                      = "index-name"
 	dataFlagIndexSpecFile                  = "index-path"
+	dataFlagIncludeBinaryData              = "include-binary"
+	dataFlagLimit                          = "limit"
 
 	datapipelineFlagSchedule       = "schedule"
 	datapipelineFlagEnableBackfill = "enable-backfill"
@@ -1476,6 +1478,27 @@ Note: There is no progress meter while copying is in progress.
 								},
 							},
 							Action: createActionCommandWithT[dataQueryMQLArgs](DataQueryMQLAction),
+						},
+						{
+							Name:      "binary",
+							Usage:     "query binary data metadata by filter",
+							UsageText: createUsageText("data query binary", nil, true, false),
+							Flags: append([]cli.Flag{
+								&cli.StringFlag{
+									Name:      generalFlagDestination,
+									Usage:     "output directory for query results; prints to stdout if omitted",
+									TakesFile: true,
+								},
+								&cli.BoolFlag{
+									Name:  dataFlagIncludeBinaryData,
+									Usage: "include the binary payload (base64-encoded) in each result; metadata only if omitted",
+								},
+								&cli.UintFlag{
+									Name:  dataFlagLimit,
+									Usage: "maximum number of results to return; 0 returns all matches",
+								},
+							}, commonFilterFlags...),
+							Action: createActionCommandWithT[dataQueryBinaryArgs](DataQueryBinaryAction),
 						},
 					},
 				},

--- a/cli/app.go
+++ b/cli/app.go
@@ -148,7 +148,6 @@ const (
 	dataFlagDataSourceType                 = "data-source-type"
 	dataFlagIndexName                      = "index-name"
 	dataFlagIndexSpecFile                  = "index-path"
-	dataFlagIncludeBinaryData              = "include-binary"
 	dataFlagLimit                          = "limit"
 
 	datapipelineFlagSchedule       = "schedule"
@@ -1508,10 +1507,6 @@ Note: There is no progress meter while copying is in progress.
 									Name:      generalFlagDestination,
 									Usage:     "output directory for query results; prints to stdout if omitted",
 									TakesFile: true,
-								},
-								&cli.BoolFlag{
-									Name:  dataFlagIncludeBinaryData,
-									Usage: "include the binary payload (base64-encoded) in each result; metadata only if omitted",
 								},
 								&cli.UintFlag{
 									Name:  dataFlagLimit,

--- a/cli/data.go
+++ b/cli/data.go
@@ -598,7 +598,7 @@ func (c *viamClient) dataQueryBinaryAction(ctx context.Context, args dataQueryBi
 		last = resp.GetLast()
 
 		for _, bd := range resp.GetData() {
-			jsonRow, err := protojson.Marshal(bd)
+			jsonRow, err := protojson.Marshal(bd.GetMetadata())
 			if err != nil {
 				return errors.Wrap(err, "error formatting query result")
 			}

--- a/cli/data.go
+++ b/cli/data.go
@@ -75,7 +75,7 @@ var (
 		datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK: "Pipeline Sink",
 	}
 
-	// tabularDataByMQLDataSourceTypes is the set of data sources accepted by `data query mql`.
+	// tabularDataByMQLDataSourceTypes is the set of data sources accepted by `data query tabular mql`.
 	tabularDataByMQLDataSourceTypes = []string{standardDataSourceType, hotStorageDataSourceType, pipelineSinkDataSourceType}
 )
 
@@ -159,7 +159,7 @@ type dataQuerySQLArgs struct {
 	Destination string
 }
 
-// DataQuerySQLAction is the corresponding action for 'data query sql'.
+// DataQuerySQLAction is the corresponding action for 'data query tabular sql'.
 func DataQuerySQLAction(ctx context.Context, cmd *cli.Command, args dataQuerySQLArgs) error {
 	client, err := newViamClient(ctx, cmd)
 	if err != nil {
@@ -179,7 +179,7 @@ type dataQueryMQLArgs struct {
 	Destination    string
 }
 
-// DataQueryMQLAction is the corresponding action for 'data query mql'.
+// DataQueryMQLAction is the corresponding action for 'data query tabular mql'.
 func DataQueryMQLAction(ctx context.Context, cmd *cli.Command, args dataQueryMQLArgs) error {
 	client, err := newViamClient(ctx, cmd)
 	if err != nil {
@@ -194,7 +194,7 @@ type dataQueryBinaryArgs struct {
 	Limit       uint
 }
 
-// DataQueryBinaryAction is the corresponding action for 'data query binary'.
+// DataQueryBinaryAction is the corresponding action for 'data query binary filter'.
 func DataQueryBinaryAction(ctx context.Context, cmd *cli.Command, args dataQueryBinaryArgs) error {
 	client, err := newViamClient(ctx, cmd)
 	if err != nil {

--- a/cli/data.go
+++ b/cli/data.go
@@ -549,6 +549,39 @@ func (c *viamClient) dataQueryMQLAction(ctx context.Context, args dataQueryMQLAr
 	return writeQueryResults(c.c.Root().Writer, args.Destination, resp.GetRawData())
 }
 
+// forEachBinaryDataByFilter pages through BinaryDataByFilter for the given filter, invoking fn on
+// each result. It stops when the server returns no more data, fn returns stop=true, or fn errors.
+func forEachBinaryDataByFilter(
+	ctx context.Context, client datapb.DataServiceClient, filter *datapb.Filter, pageLimit uint64,
+	fn func(*datapb.BinaryData) (stop bool, err error),
+) error {
+	var last string
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		resp, err := client.BinaryDataByFilter(ctx, &datapb.BinaryDataByFilterRequest{
+			DataRequest: &datapb.DataRequest{Filter: filter, Limit: pageLimit, Last: last},
+		})
+		if err != nil {
+			return err
+		}
+		if len(resp.GetData()) == 0 {
+			return nil
+		}
+		last = resp.GetLast()
+		for _, bd := range resp.GetData() {
+			stop, err := fn(bd)
+			if err != nil {
+				return err
+			}
+			if stop {
+				return nil
+			}
+		}
+	}
+}
+
 func (c *viamClient) dataQueryBinaryAction(ctx context.Context, args dataQueryBinaryArgs, filter *datapb.Filter) error {
 	// Output to a file under --destination, or stdout if omitted.
 	out := c.c.Root().Writer
@@ -567,46 +600,21 @@ func (c *viamClient) dataQueryBinaryAction(ctx context.Context, args dataQueryBi
 	}
 
 	bw := bufio.NewWriter(out)
-	var last string
 	var written uint
-	for {
-		// Cap each page at maxLimit (100); honor an overall --limit if set.
-		pageLimit := uint64(maxLimit)
-		if args.Limit > 0 {
-			remaining := args.Limit - written
-			if remaining == 0 {
-				break
-			}
-			if remaining < uint(maxLimit) {
-				pageLimit = uint64(remaining)
-			}
-		}
-
-		resp, err := c.dataClient.BinaryDataByFilter(ctx, &datapb.BinaryDataByFilterRequest{
-			DataRequest: &datapb.DataRequest{
-				Filter: filter,
-				Limit:  pageLimit,
-				Last:   last,
-			},
-		})
-		if err != nil {
-			return errors.Wrap(err, serverErrorMessage)
-		}
-		if len(resp.GetData()) == 0 {
-			break
-		}
-		last = resp.GetLast()
-
-		for _, bd := range resp.GetData() {
+	err := forEachBinaryDataByFilter(ctx, c.dataClient, filter, maxLimit,
+		func(bd *datapb.BinaryData) (bool, error) {
 			jsonRow, err := protojson.Marshal(bd.GetMetadata())
 			if err != nil {
-				return errors.Wrap(err, "error formatting query result")
+				return false, errors.Wrap(err, "error formatting query result")
 			}
 			if err := writeData(bw, jsonRow); err != nil {
-				return errors.Wrap(err, "error writing data")
+				return false, errors.Wrap(err, "error writing data")
 			}
 			written++
-		}
+			return args.Limit > 0 && written >= args.Limit, nil // stop at --limit
+		})
+	if err != nil {
+		return errors.Wrap(err, serverErrorMessage)
 	}
 	if err := bw.Flush(); err != nil {
 		return errors.Wrap(err, "error writing query results")
@@ -769,35 +777,12 @@ func (c *viamClient) performActionOnBinaryDataFromFilter(actionOnBinaryData func
 func getMatchingBinaryIDs(ctx context.Context, client datapb.DataServiceClient, filter *datapb.Filter,
 	ids chan string, limit uint,
 ) error {
-	var last string
 	defer close(ids)
-	for {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-
-		resp, err := client.BinaryDataByFilter(ctx, &datapb.BinaryDataByFilterRequest{
-			DataRequest: &datapb.DataRequest{
-				Filter: filter,
-				Limit:  uint64(limit),
-				Last:   last,
-			},
-			CountOnly:     false,
-			IncludeBinary: false,
-		})
-		if err != nil {
-			return err
-		}
-		// If no data is returned, there is no more data.
-		if len(resp.GetData()) == 0 {
-			return nil
-		}
-		last = resp.GetLast()
-
-		for _, bd := range resp.GetData() {
+	return forEachBinaryDataByFilter(ctx, client, filter, uint64(limit),
+		func(bd *datapb.BinaryData) (bool, error) {
 			ids <- bd.GetMetadata().GetBinaryDataId()
-		}
-	}
+			return false, nil
+		})
 }
 
 // Check for the errors returned from server that we send if the requested file is too large.

--- a/cli/data.go
+++ b/cli/data.go
@@ -600,8 +600,12 @@ func (c *viamClient) dataQueryBinaryAction(ctx context.Context, args dataQueryBi
 	}
 
 	bw := bufio.NewWriter(out)
+	pageLimit := uint64(maxLimit)
+	if args.Limit > 0 {
+		pageLimit = uint64(min(args.Limit, maxLimit))
+	}
 	var written uint
-	err := forEachBinaryDataByFilter(ctx, c.dataClient, filter, maxLimit,
+	err := forEachBinaryDataByFilter(ctx, c.dataClient, filter, pageLimit,
 		func(bd *datapb.BinaryData) (bool, error) {
 			jsonRow, err := protojson.Marshal(bd.GetMetadata())
 			if err != nil {

--- a/cli/data.go
+++ b/cli/data.go
@@ -188,6 +188,27 @@ func DataQueryMQLAction(ctx context.Context, cmd *cli.Command, args dataQueryMQL
 	return client.dataQueryMQLAction(ctx, args)
 }
 
+type dataQueryBinaryArgs struct {
+	Destination   string
+	IncludeBinary bool
+	Limit         uint
+}
+
+// DataQueryBinaryAction is the corresponding action for 'data query binary'.
+func DataQueryBinaryAction(ctx context.Context, cmd *cli.Command, args dataQueryBinaryArgs) error {
+	client, err := newViamClient(ctx, cmd)
+	if err != nil {
+		return err
+	}
+
+	filter, err := createDataFilter(cmd)
+	if err != nil {
+		return err
+	}
+
+	return client.dataQueryBinaryAction(ctx, args, filter)
+}
+
 type dataTagByFilterArgs struct {
 	Tags []string
 }
@@ -512,6 +533,76 @@ func (c *viamClient) dataQueryMQLAction(ctx context.Context, args dataQueryMQLAr
 	}
 
 	return writeQueryResults(c.c.Root().Writer, args.Destination, resp.GetRawData())
+}
+
+func (c *viamClient) dataQueryBinaryAction(ctx context.Context, args dataQueryBinaryArgs, filter *datapb.Filter) error {
+	// Output to a file under --destination, or stdout if omitted.
+	out := c.c.Root().Writer
+	var filePath string
+	if args.Destination != "" {
+		if err := makeDestinationDirs(args.Destination); err != nil {
+			return errors.Wrap(err, "could not create destination directory")
+		}
+		filePath = filepath.Join(args.Destination, dataFileName)
+		f, err := os.Create(filePath) //nolint:gosec
+		if err != nil {
+			return errors.Wrap(err, "could not create data file")
+		}
+		defer f.Close() //nolint:errcheck
+		out = f
+	}
+
+	bw := bufio.NewWriter(out)
+	var last string
+	var written uint
+	for {
+		// Cap each page at maxLimit (100); honor an overall --limit if set.
+		pageLimit := uint64(maxLimit)
+		if args.Limit > 0 {
+			remaining := args.Limit - written
+			if remaining == 0 {
+				break
+			}
+			if remaining < uint(maxLimit) {
+				pageLimit = uint64(remaining)
+			}
+		}
+
+		resp, err := c.dataClient.BinaryDataByFilter(ctx, &datapb.BinaryDataByFilterRequest{
+			DataRequest: &datapb.DataRequest{
+				Filter: filter,
+				Limit:  pageLimit,
+				Last:   last,
+			},
+			IncludeBinary: args.IncludeBinary,
+			CountOnly:     false,
+		})
+		if err != nil {
+			return errors.Wrap(err, serverErrorMessage)
+		}
+		if len(resp.GetData()) == 0 {
+			break
+		}
+		last = resp.GetLast()
+
+		for _, bd := range resp.GetData() {
+			jsonRow, err := protojson.Marshal(bd)
+			if err != nil {
+				return errors.Wrap(err, "error formatting query result")
+			}
+			if err := writeData(bw, jsonRow); err != nil {
+				return errors.Wrap(err, "error writing data")
+			}
+			written++
+		}
+	}
+	if err := bw.Flush(); err != nil {
+		return errors.Wrap(err, "error writing query results")
+	}
+	if filePath != "" {
+		printf(c.c.Root().Writer, "Wrote %d results to %s", written, filePath)
+	}
+	return nil
 }
 
 func buildTabularDataSource(dataSourceType, pipelineID string) (*datapb.TabularDataSource, error) {

--- a/cli/data.go
+++ b/cli/data.go
@@ -190,9 +190,8 @@ func DataQueryMQLAction(ctx context.Context, cmd *cli.Command, args dataQueryMQL
 }
 
 type dataQueryBinaryArgs struct {
-	Destination   string
-	IncludeBinary bool
-	Limit         uint
+	Destination string
+	Limit       uint
 }
 
 // DataQueryBinaryAction is the corresponding action for 'data query binary'.
@@ -589,8 +588,6 @@ func (c *viamClient) dataQueryBinaryAction(ctx context.Context, args dataQueryBi
 				Limit:  pageLimit,
 				Last:   last,
 			},
-			IncludeBinary: args.IncludeBinary,
-			CountOnly:     false,
 		})
 		if err != nil {
 			return errors.Wrap(err, serverErrorMessage)

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -224,3 +224,82 @@ func TestDataSourceTypeToProto(t *testing.T) {
 		}
 	})
 }
+
+func TestDataQueryBinaryAction(t *testing.T) {
+	page := &datapb.BinaryDataByFilterResponse{
+		Data: []*datapb.BinaryData{
+			{Metadata: &datapb.BinaryMetadata{BinaryDataId: "bin-1", FileName: "a.jpg"}},
+		},
+	}
+
+	t.Run("writes metadata to stdout as NDJSON and pages until exhausted", func(t *testing.T) {
+		var capturedReq *datapb.BinaryDataByFilterRequest
+		calls := 0
+		dsc := &inject.DataServiceClient{
+			BinaryDataByFilterFunc: func(ctx context.Context, in *datapb.BinaryDataByFilterRequest, opts ...grpc.CallOption,
+			) (*datapb.BinaryDataByFilterResponse, error) {
+				capturedReq = in
+				calls++
+				if calls == 1 {
+					return page, nil
+				}
+				return &datapb.BinaryDataByFilterResponse{}, nil
+			},
+		}
+
+		_, ac, out, errOut := setup(&inject.AppServiceClient{}, dsc, nil, nil, "token")
+		err := ac.dataQueryBinaryAction(context.Background(), dataQueryBinaryArgs{}, &datapb.Filter{PartId: "p1"})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+		test.That(t, calls, test.ShouldEqual, 2)
+		test.That(t, capturedReq.GetIncludeBinary(), test.ShouldBeFalse)
+		test.That(t, capturedReq.GetDataRequest().GetFilter().GetPartId(), test.ShouldEqual, "p1")
+
+		// Parse NDJSON back into maps since protojson's spacing isn't stable.
+		var actual []map[string]interface{}
+		decoder := json.NewDecoder(strings.NewReader(strings.Join(out.messages, "")))
+		for decoder.More() {
+			var row map[string]interface{}
+			test.That(t, decoder.Decode(&row), test.ShouldBeNil)
+			actual = append(actual, row)
+		}
+		test.That(t, len(actual), test.ShouldEqual, 1)
+	})
+
+	t.Run("forwards include-binary", func(t *testing.T) {
+		var capturedReq *datapb.BinaryDataByFilterRequest
+		dsc := &inject.DataServiceClient{
+			BinaryDataByFilterFunc: func(ctx context.Context, in *datapb.BinaryDataByFilterRequest, opts ...grpc.CallOption,
+			) (*datapb.BinaryDataByFilterResponse, error) {
+				capturedReq = in
+				return &datapb.BinaryDataByFilterResponse{}, nil
+			},
+		}
+
+		_, ac, _, errOut := setup(&inject.AppServiceClient{}, dsc, nil, nil, "token")
+		err := ac.dataQueryBinaryAction(context.Background(), dataQueryBinaryArgs{IncludeBinary: true}, &datapb.Filter{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+		test.That(t, capturedReq.GetIncludeBinary(), test.ShouldBeTrue)
+	})
+
+	t.Run("stops once --limit results have been written", func(t *testing.T) {
+		var capturedReq *datapb.BinaryDataByFilterRequest
+		calls := 0
+		// Return a full page every call so the loop can only end by honoring --limit.
+		dsc := &inject.DataServiceClient{
+			BinaryDataByFilterFunc: func(ctx context.Context, in *datapb.BinaryDataByFilterRequest, opts ...grpc.CallOption,
+			) (*datapb.BinaryDataByFilterResponse, error) {
+				capturedReq = in
+				calls++
+				return page, nil
+			},
+		}
+
+		_, ac, _, _ := setup(&inject.AppServiceClient{}, dsc, nil, nil, "token")
+		err := ac.dataQueryBinaryAction(context.Background(), dataQueryBinaryArgs{Limit: 1}, &datapb.Filter{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, capturedReq.GetDataRequest().GetLimit(), test.ShouldEqual, uint64(1))
+		test.That(t, calls, test.ShouldEqual, 1)
+	})
+}

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -317,7 +317,6 @@ func TestDataQueryBinaryAction(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
 		test.That(t, calls, test.ShouldEqual, 2)
-		test.That(t, capturedReq.GetIncludeBinary(), test.ShouldBeFalse)
 		test.That(t, capturedReq.GetDataRequest().GetFilter().GetPartId(), test.ShouldEqual, "p1")
 
 		// Parse NDJSON back into maps since protojson's spacing isn't stable.
@@ -329,23 +328,6 @@ func TestDataQueryBinaryAction(t *testing.T) {
 			actual = append(actual, row)
 		}
 		test.That(t, len(actual), test.ShouldEqual, 1)
-	})
-
-	t.Run("forwards include-binary", func(t *testing.T) {
-		var capturedReq *datapb.BinaryDataByFilterRequest
-		dsc := &inject.DataServiceClient{
-			BinaryDataByFilterFunc: func(ctx context.Context, in *datapb.BinaryDataByFilterRequest, opts ...grpc.CallOption,
-			) (*datapb.BinaryDataByFilterResponse, error) {
-				capturedReq = in
-				return &datapb.BinaryDataByFilterResponse{}, nil
-			},
-		}
-
-		_, ac, _, errOut := setup(&inject.AppServiceClient{}, dsc, nil, nil, "token")
-		err := ac.dataQueryBinaryAction(context.Background(), dataQueryBinaryArgs{IncludeBinary: true}, &datapb.Filter{})
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
-		test.That(t, capturedReq.GetIncludeBinary(), test.ShouldBeTrue)
 	})
 
 	t.Run("stops once --limit results have been written", func(t *testing.T) {

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -346,7 +346,7 @@ func TestDataQueryBinaryAction(t *testing.T) {
 		_, ac, _, _ := setup(&inject.AppServiceClient{}, dsc, nil, nil, "token")
 		err := ac.dataQueryBinaryAction(context.Background(), dataQueryBinaryArgs{Limit: 1}, &datapb.Filter{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, capturedReq.GetDataRequest().GetLimit(), test.ShouldEqual, uint64(maxLimit))
+		test.That(t, capturedReq.GetDataRequest().GetLimit(), test.ShouldEqual, uint64(1))
 		test.That(t, calls, test.ShouldEqual, 1)
 	})
 }

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -346,7 +346,7 @@ func TestDataQueryBinaryAction(t *testing.T) {
 		_, ac, _, _ := setup(&inject.AppServiceClient{}, dsc, nil, nil, "token")
 		err := ac.dataQueryBinaryAction(context.Background(), dataQueryBinaryArgs{Limit: 1}, &datapb.Filter{})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, capturedReq.GetDataRequest().GetLimit(), test.ShouldEqual, uint64(1))
+		test.That(t, capturedReq.GetDataRequest().GetLimit(), test.ShouldEqual, uint64(maxLimit))
 		test.That(t, calls, test.ShouldEqual, 1)
 	})
 }


### PR DESCRIPTION
## APP-16078: Add `data query binary` command to the CLI

### Summary
Adds `viam data query binary filter`, which queries binary data metadata by filter
(`BinaryDataByFilter`) and prints it as NDJSON to stdout, or to a file with
`--destination`. Previously the CLI could export/tag/delete binary data but not
query it. This is useful for migration scripts, debugging,
and integrations (e.g. piping JSON into `jq` or Claude Code). 

### Details
- Reuses `commonFilterFlags` + `createDataFilter`, so it accepts the same filters
  as `data export binary filter` (org, location, machine, part, component,
  method, mime-types, time, tags).
- `--limit` caps results; pagination follows the `last` cursor until exhausted.
- Output mirrors the tabular query commands (NDJSON, `data.ndjson` on disk).
- Also restructures the existing `data query` tree for consistency:
- `data query sql`  → `data query tabular sql`
- `data query mql`  → `data query tabular mql`

### Testing
- Unit tests in `data_test.go` cover stdout/NDJSON output + pagination,
  `--include-binary`, and `--limit`.
- Manually verified against real captured images:
  `go run ./cli/viam/main.go data query binary --org-ids <org> --mime-types image/jpeg --limit 5`
  plus `--include-binary` and `--destination`.
- Also verified error/edge handling: invalid `--limit` values, malformed
  timestamps, missing authentication, and an unwritable `--destination` all fail
  with clear errors, and queries matching no data exit cleanly with no output.