### PR TITLE
collapse collision ignoreList nested map into canonical-pair set

### DIFF
--- a/motionplan/collision.go
+++ b/motionplan/collision.go
@@ -253,18 +253,18 @@ func checkCollisionsHinted(
 	return collisions, minDistance, nil
 }
 
+func canonicalPair(a, b string) [2]string {
+	if a < b {
+		return [2]string{a, b}
+	}
+	return [2]string{b, a}
+}
+
 // Process a []Collision into a map for easy lookups.
-func makeAllowedCollisionsLookup(allowedCollisions []Collision) map[string]map[string]bool {
-	ignoreList := map[string]map[string]bool{}
-	for _, collision := range allowedCollisions {
-		if _, ok := ignoreList[collision.name1]; !ok {
-			ignoreList[collision.name1] = map[string]bool{}
-		}
-		if _, ok := ignoreList[collision.name2]; !ok {
-			ignoreList[collision.name2] = map[string]bool{}
-		}
-		ignoreList[collision.name1][collision.name2] = true
-		ignoreList[collision.name2][collision.name1] = true
+func makeAllowedCollisionsLookup(allowedCollisions []Collision) map[[2]string]bool {
+	ignoreList := make(map[[2]string]bool, len(allowedCollisions))
+	for _, c := range allowedCollisions {
+		ignoreList[canonicalPair(c.name1, c.name2)] = true
 	}
 	return ignoreList
 }
@@ -287,26 +287,20 @@ func createUniqueCollisionMap(geoms []spatialmath.Geometry) (map[string]spatialm
 	return geomMap, nil
 }
 
-func skipCollisionCheck(ignoreList map[string]map[string]bool, xName, yName string) bool {
+func skipCollisionCheck(ignoreList map[[2]string]bool, xName, yName string) bool {
 	// Skip comparing a geometry to itself
 	if xName == yName {
 		return true
 	}
 
-	if _, ok := ignoreList[yName]; ok && ignoreList[yName][xName] {
+	key := canonicalPair(xName, yName)
+	if ignoreList[key] {
 		// Already checked this pair in the other order
 		return true
 	}
 
 	// We're going to decide if x->y collides. We will not need to check if y->x collides. Mutate
 	// the ignoreList to (potentially) avoid that reverse computation.
-	for _, pair := range [][2]string{{xName, yName}, {yName, xName}} {
-		left, right := pair[0], pair[1]
-		if _, ok := ignoreList[left]; !ok {
-			ignoreList[left] = map[string]bool{}
-		}
-		ignoreList[left][right] = true
-	}
-
+	ignoreList[key] = true
 	return false
 }


### PR DESCRIPTION
collapse collision ignoreList nested map into canonical pair set

`skipCollisionCheck` and `makeAllowedCollisionsLookup` previously used `map[string]map[string]bool` to record allowed/already-checked pairs storing each pair in both directions so that lookup in either order was constant

Per `checkCollisionsHinted` call this allocated:
- one outer map[string]map[string]bool (returned, unavoidable)
- one inner map[string]bool{} per allowed-collision name (in makeAllowedCollisionsLookup)
- one inner map[string]bool{} per first-seen frame name during the cartesian loop (in skipCollisionCheck)
- a [][2]string range loop on every skipCollisionCheck call

Replace with map[[2]string]bool keyed on a sorted (canonical) name pair, so `(A,B)` and `(B,A)` resolve to one entry. Per call this collapses to a single hash + lookup with no inner-map allocations and no per-call range loop

## Compiler proof - escape analysis
`go build -gcflags='-m=2' ./motionplan/` on `collision.go`:

Before (main):
- 261: map[string]bool{} escapes to heap in makeAllowedCollisionsLookup
- 264: map[string]bool{} escapes to heap in makeAllowedCollisionsLookup
- 258: map[string]map[string]bool{} escapes to heap (return value)
- 306: map[string]bool{} escapes to heap in skipCollisionCheck

After:
- 265: make(map[[2]string]bool, ...) escapes to heap (return value)

Three hot-path heap allocations eliminated; only the unavoidable returned map remains. Inline cost of `skipCollisionCheck` drops from 75 to 39

## Sanding tests
Measured against sanding's planning/motion test suite (ran against main vs this branch three times - median): 
- Test wall time: **93.7s --> 74.7s**
- skipCollisionCheck allocations: **8.71M --> 0**
- Total allocations: **594M --> 572M**