### PR TITLE
ci: bump claude-ci-workflows to v2.2.4 and grant actions: write

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -24,6 +24,10 @@ jobs:
       # write (not read) to post the "Review Required" comment: commenting on a
       # PR needs pull-requests: write; issues: write does not cover PRs.
       pull-requests: write
+      # lets the action re-run the stale pull_request run for this commit once
+      # approvals are satisfied, so the required status turns green without a
+      # manual re-run.
+      actions: write
     steps:
       # Flaky-test fixes and dependabot bumps only require a single approval;
       # everything else needs two. Title/branch are read via env (never interpolated
@@ -49,12 +53,12 @@ jobs:
             echo "Requiring 2 approvals."
           fi
 
-      # viamrobotics/claude-ci-workflows@v2.2.1
+      # viamrobotics/claude-ci-workflows@v2.2.4
       - name: Checkout claude-ci-workflows for composite action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: viamrobotics/claude-ci-workflows
-          ref: 5506bdaf04cc7d1adbd2df0f31f108834b01aea6
+          ref: c27e2ba8d7e6e818f74271132041ab48707cc0ca
           path: .claude-ci-workflows
           sparse-checkout: |
             .github/actions/check-approvals/


### PR DESCRIPTION
## What

Bumps the pinned `claude-ci-workflows` ref in `check-approvals.yml` from v2.2.1 → **v2.2.4** (`c27e2ba`) and grants the `check-approvals` job **`actions: write`**.

## Why

v2.2.4 includes [viamrobotics/claude-ci-workflows#123](https://github.com/viamrobotics/claude-ci-workflows/pull/123), which fixes a sticky-red merge gate: when a PR's final commit lands before approvals exist, the `synchronize`-triggered `check-approvals` run fails and branch protection pins the required status to that failed run. A later approving review passes, but as a *separate* check run, so the merge box stays red until someone manually re-runs the failed run.

The fix makes the action re-run the stale `pull_request` run for the same commit once approvals are satisfied — automating that manual re-run. That requires `actions: write`, per the PR's "Action required by consumers" note. Without the permission the action degrades gracefully (logs a warning), but the auto-refresh won't take effect, so we grant it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)