### PR TITLE
resource: re-resolve dependent edges when a removed dependency is re-added

### DIFF
--- a/resource/graph_node.go
+++ b/resource/graph_node.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -448,6 +449,19 @@ func (w *GraphNode) setUnresolvedDependencies(names ...string) {
 	defer w.mu.Unlock()
 	w.unresolvedDependencies = names
 	w.needsDependencyResolution = true
+}
+
+// addUnresolvedDependency re-marks a single dependency name as unresolved and flags the
+// node for resolution, without clobbering any deps already pending. Used when a dependency
+// edge is force-dropped (e.g. the dependency node is removed) so the dependent re-resolves
+// it once it reappears.
+func (w *GraphNode) addUnresolvedDependency(name string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.needsDependencyResolution = true
+	if !slices.Contains(w.unresolvedDependencies, name) {
+		w.unresolvedDependencies = append(w.unresolvedDependencies, name)
+	}
 }
 
 // setDependenciesResolved sets that all unresolved dependencies have been

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -637,6 +637,12 @@ func (g *Graph) remove(node Name) {
 	for k, vertice := range g.parents {
 		if _, ok := vertice[node]; ok {
 			removeNodeFromNodeMap(g.parents, k, node)
+			// The dependent `k` just lost an edge to a dependency it still declares.
+			// Re-arm it for resolution so the edge is rebuilt if `node` reappears,
+			// instead of being silently stranded until `k`'s config is reprocessed.
+			if depNode, ok := g.nodes.Get(k); ok {
+				depNode.addUnresolvedDependency(node.String())
+			}
 		}
 	}
 	delete(g.transitiveClosureMatrix, node)

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -622,7 +622,7 @@ func (g *Graph) removeTransitiveClosure(child, parent Name) {
 	}
 }
 
