### PR TITLE
referenceframe: drop nameIndexMap from GeometriesInFrame

### DIFF
--- a/referenceframe/transformable.go
+++ b/referenceframe/transformable.go
@@ -266,22 +266,13 @@ func LinkInFramesFromTransformsProtobuf(protoSlice []*commonpb.Transform) ([]*Li
 type GeometriesInFrame struct {
 	frame      string
 	geometries []spatialmath.Geometry
-
-	// This is an internal data structure used for O(1) access to named sub-geometries.
-	// Do not access directly. This will not be accurate for unnamed geometries.
-	nameIndexMap map[string]int
 }
 
 // NewGeometriesInFrame generates a new GeometriesInFrame.
 func NewGeometriesInFrame(frame string, geometries []spatialmath.Geometry) *GeometriesInFrame {
-	nameIndexMap := make(map[string]int)
-	for i, geometry := range geometries {
-		nameIndexMap[geometry.Label()] = i
-	}
 	return &GeometriesInFrame{
-		frame:        frame,
-		geometries:   geometries,
-		nameIndexMap: nameIndexMap,
+		frame:      frame,
+		geometries: geometries,
 	}
 }
 
@@ -301,11 +292,10 @@ func (gF *GeometriesInFrame) Geometries() []spatialmath.Geometry {
 // GeometryByName returns the named geometry if it exists in the GeometriesInFrame, and nil otherwise.
 // If multiple geometries exist with identical names one will be chosen at random.
 func (gF *GeometriesInFrame) GeometryByName(name string) spatialmath.Geometry {
-	if gF.nameIndexMap == nil {
-		return nil
-	}
-	if i, ok := gF.nameIndexMap[name]; ok {
-		return gF.geometries[i]
+	for _, g := range gF.geometries {
+		if g.Label() == name {
+			return g
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
`GeometriesInFrame` eagerly built a `nameIndexMap` on every construction, allocated billions of times across motion planning's hot path

The map's only consumer is `GeometryByName` which has **zero** non test callers in rdk or any downstream module to my knowledge

Drop the field entirely. `GeometryByName` switches to a linear scan over geometries of a constant operation

## Why
Profiled `TestPlan/reference-run-middle` in the sanding module
- **Total alloc_space:** 110.6 GB --> 95.28 GB (**-15.3 GB, -13.8%**)
- **`NewGeometriesInFrame` flat:** 18.76 GB (17.9%) --> off top allocators