### PR TITLE
spatialmath: add QuatBetween to avoid Orientation wrapper allocation

### DIFF
--- a/motionplan/metrics.go
+++ b/motionplan/metrics.go
@@ -85,7 +85,7 @@ type SegmentFSMetric func(*SegmentFS) float64
 
 // OrientDist returns the arclength between two orientations in degrees.
 func OrientDist(o1, o2 spatial.Orientation) float64 {
-	return math.Abs(utils.RadToDeg(spatial.QuatToR4AA(spatial.OrientationBetween(o1, o2).Quaternion()).Theta))
+	return math.Abs(utils.RadToDeg(spatial.QuatToR4AA(spatial.QuatBetween(o1, o2)).Theta))
 }
 
 // WeightedSquaredNormDistance is a distance function between two poses to be used for gradient descent.
@@ -98,10 +98,10 @@ func WeightedSquaredNormDistanceWithOptions(start, end spatial.Pose, cartesianSc
 	// Increase weight for orientation since it's a small number
 	orientDelta := 0.0
 	if orientScale > 0 {
-		orientDelta = spatial.QuatToR3AA(spatial.OrientationBetween(
+		orientDelta = spatial.QuatToR3AA(spatial.QuatBetween(
 			start.Orientation(),
 			end.Orientation(),
-		).Quaternion()).Mul(orientScale).Norm2()
+		)).Mul(orientScale).Norm2()
 	}
 
 	ptDelta := 0.0

--- a/spatialmath/orientation.go
+++ b/spatialmath/orientation.go
@@ -38,12 +38,18 @@ func OrientationAlmostEqualEps(o1, o2 Orientation, epsilon float64) bool {
 		return false
 	}
 
-	return QuatToR3AA(OrientationBetween(o1, o2).Quaternion()).Norm2() < epsilon
+	return QuatToR3AA(QuatBetween(o1, o2)).Norm2() < epsilon
+}
+
+// QuatBetween returns the rotation quaternion from o1 to o2 as a raw quat.Number.
+// Unlike OrientationBetween, this does not allocate a heap-bound Orientation wrapper.
+func QuatBetween(o1, o2 Orientation) quat.Number {
+	return quat.Mul(o2.Quaternion(), quat.Conj(o1.Quaternion()))
 }
 
 // OrientationBetween returns the orientation representing the difference between the two given orientations.
 func OrientationBetween(o1, o2 Orientation) Orientation {
-	q := Quaternion(quat.Mul(o2.Quaternion(), quat.Conj(o1.Quaternion())))
+	q := Quaternion(QuatBetween(o1, o2))
 	return &q
 }
 

--- a/spatialmath/orientation_test.go
+++ b/spatialmath/orientation_test.go
@@ -171,3 +171,10 @@ func TestIsDefaultOrientation(t *testing.T) {
 	test.That(t, IsDefaultOrientation(&OrientationVectorDegrees{OX: 0, OY: 0, OZ: 1, Theta: 0}), test.ShouldBeTrue)
 	test.That(t, IsDefaultOrientation(&OrientationVectorDegrees{OX: 1, OY: 0, OZ: 1, Theta: 0}), test.ShouldBeFalse)
 }
+
+func TestQuatBetweenNoAllocs(t *testing.T) {
+	allocs := testing.AllocsPerRun(1000, func() {
+		_ = QuatBetween(ovd45x, aa45x)
+	})
+	test.That(t, allocs, test.ShouldEqual, 0)
+}

--- a/spatialmath/pose.go
+++ b/spatialmath/pose.go
@@ -143,7 +143,7 @@ func PoseInverse(p Pose) Pose {
 // by == 0 will return p1, by == 1 will return p2, and by == 0.5 will return the pose halfway between them.
 func Interpolate(p1, p2 Pose, by float64) Pose {
 	p2Orient := p2.Orientation().Quaternion()
-	if OrientationBetween(p1.Orientation(), p2.Orientation()).Quaternion().Real < 0 {
+	if QuatBetween(p1.Orientation(), p2.Orientation()).Real < 0 {
 		p2Orient = quat.Scale(-1, p2Orient)
 	}
 	intQ := newDualQuaternion()


### PR DESCRIPTION
OrientationBetween returns an interface forcing the inner Quaternion to heap allocate. Hot callers immediately call `.Quaternion()` and discard the wrapper 

## Fix
Add `QuatBetween` returning raw `quat.Number` (no heap alloc). Swap the four callers that throw the wrapper away and keep `OrientationBetween` for the one caller that uses the interface.

## Impact
In a sanding pass, `OrientationBetween` was 12.9 GB (~4%) of total alloc. After this change, it drops out of the top entries entirely. 

Plan paths is > %80 GC bound so allocation reduction translates to wall time