-func (g *Graph) remove(node Name) {
+func (g *Graph) remove(node Name, rearmDependents bool) {
 	for k := range g.parents[node] {
 		g.removeTransitiveClosure(node, k)
 	}
@@ -637,11 +637,15 @@ func (g *Graph) remove(node Name) {
 	for k, vertice := range g.parents {
 		if _, ok := vertice[node]; ok {
 			removeNodeFromNodeMap(g.parents, k, node)
-			// The dependent `k` just lost an edge to a dependency it still declares.
-			// Re-arm it for resolution so the edge is rebuilt if `node` reappears,
-			// instead of being silently stranded until `k`'s config is reprocessed.
-			if depNode, ok := g.nodes.Get(k); ok {
-				depNode.addUnresolvedDependency(node.String())
+			// Only when removing from the *live* graph: the dependent `k` just lost an edge to
+			// a dependency it still declares. Re-arm it for resolution so the edge is rebuilt if
+			// `node` reappears, instead of being silently stranded until `k`'s config is
+			// reprocessed. Skipped for clone/subgraph removals (clones share *GraphNode pointers,
+			// so re-arming there would corrupt the real nodes).
+			if rearmDependents {
+				if depNode, ok := g.nodes.Get(k); ok {
+					depNode.addUnresolvedDependency(node.String())
+				}
 			}
 		}
 	}
@@ -688,7 +692,7 @@ func (g *Graph) RemoveMarked() []Resource {
 		}
 		if rNode.MarkedForRemoval() {
 			toClose = append(toClose, NewCloseOnlyResource(name, rNode.Close))
-			g.remove(name)
+			g.remove(name, true /* rearm dependents */)
 		}
 	}
 	return toClose
@@ -703,7 +707,7 @@ func (g *Graph) MergeAdd(toAdd *Graph) error {
 	defer g.mu.Unlock()
 	for _, node := range sorted {
 		if i, ok := g.nodes.Get(node); ok && i != nil {
-			g.remove(node)
+			g.remove(node, false)
 		}
 		toAddNode, _ := toAdd.nodes.Get(node)
 		if err := g.addNode(node, toAddNode); err != nil {
@@ -795,7 +799,7 @@ func (g *Graph) topologicalSortInLevels() ([][]Name, []Name) {
 		ordered = append(ordered, leaves)
 		orderedFlattened = append(orderedFlattened, leaves...)
 		for _, leaf := range leaves {
-			temp.remove(leaf)
+			temp.remove(leaf, false)
 		}
 	}
 	return ordered, orderedFlattened
@@ -940,7 +944,7 @@ func (g *Graph) subGraphFromWithMutex(node Name) (*Graph, error) {
 	sorted := subGraph.ReverseTopologicalSort()
 	for _, n := range sorted {
 		if !subGraph.isNodeDependingOn(node, n) {
-			subGraph.remove(n)
+			subGraph.remove(n, false)
 		}
 	}
 	return subGraph, nil

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -1279,3 +1279,70 @@ func shouldMatchMultipleNodesErr(actual interface{}, expected ...interface{}) st
 	}
 	return ""
 }
+
+// TestResourceGraphRebuildEdgeAfterDependencyReadded reproduces the dependency-edge
+// stranding bug: once a node has resolved its dependencies, removing one of those
+// dependency nodes strips the edge but does NOT re-arm the dependent for resolution,
+// so re-adding the dependency never rebuilds the edge.
+//
+// Models: A (dependent) depends-by-name on B (dependency), as a modular resource would
+// after Validate() returns B in its required deps.
+func TestResourceGraphRebuildEdgeAfterDependencyReadded(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	g := NewGraph(logger)
+
+	nameA := NewName(apiA, "A")
+	nameB := NewName(apiA, "B")
+
+	parentsOfA := func() []Name { return g.GetAllParentsOf(nameA) }
+
+	// B exists (a built dependency). A is unconfigured and declares it depends on B by name,
+	// exactly as NewUnconfiguredGraphNode(conf, conf.Dependencies()) would seed it.
+	test.That(t, g.AddNode(nameB, &GraphNode{}), test.ShouldBeNil)
+	test.That(t, g.AddNode(nameA, NewUnconfiguredGraphNode(Config{API: apiA, Name: "A"}, []string{nameB.String()})), test.ShouldBeNil)
+
+	// First resolution: the A->B edge is created (this is "A resolved B once at construction").
+	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+	t.Logf("after initial resolve, parents of A = %v", parentsOfA())
+	test.That(t, parentsOfA(), test.ShouldResemble, []Name{nameB})
+
+	// The dependency's node is removed (collision / removed-from-config). This strips the edge.
+	g.remove(nameB)
+	t.Logf("after remove(B),     parents of A = %v", parentsOfA())
+	test.That(t, parentsOfA(), test.ShouldBeEmpty) // edge correctly dropped
+
+	// The dependency comes back as a fresh node, and the resolver runs again (as completeConfig
+	// does every pass). EXPECTED: the A->B edge is rebuilt. (This is the assertion that fails today.)
+	test.That(t, g.AddNode(nameB, &GraphNode{}), test.ShouldBeNil)
+	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+	t.Logf("after readd + resolve, parents of A = %v  (want [%v])", parentsOfA(), nameB)
+	test.That(t, parentsOfA(), test.ShouldResemble, []Name{nameB})
+}
+
+// TestResourceGraphRebuildEdgeViaFullReseed shows the "cure" path: when the dependent is
+// re-seeded with its full declared dependency list (what markResourceForUpdate /
+// ResolveImplicitDependencies do on a config reprocess / module restart), the edge is rebuilt.
+func TestResourceGraphRebuildEdgeViaFullReseed(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	g := NewGraph(logger)
+
+	nameA := NewName(apiA, "A")
+	nameB := NewName(apiA, "B")
+	parentsOfA := func() []Name { return g.GetAllParentsOf(nameA) }
+
+	test.That(t, g.AddNode(nameB, &GraphNode{}), test.ShouldBeNil)
+	nodeA := NewUnconfiguredGraphNode(Config{API: apiA, Name: "A"}, []string{nameB.String()})
+	test.That(t, g.AddNode(nameA, nodeA), test.ShouldBeNil)
+	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+	test.That(t, parentsOfA(), test.ShouldResemble, []Name{nameB})
+
+	g.remove(nameB)
+	test.That(t, parentsOfA(), test.ShouldBeEmpty)
+
+	// Re-add B, and re-seed A's full declared deps (the config-reprocess path).
+	test.That(t, g.AddNode(nameB, &GraphNode{}), test.ShouldBeNil)
+	nodeA.SetNewConfig(Config{API: apiA, Name: "A"}, []string{nameB.String()})
+	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+	t.Logf("after full re-seed + resolve, parents of A = %v", parentsOfA())
+	test.That(t, parentsOfA(), test.ShouldResemble, []Name{nameB})
+}

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -191,7 +191,7 @@ func TestResourceGraphGetParentsAndChildren(t *testing.T) {
 	for _, p := range g.GetAllParentsOf(NewName(apiA, "F")) {
 		g.removeChild(NewName(apiA, "F"), p)
 	}
-	g.remove(NewName(apiA, "F"))
+	g.remove(NewName(apiA, "F"), false)
 	out = g.TopologicalSort()
 	test.That(t, newResourceNameSet(out[0:3]...), test.ShouldResemble,
 		newResourceNameSet([]Name{
@@ -892,7 +892,7 @@ func TestResourceGraphRandomRemoval(t *testing.T) {
 		}
 	}
 
-	g.remove(name)
+	g.remove(name, false)
 	test.That(t, g.GetAllParentsOf(name), test.ShouldBeEmpty)
 	test.That(t, g.GetAllChildrenOf(name), test.ShouldBeEmpty)
 }
@@ -1115,7 +1115,7 @@ func TestResourceGraphResolveDependencies(t *testing.T) {
 	test.That(t, node3.hasUnresolvedDependencies(), test.ShouldBeTrue)
 	test.That(t, node4.hasUnresolvedDependencies(), test.ShouldBeTrue)
 
-	g.remove(name3)
+	g.remove(name3, false)
 	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
 
 	test.That(t, node1.UnresolvedDependencies(), test.ShouldResemble, []string{"d"})
@@ -1307,7 +1307,7 @@ func TestResourceGraphRebuildEdgeAfterDependencyReadded(t *testing.T) {
 	test.That(t, parentsOfA(), test.ShouldResemble, []Name{nameB})
 
 	// The dependency's node is removed (collision / removed-from-config). This strips the edge.
-	g.remove(nameB)
+	g.remove(nameB, true)
 	t.Logf("after remove(B),     parents of A = %v", parentsOfA())
 	test.That(t, parentsOfA(), test.ShouldBeEmpty) // edge correctly dropped
 
@@ -1336,7 +1336,7 @@ func TestResourceGraphRebuildEdgeViaFullReseed(t *testing.T) {
 	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
 	test.That(t, parentsOfA(), test.ShouldResemble, []Name{nameB})
 
-	g.remove(nameB)
+	g.remove(nameB, false)
 	test.That(t, parentsOfA(), test.ShouldBeEmpty)
 
 	// Re-add B, and re-seed A's full declared deps (the config-reprocess path).

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -5709,3 +5709,71 @@ func TestReconfigureTracing(t *testing.T) {
 		testReconfigureTracing(t, "fake-cloud-id")
 	})
 }
+
+// TestDependentReconnectsAfterDependencyNodeReadded is a deterministic robot-level repro of
+// the incident: a dependency's node is removed (via a name collision) while a surviving
+// dependent has already resolved it, then re-added. The dependent must end up with its edge
+// to the dependency rebuilt once the dependency is healthy again. Asserts on the EDGE, because
+// a dependent that tolerates a missing dep can look "Ready" while silently disconnected.
+func TestDependentReconnectsAfterDependencyNodeReadded(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+
+	x := resource.Config{Name: "x", Model: fakeModel, API: base.API}
+	d := resource.Config{Name: "d", Model: fakeModel, API: base.API}
+	aSvc := resource.Config{Name: "a-svc", Model: fakeModel, API: slam.API}
+	bCmp := resource.Config{
+		Name: "b-cmp", Model: fakeModel, API: motor.API,
+		DependsOn: []string{"a-svc"}, ConvertedAttributes: &fakemotor.Config{},
+	}
+	bn := motor.Named("b-cmp")
+
+	r := setupLocalRobot(t, ctx, &config.Config{Components: []resource.Config{x}}, logger, WithDisableCompleteConfigWorker())
+	lr := r.(*localRobot)
+
+	// collision (a-svc duplicated) with b freshly added; then collision persists; then cleared.
+	r.Reconfigure(ctx, &config.Config{Components: []resource.Config{x, bCmp}, Services: []resource.Config{aSvc, aSvc}})
+	r.Reconfigure(ctx, &config.Config{Components: []resource.Config{x, d, bCmp}, Services: []resource.Config{aSvc, aSvc}})
+	r.Reconfigure(ctx, &config.Config{Components: []resource.Config{x, d, bCmp}, Services: []resource.Config{aSvc}})
+
+	// a-svc is healthy now; b-cmp must be wired to it.
+	parents := lr.manager.resources.GetAllParentsOf(bn)
+	test.That(t, parents, test.ShouldContain, slam.Named("a-svc"))
+}
+
+// TestFixDoesNotResurrectDroppedDependency guards the re-arm fix: if B used to depend on A,
+// and a reconfigure both drops B's dependency on A and removes A, B must NOT be re-armed with
+// a stale dependency on A. A dependent that legitimately dropped a dependency has its edge
+// severed by markResourceForUpdate (parentage reset) before the node is removed, so the
+// removal-time re-arm must not touch it.
+func TestFixDoesNotResurrectDroppedDependency(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+
+	a := resource.Config{Name: "a", Model: fakeModel, API: base.API}
+	bDep := resource.Config{
+		Name: "b", Model: fakeModel, API: motor.API,
+		DependsOn: []string{"a"}, ConvertedAttributes: &fakemotor.Config{},
+	}
+	bNoDep := resource.Config{
+		Name: "b", Model: fakeModel, API: motor.API,
+		DependsOn: []string{}, ConvertedAttributes: &fakemotor.Config{},
+	}
+	bn := motor.Named("b")
+
+	r := setupLocalRobot(t, ctx, &config.Config{Components: []resource.Config{a, bDep}}, logger,
+		WithDisableCompleteConfigWorker())
+	lr := r.(*localRobot)
+
+	// Drop B's dependency on A and remove A entirely, in one reconfigure.
+	r.Reconfigure(ctx, &config.Config{Components: []resource.Config{bNoDep}})
+	_, errB := r.ResourceByName(bn)
+	test.That(t, errB, test.ShouldBeNil)                                       // B healthy, not stranded
+	test.That(t, lr.manager.resources.GetAllParentsOf(bn), test.ShouldBeEmpty) // no stale edge to 'a'
+
+	// Bring A back as an unrelated resource; B must not re-link to it.
+	r.Reconfigure(ctx, &config.Config{Components: []resource.Config{a, bNoDep}})
+	_, errB2 := r.ResourceByName(bn)
+	test.That(t, errB2, test.ShouldBeNil)
+	test.That(t, lr.manager.resources.GetAllParentsOf(bn), test.ShouldBeEmpty)
+}


### PR DESCRIPTION
## Summary

Fixes a dependency-graph bug where a resource that loses a dependency (because the **dependency's node** is removed from the graph) is permanently stranded — it keeps failing with `Resource missing from dependencies` even after the dependency comes back healthy, until its own config is reprocessed (e.g. its module is restarted).

## How it showed up

A machine briefly had two fragments enabled that define the same resources by name (`sonar-ai-v3` + `sonar-ai-v3-staging`). The name collision removed the shared `vision-predict-fish` vision-service node. A dependent generic component in another module (`placemarker-ai`) had already resolved it at construction. After the collision cleared and `vision-predict-fish` was rebuilt healthy, `placemarker-ai` looped on `Resource missing from dependencies: rdk:service:vision/vision-predict-fish` for ~35 min and only recovered when its module was manually restarted.

## Root cause

- Edges live only in the graph adjacency and are (re)built by `Graph.ResolveDependencies`, driven entirely by each node's `unresolvedDependencies` list.
- That list is emptied once a node resolves (`setDependenciesResolved`, and `SwapResource` nils it). After that, the **edge** is the only runtime record of the requirement.
- `Graph.remove` strips the removed node out of every dependent's parent set — but does **not** put the dependency name back on the dependent's unresolved list or flag it for resolution.
- The "your dependency changed" notify paths (`SetNeedsUpdate` / `SetNeedsRebuild`) re-seed `unresolvedDependencies` from the now-empty `UnresolvedDependencies()`, so they carry nothing to resolve.

Net: once a dependency node is removed, a surviving dependent's edge is never re-derived. Only a path that re-seeds the full declared deps (`SetNewConfig` via `markResourceForUpdate` / `ResolveImplicitDependencies`) rebuilds it — which is why a module restart is the only thing that fixes it.

This regressed in #2225 (Reconfiguration Refactor, Apr 2023), which introduced the lazy resolve-once model. Before it, `completeConfig` re-derived edges from `conf.Dependencies()` every pass, so the dependent re-wired on the next reconfigure. The `Graph.remove` edge-strip itself dates to #434 (2022) but was benign pre-#2225.

## Fix

In `Graph.remove`, when stripping the removed node from a dependent's parent set, re-mark the dependency as unresolved on that dependent (`addUnresolvedDependency`). This puts the dependent back into the same self-healing resolve loop that brand-new resources already use, so the edge is rebuilt automatically the moment the dependency reappears — no config reprocess / module restart needed. Paths that rebuild a dependency *in place* (module restart of the provider, attribute/model rebuild) don't call `remove`, so they're unaffected.

## Tests

- `TestResourceGraphRebuildEdgeAfterDependencyReadded` — resolve `A→B`, `remove(B)`, re-add `B`, re-run `ResolveDependencies`; asserts the edge is restored. **Fails without this fix**, passes with it.
- `TestResourceGraphRebuildEdgeViaFullReseed` — documents the existing recovery path (full re-seed via `SetNewConfig`).

## Open questions for reviewers

- This is the **graph-level** fix. Worth also adding a `resource_manager`/`local_robot` integration test that removes+re-adds a dependency through `completeConfig` and asserts the dependent recovers — happy to add.
- `Graph.remove` now calls into the node mutex while holding the graph mutex — the same `g.mu → node.mu` ordering `ResolveDependencies` already uses, but flagging for a second look.
- Re-arming a dependent that is *itself* being torn down adds a harmless unresolved entry that's cleared on its own removal; confirm that's acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
