### PR TITLE
Remove extra Claude commenting conditional

### DIFF
--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -24,8 +24,7 @@ jobs:
       (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && github.event.review.state != 'approved' && github.event.review.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'claude/'))
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
       )
     # viamrobotics/claude-ci-workflows@v2.2.1
     uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@5506bdaf04cc7d1adbd2df0f31f108834b01aea6


### PR DESCRIPTION
## What

Removes the final predicate in the if conditional of the `claude-pr-assistant.yml` workflow. The Claude PR Assistant now only triggers when claude is explicitly mentioned in a timeline comment, an inline code comment, or a review summary body.

## Why

The removed predicate auto-triggered Claude on any non-approving, non-bot review submitted to a PR whose head branch started with `claude/` without requiring a claude mention. This caused Claude to activate on reviews (including plain comment-type reviews, not just changes_requested) when no one had actually asked it to do anything. The desired behavior is for Claude to respond only when explicitly mentioned, so the implicit branch-based trigger was removed.

[Description generated by Claude 🤖]

