### PR TITLE
RSDK-13894 fix flaky test: flaky test fix TestInferRemoteRobotDependencyConnectAtStartup

### DIFF
--- a/robot/impl/robot_reconfigure_remote_test.go
+++ b/robot/impl/robot_reconfigure_remote_test.go
@@ -293,6 +293,15 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	rdktestutils.VerifySameResourceNames(t, r.ResourceNames(), expectedSet)
 	test.That(t, foo.Close(context.Background()), test.ShouldBeNil)
 
+	// Reclaim the port immediately after closing `foo` so that another
+	// (possibly parallel) test cannot grab it during the offline-detection wait
+	// below. Holding this bare listener keeps the port reserved until `foo2`
+	// restarts on the same address. `foo`'s server connection has already
+	// dropped, so the local robot still detects the remote as offline while we
+	// hold the listener.
+	listener1, err = net.Listen("tcp", listener1.Addr().String())
+	test.That(t, err, test.ShouldBeNil)
+
 	// wait for local_robot to detect that the remote is now offline
 	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
 		verifyReachableResourceNames(tb, r,
@@ -301,11 +310,6 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	})
 
 	foo2 := setupLocalRobot(t, ctx, fooCfg, logger.Sublogger("foo2"))
-
-	// Note: There's a slight chance this test can fail if someone else
-	// claims the port we just released by closing the server.
-	listener1, err = net.Listen("tcp", listener1.Addr().String())
-	test.That(t, err, test.ShouldBeNil)
 	options.Network.Listener = listener1
 	err = foo2.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
## Summary

Fixes the intermittent failure of `go.viam.com/rdk/robot/impl.TestInferRemoteRobotDependencyConnectAtStartup`:

```
robot_reconfigure_remote_test.go:308
Expected: nil
Actual:   'listen tcp 0.0.0.0:33247: bind: address already in use'
```

## Root cause

The test verifies that the local robot reconnects to a remote that goes offline and then comes back online **at the same address**. To do that it:

1. closes the remote `foo` (which closes the web server's listener and **releases the TCP port**),
2. runs a long offline-detection wait loop (`WaitForAssertionWithSleep`, up to ~30s), and only then
3. re-binds a new listener to that same port for `foo2`.

The port is therefore free for the entire duration of the wait loop. Every test in this package runs with `t.Parallel()` and acquires ports via `ReserveRandomListener` (`net.ListenTCP` with `Port: 0`). If a parallel test happens to be assigned the just-released ephemeral port during that window, the later `net.Listen` on the fixed address fails with `bind: address already in use`. The pre-existing comment already acknowledged this race ("slight chance this test can fail if someone else claims the port we just released").

## Fix

Reclaim the listener **immediately** after closing `foo`, before the offline-detection wait, and hand that same listener to `foo2`. This keeps the port reserved throughout the wait, shrinking the vulnerable window from the full wait loop down to a couple of instructions.

Holding a bare (non-serving) listener does not affect offline detection: `foo`'s server connection has already dropped when it was closed, so the local robot still marks the remote unreachable. The bare listener only causes reconnection attempts to fail (which is the desired "offline" behavior) until `foo2` takes over the listener and starts serving.

## Testing

- `go test ./robot/impl/ -run '^TestInferRemoteRobotDependencyConnectAtStartup$' -count=5` — pass
- `go test ./robot/impl/ -run '^TestInferRemoteRobotDependencyConnectAtStartup$' -race -count=2` — pass
- `go test ./robot/impl/ -run '^TestRemoteRobots|^TestInferRemoteRobot' -count=2` (parallel contention) — pass
- `gofmt`/`go vet` clean for the changed file

Key: RSDK-13894

Co-authored by Claude agent for Jira.