### PR TITLE
optimize InterpolateSegmentFS allocation in hot CheckPath path

### DIFF
--- a/motionplan/constraint_checker.go
+++ b/motionplan/constraint_checker.go
@@ -323,10 +323,10 @@ func InterpolateSegmentFS(ci *SegmentFS, resolution float64) ([]*referenceframe.
 	}
 
 	// Create interpolated configurations for all frames
-	var interpolatedConfigurations []*referenceframe.LinearInputs
+	interpolatedConfigurations := make([]*referenceframe.LinearInputs, 0, maxSteps+1)
 	for i := 0; i <= maxSteps; i++ {
 		interp := float64(i) / float64(maxSteps)
-		frameConfigs := referenceframe.NewLinearInputs()
+		frameConfigs := ci.StartConfiguration.CopyWithZeros()
 
 		// Interpolate each frame's configuration
 		for frameName, startConfig := range ci.StartConfiguration.Items() {


### PR DESCRIPTION
Two changes to `InterpolateSegmentFS`
- Preaallocate the output slice to `maxSteps+1`
- Build each per step `LinearInputs` from `ci.StartConfiguration.CopyWithZeros()` instead of `NewLinearInputs()`

## Impact
