### PR TITLE
ci: match flake/flaky title variants in flaky-PR workflows

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -36,7 +36,9 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           title_lc="${PR_TITLE,,}"
-          if [[ "$title_lc" == *flaky* ]]; then
+          # Match flake/flakes/flaky/flakiness — title wording varies. Keep this
+          # pattern in sync with flaky-pr-reviewer.yml.
+          if [[ "$title_lc" == *flak* ]]; then
             echo "min_approvals=1" >> "$GITHUB_OUTPUT"
             echo "Flaky-test PR detected; requiring 1 approval."
           elif [[ "$HEAD_REF" == claude/dependabot* ]]; then

--- a/.github/workflows/flaky-pr-reviewer.yml
+++ b/.github/workflows/flaky-pr-reviewer.yml
@@ -34,7 +34,9 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           title_lc="${PR_TITLE,,}"
-          if [[ "$title_lc" == *flaky* ]]; then
+          # Match flake/flakes/flaky/flakiness — title wording varies. Keep this
+          # pattern in sync with check-approvals.yml.
+          if [[ "$title_lc" == *flak* ]]; then
             echo "is_flaky=true" >> "$GITHUB_OUTPUT"
             echo "Flaky-test PR detected; will assign a netcode reviewer."
           else


### PR DESCRIPTION
The flaky-PR detection in check-approvals.yml and flaky-pr-reviewer.yml matched the literal substring "flaky", so PRs titled with "flake" (e.g. "Fix TestWebRTCSpans flake ...", as produced by claude-jira.yml) were not recognized as flaky-test PRs: no netcode reviewer was assigned and the 2-approval requirement was not relaxed.

Broaden both checks to "*flak*" (covers flake/flakes/flaky/flakiness) and add cross-referencing comments to keep the two patterns in sync.