### PR TITLE
referenceframe: invalidate cachedBFSNames lazily instead of eager rebuild

### DIFF
--- a/referenceframe/frame_system.go
+++ b/referenceframe/frame_system.go
@@ -273,7 +273,7 @@ func (sfs *FrameSystem) RemoveFrame(frame Frame) {
 		}
 	}
 	sfs.removeFrameRecursive(frame)
-	sfs.cachedBFSNames = bfsFrameNames(sfs)
+	sfs.cachedBFSNames = nil
 }
 
 func (sfs *FrameSystem) removeFrameRecursive(frame Frame) {
@@ -375,6 +375,9 @@ func (sfs *FrameSystem) TracebackFrame(query Frame) ([]Frame, error) {
 // FrameNames returns the list of frame names registered in the frame system,
 // in BFS order from world, excluding flattened-model internals.
 func (sfs *FrameSystem) FrameNames() []string {
+	if sfs.cachedBFSNames == nil {
+		sfs.cachedBFSNames = bfsFrameNames(sfs)
+	}
 	return sfs.cachedBFSNames
 }
 
@@ -398,7 +401,7 @@ func (sfs *FrameSystem) AddFrame(frame, parent Frame) error {
 	// add to frame system
 	sfs.frames[frame.Name()] = frame
 	sfs.parents[frame.Name()] = parent.Name()
-	sfs.cachedBFSNames = bfsFrameNames(sfs)
+	sfs.cachedBFSNames = nil
 
 	if sm := asFlattenableModel(frame); sm != nil {
 		if err := flattenModelIntoFS(sfs, sm, frame.Name(), parent); err != nil {
@@ -1192,9 +1195,8 @@ func flattenModelIntoFS(outerFS *FrameSystem, model *SimpleModel, componentName 
 	internalNames := bfsFrameNames(internalFS)
 
 	// Install the bundle and tag every namespaced name as an internal
-	// upfront. AddFrame's auto-recomputed bfsFrameNames cache must know to
-	// filter these out, and resolveFrameInputs may be hit while we're still
-	// adding frames.
+	// upfront, since resolveFrameInputs may be hit while we're still adding
+	// frames.
 	bundle := &flattenedComponent{
 		model:         model,
 		internalNames: make([]string, 0, len(internalNames)),


### PR DESCRIPTION
`FrameSystem.AddFrame` rebuilt `cachedBFSNames` on every call - building a FrameSystem one frame at a time was Big O n^2 in cache churn

Cache originally introduced in this PR: https://github.com/viamrobotics/rdk/pull/5759/changes 

Switch to lazy invalidation - `AddFrame` and `RemoveFrame` set the cache to nil and `FrameNames` rebuilds on first read

## Why
Profiled `TestPlan/reference-run-middle` in the sanding module
- **Total alloc:** 110.6 GB --> 104.8 GB (**-5.8 GB, -5.2%**)
- **`bfsFrameNames` flat:** 5.86 GB --> 168 MB 