### PR TITLE
make DefaultCamera lookup in GetObjectPointClouds a best effort

### DIFF
--- a/services/vision/server.go
+++ b/services/vision/server.go
@@ -177,13 +177,15 @@ func (server *serviceServer) GetObjectPointClouds(
 	if err != nil {
 		return nil, err
 	}
-	props, err := svc.GetProperties(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
 	cameraName := req.CameraName
-	if cameraName == "" && props.DefaultCamera != nil {
-		cameraName = *props.DefaultCamera
+	if cameraName == "" {
+		// Do a best effort lookup of DefaultCamera.
+		// Some vision services do not implement GetProperties. Failing
+		// the RPC here would break their GetObjectPointClouds, so we fall back
+		// to the empty reference frame instead.
+		if props, propsErr := svc.GetProperties(ctx, nil); propsErr == nil && props.DefaultCamera != nil {
+			cameraName = *props.DefaultCamera
+		}
 	}
 	protoSegments, err := segmentsToProto(cameraName, objects)
 	if err != nil {

--- a/services/vision/server_test.go
+++ b/services/vision/server_test.go
@@ -286,14 +286,17 @@ func TestServerGetObjectPointClouds(t *testing.T) {
 		test.That(t, resp.Objects[0].Geometries.ReferenceFrame, test.ShouldEqual, "requestedCam")
 	})
 
-	// case 4: GetProperties returns an error → error is propagated to caller
-	t.Run("GetProperties error is propagated", func(t *testing.T) {
-		someError := errors.New("properties failed")
+	// case 4: GetProperties returns an error → error is swallowed and ReferenceFrame falls back to "".
+	// Some vision services (including third-party modules) do not implement GetProperties; a failure
+	// in the optional DefaultCamera lookup must not break a successful GetObjectPointClouds RPC.
+	t.Run("GetProperties error does not fail the RPC", func(t *testing.T) {
 		injectVS.GetPropertiesFunc = func(ctx context.Context, extra map[string]interface{}) (*vision.Properties, error) {
-			return nil, someError
+			return nil, errors.New("properties failed")
 		}
-		_, err := server.GetObjectPointClouds(context.Background(), buildRequest(""))
-		test.That(t, err, test.ShouldBeError, someError)
+		resp, err := server.GetObjectPointClouds(context.Background(), buildRequest(""))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(resp.Objects), test.ShouldEqual, 1)
+		test.That(t, resp.Objects[0].Geometries.ReferenceFrame, test.ShouldEqual, "")
 	})
 }
 


### PR DESCRIPTION
#6161 made `GetObjectPointClouds` call `svc.GetProperties` and hard fail the RCP on error just to loop up an optional DefaultCamera for ReferenceFrame

This silently broke any vision service impl whose `GetProperties` errors or isn't implemented

## Fix
Make the `DefaultCamera` lookup best effort - only call `GetProperties` when `req.Cameraname` is empty, swallow errors and fall back to empty `ReferenceName`