### PR TITLE
use cached point geometry in BasicOctree.CollidesWith leaf path

### DIFF
--- a/pointcloud/basic_octree.go
+++ b/pointcloud/basic_octree.go
@@ -345,7 +345,7 @@ func (octree *BasicOctree) CollidesWith(geom spatialmath.Geometry, collisionBuff
 	case leafNodeEmpty:
 		return false, math.Inf(1), nil
 	case leafNodeFilled:
-		return geom.CollidesWith(spatialmath.NewPoint(octree.node.point.P, ""), collisionBufferMM)
+		return geom.CollidesWith(octree.node.pointGeometry(), collisionBufferMM)
 	}
 	return false, collisionBufferMM, errors.New("unknown octree node type")
 }


### PR DESCRIPTION
BasicOctree.CollidesWith allocated a fresh Point geometry on every leaf node visit using spatialmath.NewPoint

basicOctreeNode.pointGeometry() already exists and is used in accumulatePointsCollidingWith - CollidesWith does not 

## Where this started
After [#6123](https://github.com/viamrobotics/rdk/pull/6123) - pprof pointed at a forgotten leaf node cache as the next biggest allocation source. Quantified with three TestMeshSegmentation cases in viamrobotics/sanding:
- 22.0s --> 13.5s
- 11.1s --> 10.4s
- 14.1s --> 11.9s