### PR TITLE
RSDK-13779: Disk summary stats should include in-progress and arbitrary files

### DIFF
--- a/services/datamanager/builtin/disk_summary_tracker.go
+++ b/services/datamanager/builtin/disk_summary_tracker.go
@@ -98,7 +98,7 @@ func (poller *diskSummaryTracker) calculateAndSetSummary(ctx context.Context, di
 	var totalFiles int64
 	var totalBytes int64
 	var earliestTime *time.Time
-	var earliestCompletedCaptureTime *time.Time
+	var earliestSyncableFileTime *time.Time
 
 	for i, summary := range summaries {
 		// Log any errors from the directory summary.
@@ -129,10 +129,11 @@ func (poller *diskSummaryTracker) calculateAndSetSummary(ctx context.Context, di
 			}
 		}
 
-		// Track earliest completed capture file time (excludes in-progress .prog files).
-		if summary.CompletedCaptureTimeRange != nil {
-			if earliestCompletedCaptureTime == nil || summary.CompletedCaptureTimeRange.Start.Before(*earliestCompletedCaptureTime) {
-				earliestCompletedCaptureTime = &summary.CompletedCaptureTimeRange.Start
+		// Track earliest syncable file time: completed capture (.capture) files and
+		// arbitrary files, excluding in-progress (.prog) files.
+		if summary.SyncableFileTimeRange != nil {
+			if earliestSyncableFileTime == nil || summary.SyncableFileTimeRange.Start.Before(*earliestSyncableFileTime) {
+				earliestSyncableFileTime = &summary.SyncableFileTimeRange.Start
 			}
 		}
 	}
@@ -141,7 +142,7 @@ func (poller *diskSummaryTracker) calculateAndSetSummary(ctx context.Context, di
 	diskSummary.SyncPaths.TotalSizeBytes = totalBytes
 	diskSummary.OldestCaptureFileTime = earliestTime
 
-	poller.checkAndLogStaleData(ctx, earliestCompletedCaptureTime, totalFiles, totalBytes)
+	poller.checkAndLogStaleData(ctx, earliestSyncableFileTime, totalFiles, totalBytes)
 	poller.setSummary(diskSummary)
 }
 

--- a/services/datamanager/builtin/disk_summary_tracker_test.go
+++ b/services/datamanager/builtin/disk_summary_tracker_test.go
@@ -169,6 +169,40 @@ func captureFileName(t time.Time, ext string) string {
 	return strings.ReplaceAll(t.Format(time.RFC3339Nano), ":", "_") + ext
 }
 
+func TestDiskSummaryArbitraryFiles(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("arbitrary file populates time ranges from filesystem create time", func(t *testing.T) {
+		dir := t.TempDir()
+		before := time.Now()
+		err := os.WriteFile(filepath.Join(dir, "arbitrary.txt"), []byte("data"), 0o644)
+		test.That(t, err, test.ShouldBeNil)
+
+		summaries := DiskSummary(ctx, dir)
+		test.That(t, len(summaries), test.ShouldEqual, 1)
+		s := summaries[0]
+		test.That(t, s.FileCount, test.ShouldEqual, 1)
+		// Arbitrary files have no time in their name, so the range comes from the
+		// filesystem creation time, which is around now.
+		test.That(t, s.DataTimeRange, test.ShouldNotBeNil)
+		test.That(t, s.SyncableFileTimeRange, test.ShouldNotBeNil)
+		test.That(t, s.DataTimeRange.Start.Before(before.Add(-time.Hour)), test.ShouldBeFalse)
+	})
+
+	t.Run("in-progress files are excluded from syncable range but counted in data range", func(t *testing.T) {
+		dir := t.TempDir()
+		progTime := time.Now().Add(-10 * time.Minute)
+		err := os.WriteFile(filepath.Join(dir, captureFileName(progTime, data.InProgressCaptureFileExt)), []byte("data"), 0o644)
+		test.That(t, err, test.ShouldBeNil)
+
+		summaries := DiskSummary(ctx, dir)
+		test.That(t, len(summaries), test.ShouldEqual, 1)
+		s := summaries[0]
+		test.That(t, s.DataTimeRange, test.ShouldNotBeNil)
+		test.That(t, s.SyncableFileTimeRange, test.ShouldBeNil)
+	})
+}
+
 func TestCalculateAndSetSummaryStaleWarningOnlyCaptureFiles(t *testing.T) {
 	ctx := context.Background()
 	staleTime := time.Now().Add(-10 * time.Minute)

--- a/services/datamanager/builtin/summary.go
+++ b/services/datamanager/builtin/summary.go
@@ -86,12 +86,14 @@ func DiskSummary(ctx context.Context, rootPath string) []DirSummary {
 		// sum up the size of all files in the root
 		fileSize += info.Size()
 
-		// Determine the file's data time. Capture files (.capture/.prog) encode the
-		// capture time in their name. Arbitrary files have no such metadata, so fall back
-		// to the filesystem creation time (the same time used when syncing them).
 		isCompletedCapture := strings.HasSuffix(name, data.CompletedCaptureFileExt)
 		isInProgressCapture := strings.HasSuffix(name, data.InProgressCaptureFileExt)
+
+		// Capture files (.capture/.prog) encode the capture time in their name.
 		fileTime := parseTime(name)
+
+		// Arbitrary file uploads, fall back to filesystem creation time (same timestamp
+		// used for sync).
 		if fileTime == nil && !isCompletedCapture && !isInProgressCapture {
 			fileTimes, err := utils.GetFileTimes(path)
 			if err != nil {

--- a/services/datamanager/builtin/summary.go
+++ b/services/datamanager/builtin/summary.go
@@ -10,21 +10,25 @@ import (
 	"time"
 
 	"go.viam.com/rdk/data"
+	"go.viam.com/rdk/utils"
 )
 
 // DirSummary represents a summary of the files in that directory including file counts,
-// total size of files in that directory and the time range of data capture files
-// (both .capture and .prog) in that directory.
+// total size of files in that directory and the time range of the data in that directory.
 // File and directory errors are accumulated on Err.
 type DirSummary struct {
-	Path          string
-	FileSize      int64
-	FileCount     int64
-	Err           error
+	Path      string
+	FileSize  int64
+	FileCount int64
+	Err       error
+	// DataTimeRange is the time range across all files in the directory. Capture files
+	// (.capture/.prog) use the timestamp encoded in their name; arbitrary files use their
+	// filesystem creation time.
 	DataTimeRange *DataTimeRange
-	// CompletedCaptureTimeRange is the time range of only completed (.capture) files,
-	// excluding in-progress (.prog) files.
-	CompletedCaptureTimeRange *DataTimeRange
+	// SyncableFileTimeRange is the time range of files that are complete and waiting to
+	// sync: completed capture (.capture) files and arbitrary files. In-progress (.prog)
+	// capture files are excluded since they are still being written.
+	SyncableFileTimeRange *DataTimeRange
 }
 
 // DataTimeRange represents a time range from Start to End.
@@ -50,13 +54,13 @@ func DiskSummary(ctx context.Context, rootPath string) []DirSummary {
 	// For each dirElement, sum up the size of the files in this directory
 	// call self func on all directories and add result to return
 	var (
-		fileSize                  int64
-		fileCount                 int64
-		summary                   []DirSummary
-		dirPaths                  []string
-		dataTimeRange             *DataTimeRange
-		completedCaptureTimeRange *DataTimeRange
-		rootErr                   error
+		fileSize              int64
+		fileCount             int64
+		summary               []DirSummary
+		dirPaths              []string
+		dataTimeRange         *DataTimeRange
+		syncableFileTimeRange *DataTimeRange
+		rootErr               error
 	)
 	for _, child := range children {
 		if ctx.Err() != nil {
@@ -64,38 +68,56 @@ func DiskSummary(ctx context.Context, rootPath string) []DirSummary {
 		}
 		path := filepath.Join(rootPath, child.Name())
 		if child.IsDir() {
-			// aggrigate all root's children
+			// aggregate all root's children
 			dirPaths = append(dirPaths, path)
-		} else {
-			dataTimeRange = parseTimeRange(child.Name(), dataTimeRange)
-			if strings.HasSuffix(child.Name(), data.CompletedCaptureFileExt) {
-				completedCaptureTimeRange = parseTimeRange(child.Name(), completedCaptureTimeRange)
-			}
-			fileCount++
-			info, err := child.Info()
-			if errors.Is(err, fs.ErrNotExist) {
-				continue
-			}
+			continue
+		}
+
+		name := child.Name()
+		fileCount++
+		info, err := child.Info()
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			rootErr = errors.Join(rootErr, err)
+			continue
+		}
+		// sum up the size of all files in the root
+		fileSize += info.Size()
+
+		// Determine the file's data time. Capture files (.capture/.prog) encode the
+		// capture time in their name. Arbitrary files have no such metadata, so fall back
+		// to the filesystem creation time (the same time used when syncing them).
+		isCompletedCapture := strings.HasSuffix(name, data.CompletedCaptureFileExt)
+		isInProgressCapture := strings.HasSuffix(name, data.InProgressCaptureFileExt)
+		fileTime := parseTime(name)
+		if fileTime == nil && !isCompletedCapture && !isInProgressCapture {
+			fileTimes, err := utils.GetFileTimes(path)
 			if err != nil {
-				// aggregate all errors encountered on files in this directory
-				// TODO: Test ErrPermission actually happens if you don't have permissions
 				rootErr = errors.Join(rootErr, err)
-				continue
+			} else {
+				fileTime = &fileTimes.CreateTime
 			}
-			// sum up the size of all files in the root
-			fileSize += info.Size()
+		}
+
+		dataTimeRange = extendTimeRange(dataTimeRange, fileTime)
+		// Completed capture files and arbitrary files are fully written and waiting to
+		// sync; in-progress (.prog) files are excluded since they're still being written.
+		if !isInProgressCapture {
+			syncableFileTimeRange = extendTimeRange(syncableFileTimeRange, fileTime)
 		}
 	}
 
 	// if there were files in this directory, record the size
 	if fileCount != 0 || dataTimeRange != nil {
 		summary = append(summary, DirSummary{
-			Path:                      rootPath,
-			FileSize:                  fileSize,
-			FileCount:                 fileCount,
-			Err:                       rootErr,
-			DataTimeRange:             dataTimeRange,
-			CompletedCaptureTimeRange: completedCaptureTimeRange,
+			Path:                  rootPath,
+			FileSize:              fileSize,
+			FileCount:             fileCount,
+			Err:                   rootErr,
+			DataTimeRange:         dataTimeRange,
+			SyncableFileTimeRange: syncableFileTimeRange,
 		})
 	}
 	// do the same for all children
@@ -109,10 +131,10 @@ func DiskSummary(ctx context.Context, rootPath string) []DirSummary {
 	return summary
 }
 
-func parseTimeRange(name string, dataTimeRange *DataTimeRange) *DataTimeRange {
-	tPtr := parseTime(name)
+// extendTimeRange grows dataTimeRange to include tPtr, returning the updated range.
+func extendTimeRange(dataTimeRange *DataTimeRange, tPtr *time.Time) *DataTimeRange {
 	if tPtr == nil {
-		// If we can't parse out the time from the file name, return the existing *DataTimeRange
+		// If we don't have a time for this file, return the existing *DataTimeRange
 		return dataTimeRange
 	}
 


### PR DESCRIPTION
Written by Claude. Most of the diff are white space, variable names, and comments.

Tested manually by creating some arbitrary files alongside binary and tabular .capture files.

```
steve@ROBOT-H7XRR029TG capture % find .
.
./rdk_component_camera
./rdk_component_camera/camera-1-copy-1
./rdk_component_camera/camera-1-copy-1/GetImages
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_34.151431-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_32.952684-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_34.351978-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_33.852203-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_33.351889-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_34.650503-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_34.551045-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_33.752794-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_34.250987-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_33.652788-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_33.250628-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_32.752644-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_34.449882-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_34.851678-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_35.051210-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_34.052554-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_35.152189-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_35.251287-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_35.352503-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_35.453049-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_34.751519-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_33.052809-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_33.452343-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_33.952921-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_34.950678-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_32.851628-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_33.552331-04_00.capture
./rdk_component_camera/camera-1-copy-1/GetImages/2026-06-17T13_04_33.151960-04_00.capture
./rdk_component_camera/camera-1
./rdk_component_camera/camera-1/GetImages
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_31.832647-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_32.431945-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_34.331682-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_35.233172-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_33.431756-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_32.633845-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_32.532517-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_34.833027-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_35.529757-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_34.729678-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_31.433936-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_32.733764-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_33.833098-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_34.629827-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_34.032770-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_34.530454-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_35.031981-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_33.734102-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_32.932720-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_33.532631-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_32.332015-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_34.132443-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_34.228966-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_31.631460-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_31.932553-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_31.530201-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_33.131977-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_35.132904-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_34.930293-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_33.932450-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_35.333065-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_33.331665-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_33.230867-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_35.433412-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_32.032650-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_32.231079-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_33.633713-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_32.132685-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_34.429700-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_31.732498-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_32.832749-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_31.333895-04_00.capture
./rdk_component_camera/camera-1/GetImages/2026-06-17T13_04_33.032897-04_00.capture
./rdk_component_camera/camera-1-copy-2
./rdk_component_camera/camera-1-copy-2/GetImages
./rdk_component_camera/camera-1-copy-2/GetImages/2026-06-17T13_04_34.950849-04_00.capture
./rdk_component_camera/camera-1-copy-2/GetImages/2026-06-17T13_04_34.151292-04_00.capture
./rdk_component_camera/camera-1-copy-2/GetImages/2026-06-17T13_04_34.351976-04_00.capture
./rdk_component_camera/camera-1-copy-2/GetImages/2026-06-17T13_04_34.751435-04_00.capture
./rdk_component_camera/camera-1-copy-2/GetImages/2026-06-17T13_04_35.152502-04_00.capture
./rdk_component_camera/camera-1-copy-2/GetImages/2026-06-17T13_04_35.352921-04_00.capture
./rdk_component_camera/camera-1-copy-2/GetImages/2026-06-17T13_04_34.550803-04_00.capture
./file
./rdk_component_movement_sensor
./rdk_component_movement_sensor/movement_sensor-1-copy-2
./rdk_component_movement_sensor/movement_sensor-1-copy-2/Readings
./rdk_component_movement_sensor/movement_sensor-1-copy-2/Readings/2026-06-17T13_04_31.385530-04_00.capture
./rdk_component_movement_sensor/movement_sensor-1-copy-3
./rdk_component_movement_sensor/movement_sensor-1-copy-3/Readings
./rdk_component_movement_sensor/movement_sensor-1-copy-3/Readings/2026-06-17T13_04_31.385463-04_00.capture
./rdk_component_movement_sensor/movement_sensor-1
./rdk_component_movement_sensor/movement_sensor-1/Readings
./rdk_component_movement_sensor/movement_sensor-1/Readings/2026-06-17T13_04_31.334511-04_00.capture
./rdk_component_movement_sensor/movement_sensor-1-copy-1
./rdk_component_movement_sensor/movement_sensor-1-copy-1/Readings
./rdk_component_movement_sensor/movement_sensor-1-copy-1/Readings/2026-06-17T13_04_31.385499-04_00.capture
./rdk_component_movement_sensor/movement_sensor-1-copy
./rdk_component_movement_sensor/movement_sensor-1-copy/Readings
./rdk_component_movement_sensor/movement_sensor-1-copy/Readings/2026-06-17T13_04_31.385525-04_00.capture
```

Validated that all files are accounted for
```
steve@ROBOT-H7XRR029TG rdk % go run ./services/datamanager/builtin/cmd /tmp/disktest
/tmp/disktest/capture                                                                 | file_count:  1 | file_size: 100.00 MB | duration:        0s, start: 2026-06-17 13:06:50.388325986 -0400 EDT, end: 2026-06-17 13:06:50.388325986 -0400 EDT
/tmp/disktest/capture/rdk_component_camera/camera-1/GetImages                         | file_count: 43 | file_size: 926.87 KB | duration: 4.195862s, start: 2026-06-17 13:04:31.333895 -0400 EDT, end: 2026-06-17 13:04:35.529757 -0400 EDT
/tmp/disktest/capture/rdk_component_camera/camera-1-copy-1/GetImages                  | file_count: 28 | file_size: 603.73 KB | duration: 2.700405s, start: 2026-06-17 13:04:32.752644 -0400 EDT, end: 2026-06-17 13:04:35.453049 -0400 EDT
/tmp/disktest/capture/rdk_component_camera/camera-1-copy-2/GetImages                  | file_count:  7 | file_size: 150.93 KB | duration: 1.201629s, start: 2026-06-17 13:04:34.151292 -0400 EDT, end: 2026-06-17 13:04:35.352921 -0400 EDT
/tmp/disktest/capture/rdk_component_movement_sensor/movement_sensor-1/Readings        | file_count:  1 | file_size:  23.52 KB | duration:        0s, start: 2026-06-17 13:04:31.334511 -0400 EDT, end: 2026-06-17 13:04:31.334511 -0400 EDT
/tmp/disktest/capture/rdk_component_movement_sensor/movement_sensor-1-copy/Readings   | file_count:  1 | file_size:  22.98 KB | duration:        0s, start: 2026-06-17 13:04:31.385525 -0400 EDT, end: 2026-06-17 13:04:31.385525 -0400 EDT
/tmp/disktest/capture/rdk_component_movement_sensor/movement_sensor-1-copy-1/Readings | file_count:  1 | file_size:  22.99 KB | duration:        0s, start: 2026-06-17 13:04:31.385499 -0400 EDT, end: 2026-06-17 13:04:31.385499 -0400 EDT
/tmp/disktest/capture/rdk_component_movement_sensor/movement_sensor-1-copy-2/Readings | file_count:  1 | file_size:  22.99 KB | duration:        0s, start: 2026-06-17 13:04:31.38553 -0400 EDT, end: 2026-06-17 13:04:31.38553 -0400 EDT
/tmp/disktest/capture/rdk_component_movement_sensor/movement_sensor-1-copy-3/Readings | file_count:  1 | file_size:  22.99 KB | duration:        0s, start: 2026-06-17 13:04:31.385463 -0400 EDT, end: 2026-06-17 13:04:31.385463 -0400 EDT
```