### PR TITLE
collapse CheckCollisions wrapper into checkCollisionsHinted

### DIFF
--- a/motionplan/collision.go
+++ b/motionplan/collision.go
@@ -131,27 +131,12 @@ func collisionSpecifications(
 	return allowedCollisions, nil
 }
 
-// CheckCollisions checks whether any geometries in one set collide with any geometries in another,
+// checkCollisionsHinted checks whether any geometries in one set collide with any geometries in another,
 // ignoring allowed collisions. It will return a lower-bound estimate of the closest distance between non-colliding geometries.
 // If collectAllCollisions is false it will return early after the first collision found. Otherwise it will return all found collisions.
-func CheckCollisions(
-	gg, other []spatialmath.Geometry,
-	allowedCollisions []Collision,
-	collisionBufferMM float64,
-	collectAllCollisions bool, // Allows us to exit early and skip lots of unnecessary computation
-	logger logging.Logger,
-) ([]Collision, float64, error) {
-	return checkCollisionsHinted(
-		gg, other, makeAllowedCollisionsLookup(allowedCollisions),
-		collisionBufferMM, collectAllCollisions, nil, logger,
-	)
-}
-
-// checkCollisionsHinted is the workhorse for CheckCollisions plus an optional
-// "last-violated pair" hint. When hint is non-nil and the previously-violated
-// pair still exists, that pair is checked first; on a new collision the hint
-// is atomically updated. Per-mesh witness caching for the inner-loop short-
-// circuit lives on spatialmath.Mesh itself; no plumbing needed here.
+// When hint is non-nil and the previously-violated pair still exists, that pair is checked first; on a new collision the hint
+// is atomically updated. Per-mesh witness caching for the inner-loop short-circuit lives on spatialmath.Mesh itself; no plumbing
+// needed here.
 func checkCollisionsHinted(
 	gg, other []spatialmath.Geometry,
 	allowed map[[2]string]bool,

--- a/motionplan/collision_test.go
+++ b/motionplan/collision_test.go
@@ -122,7 +122,9 @@ func TestUniqueCollisions(t *testing.T) {
 	test.That(t, internalGeometries, test.ShouldNotBeNil)
 
 	zeroGeoms := internalGeometries.Geometries()
-	zeroPositionCollisions, _, err := checkCollisionsHinted(zeroGeoms, zeroGeoms, nil, defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t))
+	zeroPositionCollisions, _, err := checkCollisionsHinted(
+		zeroGeoms, zeroGeoms, nil, defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t),
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	// case 1: no self collision - check no new collisions are returned
@@ -131,7 +133,10 @@ func TestUniqueCollisions(t *testing.T) {
 	test.That(t, internalGeometries, test.ShouldNotBeNil)
 
 	geoms := internalGeometries.Geometries()
-	collisions, _, err := checkCollisionsHinted(geoms, geoms, makeAllowedCollisionsLookup(zeroPositionCollisions), defaultCollisionBufferMM, false, nil, logging.NewTestLogger(t))
+	collisions, _, err := checkCollisionsHinted(
+		geoms, geoms, makeAllowedCollisionsLookup(zeroPositionCollisions),
+		defaultCollisionBufferMM, false, nil, logging.NewTestLogger(t),
+	)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(collisions), test.ShouldEqual, 0)
 
@@ -141,7 +146,10 @@ func TestUniqueCollisions(t *testing.T) {
 	test.That(t, internalGeometries, test.ShouldNotBeNil)
 
 	geoms = internalGeometries.Geometries()
-	collisions, _, err = checkCollisionsHinted(geoms, geoms, makeAllowedCollisionsLookup(zeroPositionCollisions), defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t))
+	collisions, _, err = checkCollisionsHinted(
+		geoms, geoms, makeAllowedCollisionsLookup(zeroPositionCollisions),
+		defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t),
+	)
 	test.That(t, err, test.ShouldBeNil)
 	expectedCollisions := []Collision{
 		{"xArm6:base_top", "xArm6:gripper_mount"},
@@ -152,7 +160,10 @@ func TestUniqueCollisions(t *testing.T) {
 	// case 3: add a collision specification that the last element of expectedCollisions should be ignored
 	zeroPositionCollisions = append(zeroPositionCollisions, expectedCollisions[len(expectedCollisions)-1])
 
-	collisions, _, err = checkCollisionsHinted(geoms, geoms, makeAllowedCollisionsLookup(zeroPositionCollisions), defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t))
+	collisions, _, err = checkCollisionsHinted(
+		geoms, geoms, makeAllowedCollisionsLookup(zeroPositionCollisions),
+		defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t),
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(

--- a/motionplan/collision_test.go
+++ b/motionplan/collision_test.go
@@ -69,7 +69,7 @@ func TestCollisionListsEqual(t *testing.T) {
 	test.That(t, collisionListsAlmostEqual(list1, []Collision{}), test.ShouldBeFalse)
 }
 
-func TestCheckCollisions(t *testing.T) {
+func TestCheckCollisionsHinted(t *testing.T) {
 	// case 1: small collection of custom geometries, expecting:
 	//      - collisions reported between robot and obstacles
 	//      - no collision between two obstacle geometries or robot geometries
@@ -91,7 +91,7 @@ func TestCheckCollisions(t *testing.T) {
 	obstacles = append(obstacles, bc1.Transform(spatial.NewPoseFromPoint(r3.Vector{6, 6, 6})))
 	obstacles[2].SetLabel("obstacleCube666")
 
-	collisions, _, err := CheckCollisions(robot, obstacles, nil, defaultCollisionBufferMM, true, logging.NewTestLogger(t))
+	collisions, _, err := checkCollisionsHinted(robot, obstacles, nil, defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t))
 	test.That(t, err, test.ShouldBeNil)
 	expectedCollisions := []Collision{
 		{"robotCube333", "obstacleCube444"},
@@ -107,7 +107,7 @@ func TestCheckCollisions(t *testing.T) {
 	test.That(t, gf, test.ShouldNotBeNil)
 
 	selfGeoms := gf.Geometries()
-	collisions, _, err = CheckCollisions(selfGeoms, selfGeoms, nil, defaultCollisionBufferMM, true, logging.NewTestLogger(t))
+	collisions, _, err = checkCollisionsHinted(selfGeoms, selfGeoms, nil, defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(collisions), test.ShouldEqual, 5)
 }
@@ -122,7 +122,7 @@ func TestUniqueCollisions(t *testing.T) {
 	test.That(t, internalGeometries, test.ShouldNotBeNil)
 
 	zeroGeoms := internalGeometries.Geometries()
-	zeroPositionCollisions, _, err := CheckCollisions(zeroGeoms, zeroGeoms, nil, defaultCollisionBufferMM, true, logging.NewTestLogger(t))
+	zeroPositionCollisions, _, err := checkCollisionsHinted(zeroGeoms, zeroGeoms, nil, defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t))
 	test.That(t, err, test.ShouldBeNil)
 
 	// case 1: no self collision - check no new collisions are returned
@@ -131,7 +131,7 @@ func TestUniqueCollisions(t *testing.T) {
 	test.That(t, internalGeometries, test.ShouldNotBeNil)
 
 	geoms := internalGeometries.Geometries()
-	collisions, _, err := CheckCollisions(geoms, geoms, zeroPositionCollisions, defaultCollisionBufferMM, false, logging.NewTestLogger(t))
+	collisions, _, err := checkCollisionsHinted(geoms, geoms, makeAllowedCollisionsLookup(zeroPositionCollisions), defaultCollisionBufferMM, false, nil, logging.NewTestLogger(t))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(collisions), test.ShouldEqual, 0)
 
@@ -141,7 +141,7 @@ func TestUniqueCollisions(t *testing.T) {
 	test.That(t, internalGeometries, test.ShouldNotBeNil)
 
 	geoms = internalGeometries.Geometries()
-	collisions, _, err = CheckCollisions(geoms, geoms, zeroPositionCollisions, defaultCollisionBufferMM, true, logging.NewTestLogger(t))
+	collisions, _, err = checkCollisionsHinted(geoms, geoms, makeAllowedCollisionsLookup(zeroPositionCollisions), defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t))
 	test.That(t, err, test.ShouldBeNil)
 	expectedCollisions := []Collision{
 		{"xArm6:base_top", "xArm6:gripper_mount"},
@@ -152,7 +152,7 @@ func TestUniqueCollisions(t *testing.T) {
 	// case 3: add a collision specification that the last element of expectedCollisions should be ignored
 	zeroPositionCollisions = append(zeroPositionCollisions, expectedCollisions[len(expectedCollisions)-1])
 
-	collisions, _, err = CheckCollisions(geoms, geoms, zeroPositionCollisions, defaultCollisionBufferMM, true, logging.NewTestLogger(t))
+	collisions, _, err = checkCollisionsHinted(geoms, geoms, makeAllowedCollisionsLookup(zeroPositionCollisions), defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t))
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(
@@ -201,8 +201,8 @@ func TestCollisionMinDistance(t *testing.T) {
 	geom2 := bc1.Transform(spatial.NewPoseFromPoint(r3.Vector{10, 0, 0}))
 	geom2.SetLabel("box2")
 
-	collisions, minDist, err := CheckCollisions(
-		[]spatial.Geometry{geom1}, []spatial.Geometry{geom2}, nil, defaultCollisionBufferMM, true, logging.NewTestLogger(t),
+	collisions, minDist, err := checkCollisionsHinted(
+		[]spatial.Geometry{geom1}, []spatial.Geometry{geom2}, nil, defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t),
 	)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(collisions), test.ShouldEqual, 0)
@@ -224,12 +224,12 @@ func TestCollisionEarlyExit(t *testing.T) {
 	geoms := []spatial.Geometry{geom1, geom2, geom3}
 
 	// With collectAllCollisions=false, should return first collision only
-	collisions, _, err := CheckCollisions(geoms, geoms, nil, defaultCollisionBufferMM, false, logging.NewTestLogger(t))
+	collisions, _, err := checkCollisionsHinted(geoms, geoms, nil, defaultCollisionBufferMM, false, nil, logging.NewTestLogger(t))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(collisions), test.ShouldEqual, 1)
 
 	// With collectAllCollisions=true, should return all collisions
-	collisions, _, err = CheckCollisions(geoms, geoms, nil, defaultCollisionBufferMM, true, logging.NewTestLogger(t))
+	collisions, _, err = checkCollisionsHinted(geoms, geoms, nil, defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(collisions), test.ShouldBeGreaterThan, 1)
 }

--- a/motionplan/constraint_checker.go
+++ b/motionplan/constraint_checker.go
@@ -551,8 +551,8 @@ func computeInitialCollisionsToIgnore(
 	logger logging.Logger,
 ) ([]Collision, error) {
 	// Geometries in collision at move start should thereafter be ignored
-	initialCollisions, _, err := CheckCollisions(
-		group1, group2, collisionSpecifications, collisionBufferMM, true, logger)
+	initialCollisions, _, err := checkCollisionsHinted(
+		group1, group2, makeAllowedCollisionsLookup(collisionSpecifications), collisionBufferMM, true, nil, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/motionplan/constraint_test.go
+++ b/motionplan/constraint_test.go
@@ -497,8 +497,8 @@ func TestCollisionDistance(t *testing.T) {
 		geom2 := bc1.Transform(spatial.NewZeroPose())
 		geom2.SetLabel("box2")
 
-		collisions, _, err := CheckCollisions([]spatial.Geometry{geom1}, []spatial.Geometry{geom2}, nil,
-			defaultCollisionBufferMM, false, logging.NewTestLogger(t))
+		collisions, _, err := checkCollisionsHinted([]spatial.Geometry{geom1}, []spatial.Geometry{geom2}, nil,
+			defaultCollisionBufferMM, false, nil, logging.NewTestLogger(t))
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, collisions, test.ShouldNotBeEmpty)
 		test.That(t, collisions[0].name1, test.ShouldBeIn, "box1", "box2")
@@ -511,8 +511,8 @@ func TestCollisionDistance(t *testing.T) {
 		geom2 := bc1.Transform(spatial.NewPoseFromPoint(r3.Vector{10, 0, 0}))
 		geom2.SetLabel("box2")
 
-		collisions, minDist, err := CheckCollisions(
-			[]spatial.Geometry{geom1}, []spatial.Geometry{geom2}, nil, defaultCollisionBufferMM, false, logging.NewTestLogger(t),
+		collisions, minDist, err := checkCollisionsHinted(
+			[]spatial.Geometry{geom1}, []spatial.Geometry{geom2}, nil, defaultCollisionBufferMM, false, nil, logging.NewTestLogger(t),
 		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, collisions, test.ShouldBeEmpty)
@@ -526,8 +526,9 @@ func TestCollisionDistance(t *testing.T) {
 		geom2.SetLabel("box2")
 
 		ignoreList := []Collision{{"box1", "box2"}}
-		collisions, minDist, err := CheckCollisions(
-			[]spatial.Geometry{geom1}, []spatial.Geometry{geom2}, ignoreList, defaultCollisionBufferMM, false, logging.NewTestLogger(t),
+		collisions, minDist, err := checkCollisionsHinted(
+			[]spatial.Geometry{geom1}, []spatial.Geometry{geom2}, makeAllowedCollisionsLookup(ignoreList),
+			defaultCollisionBufferMM, false, nil, logging.NewTestLogger(t),
 		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, collisions, test.ShouldBeEmpty)


### PR DESCRIPTION
Delete the `CheckCollisions` wrapper. All callers now invoke `checkCollisionsHinted` directly

Follow up to #6149 