### PR TITLE
calcJump has been a no-op for a while - fixing it breaks a few ik tests

### DIFF
--- a/motionplan/ik/nlopt.go
+++ b/motionplan/ik/nlopt.go
@@ -298,10 +298,5 @@ func (ik *NloptIK) calcJump(ctx context.Context, testJump float64,
 			jump = append(jump, testJump)
 		}
 	}
-	for i := range jump {
-		if jump[i] > testJump {
-			jump[i] = testJump
-		}
-	}
 	return jump
 }

--- a/motionplan/ik/nlopt.go
+++ b/motionplan/ik/nlopt.go
@@ -269,4 +269,3 @@ func (ik *NloptIK) Solve(ctx context.Context,
 
 	return solutionsFound, meta, nil
 }
-

--- a/motionplan/ik/nlopt.go
+++ b/motionplan/ik/nlopt.go
@@ -286,7 +286,7 @@ func (ik *NloptIK) calcJump(ctx context.Context, testJump float64,
 				}
 			}
 
-			checkDist := minFunc(ctx, seed)
+			checkDist := minFunc(ctx, seedTest)
 
 			// Use the smallest value that yields a change in distance
 			if checkDist != seedDist {

--- a/motionplan/ik/nlopt.go
+++ b/motionplan/ik/nlopt.go
@@ -298,5 +298,10 @@ func (ik *NloptIK) calcJump(ctx context.Context, testJump float64,
 			jump = append(jump, testJump)
 		}
 	}
+	for i := range jump {
+		if jump[i] > testJump {
+			jump[i] = testJump
+		}
+	}
 	return jump
 }

--- a/motionplan/ik/nlopt.go
+++ b/motionplan/ik/nlopt.go
@@ -102,8 +102,11 @@ func (ik *NloptIK) newSeedState(ctx context.Context, seedNumber int, minFunc Cos
 		}
 	}
 
-	// Determine optimal jump values; start with default, and if gradient is zero, increase to 1 to try to avoid underflow.
-	ss.jump = ik.calcJump(ctx, defaultJump, s, limits, minFunc)
+	// Per-joint finite-difference step for the gradient computation in getMinFunc.
+	ss.jump = make([]float64, len(s))
+	for i := range ss.jump {
+		ss.jump[i] = defaultJump
+	}
 	ss.opt, err = nlopt.NewNLopt(NloptAlg, uint(len(ss.lowerBound)))
 	if err != nil {
 		return nil, errors.Wrap(err, "nlopt creation error")
@@ -267,36 +270,3 @@ func (ik *NloptIK) Solve(ctx context.Context,
 	return solutionsFound, meta, nil
 }
 
-func (ik *NloptIK) calcJump(ctx context.Context, testJump float64,
-	seed []float64, limits []referenceframe.Limit, minFunc CostFunc,
-) []float64 {
-	jump := make([]float64, 0, len(seed))
-	lowerBound, upperBound := limitsToArrays(limits)
-
-	seedDist := minFunc(ctx, seed)
-	for i, testVal := range seed {
-		seedTest := append(make([]float64, 0, len(seed)), seed...)
-		for jumpVal := testJump; jumpVal < 0.1; jumpVal *= 10 {
-			seedTest[i] = testVal + jumpVal
-			if seedTest[i] > upperBound[i] {
-				seedTest[i] = testVal - jumpVal
-				if seedTest[i] < lowerBound[i] {
-					jump = append(jump, testJump)
-					break
-				}
-			}
-
-			checkDist := minFunc(ctx, seedTest)
-
-			// Use the smallest value that yields a change in distance
-			if checkDist != seedDist {
-				jump = append(jump, jumpVal)
-				break
-			}
-		}
-		if len(jump) != i+1 {
-			jump = append(jump, testJump)
-		}
-	}
-	return jump
-}


### PR DESCRIPTION
## The bug
calcJump was supposed to find the smallest difference jump per joint that produces a measurable cost change, but called minFunc on the unperturbed seed instead of seedTest

The break on change branch was unreachable - every joint fell through to testJump = 1e-8

Bug introduced december 2023

## Why this is a draft
With this fix, four tests fail. Reverting makes them pass.

- TestArmGantryCheckPlan
- TestOrbPlanTooManySteps
- TestBadSpray1
- TestSimpleLinearMotion

## What I'm not sure about
Is the right move to 
- (a) revert and document the no op
- (b) cap calcJump's output at testJump as a workaround (all tests pass then)
- (c) retune ik to handle accurate gradients