### PR TITLE
RSDK-12661 Re-export rpc dial options in rdk to avoid goutils imports

### DIFF
--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -197,6 +197,68 @@ func makeRPCServer(logger logging.Logger, option rpc.ServerOption) (rpc.Server, 
 	return nil, nil, err
 }
 
+// TestReExportedDialOptions verifies that a machine connection can be established using
+// only the client dial options re-exported by this package (see dial_options.go), without
+// importing go.viam.com/utils/rpc directly. This is the surface SDK users rely on, so
+// exercise it end-to-end against an authenticated server.
+func TestReExportedDialOptions(t *testing.T) {
+	const (
+		apiKeyID = "some-key-id"
+		apiKey   = "some-key-payload"
+	)
+
+	logger := logging.NewTestLogger(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Stand up a server that requires API-key credentials. Note that the re-exported
+	// CredentialsTypeAPIKey (a type alias) is accepted directly by the goutils server
+	// option, demonstrating the alias interops both ways.
+	rpcServer, listener, err := makeRPCServer(logger,
+		rpc.WithAuthHandler(CredentialsTypeAPIKey, rpc.MakeSimpleAuthHandler([]string{apiKeyID}, apiKey)))
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, rpcServer.Stop(), test.ShouldBeNil)
+	}()
+
+	err = rpcServer.RegisterServiceServer(
+		ctx,
+		&pb.RobotService_ServiceDesc,
+		&mockRPCSubtypesImplemented{ResourceNamesFunc: resourceFunc1},
+		pb.RegisterRobotServiceHandlerFromEndpoint,
+	)
+	test.That(t, err, test.ShouldBeNil)
+
+	go func() {
+		test.That(t, rpcServer.Serve(listener), test.ShouldBeNil)
+	}()
+
+	addr := listener.Addr().String()
+
+	// Without credentials, the server rejects the connection.
+	_, err = New(ctx, addr, logger)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "authentication required")
+
+	// Connect using only the re-exported dial options. These resolve to the underlying
+	// goutils rpc implementation but are referenced through this package's own API.
+	machine, err := New(ctx, addr, logger, WithDialOptions(
+		WithAllowInsecureWithCredentialsDowngrade(),
+		WithForceDirectGRPC(),
+		WithEntityCredentials(apiKeyID, Credentials{
+			Type:    CredentialsTypeAPIKey,
+			Payload: apiKey,
+		}),
+	))
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, machine.Close(ctx), test.ShouldBeNil)
+	}()
+
+	test.That(t, machine.Connected(), test.ShouldBeTrue)
+	test.That(t, machine.ResourceNames(), test.ShouldResemble, []resource.Name{board.Named("board1")})
+}
+
 func TestUnimplementedRPCSubtypes(t *testing.T) {
 	var client1 *RobotClient // test implemented
 	var client2 *RobotClient // test unimplemented

--- a/robot/client/dial_options.go
+++ b/robot/client/dial_options.go
@@ -1,0 +1,137 @@
+package client
+
+import (
+	"crypto/tls"
+
+	"go.viam.com/utils/rpc"
+)
+
+// This file re-exports the client-side dial-option surface of go.viam.com/utils/rpc so
+// that SDK users can configure machine connections without importing
+// go.viam.com/utils/rpc directly. The underlying implementation still lives in goutils;
+// these aliases and wrappers are the rdk-owned entry point for it.
+
+// DialOption configures how a client dials a gRPC server. It is accepted by
+// WithDialOptions.
+type DialOption = rpc.DialOption
+
+// ClientConn is an established client connection to a gRPC server.
+type ClientConn = rpc.ClientConn
+
+// Credentials packages up both a type of credential along with its payload which
+// is formatted specific to the type.
+type Credentials = rpc.Credentials
+
+// CredentialsType signifies a means of representing a credential. For example,
+// an API key.
+type CredentialsType = rpc.CredentialsType
+
+// DialWebRTCOptions control how WebRTC is utilized in a dial attempt.
+type DialWebRTCOptions = rpc.DialWebRTCOptions
+
+// DialMulticastDNSOptions dictate any special settings to apply while dialing via mDNS.
+type DialMulticastDNSOptions = rpc.DialMulticastDNSOptions
+
+const (
+	// CredentialsTypeAPIKey is intended for external users, human and computer.
+	CredentialsTypeAPIKey = rpc.CredentialsTypeAPIKey
+
+	// CredentialsTypeExternal is for credentials that are to be produced by some external
+	// authentication endpoint intended for another, different consumer at a different
+	// endpoint.
+	CredentialsTypeExternal = rpc.CredentialsTypeExternal
+)
+
+// WithInsecure returns a DialOption which disables transport security for this
+// ClientConn. Note that transport security is required unless WithInsecure is set.
+func WithInsecure() DialOption {
+	return rpc.WithInsecure()
+}
+
+// WithCredentials returns a DialOption which sets the credentials to use for
+// authenticating the request. The associated entity is assumed to be the address of the
+// server. This is mutually exclusive with WithEntityCredentials.
+func WithCredentials(creds Credentials) DialOption {
+	return rpc.WithCredentials(creds)
+}
+
+// WithEntityCredentials returns a DialOption which sets the entity credentials to use for
+// authenticating the request. This is mutually exclusive with WithCredentials.
+func WithEntityCredentials(entity string, creds Credentials) DialOption {
+	return rpc.WithEntityCredentials(entity, creds)
+}
+
+// WithExternalAuth returns a DialOption which sets the address to use to perform
+// authentication. Authentication done in this manner will never have the dialed address
+// be authenticated against but instead have access tokens sent directly to it.
+func WithExternalAuth(addr, toEntity string) DialOption {
+	return rpc.WithExternalAuth(addr, toEntity)
+}
+
+// WithExternalAuthInsecure returns a DialOption which disables transport security for
+// this ClientConn when doing external auth.
+func WithExternalAuthInsecure() DialOption {
+	return rpc.WithExternalAuthInsecure()
+}
+
+// WithStaticAuthenticationMaterial returns a DialOption which sets the already
+// authenticated material (opaque) to use for authenticated requests.
+func WithStaticAuthenticationMaterial(authMaterial string) DialOption {
+	return rpc.WithStaticAuthenticationMaterial(authMaterial)
+}
+
+// WithStaticExternalAuthenticationMaterial returns a DialOption which sets the already
+// authenticated material (opaque) to use for authenticated requests against an external
+// auth service.
+func WithStaticExternalAuthenticationMaterial(authMaterial string) DialOption {
+	return rpc.WithStaticExternalAuthenticationMaterial(authMaterial)
+}
+
+// WithTLSConfig sets the TLS configuration to use for all secured connections.
+func WithTLSConfig(config *tls.Config) DialOption {
+	return rpc.WithTLSConfig(config)
+}
+
+// WithWebRTCOptions returns a DialOption which sets the WebRTC options to use if the
+// dialer tries to establish a WebRTC connection.
+func WithWebRTCOptions(webrtcOpts DialWebRTCOptions) DialOption {
+	return rpc.WithWebRTCOptions(webrtcOpts)
+}
+
+// WithDialDebug returns a DialOption which informs the client to be in a debug mode as
+// much as possible.
+func WithDialDebug() DialOption {
+	return rpc.WithDialDebug()
+}
+
+// WithAllowInsecureDowngrade returns a DialOption which allows connections to be
+// downgraded to plaintext if TLS cannot be detected properly. This is not used when there
+// are credentials present.
+func WithAllowInsecureDowngrade() DialOption {
+	return rpc.WithAllowInsecureDowngrade()
+}
+
+// WithAllowInsecureWithCredentialsDowngrade returns a DialOption which allows connections
+// to be downgraded to plaintext if TLS cannot be detected properly while using
+// credentials. This is generally unsafe to use but can be requested.
+func WithAllowInsecureWithCredentialsDowngrade() DialOption {
+	return rpc.WithAllowInsecureWithCredentialsDowngrade()
+}
+
+// WithDialMulticastDNSOptions returns a DialOption which allows setting options to
+// specifically be used while doing a dial based off mDNS discovery.
+func WithDialMulticastDNSOptions(opts DialMulticastDNSOptions) DialOption {
+	return rpc.WithDialMulticastDNSOptions(opts)
+}
+
+// WithDisableDirectGRPC returns a DialOption which disables directly dialing a gRPC
+// server. There's not really a good reason to use this unless it's for testing.
+func WithDisableDirectGRPC() DialOption {
+	return rpc.WithDisableDirectGRPC()
+}
+
+// WithForceDirectGRPC forces direct dialing to the target address. This option disables
+// WebRTC connections and mDNS lookup.
+func WithForceDirectGRPC() DialOption {
+	return rpc.WithForceDirectGRPC()
+}

--- a/robot/client/dial_options.go
+++ b/robot/client/dial_options.go
@@ -16,6 +16,8 @@ import (
 type DialOption = rpc.DialOption
 
 // ClientConn is an established client connection to a gRPC server.
+//
+//nolint:revive
 type ClientConn = rpc.ClientConn
 
 // Credentials packages up both a type of credential along with its payload which


### PR DESCRIPTION
## What

Adds `robot/client/dial_options.go`, an rdk-owned re-export of the client-side dial-option surface of `go.viam.com/utils/rpc`. It exposes:

  - **Type aliases:** `DialOption`, `ClientConn`, `Credentials`, `CredentialsType`, `DialWebRTCOptions`, `DialMulticastDNSOptions`
  - **Constants:** `CredentialsTypeAPIKey`, `CredentialsTypeExternal`
  - **Wrapper functions** for the client dial options: `WithEntityCredentials`, `WithCredentials`, `WithInsecure`, `WithTLSConfig`, `WithExternalAuth`, `WithWebRTCOptions`, `WithForceDirectGRPC`, `WithStaticAuthenticationMaterial`, and the rest of the `With*` options

These sit next to the existing `client.WithDialOptions`, so a downstream caller can configure a machine connection entirely through `go.viam.com/rdk/robot/client`.

### Why

SDK users currently have to import `go.viam.com/utils/rpc` directly just to build the dial options passed to `client.WithDialOptions` (e.g. `rpc.WithEntityCredentials`, `rpc.Credentials`, `rpc.CredentialsTypeAPIKey`). That makes `go.viam.com/utils` a  *direct* dependency of every consumer of the Go SDK.

With this re-export, a consumer writes:

  ```go
package main

import (
	"context"

	"go.viam.com/rdk/logging"
	"go.viam.com/rdk/robot/client"
	// NO go.viam.com/utils/rpc IMPORT HERE
)

func main() {
	logger := logging.NewDebugLogger("client")
	machine, err := client.New(
		context.Background(),
		"[uri]",
		logger,
		client.WithDialOptions(client.WithEntityCredentials(
			"[api-key-id]",
			client.Credentials{
				Type: client.CredentialsTypeAPIKey,
				Payload: "[api-key]",
			})),
	)
	if err != nil {
		logger.Fatal(err)
	}

	defer machine.Close(context.Background())
	logger.Info("Resources:")
	logger.Info(machine.ResourceNames())
}
```

and go.viam.com/utils drops to an `// indirect dependency` in their `go.mod`.

This change importantly does not _break_ any existing Golang SDK code that uses the `go.viam.com/utils/rpc` imports. It only allows users to just use `go.viam.com/rdk/client` imports instead and avoid the extra required dependency.

## Testing

  - Verified against a downstream Go SDK example: switching rpc.* calls to client.* and running go mod tidy moves go.viam.com/utils into the indirect require block while the client still builds and runs
  - Added `TestReExportedDialOptions` to ensure the options work as expected

[ 🤖 Generated with Claude Code ]
