### PR TITLE
APP-16652 Proactively log that a message will be deduplicated

### DIFF
--- a/logging/impl.go
+++ b/logging/impl.go
@@ -300,8 +300,25 @@ func (imp *impl) Write(entry *LogEntry) {
 		imp.recentMessageCounts[hashkeyedEntry]++
 		imp.recentMessageEntries[hashkeyedEntry] = *entry
 
-		if imp.recentMessageCounts[hashkeyedEntry] > noisyMessageCountThreshold {
-			// If entry's message is reportedly "noisy," return early.
+		if count := imp.recentMessageCounts[hashkeyedEntry]; count > noisyMessageCountThreshold {
+			// If entry's message is reportedly "noisy," return early. The first time we cross
+			// the threshold, emit a notice that suppression has started so the log does not
+			// appear to silently stop for the rest of the window.
+			if count == noisyMessageCountThreshold+1 {
+				suppressedEntry := *entry
+				suppressedEntry.Message = fmt.Sprintf(
+					"Message logged %d times; suppressing for rest of window (%v): %s",
+					noisyMessageCountThreshold, noisyMessageWindowDuration, entry.Message)
+
+				imp.testHelper()
+				for _, appender := range imp.appenders {
+					err := appender.Write(suppressedEntry.Entry, suppressedEntry.Fields)
+					if err != nil {
+						fmt.Fprint(os.Stderr, err)
+					}
+				}
+			}
+
 			imp.recentMessageMu.Unlock()
 			return
 		}

--- a/logging/impl_test.go
+++ b/logging/impl_test.go
@@ -528,7 +528,10 @@ func TestLoggingDeduplication(t *testing.T) {
 		assertLogMatches(t, notStdout,
 			`2023-10-30T13:19:45.806Z	INFO	impl	logging/impl_test.go:132	identical message	{"key":"value"}`)
 	}
-	loggerWith.Info(identicalMsg) // not output due to being noisy
+	loggerWith.Info(identicalMsg) // not output due to being noisy; emits suppression notice
+	assertLogMatches(t, notStdout,
+		//nolint:lll
+		`2023-10-30T13:19:45.806Z	INFO	impl	logging/impl_test.go:132	Message logged 3 times; suppressing for rest of window (500ms): identical message	{"key":"value"}`)
 	time.Sleep(noisyMessageWindowDuration)
 	loggerWith.Info("foo") // log arbitrary message to force output of aggregated message
 	assertLogMatches(t, notStdout,
@@ -542,7 +545,10 @@ func TestLoggingDeduplication(t *testing.T) {
 		assertLogMatches(t, notStdout,
 			`2023-10-30T13:19:45.806Z	INFO	impl	logging/impl_test.go:132	identical message	{"key":"value"}`)
 	}
-	loggerWith.Info(identicalMsg) // not output due to being noisy
+	loggerWith.Info(identicalMsg) // not output due to being noisy; emits suppression notice
+	assertLogMatches(t, notStdout,
+		//nolint:lll
+		`2023-10-30T13:19:45.806Z	INFO	impl	logging/impl_test.go:132	Message logged 3 times; suppressing for rest of window (500ms): identical message	{"key":"value"}`)
 	time.Sleep(noisyMessageWindowDuration)
 	loggerWith.Info("foo") // log arbitrary message to force output of aggregated message
 	assertLogMatches(t, notStdout,
@@ -581,7 +587,10 @@ func TestLoggingDeduplication(t *testing.T) {
 		assertLogMatches(t, notStdout,
 			`2023-10-30T13:19:45.806Z	INFO	impl	logging/impl_test.go:132	identical message	{"key":"value"}`)
 	}
-	loggerWith.Error(identicalMsg) // not output due to being noisy
+	loggerWith.Error(identicalMsg) // not output due to being noisy; emits suppression notice
+	assertLogMatches(t, notStdout,
+		//nolint:lll
+		`2023-10-30T13:19:45.806Z	ERROR	impl	logging/impl_test.go:132	Message logged 3 times; suppressing for rest of window (500ms): identical message	{"key":"value"}`)
 	time.Sleep(noisyMessageWindowDuration)
 	loggerWith.Info("foo") // log arbitrary message to force output of aggregated message
 	assertLogMatches(t, notStdout,
@@ -597,7 +606,10 @@ func TestLoggingDeduplication(t *testing.T) {
 				`2023-10-30T13:19:45.806Z	INFO	impl	logging/impl_test.go:132	identical message	{"%s":"bar","key":"value"}`,
 				ignoredLogFieldKey))
 	}
-	loggerWith.Info(identicalMsg) // not output due to being noisy
+	loggerWith.Info(identicalMsg) // not output due to being noisy; emits suppression notice
+	assertLogMatches(t, notStdout,
+		//nolint:lll
+		`2023-10-30T13:19:45.806Z	INFO	impl	logging/impl_test.go:132	Message logged 3 times; suppressing for rest of window (500ms): identical message	{"key":"value"}`)
 	time.Sleep(noisyMessageWindowDuration)
 	loggerWith.Info("foo") // log arbitrary message to force output of aggregated message
 	assertLogMatches(t, notStdout,
@@ -644,11 +656,15 @@ func TestDebugLevelNeverDeduplicates(t *testing.T) {
 	for range 4 {
 		logger.Info("identical message")
 	}
-	// Only the first three (up to noisyMessageCountThreshold) should appear.
+	// Only the first three (up to noisyMessageCountThreshold) should appear, followed by
+	// a single notice that suppression has started.
 	for range noisyMessageCountThreshold {
 		assertLogMatches(t, notStdout,
 			`2023-10-30T13:19:45.806Z	INFO	impl	logging/impl_test.go:132	identical message`)
 	}
+	assertLogMatches(t, notStdout,
+		//nolint:lll
+		`2023-10-30T13:19:45.806Z	INFO	impl	logging/impl_test.go:132	Message logged 3 times; suppressing for rest of window (500ms): identical message`)
 	test.That(t, notStdout.Len(), test.ShouldEqual, 0)
 }
 
@@ -694,11 +710,15 @@ func TestGlobalDebugLevelNeverDeduplicates(t *testing.T) {
 	for range 4 {
 		logger.Info("identical message")
 	}
-	// Only the first three (up to noisyMessageCountThreshold) should appear.
+	// Only the first three (up to noisyMessageCountThreshold) should appear, followed by
+	// a single notice that suppression has started.
 	for range noisyMessageCountThreshold {
 		assertLogMatches(t, notStdout,
 			`2023-10-30T13:19:45.806Z	INFO	impl	logging/impl_test.go:132	identical message`)
 	}
+	assertLogMatches(t, notStdout,
+		//nolint:lll
+		`2023-10-30T13:19:45.806Z	INFO	impl	logging/impl_test.go:132	Message logged 3 times; suppressing for rest of window (500ms): identical message`)
 	test.That(t, notStdout.Len(), test.ShouldEqual, 0)
 }
 


### PR DESCRIPTION
## What

Adds a proactive log line when a noisy message first crosses the deduplication threshold. In `logging/impl.go`, when an identical message reaches `noisyMessageCountThreshold + 1` within the window, `Write` now emits a one-time notice before it begins silently dropping further occurrences. Updates the existing dedup tests in `logging/impl_test.go` to assert the new notice.

## Why

 The log deduplication logic counts identical messages within a window (`noisyMessageWindowDuration`: one minute) and, after `noisyMessageCountThreshold` occurrences, suppresses the rest until the window closes. Previously the only signal of suppression was the aggregated: `"Message logged X times in past 1m0s: ..."` summary emitted at the start of the next window — up to a minute later.

That meant a noisy log would appear to quietly stop with no explanation for the remainder of the window. Logging a notice at the moment suppression begins makes the behavior obvious in real time, so anyone reading logs understands the message is being deduplicated rather than that  it simply stopped occurring. The notice fires exactly once per message per window (gated on `count == noisyMessageCountThreshold+1`) so it doesn't reintroduce noise.
  
## Testing

  - Extended `TestLoggingDeduplication` to assert the suppression notice is emitted on the threshold-crossing message across the existing scenarios
  - Updated `TestDebugLevelNeverDeduplicates` and `TestGlobalDebugLevelNeverDeduplicates` to consume the new notice line before their buffer-empty assertions

  [Description generated by Claude 🤖]
