### PR TITLE
[RSDK-13818] Clarify request-limit-exceeded messaging for modules/clients

### DIFF
--- a/logging/appender.go
+++ b/logging/appender.go
@@ -52,6 +52,11 @@ func NewStdoutAppender() ConsoleAppender {
 	return ConsoleAppender{os.Stdout}
 }
 
+// NewStderrAppender creates a new appender that prints to stderr.
+func NewStderrAppender() ConsoleAppender {
+	return ConsoleAppender{os.Stderr}
+}
+
 // NewWriterAppender creates a new appender that prints to the input writer.
 func NewWriterAppender(writer io.Writer) ConsoleAppender {
 	return ConsoleAppender{writer}

--- a/module/log.go
+++ b/module/log.go
@@ -12,6 +12,7 @@ import (
 
 type moduleAppender struct {
 	stdoutAppender *logging.ConsoleAppender
+	stderrAppender *logging.ConsoleAppender
 
 	// If Module is set, moduleAppender sends log events to the Unix socket at
 	// Module.parentAddr via gRPC. Otherwise, moduleAppender logs to STDOUT.
@@ -20,7 +21,8 @@ type moduleAppender struct {
 
 func newModuleAppender() *moduleAppender {
 	stdoutAppender := logging.NewStdoutAppender()
-	return &moduleAppender{stdoutAppender: &stdoutAppender}
+	stderrAppender := logging.NewStderrAppender()
+	return &moduleAppender{stdoutAppender: &stdoutAppender, stderrAppender: &stderrAppender}
 }
 
 func (ma *moduleAppender) setModule(m *Module) {
@@ -38,7 +40,17 @@ func (ma *moduleAppender) Write(log zapcore.Entry, fields []zapcore.Field) error
 	// down or otherwise unreachable.
 	moduleLogCtx, moduleLogCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer moduleLogCancel()
-	return ma.module.parent.Log(moduleLogCtx, log, fields)
+	if err := ma.module.parent.Log(moduleLogCtx, log, fields); err != nil {
+		// Shipping logs to the parent is best-effort. If the parent is unreachable or
+		// rate-limiting us, fall back to the local console rather than returning the
+		// error; otherwise the returned error is printed to STDERR as a confusing blob
+		// of gRPC errors instead of the log we meant to emit.
+		if log.Level >= zapcore.ErrorLevel {
+			return ma.stderrAppender.Write(log, fields)
+		}
+		return ma.stdoutAppender.Write(log, fields)
+	}
+	return nil
 }
 
 // Sync is a no-op (moduleAppenders do not currently have buffers that needs

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -702,7 +702,7 @@ func (rc *RobotClient) checkConnection(ctx context.Context, checkEvery, reconnec
 					// Doing so would mask the rate limit as a "not connected to remote robot"
 					// error and cause needless reconnect churn. ResourceExhausted will surface
 					// to callers making requests.
-					rc.Logger().CWarnw(ctx,
+					rc.Logger().CInfow(ctx,
 						"connection health checks to remote are failing due to a request rate limit, "+
 							"likely caused by a different client or module; leaving connection up",
 						"error", outerError,

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -195,6 +195,18 @@ func (rc *RobotClient) notConnectedToRemoteError() error {
 	return fmt.Errorf("not connected to remote robot at %s", rc.address)
 }
 
+func isResourceExhaustedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	for _, e := range multierr.Errors(err) {
+		if status.Code(e) == codes.ResourceExhausted {
+			return true
+		}
+	}
+	return false
+}
+
 func (rc *RobotClient) handleUnaryDisconnect(
 	ctx context.Context,
 	method string,
@@ -672,7 +684,9 @@ func (rc *RobotClient) checkConnection(ctx context.Context, checkEvery, reconnec
 				err := check()
 				if err != nil {
 					outerError = err
-					if isDisconnectedError(err) {
+					// A disconnect is terminal for this cycle, and immediately retrying a
+					// rate-limited request would only add load, so stop early in both cases.
+					if isDisconnectedError(err) || isResourceExhaustedError(err) {
 						break
 					}
 					// otherwise retry
@@ -682,6 +696,20 @@ func (rc *RobotClient) checkConnection(ctx context.Context, checkEvery, reconnec
 				break
 			}
 			if outerError != nil {
+				if isResourceExhaustedError(outerError) {
+					// The remote is reachable but is rate-limiting our health-check requests.
+					// The connection itself is healthy, so do not mark the client disconnected.
+					// Doing so would mask the rate limit as a "not connected to remote robot"
+					// error and cause needless reconnect churn. ResourceExhausted will surface
+					// to callers making requests.
+					rc.Logger().CWarnw(ctx,
+						"connection health checks to remote are failing due to a request rate limit, "+
+							"likely caused by a different client or module; leaving connection up",
+						"error", outerError,
+						"address", rc.address,
+					)
+					continue
+				}
 				rc.Logger().CErrorw(ctx,
 					"lost connection to remote",
 					"error", outerError,

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/golang/geo/r3"
 	"github.com/google/uuid"
 	"github.com/jhump/protoreflect/grpcreflect"
+	"go.uber.org/multierr"
 	"go.uber.org/zap/zapcore"
 	commonpb "go.viam.com/api/common/v1"
 	armpb "go.viam.com/api/component/arm/v1"
@@ -879,6 +880,84 @@ func TestClientDisconnect(t *testing.T) {
 	test.That(t, len(client.ResourceNames()), test.ShouldEqual, 0)
 	_, err = client.ResourceByName(arm.Named("arm1"))
 	test.That(t, err, test.ShouldBeError, client.checkConnected())
+}
+
+func TestClientHealthCheckRateLimitedStaysConnected(t *testing.T) {
+	logger, logs := logging.NewObservedTestLogger(t)
+	listener, err := net.Listen("tcp", "localhost:0")
+	test.That(t, err, test.ShouldBeNil)
+
+	// Once enabled, the interceptor rate-limits every request, including the background
+	// health check's ResourceNames call.
+	var rateLimited atomic.Bool
+	rateLimitInterceptor := grpc.ChainUnaryInterceptor(
+		func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+			if rateLimited.Load() {
+				return nil, status.Error(codes.ResourceExhausted, "exceeded request limit")
+			}
+			return handler(ctx, req)
+		},
+	)
+	gServer := grpc.NewServer(rateLimitInterceptor)
+	injectRobot := &inject.Robot{}
+	pb.RegisterRobotServiceServer(gServer, server.New(injectRobot))
+	injectRobot.ResourceRPCAPIsFunc = func() []resource.RPCAPI { return nil }
+	injectRobot.ResourceNamesFunc = func() []resource.Name {
+		return []resource.Name{arm.Named("arm1")}
+	}
+	injectRobot.MachineStatusFunc = func(context.Context) (robot.MachineStatus, error) {
+		return robot.MachineStatus{State: robot.StateRunning}, nil
+	}
+	injectRobot.FrameSystemConfigFunc = func(ctx context.Context) (*framesystem.Config, error) {
+		return &framesystem.Config{}, nil
+	}
+
+	go gServer.Serve(listener)
+	defer gServer.Stop()
+
+	dur := 50 * time.Millisecond
+	client, err := New(
+		context.Background(),
+		listener.Addr().String(),
+		logger,
+		WithCheckConnectedEvery(dur),
+		WithReconnectEvery(dur),
+	)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, client.Close(context.Background()), test.ShouldBeNil)
+	}()
+	test.That(t, client.Connected(), test.ShouldBeTrue)
+
+	// Start rate-limiting all requests, then let the background health check run several
+	// cycles. The client must stay connected: rate limiting is not a connection loss.
+	rateLimited.Store(true)
+	time.Sleep(5 * dur)
+	test.That(t, client.Connected(), test.ShouldBeTrue)
+
+	// The health check should have logged that it is leaving the connection up despite the
+	// rate limiting, rather than logging a lost connection.
+	test.That(t, logs.FilterMessageSnippet("health checks to remote are failing due to a request rate limit").Len(),
+		test.ShouldBeGreaterThan, 0)
+	test.That(t, logs.FilterMessageSnippet("lost connection to remote").Len(), test.ShouldEqual, 0)
+
+	// A request now surfaces the true ResourceExhausted error rather than a spurious
+	// "not connected to remote robot" error.
+	_, err = client.MachineStatus(context.Background())
+	test.That(t, status.Code(err), test.ShouldEqual, codes.ResourceExhausted)
+}
+
+func TestIsResourceExhaustedError(t *testing.T) {
+	resourceExhausted := status.Error(codes.ResourceExhausted, "exceeded request limit")
+	unavailable := status.Error(codes.Unavailable, "not connected")
+
+	test.That(t, isResourceExhaustedError(nil), test.ShouldBeFalse)
+	test.That(t, isResourceExhaustedError(errors.New("plain")), test.ShouldBeFalse)
+	test.That(t, isResourceExhaustedError(unavailable), test.ShouldBeFalse)
+	test.That(t, isResourceExhaustedError(resourceExhausted), test.ShouldBeTrue)
+	// A ResourceExhausted combined with other errors (as Refresh may return) is still detected.
+	test.That(t, isResourceExhaustedError(multierr.Combine(unavailable, resourceExhausted)), test.ShouldBeTrue)
+	test.That(t, isResourceExhaustedError(multierr.Combine(unavailable, errors.New("plain"))), test.ShouldBeFalse)
 }
 
 func TestClientUnaryDisconnectHandler(t *testing.T) {

--- a/robot/web/request_counter.go
+++ b/robot/web/request_counter.go
@@ -39,7 +39,9 @@ type RequestLimitExceededError struct {
 
 func (e RequestLimitExceededError) Error() string {
 	return fmt.Sprintf(
-		"exceeded request limit %v on resource %v (your client is responsible for %v). See %v for troubleshooting steps",
+		"exceeded the shared concurrent-request limit of %v on resource %v. This limit is shared "+
+			"across all clients/modules (your client has %v in-flight requests). Check the viam-server "+
+			`logs for "Request limit exceeded" to find the offending client. See %v for troubleshooting steps`,
 		e.limit, e.resource, e.numInFlightRequestsForClient, ReqLimitExceededURL)
 }
 
@@ -369,9 +371,19 @@ func (rc *RequestCounter) logRequestLimitExceeded(
 		return true
 	})
 
+	offendingClientDesc := "already_disconnected"
+	if offendingClientInformation != nil {
+		offendingClientDesc = fmt.Sprintf("%s [%s]",
+			offendingClientInformation.ClientMetadata, offendingClientInformation.ConnectionID)
+	}
+
 	msg := fmt.Sprintf(
-		"Request limit exceeded for resource. See %s for troubleshooting steps. "+
+		"Request limit exceeded for resource %q (limit %d, method %q) by %s. See %s for troubleshooting steps. "+
 			`{"method":%q,"resource":%q,"offending_client_information":%v,"all_other_client_information":%v}`,
+		resource,
+		rc.inFlightLimit,
+		apiMethodString,
+		offendingClientDesc,
 		ReqLimitExceededURL,
 		apiMethodString,
 		resource,

--- a/robot/web/request_counter.go
+++ b/robot/web/request_counter.go
@@ -41,7 +41,7 @@ func (e RequestLimitExceededError) Error() string {
 	return fmt.Sprintf(
 		"exceeded the shared concurrent-request limit of %v on resource %v. This limit is shared "+
 			"across all clients/modules (your client has %v in-flight requests). Check the viam-server "+
-			`logs for "Request limit exceeded" to find the offending client. See %v for troubleshooting steps`,
+			`logs for 'Request limit exceeded' to find the offending client. See %v for troubleshooting steps`,
 		e.limit, e.resource, e.numInFlightRequestsForClient, ReqLimitExceededURL)
 }
 

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -1626,8 +1626,9 @@ func testResourceLimitsAndFTDC(
 	test.That(t, status.Convert(err).Code(), test.ShouldEqual, codes.ResourceExhausted)
 	test.That(t, err.Error(), test.ShouldEndWith,
 		fmt.Sprintf(
-			"exceeded request limit 1 on resource %v (your client is responsible for 1). "+
-				"See %v for troubleshooting steps",
+			"exceeded the shared concurrent-request limit of 1 on resource %v. This limit is shared "+
+				"across all clients/modules (your client has 1 in-flight requests). Check the viam-server "+
+				`logs for "Request limit exceeded" to find the offending client. See %v for troubleshooting steps`,
 			keyPrefix,
 			ReqLimitExceededURL,
 		),
@@ -1637,17 +1638,20 @@ func testResourceLimitsAndFTDC(
 	reqLimitExceededLogs := logs.FilterMessageSnippet("Request limit exceeded").All()
 	test.That(t, reqLimitExceededLogs, test.ShouldHaveLength, 1)
 	test.That(t, reqLimitExceededLogs[0].Level, test.ShouldEqual, zapcore.WarnLevel)
-	expectedMsg := fmt.Sprintf("Request limit exceeded for resource. See %v for troubleshooting steps. ", ReqLimitExceededURL)
-	test.That(t, reqLimitExceededLogs[0].Message, test.ShouldStartWith, expectedMsg)
+	test.That(t, reqLimitExceededLogs[0].Message, test.ShouldContainSubstring, ReqLimitExceededURL)
 
 	var fields map[string]any
 	err = json.Unmarshal(
-		[]byte(strings.TrimPrefix(reqLimitExceededLogs[0].Message, expectedMsg)),
+		[]byte(jsonSuffix(reqLimitExceededLogs[0].Message)),
 		&fields,
 	)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, fields["method"], test.ShouldEqual, method)
 	test.That(t, fields["resource"], test.ShouldEqual, keyPrefix)
+	// The human-readable lead before the JSON should call out the resource, limit, method,
+	// and offending client.
+	test.That(t, reqLimitExceededLogs[0].Message, test.ShouldContainSubstring,
+		fmt.Sprintf("Request limit exceeded for resource %q (limit 1, method %q) by ", keyPrefix, method))
 	{
 		offendingClientInformation := fields["offending_client_information"]
 		offendingClientInformationM, ok := offendingClientInformation.(map[string]any)
@@ -1682,6 +1686,16 @@ func testResourceLimitsAndFTDC(
 	// In-flight requests counter should be back to 0
 	stats = svc.RequestCounter().Stats().(map[string]int64)
 	test.That(t, stats[statsKey], test.ShouldEqual, 0)
+}
+
+// jsonSuffix returns the JSON object suffix of a "Request limit exceeded" log message
+// (everything from the first "{"), so tests can parse the structured fields without
+// depending on the exact human-readable lead that precedes it.
+func jsonSuffix(msg string) string {
+	if i := strings.Index(msg, "{"); i >= 0 {
+		return msg[i:]
+	}
+	return msg
 }
 
 func TestPerResourceLimitsAndFTDC(t *testing.T) {
@@ -1829,8 +1843,9 @@ func TestPerResourceLimitsAndFTDC(t *testing.T) {
 		test.That(t, status.Convert(err).Code(), test.ShouldEqual, codes.ResourceExhausted)
 		test.That(t, err.Error(), test.ShouldEndWith,
 			fmt.Sprintf(
-				"exceeded request limit 1 on resource arm1.viam.component.arm.v1.ArmService (your client is responsible for 1). "+
-					"See %v for troubleshooting steps",
+				"exceeded the shared concurrent-request limit of 1 on resource arm1.viam.component.arm.v1.ArmService. "+
+					"This limit is shared across all clients/modules (your client has 1 in-flight requests). Check "+
+					`the viam-server logs for "Request limit exceeded" to find the offending client. See %v for troubleshooting steps`,
 				ReqLimitExceededURL,
 			),
 		)
@@ -1841,11 +1856,10 @@ func TestPerResourceLimitsAndFTDC(t *testing.T) {
 		reqLimitExceededLogs := logs.FilterMessageSnippet("Request limit exceeded").All()
 		test.That(t, reqLimitExceededLogs, test.ShouldHaveLength, 1)
 		test.That(t, reqLimitExceededLogs[0].Level, test.ShouldEqual, zapcore.WarnLevel)
-		expectedMsg := fmt.Sprintf("Request limit exceeded for resource. See %v for troubleshooting steps. ", ReqLimitExceededURL)
-		test.That(t, reqLimitExceededLogs[0].Message, test.ShouldStartWith, expectedMsg)
+		test.That(t, reqLimitExceededLogs[0].Message, test.ShouldContainSubstring, ReqLimitExceededURL)
 		var fields map[string]any
 		err = json.Unmarshal(
-			[]byte(strings.TrimPrefix(reqLimitExceededLogs[0].Message, expectedMsg)),
+			[]byte(jsonSuffix(reqLimitExceededLogs[0].Message)),
 			&fields,
 		)
 		test.That(t, err, test.ShouldBeNil)
@@ -1943,11 +1957,10 @@ func TestPerResourceLimitsAndFTDC(t *testing.T) {
 		reqLimitExceededLogs := logs.FilterMessageSnippet("Request limit exceeded").All()
 		test.That(t, reqLimitExceededLogs, test.ShouldHaveLength, 1)
 		test.That(t, reqLimitExceededLogs[0].Level, test.ShouldEqual, zapcore.WarnLevel)
-		expectedMsg := fmt.Sprintf("Request limit exceeded for resource. See %v for troubleshooting steps. ", ReqLimitExceededURL)
-		test.That(t, reqLimitExceededLogs[0].Message, test.ShouldStartWith, expectedMsg)
+		test.That(t, reqLimitExceededLogs[0].Message, test.ShouldContainSubstring, ReqLimitExceededURL)
 		var fields map[string]any
 		err = json.Unmarshal(
-			[]byte(strings.TrimPrefix(reqLimitExceededLogs[0].Message, expectedMsg)),
+			[]byte(jsonSuffix(reqLimitExceededLogs[0].Message)),
 			&fields,
 		)
 		test.That(t, err, test.ShouldBeNil)

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -1628,7 +1628,7 @@ func testResourceLimitsAndFTDC(
 		fmt.Sprintf(
 			"exceeded the shared concurrent-request limit of 1 on resource %v. This limit is shared "+
 				"across all clients/modules (your client has 1 in-flight requests). Check the viam-server "+
-				`logs for "Request limit exceeded" to find the offending client. See %v for troubleshooting steps`,
+				`logs for 'Request limit exceeded' to find the offending client. See %v for troubleshooting steps`,
 			keyPrefix,
 			ReqLimitExceededURL,
 		),
@@ -1845,7 +1845,7 @@ func TestPerResourceLimitsAndFTDC(t *testing.T) {
 			fmt.Sprintf(
 				"exceeded the shared concurrent-request limit of 1 on resource arm1.viam.component.arm.v1.ArmService. "+
 					"This limit is shared across all clients/modules (your client has 1 in-flight requests). Check "+
-					`the viam-server logs for "Request limit exceeded" to find the offending client. See %v for troubleshooting steps`,
+					`the viam-server logs for 'Request limit exceeded' to find the offending client. See %v for troubleshooting steps`,
 				ReqLimitExceededURL,
 			),
 		)


### PR DESCRIPTION
## Summary

[RSDK-13818](https://viam.atlassian.net/browse/RSDK-13818) Improve `ResourceExhausted` log messaging for modules

A TypeScript client was hammering `RobotService/GetPose` hard enough to exhaust the shared
per-resource request limit, which made the whole `RobotService` unavailable. The fallout in the
logs was confusing and hard to act on. This PR makes three changes so the failure is legible.

## Changes

**1. Stop dumping rate-limited log-ship errors to a module's stderr.**

The confusing log reported in the ticket:
```
4/23/2026, 11:07:26 AM error rdk.modmanager.viam_find-webcams.StdErr   pexec/managed_process.go:442   \_ rpc error: code = ResourceExhausted desc = exceeded request limit 100 on resource viam.robot.v1.RobotService (your client is responsible for 0)...
```
wasn't the module's actual work failing, it was the module trying to ship a log line to `viam-server` through the `RobotService/Log` RPC and getting a rate-limited error, which was then logged instead of the line it meant to emit. 

I changed it so that when a module fails to log through the `Log` method, we fall back to `Stderr`/`Stdout` depending on the log level. This eliminates the confusing, ugly log, and modules can keep logging even while `RobotService` is rate-limited.

**2. Don't tear down the parent connection on a rate-limited health check.**

That same log also contained:
```
rpc error: code = Unavailable desc = not connected to remote robot at unix:///tmp/viam-module-695699077/parent.sock
```
which added even more confusion. This is because the module's background connection health
check (`RobotClient.checkConnection` --> `Refresh`/`ResourceNames`, also `RobotService` methods) was
itself getting `ResourceExhausted`, and the old code treated a persistent health-check failure
as a lost connection and marked the client disconnected. Once disconnected, every subsequent call failed fast with "not connected to remote robot", and the client churned through needless reconnect cycles.

I changed this so that if we encounter `ResourceExhausted` we skip the connection teardown, log
the rate-limit, and continue to loop. The remote is reachable, it's just rate-limiting us, so
the real `ResourceExhausted` surfaces to callers instead of a spurious "not connected".

**3. Make the `ResourceExhausted` error and its server-side log clearer.**

Finally, I changed the `ResourceExhausted` error to clarify the nature of the limit (it's shared
across all clients/modules) and to point at the server-side `Request limit exceeded` log for more
information. I also improved the wording of that log, adding a human-readable lead (resource,
limit, method, and the offending client) before its JSON payload so you can immediately see who
saturated the limit.

## Result

We eliminate the confusing module log, modules keep logging through a rate-limited
`RobotService`, and the resource rate-limit logs are clearer and more obvious about what the
limit is and who is responsible.

## Testing

- Unit: `TestClientHealthCheckRateLimitedStaysConnected`, `TestIsResourceExhaustedError`, and
  updated request-counter assertions.
- Manual: ran a module that logs heavily under a viam-server with `VIAM_RESOURCE_REQUESTS_LIMIT=1`.
  Confirmed the gRPC-error stderr blob no longer appears; error-level module logs fall back to
  `…StdErr` and info-level to `…StdOut` as the real log lines; and the server emits the clearer
  `Request limit exceeded` warning.

[RSDK-13818]: https://viam.atlassian.net/browse/RSDK-13818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
