### PR TITLE
RSDK-13894 - fix flaky test TestInferRemoteRobotDependencyConnectAtStartup

### DIFF
--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -1071,6 +1071,11 @@ func TestClientReconnect(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
 	var listener net.Listener = gotestutils.ReserveRandomListener(t)
+	// Hold the port so it survives gServer.Stop below and gServer2 can reuse the
+	// exact same socket, with no window for another process to claim the port.
+	// grpc.Server.Stop fires its quit signal, so Serve still exits even though the
+	// held listener's Close only arms a deadline rather than closing the socket.
+	hold := testutils.HoldPort(t, listener)
 	gServer := grpc.NewServer()
 	injectRobot := &inject.Robot{}
 	pb.RegisterRobotServiceServer(gServer, server.New(injectRobot))
@@ -1096,7 +1101,7 @@ func TestClientReconnect(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	gServer.RegisterService(&armpb.ArmService_ServiceDesc, arm.NewRPCServiceServer(armSvc2, logger))
 
-	go gServer.Serve(listener)
+	go gServer.Serve(hold)
 
 	dur := 100 * time.Millisecond
 	client, err := New(
@@ -1132,11 +1137,10 @@ func TestClientReconnect(t *testing.T) {
 	pb.RegisterRobotServiceServer(gServer2, server.New(injectRobot))
 	gServer2.RegisterService(&armpb.ArmService_ServiceDesc, arm.NewRPCServiceServer(armSvc2, logger))
 
-	// Note: There's a slight chance this test can fail if someone else
-	// claims the port we just released by closing the server.
-	listener, err = net.Listen("tcp", listener.Addr().String())
-	test.That(t, err, test.ShouldBeNil)
-	go gServer2.Serve(listener)
+	// Re-arm the held listener and bring gServer2 up on the very same socket gServer
+	// used. The port was never released, so there was no chance for it to be claimed.
+	hold.Rearm(t)
+	go gServer2.Serve(hold)
 	defer gServer2.Stop()
 
 	test.That(t, <-client.Changed(), test.ShouldBeTrue)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -4259,9 +4259,12 @@ func TestStickyWebRTCConnection(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
 
-	// Start a robot and stand up its "web".
+	// Start a robot and stand up its "web". Hold the port so every restart below can
+	// reuse the exact same socket, with no window for another process to claim it.
 	robot := setupLocalRobot(t, ctx, &config.Config{}, logger.Sublogger("robot"))
-	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
+	options, lis, addr := robottestutils.CreateBaseOptionsAndListener(t)
+	hold := rtestutils.HoldPort(t, lis)
+	options.Network.Listener = hold
 	err := robot.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 	defer robot.StopWeb()
@@ -4278,10 +4281,10 @@ func TestStickyWebRTCConnection(t *testing.T) {
 	// and error.
 	assertDialFails(t, robotClient)
 
-	// Massage the options to restart the "web" on the same port as before. Note: this can result in
-	// a test bug/failure as another test may have picked up the same port in the meantime.
-	options.Network.BindAddress = addr
-	options.Network.Listener = nil
+	// Re-arm the held listener and restart the "web" on the very same socket as
+	// before. The port was never released, so there was no chance for it to be
+	// claimed in the meantime.
+	hold.Rearm(t)
 	err = robot.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -4294,7 +4297,8 @@ func TestStickyWebRTCConnection(t *testing.T) {
 	robot.StopWeb()
 	assertDialFails(t, robotClient)
 
-	// Restart the "web" but only accept direct gRPC connections.
+	// Restart the "web" on the same held socket but only accept direct gRPC connections.
+	hold.Rearm(t)
 	options.DisallowWebRTC = true
 	err = robot.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/optional_dependencies_test.go
+++ b/robot/impl/optional_dependencies_test.go
@@ -3,7 +3,6 @@ package robotimpl
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
 	"slices"
 	"testing"
@@ -844,7 +843,11 @@ func TestModularOptionalDependencyOnRemote(t *testing.T) {
 		},
 	}
 	remote := setupLocalRobot(t, ctx, remoteCfg, logger.Sublogger("remote"))
-	options, listener, addr := robottestutils.CreateBaseOptionsAndListener(t)
+	// Hold remote's port so it survives remote's Close below and remote2 can reuse
+	// the exact same socket, with no window for another process to claim the port.
+	options, lis, addr := robottestutils.CreateBaseOptionsAndListener(t)
+	hold := holdPort(t, lis)
+	options.Network.Listener = hold
 	err := remote.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -916,11 +919,10 @@ func TestModularOptionalDependencyOnRemote(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, doCommandResp, test.ShouldResemble, map[string]any{"optional_motor_state": "unreachable"})
 
-	// Bring up a new remote robot on the same address and wait for local robot to notice.
+	// Bring up a new remote robot on the very same socket remote used. The port was
+	// never released, so there was no chance for it to be claimed in between.
+	hold.rearm(t)
 	remote2 := setupLocalRobot(t, ctx, remoteCfg, logger.Sublogger("remote2"))
-	listener, err = net.Listen("tcp", listener.Addr().String())
-	test.That(t, err, test.ShouldBeNil)
-	options.Network.Listener = listener
 	err = remote2.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/robot/impl/optional_dependencies_test.go
+++ b/robot/impl/optional_dependencies_test.go
@@ -846,7 +846,7 @@ func TestModularOptionalDependencyOnRemote(t *testing.T) {
 	// Hold remote's port so it survives remote's Close below and remote2 can reuse
 	// the exact same socket, with no window for another process to claim the port.
 	options, lis, addr := robottestutils.CreateBaseOptionsAndListener(t)
-	hold := holdPort(t, lis)
+	hold := testutils.HoldPort(t, lis)
 	options.Network.Listener = hold
 	err := remote.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
@@ -921,7 +921,7 @@ func TestModularOptionalDependencyOnRemote(t *testing.T) {
 
 	// Bring up a new remote robot on the very same socket remote used. The port was
 	// never released, so there was no chance for it to be claimed in between.
-	hold.rearm(t)
+	hold.Rearm(t)
 	remote2 := setupLocalRobot(t, ctx, remoteCfg, logger.Sublogger("remote2"))
 	err = remote2.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/robot_reconfigure_remote_test.go
+++ b/robot/impl/robot_reconfigure_remote_test.go
@@ -3,7 +3,6 @@ package robotimpl
 import (
 	"context"
 	"errors"
-	"net"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -29,49 +28,6 @@ import (
 	"go.viam.com/rdk/testutils/robottestutils"
 	"go.viam.com/rdk/utils"
 )
-
-// holdPortListener wraps a *net.TCPListener so that a web server shutting down
-// does not release the underlying port. The web server stops serving by calling
-// Close on its listener (via http.Server.Shutdown); instead of closing the socket
-// (which frees the port), holdPortListener sets a deadline in the past, which
-// makes the blocked Accept return so http.Server.Serve exits via its already-set
-// shutdown done-channel. Because the socket is never closed, the port stays
-// reserved with zero window for another process (e.g. a parallel test) to claim
-// it. Re-arm with rearm before serving on it again.
-//
-// NOTE: this relies on the http.Server serve path used by StartWeb (which checks
-// its shutdown channel before the temporary-error backoff). It is NOT safe for a
-// raw grpc.Server, which treats the deadline error as temporary and would busy
-// loop instead of exiting.
-type holdPortListener struct {
-	*net.TCPListener
-}
-
-// Close is invoked by http.Server.Shutdown. Set a deadline in the past instead of
-// closing the socket so the server's Accept unblocks and its Serve loop exits,
-// while the port remains bound.
-func (h *holdPortListener) Close() error {
-	return h.SetDeadline(time.Unix(1, 0))
-}
-
-// rearm clears the deadline so the listener can accept connections for the next
-// server. Call it after the previous server has fully closed and before serving
-// again on the same listener.
-func (h *holdPortListener) rearm(tb testing.TB) {
-	tb.Helper()
-	test.That(tb, h.SetDeadline(time.Time{}), test.ShouldBeNil)
-}
-
-// holdPort wraps lis (which must be a *net.TCPListener) so its port survives web
-// server restarts, and registers cleanup to truly close the socket at test end.
-func holdPort(tb testing.TB, lis net.Listener) *holdPortListener {
-	tb.Helper()
-	tcp, ok := lis.(*net.TCPListener)
-	test.That(tb, ok, test.ShouldBeTrue)
-	h := &holdPortListener{tcp}
-	tb.Cleanup(func() { goutils.UncheckedError(h.TCPListener.Close()) })
-	return h
-}
 
 func TestRemoteRobotsGold(t *testing.T) {
 	t.Parallel()
@@ -119,7 +75,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 	// with no window for another process to claim the port in between.
 	remote2 := setupLocalRobot(t, ctx, remoteConfig, logger.Sublogger("remote2"))
 	options, lis2, addr2 := robottestutils.CreateBaseOptionsAndListener(t)
-	hold2 := holdPort(t, lis2)
+	hold2 := rdktestutils.HoldPort(t, lis2)
 	options.Network.Listener = hold2
 
 	localConfig := &config.Config{
@@ -203,7 +159,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 
 	// Re-arm the held listener and bring remote3 up on the very same socket remote2
 	// used. The port was never released, so there was no chance for it to be claimed.
-	hold2.rearm(t)
+	hold2.Rearm(t)
 	remote3 := setupLocalRobot(t, ctx, remoteConfig, logger.Sublogger("remote3"))
 	err = remote3.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
@@ -308,7 +264,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	// Hold foo's port so it survives foo's Close below and foo2 can reuse the exact
 	// same socket, with no window for another process to claim the port in between.
 	options, lis, addr1 := robottestutils.CreateBaseOptionsAndListener(t)
-	hold := holdPort(t, lis)
+	hold := rdktestutils.HoldPort(t, lis)
 	options.Network.Listener = hold
 	err := foo.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
@@ -350,7 +306,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	})
 
 	// Re-arm the held listener and bring foo2 up on the very same socket foo used.
-	hold.rearm(t)
+	hold.Rearm(t)
 	foo2 := setupLocalRobot(t, ctx, fooCfg, logger.Sublogger("foo2"))
 	err = foo2.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)

--- a/robot/impl/robot_reconfigure_remote_test.go
+++ b/robot/impl/robot_reconfigure_remote_test.go
@@ -30,6 +30,49 @@ import (
 	"go.viam.com/rdk/utils"
 )
 
+// holdPortListener wraps a *net.TCPListener so that a web server shutting down
+// does not release the underlying port. The web server stops serving by calling
+// Close on its listener (via http.Server.Shutdown); instead of closing the socket
+// (which frees the port), holdPortListener sets a deadline in the past, which
+// makes the blocked Accept return so http.Server.Serve exits via its already-set
+// shutdown done-channel. Because the socket is never closed, the port stays
+// reserved with zero window for another process (e.g. a parallel test) to claim
+// it. Re-arm with rearm before serving on it again.
+//
+// NOTE: this relies on the http.Server serve path used by StartWeb (which checks
+// its shutdown channel before the temporary-error backoff). It is NOT safe for a
+// raw grpc.Server, which treats the deadline error as temporary and would busy
+// loop instead of exiting.
+type holdPortListener struct {
+	*net.TCPListener
+}
+
+// Close is invoked by http.Server.Shutdown. Set a deadline in the past instead of
+// closing the socket so the server's Accept unblocks and its Serve loop exits,
+// while the port remains bound.
+func (h *holdPortListener) Close() error {
+	return h.SetDeadline(time.Unix(1, 0))
+}
+
+// rearm clears the deadline so the listener can accept connections for the next
+// server. Call it after the previous server has fully closed and before serving
+// again on the same listener.
+func (h *holdPortListener) rearm(tb testing.TB) {
+	tb.Helper()
+	test.That(tb, h.SetDeadline(time.Time{}), test.ShouldBeNil)
+}
+
+// holdPort wraps lis (which must be a *net.TCPListener) so its port survives web
+// server restarts, and registers cleanup to truly close the socket at test end.
+func holdPort(tb testing.TB, lis net.Listener) *holdPortListener {
+	tb.Helper()
+	tcp, ok := lis.(*net.TCPListener)
+	test.That(tb, ok, test.ShouldBeTrue)
+	h := &holdPortListener{tcp}
+	tb.Cleanup(func() { goutils.UncheckedError(h.TCPListener.Close()) })
+	return h
+}
+
 func TestRemoteRobotsGold(t *testing.T) {
 	t.Parallel()
 	// This tests that a main part is able to start up with an offline remote robot, connect to it and
@@ -71,10 +114,13 @@ func TestRemoteRobotsGold(t *testing.T) {
 	err := remote1.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
-	// set up but do not start remote2's web service
+	// set up but do not start remote2's web service. Hold remote2's port so it
+	// survives remote2's Close below and remote3 can reuse the exact same socket,
+	// with no window for another process to claim the port in between.
 	remote2 := setupLocalRobot(t, ctx, remoteConfig, logger.Sublogger("remote2"))
-	options, listener2, addr2 := robottestutils.CreateBaseOptionsAndListener(t)
-	_ = addr2
+	options, lis2, addr2 := robottestutils.CreateBaseOptionsAndListener(t)
+	hold2 := holdPort(t, lis2)
+	options.Network.Listener = hold2
 
 	localConfig := &config.Config{
 		Components: []resource.Config{
@@ -142,6 +188,7 @@ func TestRemoteRobotsGold(t *testing.T) {
 			mainPartAndFooAndBarResources,
 		)
 	})
+	// remote2's Close stops its server but, via holdPort, keeps the port bound.
 	test.That(t, remote2.Close(context.Background()), test.ShouldBeNil)
 
 	// wait for local_robot to detect that the remote is now offline
@@ -154,13 +201,10 @@ func TestRemoteRobotsGold(t *testing.T) {
 		)
 	})
 
+	// Re-arm the held listener and bring remote3 up on the very same socket remote2
+	// used. The port was never released, so there was no chance for it to be claimed.
+	hold2.rearm(t)
 	remote3 := setupLocalRobot(t, ctx, remoteConfig, logger.Sublogger("remote3"))
-
-	// Note: There's a slight chance this test can fail if someone else
-	// claims the port we just released by closing the server.
-	listener2, err = net.Listen("tcp", listener2.Addr().String())
-	test.That(t, err, test.ShouldBeNil)
-	options.Network.Listener = listener2
 	err = remote3.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -261,7 +305,11 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	ctx := context.Background()
 	foo := setupLocalRobot(t, ctx, fooCfg, logger.Sublogger("foo"))
 
-	options, listener1, addr1 := robottestutils.CreateBaseOptionsAndListener(t)
+	// Hold foo's port so it survives foo's Close below and foo2 can reuse the exact
+	// same socket, with no window for another process to claim the port in between.
+	options, lis, addr1 := robottestutils.CreateBaseOptionsAndListener(t)
+	hold := holdPort(t, lis)
+	options.Network.Listener = hold
 	err := foo.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -291,6 +339,7 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 	}
 
 	rdktestutils.VerifySameResourceNames(t, r.ResourceNames(), expectedSet)
+	// foo's Close stops its server but, via holdPort, keeps the port bound.
 	test.That(t, foo.Close(context.Background()), test.ShouldBeNil)
 
 	// wait for local_robot to detect that the remote is now offline
@@ -300,13 +349,9 @@ func TestInferRemoteRobotDependencyConnectAtStartup(t *testing.T) {
 		)
 	})
 
+	// Re-arm the held listener and bring foo2 up on the very same socket foo used.
+	hold.rearm(t)
 	foo2 := setupLocalRobot(t, ctx, fooCfg, logger.Sublogger("foo2"))
-
-	// Note: There's a slight chance this test can fail if someone else
-	// claims the port we just released by closing the server.
-	listener1, err = net.Listen("tcp", listener1.Addr().String())
-	test.That(t, err, test.ShouldBeNil)
-	options.Network.Listener = listener1
 	err = foo2.StartWeb(ctx, options)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/testutils/holdport.go
+++ b/testutils/holdport.go
@@ -1,0 +1,47 @@
+package testutils
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"go.viam.com/test"
+	goutils "go.viam.com/utils"
+)
+
+// HoldPortListener keeps a server's port bound across a restart so a follow-up
+// server can reuse the exact same socket with no window for another process to
+// claim the port in between. A server stops serving by calling Close on its
+// listener (http.Server.Shutdown or grpc.Server.Stop both do this); HoldPort-
+// Listener's Close arms a past deadline instead of closing the socket, so the
+// port stays reserved. The server still shuts down cleanly because its stop
+// method also sets an internal quit flag that ends the serve loop — the deadline
+// just lets the in-progress Accept return so the loop can notice. Re-arm with
+// Rearm before serving on it again.
+type HoldPortListener struct {
+	*net.TCPListener
+}
+
+// Close is invoked by the server's stop method. Arm a past deadline to unblock
+// Accept instead of closing the socket, so the port stays bound.
+func (h *HoldPortListener) Close() error {
+	return h.SetDeadline(time.Unix(1, 0))
+}
+
+// Rearm clears the deadline so the next server can accept on the listener. Call
+// it after the previous server has stopped and before serving again.
+func (h *HoldPortListener) Rearm(tb testing.TB) {
+	tb.Helper()
+	test.That(tb, h.SetDeadline(time.Time{}), test.ShouldBeNil)
+}
+
+// HoldPort wraps lis (which must be a *net.TCPListener) so its port survives a
+// server restart, and registers cleanup to truly close the socket at test end.
+func HoldPort(tb testing.TB, lis net.Listener) *HoldPortListener {
+	tb.Helper()
+	tcp, ok := lis.(*net.TCPListener)
+	test.That(tb, ok, test.ShouldBeTrue)
+	h := &HoldPortListener{tcp}
+	tb.Cleanup(func() { goutils.UncheckedError(h.TCPListener.Close()) })
+	return h
+}


### PR DESCRIPTION
thought there might be a few more cases and there might be a more complete fix, but ended up just being the same as https://github.com/viamrobotics/rdk/pull/6140 but applied to a few more tests

Fix flaky port-reuse race in remote-robot restart tests

Some tests stop a robot's web server and immediately bring a new one up on the same address (net.Listen(...Addr())). Between the close and the rebind, a concurrently-running test can claim the just-freed port, causing intermittent failures — most often in the parallel TestRemoteRobotsGold / TestInferRemoteRobotDependencyConnectAtStartup, which run amid heavy same-package port contention.

This branch adds a holdPortListener test helper that keeps the port reserved across the restart: its Close() (invoked by http.Server.Shutdown) sets a past deadline instead of closing the socket, so the server's Accept loop exits cleanly via its shutdown channel while the socket stays bound. rearm() clears the deadline before the replacement server serves on the same socket. The port is never released, so there's zero window for another process to grab it.

Applied to: TestRemoteRobotsGold, TestInferRemoteRobotDependencyConnectAtStartup, TestModularOptionalDependencyOnRemote.

Note: the trick relies on the http.Server/StartWeb serve path and is documented as unsafe for a raw grpc.Server (which would busy-loop on the deadline error).

