### PR TITLE
RSDK-14177 state: flaky test fix TestStreamState rtp_passthrough upgrade/downgrade path

### DIFF
--- a/robot/web/stream/state/state_test.go
+++ b/robot/web/stream/state/state_test.go
@@ -548,7 +548,10 @@ func TestStreamState(t *testing.T) {
 					"timed out waiting for gostream start to be called on stream which terminated unexpectedly",
 					test.ShouldBeFalse)
 			}
-			if subscribeRTPCount.Load() == 2 {
+			// Wait on startCount, which is the last operation in this sequence. SubscribeRTP()
+			// increments subscribeRTPCount before returning the error that triggers Stream.Start();
+			// waiting on subscribeRTPCount instead would race against the subsequent Start() call.
+			if startCount.Load() == 1 {
 				break
 			}
 			time.Sleep(time.Millisecond * 50)


### PR DESCRIPTION
## Summary

Fixes the intermittent failure in `TestStreamState/when_rtppassthrough.Source_is_provided_and_sometimes_returns_an_errors_(test_rtp_passthrough/gostream_upgrade/downgrade_path)` reported at `robot/web/stream/state/state_test.go:559` (`Expected: '1' Actual: '0'`).

## Root cause

In the subtest, after the subscription terminates with `subscribeRTPReturnError` set, `tick()` in `state.go` does the following on the event-handler goroutine:

1. `streamH264Passthrough()` calls `SubscribeRTP()`, which increments `subscribeRTPCount` (via `defer subscribeRTPCount.Add(1)`) and returns an error.
2. Because the error is returned, `tick()` then calls `state.Stream.Start()`, which increments `startCount`.

So `subscribeRTPCount` reaching `2` happens **before** `startCount` reaches `1`. The test's wait loop broke out as soon as `subscribeRTPCount.Load() == 2` and then immediately asserted `startCount == 1`. If the test goroutine observed the counter in the window after `SubscribeRTP` returned but before `Stream.Start()` executed, `startCount` was still `0`, producing the reported failure. The loop's own timeout message ("waiting for gostream **start** to be called") confirms the intent was to wait on `startCount`.

## Fix

Wait on `startCount.Load() == 1` — the terminal operation in this sequence — rather than the intermediate `subscribeRTPCount`. This mirrors the analogous wait loop later in the same test (which correctly waits on `startCount == 4`). Once `startCount == 1`, `SubscribeRTP` has necessarily already run, so all four subsequent assertions are satisfied without a race.

## Verification

- Temporarily widening the window between the failed `SubscribeRTP` and `Stream.Start()` reproduced the exact reported failure (`Expected: '1' Actual: '0'`) with the original condition, and the fix passed with the same widened window.
- `go test ./robot/web/stream/state/ -run TestStreamState` passes, including `-count=30` on the target subtest and under `-race`.
- `gofmt` and `go vet` are clean. No production code changed; only the test's wait condition.

Key: RSDK-14177

Co-authored by Claude agent for Jira.