### PR TITLE
RSDK-14178 Fix port race: flaky test fix TestCloudModulesRespondToDebugAndLogChanges

### DIFF
--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -646,13 +646,19 @@ func TestCloudModulesRespondToDebugAndLogChanges(t *testing.T) {
 	testModulePath := testutils.BuildTempModule(t, "module/testmodule")
 	helperModel := resource.NewModel("rdk", "test", "helper")
 
-	// Find a free port for the machine to bind to. Using :0 lets the OS pick an
-	// available ephemeral port, avoiding both hard-coded port conflicts and the
+	// Reserve a free port for the machine to bind to. Using :0 lets the OS pick
+	// an available ephemeral port, avoiding hard-coded port conflicts and the
 	// Windows TIME_WAIT delay that prevents immediate port reuse after close.
+	//
+	// Keep the listener open through setup so that nothing else can grab the
+	// same port in the meantime. In particular, NewFakeCloudServer below also
+	// allocates an ephemeral port, and if this listener were already closed the
+	// OS could hand the just-freed port to the fake cloud server, causing
+	// RunServer to fail with "bind: address already in use". The listener is
+	// closed just before RunServer binds to the port (see below).
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	test.That(t, err, test.ShouldBeNil)
 	machineAddress := listener.Addr().String()
-	listener.Close()
 
 	// Set up fake cloud server.
 	fakeServer, cleanup := configtestutils.NewFakeCloudServer(t, ctx, logger)
@@ -725,6 +731,10 @@ func TestCloudModulesRespondToDebugAndLogChanges(t *testing.T) {
 		deviceID, appAddress, configtestutils.FakeCredentialPayLoad, refreshInterval,
 	)
 	test.That(t, os.WriteFile(cfgFile, []byte(cfgJSON), 0o644), test.ShouldBeNil)
+
+	// Release the reserved machine port immediately before RunServer binds to
+	// it, minimizing the window in which another listener could claim it.
+	test.That(t, listener.Close(), test.ShouldBeNil)
 
 	// Start RunServer in a goroutine. Use -no-tls since the fake cloud
 	// returns empty TLS certs.


### PR DESCRIPTION
## Summary

Fixes the intermittent failure of `TestCloudModulesRespondToDebugAndLogChanges` in `web/server/entrypoint_test.go`, which failed with:

```
entrypoint_test.go:735: Expected: nil
    Actual:   'listen tcp 127.0.0.1:41509: bind: address already in use'
```

## Root cause

The test reserved a free machine port using `net.Listen("tcp", "127.0.0.1:0")` and then **immediately closed** the listener:

```go
listener, err := net.Listen("tcp", "127.0.0.1:0")
machineAddress := listener.Addr().String()
listener.Close()        // port freed here

fakeServer, cleanup := configtestutils.NewFakeCloudServer(...) // also allocates an ephemeral :0 port
```

`NewFakeCloudServer` allocates its own ephemeral port via `net.ListenTCP("tcp", &net.TCPAddr{Port: 0})` right afterwards. Because the machine listener had already been closed, the OS could hand the **just-freed** machine port back to the fake cloud server. When `RunServer` later tried to bind `machineAddress`, that port was already held by the fake cloud server → `bind: address already in use`.

This matches the failure logs precisely: the SDK client "successfully connected" to `127.0.0.1:41509` and received `AuthService.Authenticate` / `RobotService.Config` / `RobotService.Log` responses — those are served by `FakeCloudServer`, not the rdk machine — while `RunServer` simultaneously failed to bind `41509`. The follow-on assertion at line 762 (`resource ... helper not found`) is a downstream effect of the server never starting.

## Fix

Keep the machine port reservation (listener) **open** throughout setup so nothing — in particular the fake cloud server — can claim it, and close it only immediately before `RunServer` binds. This:

- Deterministically prevents the fake-cloud-server-vs-machine port collision (they can no longer be the same port).
- Minimizes the close→bind window to nearly zero (previously the listener was closed long before `RunServer`, with fake-server creation, proto building, and file writes in between).

The change is confined to the test file.

## Testing

Go 1.25.9 (required by `go.mod`) could not be downloaded in this environment (toolchain host blocked by egress policy), so the suite could not be executed here. The change is small, `gofmt`-clean, and self-contained; CI will exercise it.

Key: RSDK-14178

Co-authored by Claude agent for Jira.