### PR TITLE
RSDK-14166 - Transient module Validate err permanently drops required dependencies

### DIFF
--- a/module/modmanager/manager_test.go
+++ b/module/modmanager/manager_test.go
@@ -572,7 +572,10 @@ func TestModManagerValidation(t *testing.T) {
 		`rpc error: code = Unknown desc = error validating resource: expected "motorL" attribute for mybase "mybase2"`)
 
 	// Test that ValidateConfig respects validateConfigTimeout by artificially
-	// lowering it to an impossibly small duration.
+	// lowering it to an impossibly small duration. Restore it afterward so the global
+	// does not leak into later tests in this package.
+	origValidateConfigTimeout := validateConfigTimeout
+	defer func() { validateConfigTimeout = origValidateConfigTimeout }()
 	validateConfigTimeout = 1 * time.Nanosecond
 	_, _, err = mgr.ValidateConfig(ctx, cfgMyBase1)
 	test.That(t, err, test.ShouldNotBeNil)

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -808,11 +809,32 @@ func (manager *resourceManager) completeConfig(
 						return
 					}
 					if manager.moduleManager.Provides(conf) {
-						if _, _, err := manager.moduleManager.ValidateConfig(ctxWithTimeout, conf); err != nil {
+						implicitDeps, implicitOptionalDeps, err := manager.moduleManager.ValidateConfig(ctxWithTimeout, conf)
+						if err != nil {
 							gNode.LogAndSetLastError(
 								fmt.Errorf("modular resource config validation error: %w", err),
 								"resource", conf.ResourceName(),
 								"model", conf.Model)
+							return
+						}
+
+						// If the freshly-validated implicit dependencies differ from the set the node
+						// was configured with, the node's dependency edges are stale. This happens when
+						// ResolveImplicitDependencies hit a transient Validate error (e.g. a
+						// DeadlineExceeded timeout) and dropped the dependencies, but Validate now
+						// succeeds. Re-apply the dependencies and defer the build by one pass so they
+						// get resolved into graph edges first; building now would construct the resource
+						// with an incomplete dependency set (e.g. a missing camera dependency).
+						if !equalUnordered(implicitDeps, conf.ImplicitDependsOn) ||
+							!equalUnordered(implicitOptionalDeps, conf.ImplicitOptionalDependsOn) {
+							manager.logger.CInfow(ctx,
+								"modular resource implicit dependencies changed since last validation; re-resolving before building",
+								"resource", conf.ResourceName(), "model", conf.Model,
+								"old", conf.ImplicitDependsOn, "new", implicitDeps)
+							conf.ImplicitDependsOn = implicitDeps
+							conf.ImplicitOptionalDependsOn = implicitOptionalDeps
+							gNode.SetNewConfig(conf, conf.Dependencies())
+							lr.sendTriggerConfig("modular dependency re-resolution")
 							return
 						}
 					}
@@ -1159,6 +1181,19 @@ func (manager *resourceManager) processResource(
 // resource graph. If a resource with the given name already exists in the resource graph,
 // the pre-existing resource is marked for removal, no new graph node is created, and an
 // error is returned.
+// equalUnordered reports whether two string slices contain the same elements,
+// ignoring order. A nil and an empty slice are considered equal.
+func equalUnordered(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aSorted := slices.Clone(a)
+	bSorted := slices.Clone(b)
+	slices.Sort(aSorted)
+	slices.Sort(bSorted)
+	return slices.Equal(aSorted, bSorted)
+}
+
 func (manager *resourceManager) addToBeConstructedResource(
 	name resource.Name,
 	conf resource.Config,

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -1177,10 +1177,6 @@ func (manager *resourceManager) processResource(
 	return newRes, nil
 }
 
-// addToBeConstructedResource adds a new, unconfigured graph node for a resource to the
-// resource graph. If a resource with the given name already exists in the resource graph,
-// the pre-existing resource is marked for removal, no new graph node is created, and an
-// error is returned.
 // equalUnordered reports whether two string slices contain the same elements,
 // ignoring order. A nil and an empty slice are considered equal.
 func equalUnordered(a, b []string) bool {
@@ -1194,6 +1190,10 @@ func equalUnordered(a, b []string) bool {
 	return slices.Equal(aSorted, bSorted)
 }
 
+// addToBeConstructedResource adds a new, unconfigured graph node for a resource to the
+// resource graph. If a resource with the given name already exists in the resource graph,
+// the pre-existing resource is marked for removal, no new graph node is created, and an
+// error is returned.
 func (manager *resourceManager) addToBeConstructedResource(
 	name resource.Name,
 	conf resource.Config,

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -35,7 +35,7 @@ func TestModularResources(t *testing.T) {
 		svcModel = resource.ModelNamespace("acme").WithFamily("signage").WithModel("handheld")
 	)
 
-	setupTest := func(t *testing.T) (*localRobot, *dummyModMan) {
+	setupTest := func(t *testing.T, opts ...Option) (*localRobot, *dummyModMan) {
 		t.Helper()
 
 		logger := logging.NewTestLogger(t)
@@ -49,7 +49,7 @@ func TestModularResources(t *testing.T) {
 			state:      make(map[resource.Name]bool),
 		}
 
-		r := setupLocalRobot(t, context.Background(), &config.Config{}, logger)
+		r := setupLocalRobot(t, context.Background(), &config.Config{}, logger, opts...)
 		actualR := r.(*localRobot)
 		actualR.manager.moduleManager = mod
 
@@ -341,6 +341,43 @@ func TestModularResources(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, res2, test.ShouldNotEqual, res1)
 	})
+
+	// When a modular resource's implicit dependencies are dropped during resolution (e.g. a
+	// transient Validate timeout), completeConfig's re-validation should re-resolve them
+	// before building rather than constructing the resource with an incomplete dependency set.
+	// Here ResolveImplicitDependencies is a no-op (the dropped deps) while ValidateConfig
+	// reports the dependency.
+	t.Run("recovers dropped modular dependencies", func(t *testing.T) {
+		// Disable the background worker so the re-resolution pass is driven synchronously.
+		r, mod := setupTest(t, WithDisableCompleteConfigWorker())
+		mod.validateRequiredDeps = []string{"builtin"}
+
+		motorCfg := resource.Config{
+			Name:                "builtin",
+			API:                 motor.API,
+			Model:               resource.DefaultModelFamily.WithModel("fake"),
+			ConvertedAttributes: &fake.Config{},
+		}
+		compCfg := resource.Config{Name: "oneton", API: compAPI, Model: compModel, Attributes: utils.AttributeMap{"arg1": "one"}}
+
+		// First pass re-validates, sees the dropped dependency, and defers the build.
+		r.Reconfigure(context.Background(), &config.Config{
+			Components: []resource.Config{motorCfg, compCfg},
+		})
+
+		// Retry pass resolves the recovered dependency into a graph edge and builds.
+		test.That(t, r.updateRemotesAndRetryResourceConfigure(), test.ShouldBeTrue)
+		_, err := r.ResourceByName(compCfg.ResourceName())
+		test.That(t, err, test.ShouldBeNil)
+
+		// The resource is built with "builtin" as a dependency rather than the empty set it
+		// would have received had the build used the dropped dependencies.
+		mod.mu.Lock()
+		deps := mod.addDeps[compCfg.ResourceName()]
+		mod.mu.Unlock()
+		test.That(t, deps, test.ShouldHaveLength, 1)
+		test.That(t, deps[0], test.ShouldContainSubstring, "builtin")
+	})
 }
 
 type dummyRes struct {
@@ -353,16 +390,25 @@ type dummyModMan struct {
 	*modmanager.Manager
 	mu         sync.Mutex
 	add        []resource.Config
+	addDeps    map[resource.Name][]string
 	remove     []resource.Name
 	compAPISvc resource.APIResourceCollection[resource.Resource]
 	svcAPISvc  resource.APIResourceCollection[resource.Resource]
 	state      map[resource.Name]bool
+
+	// validateRequiredDeps is returned by ValidateConfig as the modular resource's required
+	// implicit dependencies. Defaults to nil to preserve existing test behavior.
+	validateRequiredDeps []string
 }
 
 func (m *dummyModMan) AddResource(ctx context.Context, conf resource.Config, deps []string) (resource.Resource, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.add = append(m.add, conf)
+	if m.addDeps == nil {
+		m.addDeps = make(map[resource.Name][]string)
+	}
+	m.addDeps[conf.ResourceName()] = deps
 	m.state[conf.ResourceName()] = true
 	res := &dummyRes{
 		Named: conf.ResourceName().AsNamed(),
@@ -417,7 +463,7 @@ func (m *dummyModMan) Provides(cfg resource.Config) bool {
 func (m *dummyModMan) ValidateConfig(ctx context.Context, cfg resource.Config) ([]string, []string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return nil, nil, nil
+	return m.validateRequiredDeps, nil, nil
 }
 
 func (m *dummyModMan) ResolveImplicitDependencies(ctx context.Context, conf *config.Diff) {


### PR DESCRIPTION
see ticket for more description.

but basically we weren't saving the revalidated config if it was different from the first time (when it failed)