### PR TITLE
RSDK-14124 - Remove packagepath from config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -61,9 +61,6 @@ type Config struct {
 	// error messages that can indicate flags/config fields to use.
 	FromCommand bool
 
-	// PackagePath sets the directory used to store packages locally. Defaults to ~/.viam/packages
-	PackagePath string
-
 	// EnableWebProfile turns pprof http server in localhost. Defaults to false.
 	EnableWebProfile bool
 
@@ -135,7 +132,6 @@ type configData struct {
 	LogConfig               []logging.LoggerPatternConfig `json:"log,omitempty"`
 	Revision                string                        `json:"revision,omitempty"`
 	MaintenanceConfig       *MaintenanceConfig            `json:"maintenance,omitempty"`
-	PackagePath             string                        `json:"package_path,omitempty"`
 	DisableLogDeduplication bool                          `json:"disable_log_deduplication"`
 	Jobs                    []JobConfig                   `json:"jobs,omitempty"`
 	Tracing                 TracingConfig                 `json:"tracing,omitempty"`
@@ -298,7 +294,6 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	c.LogConfig = conf.LogConfig
 	c.Revision = conf.Revision
 	c.MaintenanceConfig = conf.MaintenanceConfig
-	c.PackagePath = conf.PackagePath
 	c.DisableLogDeduplication = conf.DisableLogDeduplication
 	c.Jobs = conf.Jobs
 	c.Tracing = conf.Tracing
@@ -330,7 +325,6 @@ func (c Config) MarshalJSON() ([]byte, error) {
 		LogConfig:               c.LogConfig,
 		Revision:                c.Revision,
 		MaintenanceConfig:       c.MaintenanceConfig,
-		PackagePath:             c.PackagePath,
 		DisableLogDeduplication: c.DisableLogDeduplication,
 		Jobs:                    c.Jobs,
 		Tracing:                 c.Tracing,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1125,15 +1125,6 @@ func TestConfigJSONMarshalRoundtrip(t *testing.T) {
 			},
 		},
 		{
-			name: "package path",
-			c: config.Config{
-				PackagePath: "path/to/home/depot",
-			},
-			expected: config.Config{
-				PackagePath: "path/to/home/depot",
-			},
-		},
-		{
 			name: "traffic tunnel endpoints",
 			c: config.Config{
 				Network: config.NetworkConfig{

--- a/config/placeholder_replacement.go
+++ b/config/placeholder_replacement.go
@@ -196,7 +196,7 @@ func (v *placeholderReplacementVisitor) replacePackagePlaceholder(toReplace stri
 			errors.Errorf("placeholder %q is looking for a package of type %q but a package of type %q was found. Try %q",
 				toReplace, packageType, string(packageConfig.Type), expectedPlaceholder)
 	}
-	return packageConfig.LocalDataDirectory(viamPackagesDir), nil
+	return packageConfig.LocalDataDirectory(DefaultPackagesDir()), nil
 }
 
 func (v *placeholderReplacementVisitor) replaceEnvironmentPlaceholder(toReplace string) (string, error) {

--- a/config/reader.go
+++ b/config/reader.go
@@ -78,12 +78,6 @@ func getAgentInfo(logger logging.Logger) (*apppb.AgentInfo, error) {
 	}, nil
 }
 
-var viamPackagesDir string
-
-func init() {
-	viamPackagesDir = DefaultPackagesDir()
-}
-
 // DefaultPackagesDir is the directory used to store packages locally: ~/.viam/packages.
 // It is read fresh from [rutils.ViamDotDir] on each call so tests can redirect it.
 func DefaultPackagesDir() string {

--- a/config/reader.go
+++ b/config/reader.go
@@ -81,7 +81,13 @@ func getAgentInfo(logger logging.Logger) (*apppb.AgentInfo, error) {
 var viamPackagesDir string
 
 func init() {
-	viamPackagesDir = filepath.Join(rutils.ViamDotDir, PackagesDirName)
+	viamPackagesDir = DefaultPackagesDir()
+}
+
+// DefaultPackagesDir is the directory used to store packages locally: ~/.viam/packages.
+// It is read fresh from [rutils.ViamDotDir] on each call so tests can redirect it.
+func DefaultPackagesDir() string {
+	return filepath.Join(rutils.ViamDotDir, PackagesDirName)
 }
 
 func getCloudCacheFilePath(id string) string {

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -472,6 +472,9 @@ func newWithResources(
 	if rOpts.viamHomeDir != "" {
 		homeDir = rOpts.viamHomeDir
 	}
+	// Derive the packages dir from this robot's home dir (rather than the global
+	// config.DefaultPackagesDir) so that WithViamHomeDir fully isolates package storage in tests.
+	packagesDir := filepath.Join(homeDir, config.PackagesDirName)
 
 	closeCtx, cancel := context.WithCancel(ctx)
 	r := &localRobot{
@@ -531,14 +534,14 @@ func newWithResources(
 				return packagespb.NewPackageServiceClient(cloudConn), err
 			},
 			cfg.Cloud,
-			config.DefaultPackagesDir(),
+			packagesDir,
 			packageLogger,
 		)
 	} else {
 		r.logger.CDebug(ctx, "Using no-op PackageManager when Cloud config is not available")
 		r.packageManager = packages.NewNoopManager()
 	}
-	r.localPackages, err = packages.NewLocalManager(config.DefaultPackagesDir(), packageLogger)
+	r.localPackages, err = packages.NewLocalManager(packagesDir, packageLogger)
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +600,7 @@ func newWithResources(
 		homeDir,
 		cloudID,
 		logger,
-		config.DefaultPackagesDir(),
+		packagesDir,
 		r.webSvc.ModPeerConnTracker(),
 	); err != nil {
 		return nil, err

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -531,14 +531,14 @@ func newWithResources(
 				return packagespb.NewPackageServiceClient(cloudConn), err
 			},
 			cfg.Cloud,
-			cfg.PackagePath,
+			config.DefaultPackagesDir(),
 			packageLogger,
 		)
 	} else {
 		r.logger.CDebug(ctx, "Using no-op PackageManager when Cloud config is not available")
 		r.packageManager = packages.NewNoopManager()
 	}
-	r.localPackages, err = packages.NewLocalManager(cfg, packageLogger)
+	r.localPackages, err = packages.NewLocalManager(config.DefaultPackagesDir(), packageLogger)
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +597,7 @@ func newWithResources(
 		homeDir,
 		cloudID,
 		logger,
-		cfg.PackagePath,
+		config.DefaultPackagesDir(),
 		r.webSvc.ModPeerConnTracker(),
 	); err != nil {
 		return nil, err

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1392,12 +1392,9 @@ func TestConfigPackages(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	defer utils.UncheckedErrorFunc(fakePackageServer.Shutdown)
 
-	packageDir := t.TempDir()
-	// Packages are stored under config.DefaultPackagesDir() (~/.viam/packages). Redirect
-	// the viam dir to a temp dir so this test doesn't touch the real home directory.
-	origViamDotDir := rutils.ViamDotDir
-	rutils.ViamDotDir = packageDir
-	t.Cleanup(func() { rutils.ViamDotDir = origViamDotDir })
+	// Isolate package storage to a temp home dir (via WithViamHomeDir below) so this test
+	// doesn't touch the real home directory. Packages are stored under <homeDir>/packages.
+	viamHomeDir := t.TempDir()
 
 	robotConfig := &config.Config{
 		Packages: []config.PackageConfig{
@@ -1412,7 +1409,7 @@ func TestConfigPackages(t *testing.T) {
 		},
 	}
 
-	r := setupLocalRobot(t, ctx, robotConfig, logger)
+	r := setupLocalRobot(t, ctx, robotConfig, logger, WithViamHomeDir(viamHomeDir))
 
 	_, err = r.PackageManager().PackagePath("some-name-1")
 	test.That(t, err, test.ShouldEqual, packages.ErrPackageMissing)
@@ -1440,13 +1437,14 @@ func TestConfigPackages(t *testing.T) {
 	fakePackageServer.StorePackage(robotConfig2.Packages...)
 	r.Reconfigure(ctx, robotConfig2)
 
+	packagesDir := path.Join(viamHomeDir, config.PackagesDirName)
 	path1, err := r.PackageManager().PackagePath("some-name-1")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, path1, test.ShouldEqual, path.Join(config.DefaultPackagesDir(), "data", "ml_model", "package-1-v1"))
+	test.That(t, path1, test.ShouldEqual, path.Join(packagesDir, "data", "ml_model", "package-1-v1"))
 
 	path2, err := r.PackageManager().PackagePath("some-name-2")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, path2, test.ShouldEqual, path.Join(config.DefaultPackagesDir(), "data", "ml_model", "package-2-v2"))
+	test.That(t, path2, test.ShouldEqual, path.Join(packagesDir, "data", "ml_model", "package-2-v2"))
 }
 
 // removeDefaultServices removes default services and returns the removed

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1393,6 +1393,11 @@ func TestConfigPackages(t *testing.T) {
 	defer utils.UncheckedErrorFunc(fakePackageServer.Shutdown)
 
 	packageDir := t.TempDir()
+	// Packages are stored under config.DefaultPackagesDir() (~/.viam/packages). Redirect
+	// the viam dir to a temp dir so this test doesn't touch the real home directory.
+	origViamDotDir := rutils.ViamDotDir
+	rutils.ViamDotDir = packageDir
+	t.Cleanup(func() { rutils.ViamDotDir = origViamDotDir })
 
 	robotConfig := &config.Config{
 		Packages: []config.PackageConfig{
@@ -1405,7 +1410,6 @@ func TestConfigPackages(t *testing.T) {
 		Cloud: &config.Cloud{
 			AppAddress: fmt.Sprintf("http://%s", fakePackageServer.Addr().String()),
 		},
-		PackagePath: packageDir,
 	}
 
 	r := setupLocalRobot(t, ctx, robotConfig, logger)
@@ -1431,7 +1435,6 @@ func TestConfigPackages(t *testing.T) {
 		Cloud: &config.Cloud{
 			AppAddress: fmt.Sprintf("http://%s", fakePackageServer.Addr().String()),
 		},
-		PackagePath: packageDir,
 	}
 
 	fakePackageServer.StorePackage(robotConfig2.Packages...)
@@ -1439,11 +1442,11 @@ func TestConfigPackages(t *testing.T) {
 
 	path1, err := r.PackageManager().PackagePath("some-name-1")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, path1, test.ShouldEqual, path.Join(packageDir, "data", "ml_model", "package-1-v1"))
+	test.That(t, path1, test.ShouldEqual, path.Join(config.DefaultPackagesDir(), "data", "ml_model", "package-1-v1"))
 
 	path2, err := r.PackageManager().PackagePath("some-name-2")
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, path2, test.ShouldEqual, path.Join(packageDir, "data", "ml_model", "package-2-v2"))
+	test.That(t, path2, test.ShouldEqual, path.Join(config.DefaultPackagesDir(), "data", "ml_model", "package-2-v2"))
 }
 
 // removeDefaultServices removes default services and returns the removed

--- a/robot/impl/utils.go
+++ b/robot/impl/utils.go
@@ -33,11 +33,10 @@ func setupLocalRobot(
 		test.That(t, err, test.ShouldBeNil)
 	}
 
-	// use a temporary home directory so that it doesn't collide with
-	// the user's/other tests' viam home directory
-	var rOpts []Option
+	// Default to a temporary home directory so that it doesn't collide with the user's/other
+	// tests' viam home directory. Listed first so a caller-supplied WithViamHomeDir wins.
+	rOpts := []Option{WithViamHomeDir(t.TempDir())}
 	rOpts = append(rOpts, opts...)
-	rOpts = append(rOpts, WithViamHomeDir(t.TempDir()))
 	r, err := New(ctx, cfg, conn, logger.Sublogger("rdk"), rOpts...)
 	test.That(t, err, test.ShouldBeNil)
 	t.Cleanup(func() {

--- a/robot/packages/local_package_manager.go
+++ b/robot/packages/local_package_manager.go
@@ -50,17 +50,9 @@ type managedModuleMap map[string]*managedModule
 func NewLocalManager(packagesParentDir string, logger logging.Logger) (ManagerSyncer, error) {
 	packagesDir := LocalPackagesDir(packagesParentDir)
 	packagesDataDir := filepath.Join(packagesDir, "data")
-	// if the package path isn't set, don't generate folders because they're not used and won't get deleted
-	if packagesParentDir != "" {
-		if err := os.MkdirAll(packagesDir, 0o700); err != nil {
-			return nil, err
-		}
-
-		if err := os.MkdirAll(packagesDataDir, 0o700); err != nil {
-			return nil, err
-		}
-	}
-
+	// Don't eagerly create the package directories: a robot with no local tarball modules never
+	// uses them, and creating them here would litter the package dir (~/.viam/packages-local) for
+	// every robot/test that doesn't sync local packages. installPackage creates them on demand.
 	return &localManager{
 		Named:           InternalServiceName.AsNamed(),
 		managedModules:  make(managedModuleMap),

--- a/robot/packages/local_package_manager.go
+++ b/robot/packages/local_package_manager.go
@@ -46,11 +46,12 @@ type managedModule struct {
 type managedModuleMap map[string]*managedModule
 
 // NewLocalManager returns a noop package manager that does nothing. On path requests it returns the name of the package.
-func NewLocalManager(conf *config.Config, logger logging.Logger) (ManagerSyncer, error) {
-	packagesDir := LocalPackagesDir(conf.PackagePath)
+// packagesParentDir is the parent directory packages are stored under (the local manager appends its own suffix).
+func NewLocalManager(packagesParentDir string, logger logging.Logger) (ManagerSyncer, error) {
+	packagesDir := LocalPackagesDir(packagesParentDir)
 	packagesDataDir := filepath.Join(packagesDir, "data")
 	// if the package path isn't set, don't generate folders because they're not used and won't get deleted
-	if conf.PackagePath != "" {
+	if packagesParentDir != "" {
 		if err := os.MkdirAll(packagesDir, 0o700); err != nil {
 			return nil, err
 		}

--- a/robot/packages/local_package_manager.go
+++ b/robot/packages/local_package_manager.go
@@ -45,8 +45,9 @@ type managedModule struct {
 
 type managedModuleMap map[string]*managedModule
 
-// NewLocalManager returns a noop package manager that does nothing. On path requests it returns the name of the package.
-// packagesParentDir is the parent directory packages are stored under (the local manager appends its own suffix).
+// NewLocalManager returns a manager that unpacks local tarball modules into the package directory.
+// On path requests it returns the name of the package. packagesParentDir is the parent directory
+// packages are stored under (the local manager appends its own suffix).
 func NewLocalManager(packagesParentDir string, logger logging.Logger) (ManagerSyncer, error) {
 	packagesDir := LocalPackagesDir(packagesParentDir)
 	packagesDataDir := filepath.Join(packagesDir, "data")

--- a/robot/packages/local_package_manager_test.go
+++ b/robot/packages/local_package_manager_test.go
@@ -20,7 +20,7 @@ const testTarPath = "test_package.tar.gz"
 func TestLocalManagerUtils(t *testing.T) {
 	tmp := t.TempDir()
 	mgr, err := NewLocalManager(
-		&config.Config{PackagePath: filepath.Join(tmp, "pkg")},
+		filepath.Join(tmp, "pkg"),
 		logging.NewTestLogger(t),
 	)
 	test.That(t, err, test.ShouldBeNil)
@@ -45,7 +45,7 @@ func TestLocalManagerUtils(t *testing.T) {
 	t.Run("getAddedAndChanged", func(t *testing.T) {
 		tmp := t.TempDir()
 		logger := logging.NewTestLogger(t)
-		mgr, err := NewLocalManager(&config.Config{PackagePath: filepath.Join(tmp, "pkg")}, logger)
+		mgr, err := NewLocalManager(filepath.Join(tmp, "pkg"), logger)
 		test.That(t, err, test.ShouldBeNil)
 		local := mgr.(*localManager)
 
@@ -184,7 +184,7 @@ func modTime(t *testing.T, path string) time.Time {
 
 func TestLocalManagerSync(t *testing.T) {
 	tmp := t.TempDir()
-	mgr, err := NewLocalManager(&config.Config{PackagePath: filepath.Join(tmp, "pkg")}, logging.NewTestLogger(t))
+	mgr, err := NewLocalManager(filepath.Join(tmp, "pkg"), logging.NewTestLogger(t))
 	test.That(t, err, test.ShouldBeNil)
 	local := mgr.(*localManager)
 

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"runtime/pprof"
@@ -383,11 +382,6 @@ func (s *robotServer) processConfig(in *config.Config) (*config.Config, error) {
 				out.Modules[i].LogLevel = "debug"
 			}
 		}
-	}
-
-	// Use ~/.viam/packages for package path if one was not specified.
-	if in.PackagePath == "" {
-		out.PackagePath = path.Join(rutils.ViamDotDir, "packages")
 	}
 
 	return out, nil

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -244,8 +244,9 @@ func TestMachineState(t *testing.T) {
 
 	// Create a fake package directory using `t.TempDir`. Set it up to be identical to the
 	// expected file tree of the local package manager. Place a single file `foo` in a
-	// `fake-module` directory. Redirect the viam dir to this temp dir so the local package
-	// manager (which always uses config.DefaultPackagesDir()) looks here.
+	// `fake-module` directory. The local package manager stores packages under
+	// <viam home>/packages-local, and the server (started via RunServer below) uses the global
+	// utils.ViamDotDir as its home dir, so redirect that to this temp dir to point it here.
 	tempDir := t.TempDir()
 	origViamDotDir := utils.ViamDotDir
 	utils.ViamDotDir = tempDir

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -242,18 +242,24 @@ func TestMachineState(t *testing.T) {
 
 	machineAddress := "127.0.0.1:23654"
 
-	// Create a fake package directory using `t.TempDir`. Set it up to be identical to the
-	// expected file tree of the local package manager. Place a single file `foo` in a
-	// `fake-module` directory. The local package manager stores packages under
-	// <viam home>/packages-local, and the server (started via RunServer below) uses the global
-	// utils.ViamDotDir as its home dir, so redirect that to this temp dir to point it here.
-	tempDir := t.TempDir()
+	// Create a fake package directory and set it up to be identical to the expected file tree of
+	// the local package manager: a single file `foo` in a `fake-module` directory. The local
+	// package manager stores packages under <viam home>/packages-local, and the server (started
+	// via RunServer below) uses the global utils.ViamDotDir as its home dir, so redirect that to
+	// this temp dir to point it here.
+	//
+	// Use a short temp dir (not t.TempDir, whose Windows path is long) because redirecting
+	// ViamDotDir also relocates the module socket dir on Windows, and the unix socket path has a
+	// 103-char OS limit (see module.CreateSocketAddress).
+	tempDir, err := os.MkdirTemp("", "vds")
+	test.That(t, err, test.ShouldBeNil)
+	t.Cleanup(func() { goutils.UncheckedError(os.RemoveAll(tempDir)) })
 	origViamDotDir := utils.ViamDotDir
 	utils.ViamDotDir = tempDir
 	t.Cleanup(func() { utils.ViamDotDir = origViamDotDir })
 	fakePackagePath := filepath.Join(tempDir, fmt.Sprint("packages", config.LocalPackagesSuffix))
 	fakeModuleDataPath := filepath.Join(fakePackagePath, "data", "fake-module")
-	err := os.MkdirAll(fakeModuleDataPath, 0o777) // should create all dirs along path
+	err = os.MkdirAll(fakeModuleDataPath, 0o777) // should create all dirs along path
 	test.That(t, err, test.ShouldBeNil)
 	fakeModuleDataFile, err := os.Create(filepath.Join(fakeModuleDataPath, "foo"))
 	test.That(t, err, test.ShouldBeNil)

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -235,7 +235,8 @@ func isExpectedShutdownError(err error, testLogger logging.Logger) bool {
 
 // Tests that machine state properly reports initializing or running.
 func TestMachineState(t *testing.T) {
-	t.Parallel()
+	// NOTE: not parallel — this test redirects the global utils.ViamDotDir, which would race
+	// with other parallel tests that construct robots.
 	logger := logging.NewTestLogger(t)
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -243,8 +244,12 @@ func TestMachineState(t *testing.T) {
 
 	// Create a fake package directory using `t.TempDir`. Set it up to be identical to the
 	// expected file tree of the local package manager. Place a single file `foo` in a
-	// `fake-module` directory.
+	// `fake-module` directory. Redirect the viam dir to this temp dir so the local package
+	// manager (which always uses config.DefaultPackagesDir()) looks here.
 	tempDir := t.TempDir()
+	origViamDotDir := utils.ViamDotDir
+	utils.ViamDotDir = tempDir
+	t.Cleanup(func() { utils.ViamDotDir = origViamDotDir })
 	fakePackagePath := filepath.Join(tempDir, fmt.Sprint("packages", config.LocalPackagesSuffix))
 	fakeModuleDataPath := filepath.Join(fakePackagePath, "data", "fake-module")
 	err := os.MkdirAll(fakeModuleDataPath, 0o777) // should create all dirs along path
@@ -289,9 +294,6 @@ func TestMachineState(t *testing.T) {
 		defer wg.Done()
 
 		cfg := &config.Config{
-			// Set PackagePath to temp dir created at top of test with the "-local" piece trimmed. Local
-			// package manager will automatically add that suffix.
-			PackagePath: strings.TrimSuffix(fakePackagePath, config.LocalPackagesSuffix),
 			Components: []resource.Config{
 				{
 					Name:  "slowpoke",


### PR DESCRIPTION
as far as I can tell only one test uses it in a way that can't be easily replaced (TestMachineState).

but the existence of it implies capability we don't have - and users can already set PackagePath using the VIAM_HOME env var