### PR TITLE
RSDK-14087: Enforce callers to PlanMotion pass in a complete FrameSystem and non-moving obstacles.

### DIFF
--- a/motionplan/armplanning/api.go
+++ b/motionplan/armplanning/api.go
@@ -52,6 +52,13 @@ type PlanRequest struct {
 	myTestOptions testOptions
 }
 
+// GetWorldState is a backwards compatibility helper that turns the ObstaclesInWorldFrame back into
+// WorldState object. Presumably for interfacing/rendering with the viz-client.
+func (req *PlanRequest) GetWorldState() *referenceframe.WorldState {
+	return mustNewWorldState([]*referenceframe.GeometriesInFrame{
+		req.ObstaclesInWorldFrame}, nil)
+}
+
 // validatePlanRequest ensures PlanRequests are not malformed.
 func (req *PlanRequest) validatePlanRequest() error {
 	if req == nil {
@@ -94,31 +101,27 @@ func (req *PlanRequest) validatePlanRequest() error {
 	}
 
 	if req.PlannerOptions.MeshesAsOctrees {
-		// convert any meshes in the worldstate to octrees
-		if req.WorldState == nil {
-			return errors.New("PlanRequest must have non-nil WorldState if 'meshes_as_octrees' option is enabled")
+		// convert any meshes in the obstacles to octrees
+		if req.ObstaclesInWorldFrame == nil {
+			return errors.New("PlanRequest must have non-nil ObstaclesInWorldFrame if 'meshes_as_octrees' option is enabled")
 		}
-		obstacles := make([]*referenceframe.GeometriesInFrame, 0, len(req.WorldState.ObstacleNames()))
-		for _, gf := range req.WorldState.Obstacles() {
-			geometries := gf.Geometries()
-			pcdGeometries := make([]spatialmath.Geometry, 0, len(geometries))
-			for _, geometry := range geometries {
-				if mesh, ok := geometry.(*spatialmath.Mesh); ok {
-					octree, err := pointcloud.NewFromMesh(mesh)
-					if err != nil {
-						return err
-					}
-					geometry = octree
+
+		pcdGeometries := make([]spatialmath.Geometry, 0, len(req.ObstaclesInWorldFrame.Geometries()))
+		for _, geometry := range req.ObstaclesInWorldFrame.Geometries() {
+			if mesh, ok := geometry.(*spatialmath.Mesh); ok {
+				octree, err := pointcloud.NewFromMesh(mesh)
+				if err != nil {
+					return err
 				}
-				pcdGeometries = append(pcdGeometries, geometry)
+
+				geometry = octree
 			}
-			obstacles = append(obstacles, referenceframe.NewGeometriesInFrame(gf.Parent(), pcdGeometries))
+
+			pcdGeometries = append(pcdGeometries, geometry)
 		}
-		newWS, err := referenceframe.NewWorldState(obstacles, req.WorldState.Transforms())
-		if err != nil {
-			return err
-		}
-		req.WorldState = newWS
+
+		req.ObstaclesInWorldFrame = referenceframe.NewGeometriesInFrame(
+			req.ObstaclesInWorldFrame.Parent(), pcdGeometries)
 	}
 
 	// Validate the goals. Each goal with a pose must not also have a configuration specified. The parent frame of the pose must exist.
@@ -341,20 +344,11 @@ func resetMeshCaches(ctx context.Context, logger logging.Logger, request *PlanRe
 		}
 	}
 
-	if request.WorldState != nil {
-		// Right now, the world state is getting entirely thrown away anyways. It's always a part of
-		// the user request that is about to go out of scope. In the future, this may include
-		// geometries saved in the `WorldStateStore` service.
-		obstacles, err := request.WorldState.ObstaclesInWorldFrame(
-			request.FrameSystem,
-			request.StartState.structuredConfiguration,
-		)
-		if err != nil {
-			logger.CDebugf(ctx, "resetMeshCaches: skipping world obstacles: %v", err)
-			return
-		}
-
-		for _, geometry := range obstacles.Geometries() {
+	if request.ObstaclesInWorldFrame != nil {
+		// Right now, the ObstaclesInWorldFrame is getting entirely thrown away anyways. It's always
+		// a part of the user request that is about to go out of scope. In the future, this may
+		// include geometries saved in the `WorldStateStore` service.
+		for _, geometry := range request.ObstaclesInWorldFrame.Geometries() {
 			visit(geometry)
 		}
 	}

--- a/motionplan/armplanning/api.go
+++ b/motionplan/armplanning/api.go
@@ -43,7 +43,7 @@ type PlanRequest struct {
 	// feasibility, and then other plans can be requested to connect to that returned plan's configurations.
 	StartState *PlanState `json:"start_state"`
 	// The data representation of the robot's environment.
-	WorldState *referenceframe.WorldState `json:"world_state"`
+	ObstaclesInWorldFrame *referenceframe.GeometriesInFrame `json:"obstacles_in_world_frame"`
 	// Additional parameters constraining the motion of the robot.
 	Constraints *motionplan.Constraints `json:"constraints"`
 	// Other more granular parameters for the plan used to move the robot.

--- a/motionplan/armplanning/api.go
+++ b/motionplan/armplanning/api.go
@@ -388,15 +388,24 @@ func MoveArm(ctx context.Context, logger logging.Logger, a arm.Arm, dst spatialm
 
 // ReadRequestFromFile reads a PlanRequest from a json file. This method is compatible with legacy
 // PlanRequests containing a `world_state` key as well as modern ones that simply take in
-// `obstacles_in_world_frame`.
+// `obstacles_in_world_frame`. Files may contain a second JSON object (a response) after the
+// request; this function decodes only the first object.
 func ReadRequestFromFile(fileName string) (*PlanRequest, error) {
-	data, err := os.ReadFile(fileName) //nolint:gosec
+	f, err := os.Open(fileName) //nolint:gosec
 	if err != nil {
+		return nil, err
+	}
+	defer utils.UncheckedErrorFunc(f.Close)
+
+	decoder := json.NewDecoder(f)
+
+	var raw json.RawMessage
+	if err = decoder.Decode(&raw); err != nil {
 		return nil, err
 	}
 
 	var probe map[string]json.RawMessage
-	if err = json.Unmarshal(data, &probe); err != nil {
+	if err = json.Unmarshal(raw, &probe); err != nil {
 		return nil, err
 	}
 
@@ -404,14 +413,14 @@ func ReadRequestFromFile(fileName string) (*PlanRequest, error) {
 		// Legacy format, parse as a `PlanRequestWithWorldState` and have that "upgrade" to a modern
 		// `PlanRequest`.
 		legacy := &PlanRequestWithWorldState{}
-		if err = json.Unmarshal(data, legacy); err != nil {
+		if err = json.Unmarshal(raw, legacy); err != nil {
 			return nil, err
 		}
 		return legacy.ToPlanRequestWorldStateTransformsIgnored()
 	}
 
 	req := &PlanRequest{}
-	if err = json.Unmarshal(data, req); err != nil {
+	if err = json.Unmarshal(raw, req); err != nil {
 		return nil, err
 	}
 

--- a/motionplan/armplanning/api.go
+++ b/motionplan/armplanning/api.go
@@ -96,6 +96,11 @@ func (req *PlanRequest) validatePlanRequest() error {
 		}
 	}
 
+	if req.ObstaclesInWorldFrame != nil && req.ObstaclesInWorldFrame.Parent() != referenceframe.World {
+		return errors.Errorf("ObstaclesInWorldFrame must be parented by %q, got %q",
+			referenceframe.World, req.ObstaclesInWorldFrame.Parent())
+	}
+
 	if len(req.Goals) == 0 {
 		return errors.New("PlanRequest must have at least one goal")
 	}

--- a/motionplan/armplanning/api.go
+++ b/motionplan/armplanning/api.go
@@ -56,7 +56,8 @@ type PlanRequest struct {
 // WorldState object. Presumably for interfacing/rendering with the viz-client.
 func (req *PlanRequest) GetWorldState() *referenceframe.WorldState {
 	return mustNewWorldState([]*referenceframe.GeometriesInFrame{
-		req.ObstaclesInWorldFrame}, nil)
+		req.ObstaclesInWorldFrame,
+	}, nil)
 }
 
 // validatePlanRequest ensures PlanRequests are not malformed.

--- a/motionplan/armplanning/api.go
+++ b/motionplan/armplanning/api.go
@@ -385,20 +385,32 @@ func MoveArm(ctx context.Context, logger logging.Logger, a arm.Arm, dst spatialm
 	return a.MoveThroughJointPositions(ctx, plan, nil, nil)
 }
 
-// ReadRequestFromFile reads a PlanRequest from a json file.
+// ReadRequestFromFile reads a PlanRequest from a json file. This method is compatible with legacy
+// PlanRequests containing a `world_state` key as well as modern ones that simply take in
+// `obstacles_in_world_frame`.
 func ReadRequestFromFile(fileName string) (*PlanRequest, error) {
-	f, err := os.Open(fileName) //nolint:gosec
+	data, err := os.ReadFile(fileName) //nolint:gosec
 	if err != nil {
 		return nil, err
 	}
-	defer utils.UncheckedErrorFunc(f.Close)
 
-	decoder := json.NewDecoder(f)
+	var probe map[string]json.RawMessage
+	if err = json.Unmarshal(data, &probe); err != nil {
+		return nil, err
+	}
+
+	if _, hasWorldState := probe["world_state"]; hasWorldState {
+		// Legacy format, parse as a `PlanRequestWithWorldState` and have that "upgrade" to a modern
+		// `PlanRequest`.
+		legacy := &PlanRequestWithWorldState{}
+		if err = json.Unmarshal(data, legacy); err != nil {
+			return nil, err
+		}
+		return legacy.ToPlanRequestWorldStateTransformsIgnored()
+	}
 
 	req := &PlanRequest{}
-
-	err = decoder.Decode(req)
-	if err != nil {
+	if err = json.Unmarshal(data, req); err != nil {
 		return nil, err
 	}
 

--- a/motionplan/armplanning/cmd-plan/cmd-plan.go
+++ b/motionplan/armplanning/cmd-plan/cmd-plan.go
@@ -333,7 +333,7 @@ func visualize(req *armplanning.PlanRequest, plan motionplan.Plan, mylog *log.Lo
 	// `DrawWorldState` just draws the obstacles. I think the FrameSystem/Path are necessary
 	// because obstacles can be in terms of reference frames contained within the frame
 	// system. Such as a camera attached to an arm.
-	if err := viz.DrawWorldState(req.WorldState, req.FrameSystem, startInputs); err != nil {
+	if err := viz.DrawWorldState(req.GetWorldState(), req.FrameSystem, startInputs); err != nil {
 		return err
 	}
 
@@ -479,7 +479,7 @@ func doInteractive(req *armplanning.PlanRequest, plan motionplan.Plan, planErr e
 		return err
 	}
 
-	if err := viz.DrawWorldState(req.WorldState, req.FrameSystem, req.StartState.Configuration()); err != nil {
+	if err := viz.DrawWorldState(req.GetWorldState(), req.FrameSystem, req.StartState.Configuration()); err != nil {
 		return err
 	}
 

--- a/motionplan/armplanning/context.go
+++ b/motionplan/armplanning/context.go
@@ -162,7 +162,7 @@ func NewPlanSegmentContext(ctx context.Context, pc *PlanContext, start *referenc
 		pc.fs,
 		movingRobotGeometries, staticRobotGeometries,
 		start,
-		pc.request.WorldState,
+		pc.request.ObstaclesInWorldFrame,
 		pc.logger.Sublogger("constraint"),
 		pc.collisionCache,
 	)

--- a/motionplan/armplanning/deprecated.go
+++ b/motionplan/armplanning/deprecated.go
@@ -1,0 +1,44 @@
+package armplanning
+
+import (
+	"go.viam.com/rdk/motionplan"
+	"go.viam.com/rdk/referenceframe"
+)
+
+// PlanRequestWithWorldState is a deprecated struct that stores all the data necessary to make a
+// call to PlanMotion. Though it's deprecated as the `WorldState` is no longer used. The WorldState
+// object wraps two concepts, additional geometries and additional transforms. The new PlanRequest
+// replaces WorldState with AdditionalGeometries. WorldState transforms are expected to already be
+// merged into the `FrameSystem` part of the new PlanRequest.
+//
+// This type continues to exist as there are existing plan request files that serialized a
+// WorldState which we want to continue to be able to parse.
+type PlanRequestWithWorldState struct {
+	FrameSystem *referenceframe.FrameSystem `json:"frame_system"`
+
+	// The planner will hit each Goal in order. Each goal may be a configuration or FrameSystemPoses for holonomic motion, or must be a
+	// FrameSystemPoses for non-holonomic motion. For holonomic motion, if both a configuration and FrameSystemPoses are given,
+	// an error is thrown.
+	// TODO: Perhaps we could do something where some components are enforced to arrive at a certain configuration, but others can have IK
+	// run to solve for poses. Doing this while enforcing configurations may be tricky.
+	Goals []*PlanState `json:"goals"`
+
+	// This must always have a configuration filled in, for geometry placement purposes.
+	// If poses are also filled in, the configuration will be used to determine geometry collisions, but the poses will be used
+	// in IK to generate plan start configurations. The given configuration will NOT automatically be added to the seed tree.
+	// The use case here is that if a particularly difficult path must be planned between two poses, that can be done first to ensure
+	// feasibility, and then other plans can be requested to connect to that returned plan's configurations.
+	StartState *PlanState `json:"start_state"`
+	// The data representation of the robot's environment.
+	WorldState *referenceframe.WorldState `json:"world_state"`
+	// Additional parameters constraining the motion of the robot.
+	Constraints *motionplan.Constraints `json:"constraints"`
+	// Other more granular parameters for the plan used to move the robot.
+	PlannerOptions *PlannerOptions `json:"planner_options"`
+
+	myTestOptions testOptions
+}
+
+func (pr *PlanRequestWithWorldState) ToPlanRequestWorldStateTransformsIgnored() *PlanRequest {
+	return &PlanRequest{}
+}

--- a/motionplan/armplanning/deprecated.go
+++ b/motionplan/armplanning/deprecated.go
@@ -35,8 +35,6 @@ type PlanRequestWithWorldState struct {
 	Constraints *motionplan.Constraints `json:"constraints"`
 	// Other more granular parameters for the plan used to move the robot.
 	PlannerOptions *PlannerOptions `json:"planner_options"`
-
-	myTestOptions testOptions
 }
 
 // MustNewWorldState calls NewWorldState and panics if it returns an error.

--- a/motionplan/armplanning/deprecated.go
+++ b/motionplan/armplanning/deprecated.go
@@ -48,6 +48,24 @@ func mustNewWorldState(obstacles []*referenceframe.GeometriesInFrame, transforms
 	return ws
 }
 
-func (pr *PlanRequestWithWorldState) ToPlanRequestWorldStateTransformsIgnored() *PlanRequest {
-	return &PlanRequest{}
+// ToPlanRequestWorldStateTransformsIgnored converts a PlanRequestWithWorldState to a PlanRequest by resolving the WorldState
+// obstacles into world frame using the embedded FrameSystem and start configuration. WorldState
+// transforms are not applied; callers are responsible for merging them into the FrameSystem first.
+func (pr *PlanRequestWithWorldState) ToPlanRequestWorldStateTransformsIgnored() (*PlanRequest, error) {
+	obstaclesInWorldFrame, err := pr.WorldState.ObstaclesInWorldFrame(
+		pr.FrameSystem,
+		pr.StartState.Configuration(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PlanRequest{
+		FrameSystem:           pr.FrameSystem,
+		Goals:                 pr.Goals,
+		StartState:            pr.StartState,
+		ObstaclesInWorldFrame: obstaclesInWorldFrame,
+		Constraints:           pr.Constraints,
+		PlannerOptions:        pr.PlannerOptions,
+	}, nil
 }

--- a/motionplan/armplanning/deprecated.go
+++ b/motionplan/armplanning/deprecated.go
@@ -39,6 +39,15 @@ type PlanRequestWithWorldState struct {
 	myTestOptions testOptions
 }
 
+// MustNewWorldState calls NewWorldState and panics if it returns an error.
+func mustNewWorldState(obstacles []*referenceframe.GeometriesInFrame, transforms []*referenceframe.LinkInFrame) *referenceframe.WorldState {
+	ws, err := referenceframe.NewWorldState(obstacles, transforms)
+	if err != nil {
+		panic(err)
+	}
+	return ws
+}
+
 func (pr *PlanRequestWithWorldState) ToPlanRequestWorldStateTransformsIgnored() *PlanRequest {
 	return &PlanRequest{}
 }

--- a/motionplan/armplanning/functional_test.go
+++ b/motionplan/armplanning/functional_test.go
@@ -2,9 +2,7 @@ package armplanning
 
 import (
 	"context"
-	"encoding/json"
 	"math"
-	"os"
 	"sort"
 	"testing"
 
@@ -402,10 +400,7 @@ func TestSerializedPlanRequest(t *testing.T) {
 		Constraints:           constraints,
 	}
 
-	jsonData, err := os.ReadFile("data/plan_request_sample.json")
-	test.That(t, err, test.ShouldBeNil)
-	parsedPr := &PlanRequest{}
-	err = json.Unmarshal(jsonData, parsedPr)
+	parsedPr, err := ReadRequestFromFile("data/plan_request_sample.json")
 	test.That(t, err, test.ShouldBeNil)
 
 	goalPose1 := pr.Goals[0].Poses()["xArmVgripper"].Pose()

--- a/motionplan/armplanning/functional_test.go
+++ b/motionplan/armplanning/functional_test.go
@@ -391,19 +391,15 @@ func TestSerializedPlanRequest(t *testing.T) {
 
 	box, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{350, 0, 0}), r3.Vector{10, 8000, 8000}, "theWall")
 	test.That(t, err, test.ShouldBeNil)
-	worldState1, err := frame.NewWorldState(
-		[]*frame.GeometriesInFrame{frame.NewGeometriesInFrame(frame.World, []spatialmath.Geometry{box})},
-		nil,
-	)
-	test.That(t, err, test.ShouldBeNil)
+	obstaclesInWorldFrame := frame.NewGeometriesInFrame(frame.World, []spatialmath.Geometry{box})
 	goal := spatialmath.NewPose(r3.Vector{X: 600, Y: 100, Z: 300}, &spatialmath.OrientationVectorDegrees{OX: 1})
 
 	pr := &PlanRequest{
-		FrameSystem: fs,
-		Goals:       []*PlanState{{poses: frame.FrameSystemPoses{"xArmVgripper": frame.NewPoseInFrame(frame.World, goal)}}},
-		StartState:  &PlanState{structuredConfiguration: frame.NewNeutralFrameSystemInputs(fs)},
-		WorldState:  worldState1,
-		Constraints: constraints,
+		FrameSystem:           fs,
+		Goals:                 []*PlanState{{poses: frame.FrameSystemPoses{"xArmVgripper": frame.NewPoseInFrame(frame.World, goal)}}},
+		StartState:            &PlanState{structuredConfiguration: frame.NewNeutralFrameSystemInputs(fs)},
+		ObstaclesInWorldFrame: obstaclesInWorldFrame,
+		Constraints:           constraints,
 	}
 
 	jsonData, err := os.ReadFile("data/plan_request_sample.json")
@@ -438,17 +434,12 @@ func TestSerializedPlanRequest(t *testing.T) {
 	test.That(t, ok, test.ShouldBeTrue)
 	test.That(t, startStateConf1, test.ShouldResemble, startStateConf2)
 
-	geometryIF1 := pr.WorldState.Obstacles()[0]
-	test.That(t, parsedPr.WorldState, test.ShouldNotBeNil)
-	test.That(t, parsedPr.WorldState.Obstacles(), test.ShouldNotBeEmpty)
-	geometryIF2 := parsedPr.WorldState.Obstacles()[0]
-	test.That(t, geometryIF1.Parent(), test.ShouldEqual, geometryIF2.Parent())
-	geometries1 := geometryIF1.Geometries()
-	geometries2 := geometryIF2.Geometries()
+	test.That(t, parsedPr.ObstaclesInWorldFrame, test.ShouldNotBeNil)
+	test.That(t, pr.ObstaclesInWorldFrame.Parent(), test.ShouldEqual, parsedPr.ObstaclesInWorldFrame.Parent())
+	geometries1 := pr.ObstaclesInWorldFrame.Geometries()
+	geometries2 := parsedPr.ObstaclesInWorldFrame.Geometries()
 	test.That(t, len(geometries1), test.ShouldEqual, len(geometries2))
-	geometry1 := geometries1[0]
-	geometry2 := geometries2[0]
-	test.That(t, spatialmath.PoseAlmostEqual(geometry1.Pose(), geometry2.Pose()), test.ShouldBeTrue)
+	test.That(t, spatialmath.PoseAlmostEqual(geometries1[0].Pose(), geometries2[0].Pose()), test.ShouldBeTrue)
 
 	fs1 := pr.FrameSystem
 	fs2 := parsedPr.FrameSystem
@@ -490,20 +481,15 @@ func TestArmObstacleSolve(t *testing.T) {
 	// Set an obstacle such that it is impossible to reach the goal without colliding with it
 	obstacle, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{X: 257, Y: 210, Z: -300}), r3.Vector{10, 10, 100}, "")
 	test.That(t, err, test.ShouldBeNil)
-	worldState, err := frame.NewWorldState(
-		[]*frame.GeometriesInFrame{frame.NewGeometriesInFrame(frame.World, []spatialmath.Geometry{obstacle})},
-		nil,
-	)
-	test.That(t, err, test.ShouldBeNil)
 
 	// Set a goal unreachable by the UR
 	goal1 := spatialmath.NewPose(r3.Vector{X: 257, Y: 210, Z: -300}, &spatialmath.OrientationVectorDegrees{OZ: -1})
 	_, _, err = PlanMotion(context.Background(), logger, &PlanRequest{
-		FrameSystem:    fs,
-		Goals:          []*PlanState{{poses: frame.FrameSystemPoses{"urCamera": frame.NewPoseInFrame(frame.World, goal1)}}},
-		StartState:     &PlanState{structuredConfiguration: positions},
-		WorldState:     worldState,
-		PlannerOptions: NewBasicPlannerOptions(),
+		FrameSystem:           fs,
+		Goals:                 []*PlanState{{poses: frame.FrameSystemPoses{"urCamera": frame.NewPoseInFrame(frame.World, goal1)}}},
+		StartState:            &PlanState{structuredConfiguration: positions},
+		ObstaclesInWorldFrame: frame.NewGeometriesInFrame(frame.World, []spatialmath.Geometry{obstacle}),
+		PlannerOptions:        NewBasicPlannerOptions(),
 	})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "constraint")
@@ -657,11 +643,7 @@ func TestPlanMapMotion(t *testing.T) {
 	dst := spatialmath.NewPoseFromPoint(r3.Vector{0, 100, 0})
 	box, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{0, 50, 0}), r3.Vector{25, 25, 25}, "impediment")
 	test.That(t, err, test.ShouldBeNil)
-	worldState, err := frame.NewWorldState(
-		[]*frame.GeometriesInFrame{frame.NewGeometriesInFrame(frame.World, []spatialmath.Geometry{box})},
-		nil,
-	)
-	test.That(t, err, test.ShouldBeNil)
+	obstacles := frame.NewGeometriesInFrame(frame.World, []spatialmath.Geometry{box})
 
 	PlanMapMotion := func(
 		ctx context.Context,
@@ -669,7 +651,7 @@ func TestPlanMapMotion(t *testing.T) {
 		dst spatialmath.Pose,
 		f frame.Frame,
 		seed []frame.Input,
-		worldState *frame.WorldState,
+		obstaclesInWorldFrame *frame.GeometriesInFrame,
 	) ([][]frame.Input, error) {
 		// ephemerally create a framesystem containing just the frame for the solve
 		fs := frame.NewEmptyFrameSystem("")
@@ -679,11 +661,11 @@ func TestPlanMapMotion(t *testing.T) {
 		destination := frame.NewPoseInFrame(frame.World, dst)
 		seedMap := map[string][]frame.Input{f.Name(): seed}
 		plan, _, err := PlanMotion(ctx, logger, &PlanRequest{
-			FrameSystem:    fs,
-			Goals:          []*PlanState{{poses: frame.FrameSystemPoses{f.Name(): destination}}},
-			StartState:     &PlanState{structuredConfiguration: seedMap},
-			WorldState:     worldState,
-			PlannerOptions: NewBasicPlannerOptions(),
+			FrameSystem:           fs,
+			Goals:                 []*PlanState{{poses: frame.FrameSystemPoses{f.Name(): destination}}},
+			StartState:            &PlanState{structuredConfiguration: seedMap},
+			ObstaclesInWorldFrame: obstaclesInWorldFrame,
+			PlannerOptions:        NewBasicPlannerOptions(),
 		})
 		if err != nil {
 			return nil, err
@@ -691,7 +673,7 @@ func TestPlanMapMotion(t *testing.T) {
 		return plan.Trajectory().GetFrameInputs(f.Name())
 	}
 
-	plan, err := PlanMapMotion(ctx, logger, dst, model, make([]frame.Input, 3), worldState)
+	plan, err := PlanMapMotion(ctx, logger, dst, model, make([]frame.Input, 3), obstacles)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(plan), test.ShouldBeGreaterThan, 2)
 }
@@ -719,75 +701,57 @@ func TestArmConstraintSpecificationSolve(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, fs.AddFrame(xArmVgripper, x), test.ShouldBeNil)
 
-	checkReachable := func(worldState *frame.WorldState, constraints *motionplan.Constraints) error {
+	checkReachable := func(obstaclesInWorldFrame *frame.GeometriesInFrame, constraints *motionplan.Constraints) error {
 		goal := spatialmath.NewPose(r3.Vector{X: 600, Y: 100, Z: 300}, &spatialmath.OrientationVectorDegrees{OX: 1})
 		_, _, err = PlanMotion(context.Background(), logger, &PlanRequest{
-			FrameSystem:    fs,
-			Goals:          []*PlanState{{poses: frame.FrameSystemPoses{"xArmVgripper": frame.NewPoseInFrame(frame.World, goal)}}},
-			StartState:     &PlanState{structuredConfiguration: frame.NewNeutralFrameSystemInputs(fs)},
-			WorldState:     worldState,
-			Constraints:    constraints,
-			PlannerOptions: NewBasicPlannerOptions(),
+			FrameSystem:           fs,
+			Goals:                 []*PlanState{{poses: frame.FrameSystemPoses{"xArmVgripper": frame.NewPoseInFrame(frame.World, goal)}}},
+			StartState:            &PlanState{structuredConfiguration: frame.NewNeutralFrameSystemInputs(fs)},
+			ObstaclesInWorldFrame: obstaclesInWorldFrame,
+			Constraints:           constraints,
+			PlannerOptions:        NewBasicPlannerOptions(),
 		})
 		return err
 	}
 
 	// Verify that the goal position is reachable with no obstacles
-	test.That(t, checkReachable(frame.NewEmptyWorldState(), &motionplan.Constraints{}), test.ShouldBeNil)
+	test.That(t, checkReachable(nil, &motionplan.Constraints{}), test.ShouldBeNil)
 
-	// Add an obstacle to the WorldState
+	// Add an obstacle
 	box, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{350, 0, 0}), r3.Vector{10, 8000, 8000}, "theWall")
 	test.That(t, err, test.ShouldBeNil)
-	worldState1, err := frame.NewWorldState(
-		[]*frame.GeometriesInFrame{frame.NewGeometriesInFrame(frame.World, []spatialmath.Geometry{box})},
-		nil,
-	)
+	wallObstacles := frame.NewGeometriesInFrame(frame.World, []spatialmath.Geometry{box})
+
+	// Not reachable without a collision specification
+	err = checkReachable(wallObstacles, &motionplan.Constraints{})
+	test.That(t, err, test.ShouldNotBeNil)
+
+	// Reachable if xarm6 and gripper ignore collisions with The Wall
+	err = checkReachable(wallObstacles, &motionplan.Constraints{
+		CollisionSpecification: []motionplan.CollisionSpecification{
+			{
+				Allows: []motionplan.CollisionSpecificationAllowedFrameCollisions{
+					{Frame1: "xArm6", Frame2: "theWall"}, {Frame1: "xArmVgripper", Frame2: "theWall"},
+				},
+			},
+		},
+	})
 	test.That(t, err, test.ShouldBeNil)
 
-	testCases := []struct {
-		name       string
-		worldState *frame.WorldState
-	}{
-		{"obstacle specified through WorldState obstacles", worldState1},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Not reachable without a collision specification
-			constraints := &motionplan.Constraints{}
-			err = checkReachable(tc.worldState, constraints)
-			test.That(t, err, test.ShouldNotBeNil)
-
-			// Reachable if xarm6 and gripper ignore collisions with The Wall
-			constraints = &motionplan.Constraints{
-				CollisionSpecification: []motionplan.CollisionSpecification{
-					{
-						Allows: []motionplan.CollisionSpecificationAllowedFrameCollisions{
-							{Frame1: "xArm6", Frame2: "theWall"}, {Frame1: "xArmVgripper", Frame2: "theWall"},
-						},
-					},
+	// Reachable if the specific bits of the xarm that collide are specified instead
+	err = checkReachable(wallObstacles, &motionplan.Constraints{
+		CollisionSpecification: []motionplan.CollisionSpecification{
+			{
+				Allows: []motionplan.CollisionSpecificationAllowedFrameCollisions{
+					{Frame1: "xArmVgripper", Frame2: "theWall"},
+					{Frame1: "xArm6:wrist_link", Frame2: "theWall"},
+					{Frame1: "xArm6:lower_forearm", Frame2: "theWall"},
+					{Frame1: "xArm6:gripper_mount", Frame2: "theWall"},
 				},
-			}
-			err = checkReachable(tc.worldState, constraints)
-			test.That(t, err, test.ShouldBeNil)
-
-			// Reachable if the specific bits of the xarm that collide are specified instead
-			constraints = &motionplan.Constraints{
-				CollisionSpecification: []motionplan.CollisionSpecification{
-					{
-						Allows: []motionplan.CollisionSpecificationAllowedFrameCollisions{
-							{Frame1: "xArmVgripper", Frame2: "theWall"},
-							{Frame1: "xArm6:wrist_link", Frame2: "theWall"},
-							{Frame1: "xArm6:lower_forearm", Frame2: "theWall"},
-							{Frame1: "xArm6:gripper_mount", Frame2: "theWall"},
-						},
-					},
-				},
-			}
-			err = checkReachable(tc.worldState, constraints)
-			test.That(t, err, test.ShouldBeNil)
-		})
-	}
+			},
+		},
+	})
+	test.That(t, err, test.ShouldBeNil)
 }
 
 func TestValidatePlanRequest(t *testing.T) {

--- a/motionplan/armplanning/mpserver/server.go
+++ b/motionplan/armplanning/mpserver/server.go
@@ -1,6 +1,6 @@
 // Package mpserver is a webserver for diagnosing motion plans.
 //
-//nolint // This is a self-contained program. Most lint errors do not help find bugs.
+// nolint // This is a self-contained program. Most lint errors do not help find bugs.
 package mpserver
 
 import (
@@ -933,7 +933,7 @@ func renderState(relPath string) error {
 	if err := viz.RemoveAllSpatialObjects(); err != nil {
 		return fmt.Errorf("clearing visualizer: %w", err)
 	}
-	if err := viz.DrawWorldState(req.WorldState, req.FrameSystem, startInputs); err != nil {
+	if err := viz.DrawWorldState(req.GetWorldState(), req.FrameSystem, startInputs); err != nil {
 		return fmt.Errorf("drawing world state: %w", err)
 	}
 	if err := viz.DrawFrameSystem(req.FrameSystem, startInputs); err != nil {
@@ -952,7 +952,7 @@ func visualizeLinearTrajectory(ctx context.Context, req *armplanning.PlanRequest
 	if err := viz.RemoveAllSpatialObjects(); err != nil {
 		return err
 	}
-	if err := viz.DrawWorldState(req.WorldState, req.FrameSystem, startInputs); err != nil {
+	if err := viz.DrawWorldState(req.GetWorldState(), req.FrameSystem, startInputs); err != nil {
 		return err
 	}
 	if err := viz.DrawFrameSystem(req.FrameSystem, startInputs); err != nil {
@@ -1291,7 +1291,7 @@ func handleRenderSolution(logger logging.Logger) http.HandlerFunc {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		if err := viz.DrawWorldState(req.WorldState, req.FrameSystem, startInputs); err != nil {
+		if err := viz.DrawWorldState(req.GetWorldState(), req.FrameSystem, startInputs); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -1335,7 +1335,7 @@ func handleRenderShadows(logger logging.Logger) http.HandlerFunc {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		if err := viz.DrawWorldState(req.WorldState, req.FrameSystem, startInputs); err != nil {
+		if err := viz.DrawWorldState(req.GetWorldState(), req.FrameSystem, startInputs); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/motionplan/armplanning/mpserver/server.go
+++ b/motionplan/armplanning/mpserver/server.go
@@ -1,6 +1,6 @@
 // Package mpserver is a webserver for diagnosing motion plans.
 //
-// nolint // This is a self-contained program. Most lint errors do not help find bugs.
+//nolint // This is a self-contained program. Most lint errors do not help find bugs.
 package mpserver
 
 import (

--- a/motionplan/constraint_checker.go
+++ b/motionplan/constraint_checker.go
@@ -70,7 +70,7 @@ func NewConstraintChecker(
 	fs *referenceframe.FrameSystem,
 	movingRobotGeometries, staticRobotGeometries []spatialmath.Geometry,
 	seedMap *referenceframe.LinearInputs,
-	worldState *referenceframe.WorldState,
+	obstaclesInWorldFrame *referenceframe.GeometriesInFrame,
 	logger logging.Logger,
 	cache *CollisionCache,
 ) (*ConstraintChecker, error) {
@@ -86,11 +86,11 @@ func NewConstraintChecker(
 		return nil, err
 	}
 
-	obstaclesInFrame, err := worldState.ObstaclesInWorldFrame(fs, seedMap.ToFrameSystemInputs())
-	if err != nil {
-		return nil, err
+	worldGeometries := obstaclesInWorldFrame.Geometries()
+	obstacleNames := make(map[string]bool)
+	for _, geometry := range worldGeometries {
+		obstacleNames[geometry.Label()] = true
 	}
-	worldGeometries := obstaclesInFrame.Geometries()
 
 	frameNames := map[string]bool{}
 	for _, fName := range fs.FrameNames() {
@@ -101,7 +101,7 @@ func NewConstraintChecker(
 		constraints.CollisionSpecification,
 		frameSystemGeometries,
 		frameNames,
-		worldState.ObstacleNames(),
+		obstacleNames,
 	)
 	if err != nil {
 		return nil, err

--- a/motionplan/constraint_checker.go
+++ b/motionplan/constraint_checker.go
@@ -86,7 +86,11 @@ func NewConstraintChecker(
 		return nil, err
 	}
 
-	worldGeometries := obstaclesInWorldFrame.Geometries()
+	var worldGeometries []spatialmath.Geometry
+	if obstaclesInWorldFrame != nil {
+		worldGeometries = obstaclesInWorldFrame.Geometries()
+	}
+
 	obstacleNames := make(map[string]bool)
 	for _, geometry := range worldGeometries {
 		obstacleNames[geometry.Label()] = true

--- a/motionplan/constraint_test.go
+++ b/motionplan/constraint_test.go
@@ -115,7 +115,7 @@ func TestConstraintPath(t *testing.T) {
 		[]spatial.Geometry{}, // moving geometries
 		[]spatial.Geometry{}, // static geometries
 		referenceframe.NewNeutralLinearInputs(fs),
-		&referenceframe.WorldState{},
+		nil, // obstaclesInWorldFrame
 		logger,
 		nil,
 	)
@@ -222,7 +222,7 @@ func TestLineFollow(t *testing.T) {
 		[]spatial.Geometry{}, // moving geometries
 		[]spatial.Geometry{}, // static geometries
 		startCfg,
-		&referenceframe.WorldState{},
+		nil, // obstaclesInWorldFrame
 		logger,
 		nil,
 	)

--- a/referenceframe/transformable.go
+++ b/referenceframe/transformable.go
@@ -338,7 +338,7 @@ func ProtobufToGeometriesInFrame(proto *commonpb.GeometriesInFrame) (*Geometries
 }
 
 type geometriesInFrameJSON struct {
-	Frame      string                      `json:"frame"`
+	Frame      string                        `json:"frame"`
 	Geometries []*spatialmath.GeometryConfig `json:"geometries"`
 }
 

--- a/referenceframe/transformable.go
+++ b/referenceframe/transformable.go
@@ -1,6 +1,7 @@
 package referenceframe
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -334,4 +335,43 @@ func ProtobufToGeometriesInFrame(proto *commonpb.GeometriesInFrame) (*Geometries
 		return nil, err
 	}
 	return NewGeometriesInFrame(proto.GetReferenceFrame(), geometries), nil
+}
+
+type geometriesInFrameJSON struct {
+	Frame      string                      `json:"frame"`
+	Geometries []*spatialmath.GeometryConfig `json:"geometries"`
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (gF *GeometriesInFrame) MarshalJSON() ([]byte, error) {
+	configs := make([]*spatialmath.GeometryConfig, 0, len(gF.geometries))
+	for _, geometry := range gF.geometries {
+		config, err := spatialmath.NewGeometryConfig(geometry)
+		if err != nil {
+			return nil, err
+		}
+		configs = append(configs, config)
+	}
+	return json.Marshal(geometriesInFrameJSON{
+		Frame:      gF.frame,
+		Geometries: configs,
+	})
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (gF *GeometriesInFrame) UnmarshalJSON(data []byte) error {
+	var raw geometriesInFrameJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	geometries := make([]spatialmath.Geometry, 0, len(raw.Geometries))
+	for _, config := range raw.Geometries {
+		geometry, err := config.ParseConfig()
+		if err != nil {
+			return err
+		}
+		geometries = append(geometries, geometry)
+	}
+	*gF = *NewGeometriesInFrame(raw.Frame, geometries)
+	return nil
 }

--- a/referenceframe/transformable_test.go
+++ b/referenceframe/transformable_test.go
@@ -1,6 +1,7 @@
 package referenceframe
 
 import (
+	"encoding/json"
 	"math"
 	"testing"
 
@@ -143,4 +144,30 @@ func TestGeometriesInFrame(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gF.Parent(), test.ShouldEqual, convertedGF.Parent())
 	test.That(t, spatialmath.GeometriesAlmostEqual(one, convertedGF.GeometryByName("one")), test.ShouldBeTrue)
+}
+
+func TestGeometriesInFrameJSON(t *testing.T) {
+	pose := spatialmath.NewPose(r3.Vector{1, 2, 3}, &spatialmath.OrientationVector{math.Pi / 2, 0, 0, -1})
+	zero, err := spatialmath.NewBox(pose, r3.Vector{1, 2, 3}, "zero")
+	test.That(t, err, test.ShouldBeNil)
+	one, err := spatialmath.NewBox(pose, r3.Vector{2, 3, 4}, "one")
+	test.That(t, err, test.ShouldBeNil)
+	two, err := spatialmath.NewBox(pose, r3.Vector{3, 4, 5}, "two")
+	test.That(t, err, test.ShouldBeNil)
+	three, err := spatialmath.NewBox(pose, r3.Vector{4, 5, 6}, "three")
+	test.That(t, err, test.ShouldBeNil)
+
+	gF := NewGeometriesInFrame("frame", []spatialmath.Geometry{zero, one, two, three})
+
+	data, err := json.Marshal(gF)
+	test.That(t, err, test.ShouldBeNil)
+
+	var roundTripped GeometriesInFrame
+	err = json.Unmarshal(data, &roundTripped)
+	test.That(t, err, test.ShouldBeNil)
+
+	test.That(t, roundTripped.Parent(), test.ShouldEqual, gF.Parent())
+	for _, name := range []string{"zero", "one", "two", "three"} {
+		test.That(t, spatialmath.GeometriesAlmostEqual(gF.GeometryByName(name), roundTripped.GeometryByName(name)), test.ShouldBeTrue)
+	}
 }

--- a/referenceframe/worldstate.go
+++ b/referenceframe/worldstate.go
@@ -194,5 +194,12 @@ func (ws *WorldState) ObstaclesInWorldFrame(fs *FrameSystem, inputs FrameSystemI
 		}
 		allGeometries = append(allGeometries, tf.(*GeometriesInFrame).Geometries()...)
 	}
+
+	for _, lif := range ws.transforms {
+		if lif.geometry != nil {
+			allGeometries = append(allGeometries, lif.geometry)
+		}
+	}
+
 	return NewGeometriesInFrame(World, allGeometries), nil
 }

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -499,13 +499,18 @@ func (ms *builtIn) plan(ctx context.Context, req motion.MoveReq, logger logging.
 
 	// the goal is to move the component to goalPose which is specified in coordinates of goalFrameName
 
+	obstaclesInWorldFrame, err := req.WorldState.ObstaclesInWorldFrame(frameSys, fsInputs)
+	if err != nil {
+		return nil, err
+	}
+
 	planRequest := &armplanning.PlanRequest{
-		FrameSystem:    frameSys,
-		Goals:          worldWaypoints,
-		StartState:     startState,
-		WorldState:     req.WorldState,
-		Constraints:    req.Constraints,
-		PlannerOptions: planOpts,
+		FrameSystem:           frameSys,
+		Goals:                 worldWaypoints,
+		StartState:            startState,
+		ObstaclesInWorldFrame: obstaclesInWorldFrame,
+		Constraints:           req.Constraints,
+		PlannerOptions:        planOpts,
 	}
 
 	start := time.Now()
@@ -587,13 +592,18 @@ func (ms *builtIn) planTeleop(
 		return nil, err
 	}
 
+	obstaclesInWorldFrame, err := req.WorldState.ObstaclesInWorldFrame(frameSys, fsInputs)
+	if err != nil {
+		return nil, err
+	}
+
 	planRequest := &armplanning.PlanRequest{
-		FrameSystem:    frameSys,
-		Goals:          worldWaypoints,
-		StartState:     startState,
-		WorldState:     req.WorldState,
-		Constraints:    req.Constraints,
-		PlannerOptions: planOpts,
+		FrameSystem:           frameSys,
+		Goals:                 worldWaypoints,
+		StartState:            startState,
+		ObstaclesInWorldFrame: obstaclesInWorldFrame,
+		Constraints:           req.Constraints,
+		PlannerOptions:        planOpts,
 	}
 
 	plan, _, err := armplanning.PlanMotion(ctx, logger, planRequest)


### PR DESCRIPTION
Root change: `armplanning.Request` objects no longer take a world state input (obstacles + transforms) and instead just take obstacles. The `armplanning.Request.FrameSystem` is expected to include any desired transforms.

Fallout:
* Obstacles are of type `*GeometriesInFrame`. Added a JSON serialization to those for types.
* old world-state style requests still exist and know how to "up convert"
* Some APIs that armplanning interface with still want a world state (mostly vizualization). I didn't change that. Made it easy to reconstruct a world state.

Started fixing the motion tests, when merged/tagged, I'll update the motion-testing RDK dependency.