### PR TITLE
RSDK-13843: re-add app to module (with Windows test fix)

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -3565,6 +3565,29 @@ After creation, use 'viam module update' to push your new module to app.viam.com
 					Action: createActionCommandWithT[createModuleActionArgs](CreateModuleAction),
 				},
 				{
+					Name:      "add-app",
+					Usage:     "generate a new web app and add it to an existing Go module",
+					UsageText: createUsageText("module add-app", nil, false, false),
+					Description: `Adds a web application to a Go module created with 'viam module generate'.
+Run this command from within the module directory.`,
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:  moduleFlagAppName,
+							Usage: "name for the app",
+						},
+						&cli.StringFlag{
+							Name:  moduleFlagAppType,
+							Usage: formatAcceptedValues("app type", "single_machine", "multi_machine"),
+						},
+						&cli.BoolFlag{
+							Name:   generalFlagDryRun,
+							Usage:  "indicate a dry test run, so skip regular checks",
+							Hidden: true,
+						},
+					},
+					Action: createActionCommandWithT[addAppArgs](AddAppAction),
+				},
+				{
 					Name:      "add-model",
 					Usage:     "generate a new model and add it to an existing module",
 					UsageText: createUsageText("module add-model", nil, false, false),
@@ -3595,7 +3618,7 @@ Run this command from within the module directory.`,
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:  moduleFlagGenerateType,
-							Usage: formatAcceptedValues("type of project to generate", "module", "app"),
+							Usage: formatAcceptedValues("type of project to generate", "module", "app", "module+app"),
 						},
 						&cli.StringFlag{
 							Name:  generalFlagName,

--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -85,6 +85,12 @@ type addModelArgs struct {
 	DryRun          bool
 }
 
+type addAppArgs struct {
+	AppName string
+	AppType string
+	DryRun  bool
+}
+
 // GenerateModuleAction runs the module generate cli and generates necessary module templates based on user input.
 func GenerateModuleAction(ctx context.Context, cmd *cli.Command, args generateModuleArgs) error {
 	c, err := newViamClient(ctx, cmd)
@@ -139,6 +145,8 @@ func promptGenerateType() (string, error) {
 						return "A modular resource to add custom components or services to your machine."
 					case "app":
 						return "A web application that connects to your machine via the Viam SDK."
+					case "module+app":
+						return "A Go modular resource and a web application together in the same module."
 					default:
 						return ""
 					}
@@ -146,6 +154,7 @@ func promptGenerateType() (string, error) {
 				Options(
 					huh.NewOption("Module", "module"),
 					huh.NewOption("App", "app"),
+					huh.NewOption("Module + App", "module+app"),
 				).
 				Value(&generateType),
 		),
@@ -182,8 +191,10 @@ func (c *viamClient) generateModuleAction(ctx context.Context, cmd *cli.Command,
 		return c.generateModule(ctx, cmd, args, shared)
 	case "app":
 		return c.generateApp(ctx, cmd, args, shared)
+	case "module+app":
+		return c.generateModuleAndApp(ctx, cmd, args, shared)
 	default:
-		return fmt.Errorf("invalid generate type %q: must be module or app", generateType)
+		return fmt.Errorf("invalid generate type %q: must be module, app, or module+app", generateType)
 	}
 }
 
@@ -200,6 +211,11 @@ type appTemplateData struct {
 	AppType         string
 	Namespace       string
 	Visibility      string
+	// ConfigName is the name used for the webapp Config struct and its references in the
+	// generated file. It is "Config" for a standalone generated app (the only code in the
+	// package) and "WebappConfig" when adding an app to an existing module (to avoid
+	// colliding with the Config already declared there).
+	ConfigName string
 }
 
 func (c *viamClient) generateApp(ctx context.Context, cmd *cli.Command, args generateModuleArgs, shared *sharedInputs) error {
@@ -252,6 +268,7 @@ func (c *viamClient) generateApp(ctx context.Context, cmd *cli.Command, args gen
 		AppType:         app.AppType,
 		Namespace:       moduleInputs.Namespace,
 		Visibility:      shared.Visibility,
+		ConfigName:      "Config",
 	}
 
 	// Create root directory
@@ -310,17 +327,25 @@ func (c *viamClient) generateApp(ctx context.Context, cmd *cli.Command, args gen
 	if registryURL != "" {
 		printf(cmd.Root().Writer, "You can view it here: %s", registryURL)
 	}
-	printf(cmd.Root().Writer, "\n--- Build your frontend ---")
-	printf(cmd.Root().Writer, "This module has no frontend yet. Bring your own using any framework (e.g. Svelte, Vue, React).")
-	printf(cmd.Root().Writer, "\n1. Install the Viam SDK:")
-	printf(cmd.Root().Writer, "     npm install @viamrobotics/sdk typescript-cookie")
-	printf(cmd.Root().Writer, "\n2. Build your frontend into the dist/ directory.")
-	printf(cmd.Root().Writer, "\n3. Build the module:")
-	printf(cmd.Root().Writer, "     make setup")
-	printf(cmd.Root().Writer, "     make")
-	printf(cmd.Root().Writer, "\nSee %s for full details, including how to test during development and upload to viamapplications.com.",
-		filepath.Join(appPath, "README.md"))
+	printAppBuildNextSteps(cmd.Root().Writer, filepath.Join(appPath, "README.md"))
 	return nil
+}
+
+// printAppBuildNextSteps prints the standard "build your frontend" instructions after an app
+// is created or added to a module. If readmePath is non-empty, a final line pointing to that
+// README is also printed.
+func printAppBuildNextSteps(w io.Writer, readmePath string) {
+	printf(w, "\n--- Build your frontend ---")
+	printf(w, "Replace dist/index.html with your own frontend built with any framework (e.g. Svelte, Vue, React).")
+	printf(w, "\n1. Install the Viam SDK:")
+	printf(w, "     npm install @viamrobotics/sdk typescript-cookie")
+	printf(w, "\n2. Build your frontend into the dist/ directory.")
+	printf(w, "\n3. Build the module:")
+	printf(w, "     make setup")
+	printf(w, "     make")
+	if readmePath != "" {
+		printf(w, "\nSee %s for full details, including how to test during development and upload to viamapplications.com.", readmePath)
+	}
 }
 
 // renderAppTemplate renders tmpl- prefixed files from _templates/app/ with app-specific data.
@@ -410,6 +435,47 @@ func promptAppUser(app *appInputs) error {
 		return errors.Wrap(err, "encountered an error generating app")
 	}
 
+	return nil
+}
+
+// promptAddAppInputs prompts for app name and type when adding an app to an existing module.
+func promptAddAppInputs(app *appInputs) error {
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewNote().
+				Title("Add an app to this module").
+				Description("This will add a web application to your existing module.\n"+
+					"For more details, view the documentation at \nhttps://docs.viam.com/build-apps/hosting/"),
+			huh.NewInput().
+				Title("Set an app name:").
+				Description("The app name can contain only alphanumeric characters, dashes, and underscores.").
+				Value(&app.AppName).
+				Placeholder("my-app").
+				Suggestions([]string{"my-app"}).
+				Validate(func(s string) error {
+					if s == "" {
+						return errors.New("app name must not be empty")
+					}
+					match, err := regexp.MatchString("^[a-zA-Z]+(?:[_\\-a-zA-Z0-9]+)*$", s)
+					if !match || err != nil {
+						return errors.New("app names can only contain alphanumeric characters, dashes, and underscores,\nand must start with a letter")
+					}
+					return nil
+				}),
+			huh.NewSelect[string]().
+				Title("App type:").
+				Description("Single machine apps connect to one machine.\n"+
+					"Multi machine apps can connect to multiple machines in your fleet.").
+				Options(
+					huh.NewOption("Single Machine", "single_machine"),
+					huh.NewOption("Multi Machine", "multi_machine"),
+				).
+				Value(&app.AppType),
+		),
+	).WithHeight(25).WithWidth(88)
+	if err := form.Run(); err != nil {
+		return errors.Wrap(err, "encountered an error adding app")
+	}
 	return nil
 }
 
@@ -558,6 +624,125 @@ func (c *viamClient) generateModule(ctx context.Context, cmd *cli.Command, args 
 			"To access your module in app, make sure to add \"tcp_mode\": true to the module config json\n"+
 			"and set your local module's executable path to run.bat")
 	}
+	return nil
+}
+
+// generateModuleAndApp generates a Go module and then immediately adds a web app to it.
+// All inputs (module and app) are collected upfront so generation runs without interruption.
+func (c *viamClient) generateModuleAndApp(ctx context.Context, cmd *cli.Command, args generateModuleArgs, shared *sharedInputs) error {
+	// Collect module inputs. Language is always Go for module+app; the prompt skips the
+	// language field when it is pre-set so the user is never asked to choose.
+	newModule := &modulegen.ModuleInputs{
+		ModuleName:      args.Name,
+		Language:        golang,
+		Namespace:       shared.Namespace,
+		Visibility:      shared.Visibility,
+		ResourceSubtype: args.ResourceSubtype,
+		ModelName:       args.ModelName,
+		RegisterOnApp:   args.Register,
+	}
+	if err := newModule.CheckResourceAndSetType(); err != nil {
+		return err
+	}
+	if newModule.HasEmptyInput() {
+		if err := promptModuleInputs(newModule); err != nil {
+			return err
+		}
+		newModule.Namespace = shared.Namespace
+		newModule.Visibility = shared.Visibility
+		newModule.RegisterOnApp = shared.RegisterOnApp
+	}
+
+	// Collect app inputs.
+	app := &appInputs{AppName: args.AppName, AppType: args.AppType}
+	if app.AppName == "" || app.AppType == "" {
+		if err := promptAddAppInputs(app); err != nil {
+			return err
+		}
+	}
+
+	// Generate the module. Pass pre-collected inputs through args so generateModule
+	// sees HasEmptyInput() == false and skips re-prompting.
+	// ResourceSubtype is derived from Resource (e.g. "arm component" → "arm") because
+	// promptModuleInputs sets Resource but not ResourceSubtype; HasEmptyInput checks the latter.
+	filledArgs := args
+	filledArgs.Name = newModule.ModuleName
+	filledArgs.Language = newModule.Language
+	filledArgs.PublicNamespace = newModule.Namespace
+	filledArgs.Visibility = newModule.Visibility
+	filledArgs.Register = newModule.RegisterOnApp
+	filledArgs.ResourceSubtype = strings.Split(newModule.Resource, " ")[0]
+	filledArgs.ModelName = newModule.ModelName
+	if err := c.generateModule(ctx, cmd, filledArgs, shared); err != nil {
+		return err
+	}
+
+	// Add the app to the newly generated module directory.
+	moduleDir := newModule.ModuleName
+	data := appTemplateData{
+		ModuleName:      newModule.ModuleName,
+		ModuleLowercase: strings.ReplaceAll(strings.ToLower(newModule.ModuleName), "-", ""),
+		AppName:         app.AppName,
+		AppType:         app.AppType,
+		Namespace:       newModule.Namespace,
+		Visibility:      newModule.Visibility,
+		ConfigName:      "WebappConfig",
+	}
+
+	gArgs, err := getGlobalArgs(cmd)
+	if err != nil {
+		return err
+	}
+	globalArgs := *gArgs
+
+	s := spinner.New()
+	var fatalError error
+	action := func() {
+		s.Title("Generating webapp component file...")
+		if err := addGoWebappFile(moduleDir, data); err != nil {
+			fatalError = errors.Wrap(err, "failed to generate webapp.go")
+			return
+		}
+		if err := addGoWebappToMain(filepath.Join(moduleDir, "cmd", "module", "main.go"), data); err != nil {
+			fatalError = errors.Wrap(err, "failed to update cmd/module/main.go")
+			return
+		}
+
+		s.Title("Setting up app directories and static files...")
+		if err := addAppStaticFiles(moduleDir); err != nil {
+			fatalError = errors.Wrap(err, "failed to set up app files")
+			return
+		}
+		if err := updateMakefileForApp(filepath.Join(moduleDir, "Makefile")); err != nil {
+			fatalError = errors.Wrap(err, "failed to update Makefile")
+			return
+		}
+
+		s.Title("Updating meta.json...")
+		if err := addAppToManifest(filepath.Join(moduleDir, defaultManifestFilename), app, data); err != nil {
+			fatalError = errors.Wrap(err, "failed to update meta.json")
+			return
+		}
+	}
+
+	if globalArgs.Debug {
+		action()
+	} else {
+		s.Action(action)
+		if err := s.Run(); err != nil {
+			return err
+		}
+	}
+
+	if fatalError != nil {
+		return fatalError
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "."
+	}
+	printAppBuildNextSteps(cmd.Root().Writer, filepath.Join(cwd, moduleDir, "README.md"))
 	return nil
 }
 
@@ -725,14 +910,16 @@ func promptModuleInputs(module *modulegen.ModuleInputs) error {
 				}
 				return nil
 			}),
-		huh.NewSelect[string]().
+	}
+	if module.Language == "" {
+		fields = append(fields, huh.NewSelect[string]().
 			Title("Specify the language for the module:").
 			Options(
 				huh.NewOption("Python", python),
 				huh.NewOption("Go", golang),
 				huh.NewOption("C++", cpp),
 			).
-			Value(&module.Language),
+			Value(&module.Language))
 	}
 	fields = append(fields, resourceAndModelFields(module)...)
 	form := huh.NewForm(huh.NewGroup(fields...)).WithHeight(25).WithWidth(88)
@@ -1991,5 +2178,332 @@ func AddModelAction(ctx context.Context, cmd *cli.Command, args addModelArgs) er
 		cwd = "."
 	}
 	printf(cmd.Root().Writer, "Model %s successfully added to module at %s", newModel.ModelTriple, cwd)
+	return nil
+}
+
+// addGoWebappFile renders the app module.go template into webapp.go in dir.
+// It uses appTemplateData (ModuleLowercase, Namespace, ModuleName) to fill the template.
+func addGoWebappFile(dir string, data appTemplateData) error {
+	const tmplName = "tmpl-module.go"
+	appPath := path.Join(templatesPath, "app")
+	tFile, err := templates.Open(path.Join(appPath, tmplName))
+	if err != nil {
+		return err
+	}
+	defer utils.UncheckedErrorFunc(tFile.Close)
+	tBytes, err := io.ReadAll(tFile)
+	if err != nil {
+		return err
+	}
+	tmpl, err := template.New(tmplName).Parse(string(tBytes))
+	if err != nil {
+		return err
+	}
+
+	destPath := filepath.Join(dir, "webapp.go")
+	//nolint:gosec
+	destFile, err := os.Create(destPath)
+	if err != nil {
+		return errors.Wrap(err, "unable to create webapp.go")
+	}
+	defer utils.UncheckedErrorFunc(destFile.Close)
+	if err := tmpl.Execute(destFile, data); err != nil {
+		return errors.Wrap(err, "error rendering webapp template")
+	}
+	if err := runGoImports(destFile); err != nil {
+		return errors.Wrap(err, "unable to sort imports")
+	}
+	return nil
+}
+
+// addGoWebappToMain updates cmd/module/main.go to register the webapp generic component model.
+// It adds the generic import if absent and appends the webapp APIModel to ModularMain.
+func addGoWebappToMain(mainGoPath string, data appTemplateData) error {
+	//nolint:gosec
+	rawData, err := os.ReadFile(mainGoPath)
+	if err != nil {
+		return errors.Wrap(err, "unable to read main.go")
+	}
+	content := string(rawData)
+
+	// Add generic import if not already present.
+	const genericPkg = "go.viam.com/rdk/components/generic"
+	if !strings.Contains(content, genericPkg) {
+		newImport := "\t\"go.viam.com/rdk/components/generic\""
+		const importBlockEnd = "\n)\n\nfunc main"
+		if !strings.Contains(content, importBlockEnd) {
+			return errors.New("cannot locate import block in main.go; file may have been manually edited")
+		}
+		content = strings.Replace(content, importBlockEnd, "\n"+newImport+importBlockEnd, 1)
+	}
+
+	// Append the webapp APIModel entry to the module.ModularMain call.
+	const mmFunc = "module.ModularMain("
+	mmIdx := strings.Index(content, mmFunc)
+	if mmIdx == -1 {
+		return errors.New("cannot find module.ModularMain call in main.go; file may have been manually edited")
+	}
+	afterMM := content[mmIdx+len(mmFunc):]
+	closingIdx := strings.Index(afterMM, ")")
+	if closingIdx == -1 {
+		return errors.New("cannot find closing ) of module.ModularMain in main.go")
+	}
+	newAPIModel := fmt.Sprintf(", resource.APIModel{API: generic.API, Model: %s.Model}", data.ModuleLowercase)
+	insertAt := mmIdx + len(mmFunc) + closingIdx
+	content = content[:insertAt] + newAPIModel + content[insertAt:]
+
+	//nolint:gosec
+	return os.WriteFile(mainGoPath, []byte(content), 0o644)
+}
+
+// addAppStaticFiles copies the static app files (auth.js, dist/index.html) into dir.
+// Existing files are not overwritten so that user-created frontends are preserved.
+func addAppStaticFiles(dir string) error {
+	appTemplatePath := path.Join(templatesPath, "app")
+
+	// Ensure the dist/ directory exists.
+	distDir := filepath.Join(dir, "dist")
+	if err := os.MkdirAll(distDir, 0o750); err != nil {
+		return errors.Wrap(err, "unable to create dist directory")
+	}
+
+	// Copy static files only if they don't already exist.
+	for _, f := range []struct{ src, dst string }{
+		{"auth.js", filepath.Join(dir, "auth.js")},
+		{path.Join("dist", "index.html"), filepath.Join(distDir, "index.html")},
+	} {
+		if _, err := os.Stat(f.dst); err == nil {
+			// File already exists; leave it untouched.
+			continue
+		}
+		srcFile, err := templates.Open(path.Join(appTemplatePath, f.src))
+		if err != nil {
+			return errors.Wrapf(err, "unable to open template %s", f.src)
+		}
+		defer utils.UncheckedErrorFunc(srcFile.Close)
+		srcBytes, err := io.ReadAll(srcFile)
+		if err != nil {
+			return errors.Wrapf(err, "unable to read template %s", f.src)
+		}
+		//nolint:gosec
+		if err := os.WriteFile(f.dst, srcBytes, 0o644); err != nil {
+			return errors.Wrapf(err, "unable to write %s", f.dst)
+		}
+	}
+	return nil
+}
+
+// updateMakefileForApp patches the Makefile of an existing Go module so that dist/ is included
+// in the archive and vmodutils is fetched in the setup target. The function requires that
+// MODULE_BINARY and module.tar.gz exist in the Makefile; it is otherwise tolerant of
+// customizations to their values and prerequisites. The function is idempotent.
+func updateMakefileForApp(makefilePath string) error {
+	//nolint:gosec
+	data, err := os.ReadFile(makefilePath)
+	if err != nil {
+		return errors.Wrap(err, "unable to read Makefile")
+	}
+	content := string(data)
+
+	// Idempotency guard: if ENTRYPOINT is already declared (any value), nothing to do.
+	const entrypointDecl = "ENTRYPOINT := dist/index.html"
+	if strings.Contains(content, "ENTRYPOINT :=") {
+		return nil
+	}
+
+	// 1. Declare ENTRYPOINT immediately after the MODULE_BINARY := line (any value).
+	const moduleBinaryAssign = "MODULE_BINARY :="
+	mbIdx := strings.Index(content, moduleBinaryAssign)
+	if mbIdx == -1 {
+		return errors.New("cannot locate MODULE_BINARY in Makefile")
+	}
+	eolIdx := strings.Index(content[mbIdx:], "\n")
+	if eolIdx == -1 {
+		return errors.New("malformed Makefile: MODULE_BINARY line has no newline")
+	}
+	content = content[:mbIdx+eolIdx+1] + entrypointDecl + "\n.DEFAULT_GOAL := all\n" + content[mbIdx+eolIdx+1:]
+
+	// 2. Add dist to the TAR_FILES declaration line (any existing value).
+	const tarFilesAssign = "TAR_FILES :="
+	if tfIdx := strings.Index(content, tarFilesAssign); tfIdx != -1 {
+		eol := strings.Index(content[tfIdx:], "\n")
+		if eol != -1 {
+			lineEnd := tfIdx + eol
+			content = content[:lineEnd] + " dist" + content[lineEnd:]
+		}
+	}
+
+	// 3. Add $(ENTRYPOINT) to the binary build target prerequisites (any existing deps).
+	const binaryTarget = "$(MODULE_BINARY):"
+	if bIdx := strings.Index(content, binaryTarget); bIdx != -1 {
+		eol := strings.Index(content[bIdx:], "\n")
+		if eol != -1 {
+			lineEnd := bIdx + eol
+			content = content[:lineEnd] + " $(ENTRYPOINT)" + content[lineEnd:]
+		}
+	}
+
+	// 4. Add $(ENTRYPOINT) to module.tar.gz prerequisites (any existing deps).
+	const tarTarget = "module.tar.gz:"
+	if tIdx := strings.Index(content, tarTarget); tIdx != -1 {
+		eol := strings.Index(content[tIdx:], "\n")
+		if eol != -1 {
+			lineEnd := tIdx + eol
+			content = content[:lineEnd] + " $(ENTRYPOINT)" + content[lineEnd:]
+		}
+	} else {
+		return errors.New("cannot locate module.tar.gz target in Makefile")
+	}
+
+	// 5. Add vmodutils to the setup target if not already present.
+	const setupTarget = "\nsetup:\n"
+	if strings.Contains(content, setupTarget) && !strings.Contains(content, "vmodutils") {
+		content = strings.Replace(content, setupTarget,
+			setupTarget+"\tgo get github.com/erh/vmodutils@latest\n", 1)
+	}
+
+	//nolint:gosec
+	return os.WriteFile(makefilePath, []byte(content), 0o644)
+}
+
+// addAppToManifest appends a new application entry (and its webapp model if absent) to meta.json.
+func addAppToManifest(manifestPath string, app *appInputs, data appTemplateData) error {
+	manifest, err := loadManifest(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	// Register the webapp generic component model if it isn't already listed.
+	webappModel := fmt.Sprintf("%s:%s:webapp", data.Namespace, data.ModuleName)
+	hasWebappModel := false
+	for _, m := range manifest.Models {
+		if m.Model == webappModel {
+			hasWebappModel = true
+			break
+		}
+	}
+	if !hasWebappModel {
+		manifest.Models = append(manifest.Models, ModuleComponent{
+			API:   "rdk:component:generic",
+			Model: webappModel,
+		})
+	}
+
+	manifest.Apps = append(manifest.Apps, AppComponent{
+		Name:       app.AppName,
+		Type:       app.AppType,
+		Entrypoint: "dist/index.html",
+	})
+
+	return writeManifest(manifestPath, manifest)
+}
+
+// AddAppAction adds a web application to an existing Go module created by `viam module generate`.
+// Run this command from within the module directory.
+func AddAppAction(_ context.Context, cmd *cli.Command, args addAppArgs) error {
+	// Read module-level info (language, namespace, name) from .viam-gen-info.
+	genInfo, err := readViamGenInfo(".")
+	if err != nil {
+		return err
+	}
+
+	if genInfo.Language != golang {
+		return fmt.Errorf("add-app currently only supports Go modules (this module uses %s); "+
+			"build-system integration for other languages is not yet implemented", genInfo.Language)
+	}
+
+	app := &appInputs{
+		AppName: args.AppName,
+		AppType: args.AppType,
+	}
+
+	// Prompt for any fields that are still unset.
+	if app.AppName == "" || app.AppType == "" {
+		if err := promptAddAppInputs(app); err != nil {
+			return err
+		}
+	}
+
+	gArgs, err := getGlobalArgs(cmd)
+	if err != nil {
+		return err
+	}
+	globalArgs := *gArgs
+
+	if args.DryRun {
+		printf(cmd.Root().Writer, "Dry run: would add app %q to module %s", app.AppName, genInfo.ModuleName)
+		return nil
+	}
+
+	// Guard against adding an app that already exists in meta.json.
+	manifest, err := loadManifest(defaultManifestFilename)
+	if err != nil {
+		return errors.Wrap(err, "failed to read meta.json")
+	}
+	for _, existingApp := range manifest.Apps {
+		if existingApp.Name == app.AppName {
+			return fmt.Errorf("app %q already exists in meta.json", app.AppName)
+		}
+	}
+
+	data := appTemplateData{
+		ModuleName:      genInfo.ModuleName,
+		ModuleLowercase: strings.ReplaceAll(strings.ToLower(genInfo.ModuleName), "-", ""),
+		AppName:         app.AppName,
+		AppType:         app.AppType,
+		Namespace:       genInfo.Namespace,
+		Visibility:      genInfo.Visibility,
+		ConfigName:      "WebappConfig",
+	}
+
+	s := spinner.New()
+	var fatalError error
+	action := func() {
+		s.Title("Generating webapp component file...")
+		if err := addGoWebappFile(".", data); err != nil {
+			fatalError = errors.Wrap(err, "failed to generate webapp.go")
+			return
+		}
+		if err := addGoWebappToMain(filepath.Join("cmd", "module", "main.go"), data); err != nil {
+			fatalError = errors.Wrap(err, "failed to update cmd/module/main.go")
+			return
+		}
+
+		s.Title("Setting up app directories and static files...")
+		if err := addAppStaticFiles("."); err != nil {
+			fatalError = errors.Wrap(err, "failed to set up app files")
+			return
+		}
+		if err := updateMakefileForApp("Makefile"); err != nil {
+			fatalError = errors.Wrap(err, "failed to update Makefile")
+			return
+		}
+
+		s.Title("Updating meta.json...")
+		if err := addAppToManifest(defaultManifestFilename, app, data); err != nil {
+			fatalError = errors.Wrap(err, "failed to update meta.json")
+			return
+		}
+	}
+
+	if globalArgs.Debug {
+		action()
+	} else {
+		s.Action(action)
+		if err := s.Run(); err != nil {
+			return err
+		}
+	}
+
+	if fatalError != nil {
+		return fatalError
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "."
+	}
+	printf(cmd.Root().Writer, "App %q successfully added to module at %s", app.AppName, cwd)
+	printAppBuildNextSteps(cmd.Root().Writer, "")
 	return nil
 }

--- a/cli/module_generate/_templates/app/tmpl-module.go
+++ b/cli/module_generate/_templates/app/tmpl-module.go
@@ -21,7 +21,7 @@ func distFS() (fs.FS, error) {
 
 var Model = resource.NewModel("{{ .Namespace }}", "{{ .ModuleName }}", "webapp")
 
-type Config struct {
+type {{ .ConfigName }} struct {
 	resource.TriviallyValidateConfig
 
 	Port *int `json:"port,omitempty"`
@@ -29,14 +29,14 @@ type Config struct {
 
 func init() {
 	resource.RegisterComponent(generic.API, Model,
-		resource.Registration[resource.Resource, *Config]{
+		resource.Registration[resource.Resource, *{{ .ConfigName }}]{
 			Constructor: NewServer,
 		},
 	)
 }
 
 func NewServer(_ context.Context, _ resource.Dependencies, rawConf resource.Config, logger logging.Logger) (resource.Resource, error) {
-	conf, err := resource.NativeConfig[*Config](rawConf)
+	conf, err := resource.NativeConfig[*{{ .ConfigName }}](rawConf)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/module_generate_app_test.go
+++ b/cli/module_generate_app_test.go
@@ -19,6 +19,7 @@ func TestAppTemplateCompiles(t *testing.T) {
 		AppType:         "single_machine",
 		Namespace:       "testorg",
 		Visibility:      "private",
+		ConfigName:      "Config",
 	}
 
 	cCtx := newTestContext(t, map[string]any{"local": true})

--- a/cli/module_generate_test.go
+++ b/cli/module_generate_test.go
@@ -25,8 +25,14 @@ import (
 )
 
 func TestAddModel(t *testing.T) {
-	t.Parallel()
-
+	// NOTE: do not mark this top-level test t.Parallel(). Some subtests call
+	// testChdir, which mutates the process-wide CWD. Marking a subtest
+	// non-parallel only serializes it against its siblings; if this parent ran
+	// in parallel with TestAddApp (which also chdirs), their CWD mutations would
+	// race, breaking relative-path lookups (meta.json) and, on Windows, breaking
+	// t.TempDir() cleanup ("the process cannot access the file because it is
+	// being used by another process"). Keeping the parent sequential serializes
+	// all CWD-mutating tests against each other.
 	baseModule := modulegen.ModuleInputs{
 		ModuleName:            "my-module",
 		Visibility:            moduleVisibilityPrivate,
@@ -787,7 +793,10 @@ func TestGenerateModuleAction(t *testing.T) {
 }
 
 func TestAddApp(t *testing.T) {
-	t.Parallel()
+	// NOTE: do not mark this top-level test t.Parallel(). Some subtests call
+	// testChdir, which mutates the process-wide CWD, and would race with the
+	// CWD-mutating subtests in TestAddModel if both parents ran in parallel.
+	// See the note on TestAddModel for details.
 
 	baseGenInfo := modulegen.ModuleInputs{
 		ModuleName: "my-module",

--- a/cli/module_generate_test.go
+++ b/cli/module_generate_test.go
@@ -785,3 +785,314 @@ func TestGenerateModuleAction(t *testing.T) {
 		}
 	})
 }
+
+func TestAddApp(t *testing.T) {
+	t.Parallel()
+
+	baseGenInfo := modulegen.ModuleInputs{
+		ModuleName: "my-module",
+		Language:   "go",
+		Namespace:  "my-org",
+		Visibility: moduleVisibilityPrivate,
+	}
+
+	cCtx := newTestContext(t, map[string]any{"local": true})
+
+	t.Run("addGoWebappToMain adds generic import and webapp APIModel", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		mainGoPath := filepath.Join(dir, "main.go")
+		original := `package main
+
+import (
+	"mymodule"
+	"go.viam.com/rdk/components/arm"
+	"go.viam.com/rdk/module"
+	"go.viam.com/rdk/resource"
+)
+
+func main() {
+	module.ModularMain(resource.APIModel{API: arm.API, Model: mymodule.MyModel})
+}
+`
+		test.That(t, os.WriteFile(mainGoPath, []byte(original), 0o600), test.ShouldBeNil)
+
+		data := appTemplateData{
+			ModuleName:      "my-module",
+			ModuleLowercase: "mymodule",
+			Namespace:       "my-org",
+		}
+		test.That(t, addGoWebappToMain(mainGoPath, data), test.ShouldBeNil)
+
+		result, err := os.ReadFile(mainGoPath)
+		test.That(t, err, test.ShouldBeNil)
+		content := string(result)
+		test.That(t, content, test.ShouldContainSubstring, "go.viam.com/rdk/components/generic")
+		test.That(t, content, test.ShouldContainSubstring, "resource.APIModel{API: generic.API, Model: mymodule.Model}")
+		// original registration must still be present
+		test.That(t, content, test.ShouldContainSubstring, "resource.APIModel{API: arm.API, Model: mymodule.MyModel}")
+	})
+
+	t.Run("addGoWebappToMain skips duplicate generic import", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		mainGoPath := filepath.Join(dir, "main.go")
+		original := `package main
+
+import (
+	"mymodule"
+	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/module"
+	"go.viam.com/rdk/resource"
+)
+
+func main() {
+	module.ModularMain(resource.APIModel{API: generic.API, Model: mymodule.Model})
+}
+`
+		test.That(t, os.WriteFile(mainGoPath, []byte(original), 0o600), test.ShouldBeNil)
+
+		data := appTemplateData{ModuleLowercase: "mymodule"}
+		test.That(t, addGoWebappToMain(mainGoPath, data), test.ShouldBeNil)
+
+		result, err := os.ReadFile(mainGoPath)
+		test.That(t, err, test.ShouldBeNil)
+		// import should appear exactly once
+		test.That(t, strings.Count(string(result), "go.viam.com/rdk/components/generic"), test.ShouldEqual, 1)
+	})
+
+	t.Run("addAppToManifest appends app and webapp model", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		manifestPath := filepath.Join(dir, "meta.json")
+		manifest := ModuleManifest{
+			Schema:   "https://dl.viam.dev/module.schema.json",
+			ModuleID: "my-org:my-module",
+			Models: []ModuleComponent{
+				{API: "rdk:component:arm", Model: "my-org:my-module:my-model"},
+			},
+		}
+		test.That(t, writeManifest(manifestPath, manifest), test.ShouldBeNil)
+
+		app := &appInputs{AppName: "my-app", AppType: "single_machine"}
+		data := appTemplateData{Namespace: "my-org", ModuleName: "my-module"}
+		test.That(t, addAppToManifest(manifestPath, app, data), test.ShouldBeNil)
+
+		result, err := loadManifest(manifestPath)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(result.Apps), test.ShouldEqual, 1)
+		test.That(t, result.Apps[0].Name, test.ShouldEqual, "my-app")
+		test.That(t, result.Apps[0].Type, test.ShouldEqual, "single_machine")
+		test.That(t, result.Apps[0].Entrypoint, test.ShouldEqual, "dist/index.html")
+		// original model must still be present
+		test.That(t, len(result.Models), test.ShouldEqual, 2)
+		webappFound := false
+		for _, m := range result.Models {
+			if m.Model == "my-org:my-module:webapp" {
+				webappFound = true
+				test.That(t, m.API, test.ShouldEqual, "rdk:component:generic")
+			}
+		}
+		test.That(t, webappFound, test.ShouldBeTrue)
+	})
+
+	t.Run("addAppToManifest skips duplicate webapp model", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		manifestPath := filepath.Join(dir, "meta.json")
+		manifest := ModuleManifest{
+			Schema:   "https://dl.viam.dev/module.schema.json",
+			ModuleID: "my-org:my-module",
+			Models: []ModuleComponent{
+				{API: "rdk:component:generic", Model: "my-org:my-module:webapp"},
+			},
+		}
+		test.That(t, writeManifest(manifestPath, manifest), test.ShouldBeNil)
+
+		app := &appInputs{AppName: "my-app", AppType: "multi_machine"}
+		data := appTemplateData{Namespace: "my-org", ModuleName: "my-module"}
+		test.That(t, addAppToManifest(manifestPath, app, data), test.ShouldBeNil)
+
+		result, err := loadManifest(manifestPath)
+		test.That(t, err, test.ShouldBeNil)
+		// webapp model should still appear exactly once
+		count := 0
+		for _, m := range result.Models {
+			if m.Model == "my-org:my-module:webapp" {
+				count++
+			}
+		}
+		test.That(t, count, test.ShouldEqual, 1)
+	})
+
+	t.Run("addAppStaticFiles creates dist and copies auth.js", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		test.That(t, addAppStaticFiles(dir), test.ShouldBeNil)
+
+		// dist/ directory must exist
+		info, err := os.Stat(filepath.Join(dir, "dist"))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, info.IsDir(), test.ShouldBeTrue)
+
+		// auth.js must be present and non-empty
+		authInfo, err := os.Stat(filepath.Join(dir, "auth.js"))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, authInfo.Size(), test.ShouldBeGreaterThan, 0)
+
+		// dist/index.html must be present
+		_, err = os.Stat(filepath.Join(dir, "dist", "index.html"))
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("addAppStaticFiles does not overwrite existing files", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		distDir := filepath.Join(dir, "dist")
+		test.That(t, os.MkdirAll(distDir, 0o750), test.ShouldBeNil)
+		test.That(t, os.WriteFile(filepath.Join(dir, "auth.js"), []byte("existing"), 0o600), test.ShouldBeNil)
+		test.That(t, os.WriteFile(filepath.Join(distDir, "index.html"), []byte("existing"), 0o600), test.ShouldBeNil)
+
+		test.That(t, addAppStaticFiles(dir), test.ShouldBeNil)
+
+		authBytes, err := os.ReadFile(filepath.Join(dir, "auth.js"))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, string(authBytes), test.ShouldEqual, "existing")
+
+		indexBytes, err := os.ReadFile(filepath.Join(distDir, "index.html"))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, string(indexBytes), test.ShouldEqual, "existing")
+	})
+
+	t.Run("AddAppAction dry run", func(t *testing.T) {
+		// No t.Parallel(): calls testChdir which mutates process-wide CWD.
+		dir := t.TempDir()
+		testChdir(t, dir)
+
+		data, err := json.Marshal(baseGenInfo)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, os.WriteFile(".viam-gen-info", data, 0o600), test.ShouldBeNil)
+
+		manifest := ModuleManifest{
+			Schema:   "https://dl.viam.dev/module.schema.json",
+			ModuleID: "my-org:my-module",
+		}
+		test.That(t, writeManifest(defaultManifestFilename, manifest), test.ShouldBeNil)
+
+		args := addAppArgs{AppName: "my-app", AppType: "single_machine", DryRun: true}
+		test.That(t, AddAppAction(context.Background(), cCtx, args), test.ShouldBeNil)
+
+		// meta.json must be unchanged after a dry run
+		result, err := loadManifest(defaultManifestFilename)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(result.Apps), test.ShouldEqual, 0)
+	})
+
+	t.Run("AddAppAction rejects non-Go modules", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		pythonInfo := modulegen.ModuleInputs{
+			ModuleName: "my-module",
+			Language:   "python",
+			Namespace:  "my-org",
+		}
+		data, err := json.Marshal(pythonInfo)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, os.WriteFile(filepath.Join(dir, ".viam-gen-info"), data, 0o600), test.ShouldBeNil)
+
+		// Temporarily point CWD so readViamGenInfo(".")  resolves correctly.
+		// We can't use testChdir here (parallel), so call readViamGenInfo directly.
+		info, err := readViamGenInfo(dir)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, info.Language, test.ShouldEqual, "python")
+
+		// Simulate the language guard in AddAppAction.
+		if info.Language != golang {
+			// expected path: error should mention "Go" and the actual language
+			errMsg := fmt.Sprintf("add-app only supports Go modules; this module uses %s", info.Language)
+			test.That(t, errMsg, test.ShouldContainSubstring, "python")
+		}
+	})
+
+	t.Run("AddAppAction rejects duplicate app name", func(t *testing.T) {
+		// No t.Parallel(): calls testChdir which mutates process-wide CWD.
+		dir := t.TempDir()
+		testChdir(t, dir)
+
+		data, err := json.Marshal(baseGenInfo)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, os.WriteFile(".viam-gen-info", data, 0o600), test.ShouldBeNil)
+
+		manifest := ModuleManifest{
+			Schema:   "https://dl.viam.dev/module.schema.json",
+			ModuleID: "my-org:my-module",
+			Apps:     []AppComponent{{Name: "my-app", Type: "single_machine", Entrypoint: "dist/index.html"}},
+		}
+		test.That(t, writeManifest(defaultManifestFilename, manifest), test.ShouldBeNil)
+
+		args := addAppArgs{AppName: "my-app", AppType: "single_machine"}
+		err = AddAppAction(context.Background(), cCtx, args)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "already exists")
+	})
+
+	t.Run("updateMakefileForApp adds ENTRYPOINT, dist, and vmodutils", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		makefilePath := filepath.Join(dir, "Makefile")
+		original := "\nGO_BUILD_ENV :=\nMODULE_BINARY := bin/my-module\n\n" +
+			"$(MODULE_BINARY): Makefile go.mod *.go cmd/module/*.go\n" +
+			"\tgo build -o $(MODULE_BINARY) cmd/module/main.go\n\n" +
+			"FIRST_RUN := $(shell jq -r '.first_run // empty' meta.json 2>/dev/null)\n" +
+			"TAR_FILES := meta.json $(MODULE_BINARY)\n\n" +
+			"module.tar.gz: meta.json $(MODULE_BINARY)\n" +
+			"\tstrip $(MODULE_BINARY)\n" +
+			"\ttar czf $@ $(TAR_FILES)\n\n" +
+			"setup:\n\tgo mod tidy\n"
+		test.That(t, os.WriteFile(makefilePath, []byte(original), 0o600), test.ShouldBeNil)
+
+		test.That(t, updateMakefileForApp(makefilePath), test.ShouldBeNil)
+
+		result, err := os.ReadFile(makefilePath)
+		test.That(t, err, test.ShouldBeNil)
+		content := string(result)
+
+		test.That(t, content, test.ShouldContainSubstring, "ENTRYPOINT := dist/index.html")
+		test.That(t, content, test.ShouldContainSubstring, ".DEFAULT_GOAL := all")
+		// ENTRYPOINT and .DEFAULT_GOAL must appear right after the MODULE_BINARY line
+		mbIdx := strings.Index(content, "MODULE_BINARY :=")
+		epIdx := strings.Index(content, "ENTRYPOINT :=")
+		dgIdx := strings.Index(content, ".DEFAULT_GOAL :=")
+		test.That(t, epIdx, test.ShouldBeGreaterThan, mbIdx)
+		test.That(t, dgIdx, test.ShouldBeGreaterThan, mbIdx)
+
+		test.That(t, content, test.ShouldContainSubstring, "TAR_FILES := meta.json $(MODULE_BINARY) dist")
+		test.That(t, content, test.ShouldContainSubstring, "$(MODULE_BINARY): Makefile go.mod *.go cmd/module/*.go $(ENTRYPOINT)")
+		test.That(t, content, test.ShouldContainSubstring, "module.tar.gz: meta.json $(MODULE_BINARY) $(ENTRYPOINT)")
+		test.That(t, content, test.ShouldContainSubstring, "go get github.com/erh/vmodutils@latest")
+		// vmodutils must appear before go mod tidy in setup
+		vmodIdx := strings.Index(content, "vmodutils")
+		tidyIdx := strings.Index(content, "go mod tidy")
+		test.That(t, vmodIdx, test.ShouldBeLessThan, tidyIdx)
+	})
+
+	t.Run("updateMakefileForApp is idempotent", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		makefilePath := filepath.Join(dir, "Makefile")
+		original := "\nMODULE_BINARY := bin/my-module\nENTRYPOINT := dist/custom.html\n\n" +
+			"TAR_FILES := meta.json $(MODULE_BINARY) dist\n\n" +
+			"module.tar.gz: meta.json $(MODULE_BINARY) $(ENTRYPOINT)\n" +
+			"\ttar czf $@ $(TAR_FILES)\n\n" +
+			"setup:\n\tgo get github.com/erh/vmodutils@latest\n\tgo mod tidy\n"
+		test.That(t, os.WriteFile(makefilePath, []byte(original), 0o600), test.ShouldBeNil)
+
+		test.That(t, updateMakefileForApp(makefilePath), test.ShouldBeNil)
+
+		result, err := os.ReadFile(makefilePath)
+		test.That(t, err, test.ShouldBeNil)
+		// File must be unchanged — in particular the custom ENTRYPOINT value must be preserved.
+		test.That(t, string(result), test.ShouldEqual, original)
+	})
+}

--- a/robot/packages/utils.go
+++ b/robot/packages/utils.go
@@ -297,8 +297,7 @@ func unpackFile(ctx context.Context, fromFile, toDir string) error {
 func commonCleanup(logger logging.Logger, expectedPackageEntries map[string]bool, packagesDataDir string) error {
 	topLevelFiles, err := os.ReadDir(packagesDataDir)
 	if err != nil {
-		var fsPathErr *fs.PathError
-		if errors.Is(err, fsPathErr) {
+		if os.IsNotExist(err) {
 			// Directory doesn't exist. Nothing to clean up.
 			return nil
 		}


### PR DESCRIPTION
## Summary

Re-adds the `viam module add-app` feature from #6063, which was reverted in #6138 due to a flaky Windows test failure, and fixes the underlying flake.

Two commits:
1. **Reapply "RSDK-13843 - add app to module" (#6063)** — restores the original feature diff exactly (revert of the revert).
2. **cli: fix flaky Windows failure in add-app/add-model tests** — fixes the root cause of the revert.

## Root cause of the Windows flake

`TestAddModel` and `TestAddApp` both called `t.Parallel()` at the top level, so they ran concurrently. Several of their subtests call `testChdir`, which mutates the **process-wide** working directory. Marking those subtests non-parallel only serializes them against their own siblings — not against subtests of the *other* parallel parent. The two parents' CWD mutations therefore raced:

- `AddAppAction` resolved `meta.json` against the wrong directory, so `rejects duplicate app name` got `cannot find meta.json` instead of `already exists`.
- On Windows, `t.TempDir()` cleanup failed with *"the process cannot access the file because it is being used by another process"* because the racing test left the global CWD inside the directory being removed. Unix unlinks such directories silently — which is why this only failed on Windows and passed on rerun.

## Fix

Drop `t.Parallel()` from both top-level tests so all CWD-mutating tests run sequentially (joining the already-sequential `TestGenerateModuleAction`/`TestLocalBuild`). The inner subtests that use absolute paths keep `t.Parallel()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)