### PR TITLE
referenceframe: hoist ToLinearInputs() out of ComputePoses loop

### DIFF
--- a/referenceframe/input.go
+++ b/referenceframe/input.go
@@ -95,16 +95,7 @@ func (inputs FrameSystemInputs) GetFrameInputs(frame Frame) ([]Input, error) {
 
 // ComputePoses computes the poses for each frame in a framesystem in frame of World, using the provided configuration.
 func (inputs FrameSystemInputs) ComputePoses(fs *FrameSystem) (FrameSystemPoses, error) {
-	// Compute poses from configuration using the FrameSystem
-	computedPoses := make(FrameSystemPoses)
-	for _, frameName := range fs.FrameNames() {
-		pif, err := fs.Transform(inputs.ToLinearInputs(), NewZeroPoseInFrame(frameName), World)
-		if err != nil {
-			return nil, err
-		}
-		computedPoses[frameName] = pif.(*PoseInFrame)
-	}
-	return computedPoses, nil
+	return inputs.ToLinearInputs().ComputePoses(fs)
 }
 
 // ToLinearInputs turns this structured map into a flat map of `LinearInputs`. The flat map will

--- a/referenceframe/linear_inputs.go
+++ b/referenceframe/linear_inputs.go
@@ -283,9 +283,15 @@ func (li *LinearInputs) GetFrameInputs(frame Frame) ([]Input, error) {
 // ComputePoses computes the poses for each frame in a framesystem in frame of World, using the
 // provided configuration.
 func (li *LinearInputs) ComputePoses(fs *FrameSystem) (FrameSystemPoses, error) {
-	// This method is not expected to be called in hot paths. Reuse the
-	// `FrameSystemPoses.ComputePoses` method.
-	return li.ToFrameSystemInputs().ComputePoses(fs)
+	computedPoses := make(FrameSystemPoses)
+	for _, frameName := range fs.FrameNames() {
+		pif, err := fs.Transform(li, NewZeroPoseInFrame(frameName), World)
+		if err != nil {
+			return nil, err
+		}
+		computedPoses[frameName] = pif.(*PoseInFrame)
+	}
+	return computedPoses, nil
 }
 
 // ToFrameSystemInputs creates a `FrameSystemInputs` with the same keys and values. This is a


### PR DESCRIPTION
`FrameSystemInputs.ComputePoses` was calling `inputs.ToLinearInputs()` inside its per frame loop. The receiver doesn;t mutate, so we were rebuilding the same `LinearInputs` ~18 times per call for no reason

Two small changes
- (a) `FrameSystemInputs.ComputePoses` now converts once and delegates to `LinearInputs.ComputePoses`
- (b) `LinearInputs.ComputePoses` is the real impl - no more round trips to li --> fsi --> li

## Why this matters
Profiling `TestPlan/reference-run-middle` in the sanding repo
- **Total alloc space: 147.6 GB --> 110.6 GB (25%)**
- `LinearInputs.Put`: 41.07 GB --> 7.76 GB 

Output is identical