### PR TITLE
Fix client-side handling of err field in module status

### DIFF
--- a/module/status/proto_conversions_test.go
+++ b/module/status/proto_conversions_test.go
@@ -33,6 +33,14 @@ func TestStatusToProto(t *testing.T) {
 		test.That(t, proto.Error, test.ShouldEqual, "")
 	})
 
+	t.Run("non-nil error converts in non-unhealthy state", func(t *testing.T) {
+		// errors persist through intermediate states until a module is ready, so a
+		// non-nil error must serialize even when the state isn't unhealthy.
+		proto := Status{Name: "m", State: ModuleStateStarting, Error: errors.New("boom")}.ToProto()
+		test.That(t, proto.State, test.ShouldEqual, pb.ModuleStatus_STATE_STARTING)
+		test.That(t, proto.Error, test.ShouldEqual, "boom")
+	})
+
 	t.Run("every state maps", func(t *testing.T) {
 		for state, expected := range map[State]pb.ModuleStatus_State{
 			ModuleStateUnknown:   pb.ModuleStatus_STATE_UNSPECIFIED,

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -1357,11 +1357,11 @@ func (rc *RobotClient) MachineStatus(ctx context.Context) (robot.MachineStatus, 
 				modStatus.State = modulestatus.ModuleStateReady
 			case pb.ModuleStatus_STATE_UNHEALTHY:
 				modStatus.State = modulestatus.ModuleStateUnhealthy
-				if pbModStatus.GetError() != "" {
-					modStatus.Error = errors.New(pbModStatus.GetError())
-				}
 			case pb.ModuleStatus_STATE_CLOSING:
 				modStatus.State = modulestatus.ModuleStateClosing
+			}
+			if pbModStatus.GetError() != "" {
+				modStatus.Error = errors.New(pbModStatus.GetError())
 			}
 
 			mStatus.Modules = append(mStatus.Modules, modStatus)

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -58,6 +58,7 @@ import (
 	"go.viam.com/rdk/data"
 	rgrpc "go.viam.com/rdk/grpc"
 	"go.viam.com/rdk/logging"
+	modulestatus "go.viam.com/rdk/module/status"
 	"go.viam.com/rdk/operation"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
@@ -2382,6 +2383,26 @@ func TestMachineStatus(t *testing.T) {
 							PrimaryOrgID:  "789",
 							LocationID:    "abc",
 						},
+					},
+				},
+				State: robot.StateRunning,
+			},
+			0,
+		},
+		{
+			// errors persist through intermediate states, so a non-unhealthy module
+			// can carry an error; it must survive the server/client round-trip.
+			"module with error in non-unhealthy state",
+			robot.MachineStatus{
+				Config:    config.Revision{Revision: "rev1"},
+				Resources: []resource.Status{},
+				Modules: []modulestatus.Status{
+					{
+						Name:                "mod",
+						State:               modulestatus.ModuleStateStarting,
+						LastUpdated:         time.Unix(1700000000, 0).UTC(),
+						Error:               errors.New("boom"),
+						ConsecutiveFailures: 2,
 					},
 				},
 				State: robot.StateRunning,


### PR DESCRIPTION
Very quick fix for module status - clients would not see the `error` field unless the module state was `UNHEALTHY`, because the `error` field was only conditionally unmarshalled in the `UNHEALTHY` state. I also didn't have any tests for the actual client path which is how this made it through.

Made `error` unmarshalling unconditional and added an actual test for that path (which does fail if the client change isn't in).