### PR TITLE
motionplan skip seen-map allocation for cross-set collision checks

### DIFF
--- a/motionplan/collision.go
+++ b/motionplan/collision.go
@@ -154,7 +154,19 @@ func checkCollisionsHinted(
 		return nil, math.Inf(-1), err
 	}
 
-	seen := map[[2]string]bool{}
+	// `seen` dedups pairs only when the same canonical (xName,yName) could be visited
+	// twice during the nested-loop iteration below. That requires a name to appear in
+	// both ggMap and otherMap — i.e. self-collision. For disjoint sets (the obstacle
+	// and robot-vs-robot constraints), every iteration yields a unique canonical pair,
+	// so allocating the map and writing to it on every pair is pure waste. Detect the
+	// disjoint case up front and leave seen nil; skipCollisionCheck handles nil safely.
+	var seen map[[2]string]bool
+	for k := range ggMap {
+		if _, ok := otherMap[k]; ok {
+			seen = make(map[[2]string]bool, len(ggMap)*len(otherMap)/2)
+			break
+		}
+	}
 
 	collisions := []Collision{}
 	minDistance := math.Inf(1)
@@ -259,7 +271,7 @@ func makeAllowedCollisionsLookup(allowedCollisions []Collision) map[[2]string]bo
 
 func createUniqueCollisionMap(geoms []spatialmath.Geometry) (map[string]spatialmath.Geometry, error) {
 	unnamedCnt := 0
-	geomMap := map[string]spatialmath.Geometry{}
+	geomMap := make(map[string]spatialmath.Geometry, len(geoms))
 
 	for _, geom := range geoms {
 		label := geom.Label()
@@ -282,7 +294,15 @@ func skipCollisionCheck(allowed, seen map[[2]string]bool, xName, yName string) b
 	}
 
 	key := canonicalPair(xName, yName)
-	if allowed[key] || seen[key] {
+	if allowed[key] {
+		return true
+	}
+	if seen == nil {
+		// Caller determined ggMap and otherMap are disjoint, so (xName,yName)
+		// produces a unique canonical pair on every iteration — dedup unnecessary.
+		return false
+	}
+	if seen[key] {
 		// Already checked this pair in the other order
 		return true
 	}


### PR DESCRIPTION
`checkCollisionsHinted` allocates a `seen` map on every call to dedup pair checks during its nested loop iteration. That dedup is only meaningful when the same name appears in both maps - i.e. self collision. 

For obstacle and robot vs robot constraints, the two sets are disjoint so every `(xName, yName)` pair is already unique by construction and `seen` provides zero benefit.

Before `seen` was allocated and written to on every pair in all three collision constraints. The map operations dominated the alloc profile. 

## Fix
Detect overlap up front through a single pass over `ggMap` keys. Leave `seen` nil for the disjoint case. `skipCollisionCheck` short circuits when seen is nil. Pre size seen when allocated and pre size the per call `geomMap` in createUniqueCollisionMap to avoid bucket growth churn

## Why
Measured on sanding `TestPlan/reference-run-middle`:
- total allocations: 84.08 GB --> 68.77 GB (-15.31 GB, -18%)
- skipCollisionCheck 16.2 GB --> less than a GB

Plans and sanding distance are both identical