### PR TITLE
resource: make dependency edges a reconciled projection of declared deps

### DIFF
--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -824,9 +824,10 @@ func (g *Graph) ReverseTopologicalSortInLevels() [][]Name {
 	return ordered
 }
 
-// declaredDepsMissingEdges returns the names of a node's declared dependencies (DependsOn +
-// ImplicitDependsOn) that currently have no corresponding parent edge in the graph. It is the
-// reconcile check that makes graph edges a projection of declared deps. Caller must hold g.mu.
+// declaredDepsMissingEdges returns the names of a node's declared dependencies that currently
+// have no corresponding parent edge in the graph. It reconciles graph edges with declared
+// dependencies if a resource resolves a dependency but the dependency is torn down while the
+// resource is remains. Caller must hold g.mu.
 func (g *Graph) declaredDepsMissingEdges(nodeName Name, node *GraphNode) []string {
 	cfg := node.Config()
 	declared := cfg.Dependencies()
@@ -865,17 +866,8 @@ func (g *Graph) ResolveDependencies(logger logging.Logger) error {
 
 	var allErrs error
 	for nodeName, node := range g.nodes.All() {
-		// Edges are a projection of a node's durable declared dependencies. If a node is
-		// missing an edge for a dependency it still declares (e.g. that dependency's node was
-		// removed and later re-added), re-arm it so the edge is rebuilt on this pass. This
-		// keeps the graph self-healing without relying on a write-once unresolved list.
-		//
-		// This runs for every node, not just resolved ones: in steady state all nodes are
-		// resolved so a `!hasUnresolvedDependencies()` gate would skip nothing, and gating it
-		// would leave a blind spot where a node mid-resolution (unresolved list non-empty) never
-		// notices a *different* declared dep whose edge was dropped. declaredDepsMissingEdges always
-		// contains the current unresolved deps (they have no edge yet), so replacing the list
-		// never drops a pending dep.
+		// Add any dependency declared in the resource config but not linked as a parent edge to the node
+		// to the node's unresolved dependencies.
 		if missing := g.declaredDepsMissingEdges(nodeName, node); len(missing) > 0 {
 			node.setUnresolvedDependencies(missing...)
 		}

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -824,6 +824,39 @@ func (g *Graph) ReverseTopologicalSortInLevels() [][]Name {
 	return ordered
 }
 
+// missingDeclaredDeps returns the names of a node's declared dependencies (DependsOn +
+// ImplicitDependsOn) that currently have no corresponding parent edge in the graph. It is the
+// reconcile check that makes graph edges a projection of declared deps. Caller must hold g.mu.
+func (g *Graph) missingDeclaredDeps(nodeName Name, node *GraphNode) []string {
+	cfg := node.Config()
+	declared := cfg.Dependencies()
+	if len(declared) == 0 {
+		return nil
+	}
+	parentSet := make(map[string]struct{})
+	for _, p := range g.getAllParentOf(nodeName) {
+		parentSet[p.String()] = struct{}{}
+	}
+	var missing []string
+	for _, dep := range declared {
+		resolved := ""
+		if rn, err := NewFromString(dep); err == nil {
+			resolved = rn.String()
+		} else if nn := g.FindBySimpleName(dep); len(nn) == 1 {
+			resolved = nn[0].String()
+		}
+		// Unresolvable (dependency absent) or declared-but-unedged -> needs (re)resolution.
+		if resolved == "" {
+			missing = append(missing, dep)
+			continue
+		}
+		if _, ok := parentSet[resolved]; !ok {
+			missing = append(missing, dep)
+		}
+	}
+	return missing
+}
+
 // ResolveDependencies attempts to link up unresolved dependencies after
 // new changes to the graph.
 func (g *Graph) ResolveDependencies(logger logging.Logger) error {
@@ -832,6 +865,16 @@ func (g *Graph) ResolveDependencies(logger logging.Logger) error {
 
 	var allErrs error
 	for nodeName, node := range g.nodes.All() {
+		// Edges are a projection of a node's durable declared dependencies. If a resolved
+		// node is missing an edge for a dependency it still declares (e.g. that dependency's
+		// node was removed and later re-added), re-arm it so the edge is rebuilt on this pass.
+		// This keeps the graph self-healing without relying on a write-once unresolved list.
+		if !node.hasUnresolvedDependencies() {
+			if missing := g.missingDeclaredDeps(nodeName, node); len(missing) > 0 {
+				node.setUnresolvedDependencies(missing...)
+			}
+		}
+
 		unresolvedDeps := node.UnresolvedDependencies()
 
 		if !node.hasUnresolvedDependencies() {

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -865,14 +865,19 @@ func (g *Graph) ResolveDependencies(logger logging.Logger) error {
 
 	var allErrs error
 	for nodeName, node := range g.nodes.All() {
-		// Edges are a projection of a node's durable declared dependencies. If a resolved
-		// node is missing an edge for a dependency it still declares (e.g. that dependency's
-		// node was removed and later re-added), re-arm it so the edge is rebuilt on this pass.
-		// This keeps the graph self-healing without relying on a write-once unresolved list.
-		if !node.hasUnresolvedDependencies() {
-			if missing := g.missingDeclaredDeps(nodeName, node); len(missing) > 0 {
-				node.setUnresolvedDependencies(missing...)
-			}
+		// Edges are a projection of a node's durable declared dependencies. If a node is
+		// missing an edge for a dependency it still declares (e.g. that dependency's node was
+		// removed and later re-added), re-arm it so the edge is rebuilt on this pass. This
+		// keeps the graph self-healing without relying on a write-once unresolved list.
+		//
+		// This runs for every node, not just resolved ones: in steady state all nodes are
+		// resolved so a `!hasUnresolvedDependencies()` gate would skip nothing, and gating it
+		// would leave a blind spot where a node mid-resolution (unresolved list non-empty) never
+		// notices a *different* declared dep whose edge was dropped. missingDeclaredDeps always
+		// contains the current unresolved deps (they have no edge yet), so replacing the list
+		// never drops a pending dep.
+		if missing := g.missingDeclaredDeps(nodeName, node); len(missing) > 0 {
+			node.setUnresolvedDependencies(missing...)
 		}
 
 		unresolvedDeps := node.UnresolvedDependencies()

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -824,10 +824,10 @@ func (g *Graph) ReverseTopologicalSortInLevels() [][]Name {
 	return ordered
 }
 
-// missingDeclaredDeps returns the names of a node's declared dependencies (DependsOn +
+// declaredDepsMissingEdges returns the names of a node's declared dependencies (DependsOn +
 // ImplicitDependsOn) that currently have no corresponding parent edge in the graph. It is the
 // reconcile check that makes graph edges a projection of declared deps. Caller must hold g.mu.
-func (g *Graph) missingDeclaredDeps(nodeName Name, node *GraphNode) []string {
+func (g *Graph) declaredDepsMissingEdges(nodeName Name, node *GraphNode) []string {
 	cfg := node.Config()
 	declared := cfg.Dependencies()
 	if len(declared) == 0 {
@@ -873,10 +873,10 @@ func (g *Graph) ResolveDependencies(logger logging.Logger) error {
 		// This runs for every node, not just resolved ones: in steady state all nodes are
 		// resolved so a `!hasUnresolvedDependencies()` gate would skip nothing, and gating it
 		// would leave a blind spot where a node mid-resolution (unresolved list non-empty) never
-		// notices a *different* declared dep whose edge was dropped. missingDeclaredDeps always
+		// notices a *different* declared dep whose edge was dropped. declaredDepsMissingEdges always
 		// contains the current unresolved deps (they have no edge yet), so replacing the list
 		// never drops a pending dep.
-		if missing := g.missingDeclaredDeps(nodeName, node); len(missing) > 0 {
+		if missing := g.declaredDepsMissingEdges(nodeName, node); len(missing) > 0 {
 			node.setUnresolvedDependencies(missing...)
 		}
 

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -1286,26 +1286,134 @@ func shouldMatchMultipleNodesErr(actual interface{}, expected ...interface{}) st
 // edge from the dependent's declared config deps — no re-arm bookkeeping required.
 func TestResourceGraphReconcilesDroppedDependencyEdge(t *testing.T) {
 	logger := logging.NewTestLogger(t)
+
+	t.Run("reconnects a dependent after its dependency node is re-added", func(t *testing.T) {
+		g := NewGraph(logger)
+
+		nameA := NewName(apiA, "A") // dependency
+		nameB := NewName(apiA, "B") // dependent; declares A as an implicit dep
+
+		test.That(t, g.AddNode(nameA, &GraphNode{}), test.ShouldBeNil)
+		// Declare the dependency the way modular resources do (via Validate ->
+		// ImplicitDependsOn), not the legacy explicit depends_on field.
+		bCfg := Config{API: apiA, Name: "B", ImplicitDependsOn: []string{nameA.String()}}
+		test.That(t, g.AddNode(nameB, NewUnconfiguredGraphNode(bCfg, bCfg.Dependencies())), test.ShouldBeNil)
+
+		test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+		test.That(t, g.GetAllParentsOf(nameB), test.ShouldResemble, []Name{nameA})
+
+		// Remove the dependency's node -> edge is dropped.
+		g.remove(nameA)
+		test.That(t, g.GetAllParentsOf(nameB), test.ShouldBeEmpty)
+
+		// Re-add the dependency and resolve: the edge is reconciled back from B's declared deps.
+		test.That(t, g.AddNode(nameA, &GraphNode{}), test.ShouldBeNil)
+		test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+		test.That(t, g.GetAllParentsOf(nameB), test.ShouldResemble, []Name{nameA})
+	})
+
+	t.Run("reconnects every dependent of a re-added dependency", func(t *testing.T) {
+		g := NewGraph(logger)
+
+		nameA := NewName(apiA, "A")     // shared dependency
+		nameB := NewName(apiA, "B")     // dependent 1
+		nameC := NewName(apiA, "C")     // dependent 2
+		test.That(t, g.AddNode(nameA, &GraphNode{}), test.ShouldBeNil)
+		bCfg := Config{API: apiA, Name: "B", ImplicitDependsOn: []string{nameA.String()}}
+		cCfg := Config{API: apiA, Name: "C", ImplicitDependsOn: []string{nameA.String()}}
+		test.That(t, g.AddNode(nameB, NewUnconfiguredGraphNode(bCfg, bCfg.Dependencies())), test.ShouldBeNil)
+		test.That(t, g.AddNode(nameC, NewUnconfiguredGraphNode(cCfg, cCfg.Dependencies())), test.ShouldBeNil)
+
+		test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+		test.That(t, g.GetAllParentsOf(nameB), test.ShouldResemble, []Name{nameA})
+		test.That(t, g.GetAllParentsOf(nameC), test.ShouldResemble, []Name{nameA})
+
+		g.remove(nameA)
+		test.That(t, g.GetAllParentsOf(nameB), test.ShouldBeEmpty)
+		test.That(t, g.GetAllParentsOf(nameC), test.ShouldBeEmpty)
+
+		// Both dependents must be reconciled, not just one.
+		test.That(t, g.AddNode(nameA, &GraphNode{}), test.ShouldBeNil)
+		test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+		test.That(t, g.GetAllParentsOf(nameB), test.ShouldResemble, []Name{nameA})
+		test.That(t, g.GetAllParentsOf(nameC), test.ShouldResemble, []Name{nameA})
+	})
+
+	t.Run("does not force-reconcile optional dependencies", func(t *testing.T) {
+		g := NewGraph(logger)
+
+		nameReq := NewName(apiA, "req")
+		nameOpt := NewName(apiA, "opt")
+		nameC := NewName(apiA, "C")
+		cfg := Config{
+			API: apiA, Name: "C",
+			ImplicitDependsOn:         []string{nameReq.String()},
+			ImplicitOptionalDependsOn: []string{nameOpt.String()},
+		}
+		node := NewUnconfiguredGraphNode(cfg, cfg.Dependencies())
+		test.That(t, g.AddNode(nameC, node), test.ShouldBeNil)
+
+		// Only the required dep is a reconcile candidate; the optional dep is excluded
+		// (config.Dependencies() omits ImplicitOptionalDependsOn), so a dropped optional
+		// edge stays fail-open rather than being force-rebuilt.
+		test.That(t, g.declaredDepsMissingEdges(nameC, node), test.ShouldResemble, []string{nameReq.String()})
+	})
+}
+
+// TestReconcileRearmsNodeWithPendingUnresolvedDep guards removal of the
+// !hasUnresolvedDependencies gate: a node that still has one unresolved dependency must
+// still have a *different* declared dependency's dropped edge reconciled. With the gate in
+// place, such a node is skipped entirely and the dropped edge is never rebuilt.
+func TestReconcileRearmsNodeWithPendingUnresolvedDep(t *testing.T) {
+	logger := logging.NewTestLogger(t)
 	g := NewGraph(logger)
 
-	nameA := NewName(apiA, "A") // dependency
-	nameB := NewName(apiA, "B") // dependent; declares A as an implicit dep
+	nameB := NewName(apiA, "B") // present dependency, referenced by full name
+	nameC := NewName(apiA, "C") // dependent declaring both "absent" and B
 
+	test.That(t, g.AddNode(nameB, &GraphNode{}), test.ShouldBeNil)
+	// "absent" is a simple name with no matching node, so it never resolves and keeps C on
+	// the unresolved list (needsDependencyResolution stays true); B is referenced by full
+	// name so it resolves to the real nameB node.
+	cCfg := Config{API: apiA, Name: "C", ImplicitDependsOn: []string{"absent", nameB.String()}}
+	test.That(t, g.AddNode(nameC, NewUnconfiguredGraphNode(cCfg, cCfg.Dependencies())), test.ShouldBeNil)
+
+	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+	test.That(t, g.GetAllParentsOf(nameC), test.ShouldResemble, []Name{nameB})
+
+	// Drop C's edge to B while C still has "absent" pending on its unresolved list.
+	g.remove(nameB)
+	test.That(t, g.GetAllParentsOf(nameC), test.ShouldBeEmpty)
+
+	// Re-add B ("absent" still unresolved) and resolve. Despite C having a pending unresolved
+	// dep, the reconcile must notice B's dropped edge and rebuild it.
+	test.That(t, g.AddNode(nameB, &GraphNode{}), test.ShouldBeNil)
+	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+	test.That(t, g.GetAllParentsOf(nameC), test.ShouldResemble, []Name{nameB})
+}
+
+// TestReconcileIsIdempotentInSteadyState ensures the per-pass reconcile does not re-arm
+// healthy resolved nodes (which would cause reconfigure churn). Repeated ResolveDependencies
+// calls on a steady graph must leave nodes resolved with their edges unchanged.
+func TestReconcileIsIdempotentInSteadyState(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	g := NewGraph(logger)
+
+	nameA := NewName(apiA, "A")
+	nameB := NewName(apiA, "B")
 	test.That(t, g.AddNode(nameA, &GraphNode{}), test.ShouldBeNil)
-	// Declare the dependency the way modular resources do (via Validate ->
-	// ImplicitDependsOn), not the legacy explicit depends_on field.
 	bCfg := Config{API: apiA, Name: "B", ImplicitDependsOn: []string{nameA.String()}}
-	test.That(t, g.AddNode(nameB, NewUnconfiguredGraphNode(bCfg, bCfg.Dependencies())), test.ShouldBeNil)
+	nodeB := NewUnconfiguredGraphNode(bCfg, bCfg.Dependencies())
+	test.That(t, g.AddNode(nameB, nodeB), test.ShouldBeNil)
 
 	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
 	test.That(t, g.GetAllParentsOf(nameB), test.ShouldResemble, []Name{nameA})
+	test.That(t, nodeB.hasUnresolvedDependencies(), test.ShouldBeFalse)
 
-	// Remove the dependency's node -> edge is dropped.
-	g.remove(nameA)
-	test.That(t, g.GetAllParentsOf(nameB), test.ShouldBeEmpty)
-
-	// Re-add the dependency and resolve: the edge is reconciled back from B's declared deps.
-	test.That(t, g.AddNode(nameA, &GraphNode{}), test.ShouldBeNil)
-	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
-	test.That(t, g.GetAllParentsOf(nameB), test.ShouldResemble, []Name{nameA})
+	// Subsequent passes must be no-ops: no re-arm, no edge churn.
+	for i := 0; i < 3; i++ {
+		test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+		test.That(t, nodeB.hasUnresolvedDependencies(), test.ShouldBeFalse)
+		test.That(t, g.GetAllParentsOf(nameB), test.ShouldResemble, []Name{nameA})
+	}
 }

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -1280,10 +1280,10 @@ func shouldMatchMultipleNodesErr(actual interface{}, expected ...interface{}) st
 	return ""
 }
 
-// TestResourceGraphReconcilesDroppedDependencyEdge verifies the core invariant: graph edges
-// are a reconciled projection of a node's durable declared dependencies. If a dependency's
-// node is removed (dropping the edge) and later re-added, ResolveDependencies rebuilds the
-// edge from the dependent's declared config deps — no re-arm bookkeeping required.
+// TestResourceGraphReconcilesDroppedDependencyEdge verifies the invariant that graph edges
+// represent the resources declared dependencies. If a dependency's node is removed (dropping
+// the edge) and later re-added while the dependent never goes away, ResolveDependencies ensures
+// the edge to the re-added dependency is reconciled from the dependent's declared config deps.
 func TestResourceGraphReconcilesDroppedDependencyEdge(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
@@ -1294,8 +1294,6 @@ func TestResourceGraphReconcilesDroppedDependencyEdge(t *testing.T) {
 		nameB := NewName(apiA, "B") // dependent; declares A as an implicit dep
 
 		test.That(t, g.AddNode(nameA, &GraphNode{}), test.ShouldBeNil)
-		// Declare the dependency the way modular resources do (via Validate ->
-		// ImplicitDependsOn), not the legacy explicit depends_on field.
 		bCfg := Config{API: apiA, Name: "B", ImplicitDependsOn: []string{nameA.String()}}
 		test.That(t, g.AddNode(nameB, NewUnconfiguredGraphNode(bCfg, bCfg.Dependencies())), test.ShouldBeNil)
 
@@ -1315,9 +1313,9 @@ func TestResourceGraphReconcilesDroppedDependencyEdge(t *testing.T) {
 	t.Run("reconnects every dependent of a re-added dependency", func(t *testing.T) {
 		g := NewGraph(logger)
 
-		nameA := NewName(apiA, "A")     // shared dependency
-		nameB := NewName(apiA, "B")     // dependent 1
-		nameC := NewName(apiA, "C")     // dependent 2
+		nameA := NewName(apiA, "A") // shared dependency
+		nameB := NewName(apiA, "B") // dependent 1
+		nameC := NewName(apiA, "C") // dependent 2
 		test.That(t, g.AddNode(nameA, &GraphNode{}), test.ShouldBeNil)
 		bCfg := Config{API: apiA, Name: "B", ImplicitDependsOn: []string{nameA.String()}}
 		cCfg := Config{API: apiA, Name: "C", ImplicitDependsOn: []string{nameA.String()}}
@@ -1353,67 +1351,9 @@ func TestResourceGraphReconcilesDroppedDependencyEdge(t *testing.T) {
 		node := NewUnconfiguredGraphNode(cfg, cfg.Dependencies())
 		test.That(t, g.AddNode(nameC, node), test.ShouldBeNil)
 
-		// Only the required dep is a reconcile candidate; the optional dep is excluded
-		// (config.Dependencies() omits ImplicitOptionalDependsOn), so a dropped optional
-		// edge stays fail-open rather than being force-rebuilt.
+		// The reconcile only considers required deps: config.Dependencies() omits
+		// ImplicitOptionalDependsOn, so a missing optional dep is never reported and the
+		// reconcile will never notify the node to rebuild an optional edge.
 		test.That(t, g.declaredDepsMissingEdges(nameC, node), test.ShouldResemble, []string{nameReq.String()})
 	})
-}
-
-// TestReconcileRearmsNodeWithPendingUnresolvedDep guards removal of the
-// !hasUnresolvedDependencies gate: a node that still has one unresolved dependency must
-// still have a *different* declared dependency's dropped edge reconciled. With the gate in
-// place, such a node is skipped entirely and the dropped edge is never rebuilt.
-func TestReconcileRearmsNodeWithPendingUnresolvedDep(t *testing.T) {
-	logger := logging.NewTestLogger(t)
-	g := NewGraph(logger)
-
-	nameB := NewName(apiA, "B") // present dependency, referenced by full name
-	nameC := NewName(apiA, "C") // dependent declaring both "absent" and B
-
-	test.That(t, g.AddNode(nameB, &GraphNode{}), test.ShouldBeNil)
-	// "absent" is a simple name with no matching node, so it never resolves and keeps C on
-	// the unresolved list (needsDependencyResolution stays true); B is referenced by full
-	// name so it resolves to the real nameB node.
-	cCfg := Config{API: apiA, Name: "C", ImplicitDependsOn: []string{"absent", nameB.String()}}
-	test.That(t, g.AddNode(nameC, NewUnconfiguredGraphNode(cCfg, cCfg.Dependencies())), test.ShouldBeNil)
-
-	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
-	test.That(t, g.GetAllParentsOf(nameC), test.ShouldResemble, []Name{nameB})
-
-	// Drop C's edge to B while C still has "absent" pending on its unresolved list.
-	g.remove(nameB)
-	test.That(t, g.GetAllParentsOf(nameC), test.ShouldBeEmpty)
-
-	// Re-add B ("absent" still unresolved) and resolve. Despite C having a pending unresolved
-	// dep, the reconcile must notice B's dropped edge and rebuild it.
-	test.That(t, g.AddNode(nameB, &GraphNode{}), test.ShouldBeNil)
-	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
-	test.That(t, g.GetAllParentsOf(nameC), test.ShouldResemble, []Name{nameB})
-}
-
-// TestReconcileIsIdempotentInSteadyState ensures the per-pass reconcile does not re-arm
-// healthy resolved nodes (which would cause reconfigure churn). Repeated ResolveDependencies
-// calls on a steady graph must leave nodes resolved with their edges unchanged.
-func TestReconcileIsIdempotentInSteadyState(t *testing.T) {
-	logger := logging.NewTestLogger(t)
-	g := NewGraph(logger)
-
-	nameA := NewName(apiA, "A")
-	nameB := NewName(apiA, "B")
-	test.That(t, g.AddNode(nameA, &GraphNode{}), test.ShouldBeNil)
-	bCfg := Config{API: apiA, Name: "B", ImplicitDependsOn: []string{nameA.String()}}
-	nodeB := NewUnconfiguredGraphNode(bCfg, bCfg.Dependencies())
-	test.That(t, g.AddNode(nameB, nodeB), test.ShouldBeNil)
-
-	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
-	test.That(t, g.GetAllParentsOf(nameB), test.ShouldResemble, []Name{nameA})
-	test.That(t, nodeB.hasUnresolvedDependencies(), test.ShouldBeFalse)
-
-	// Subsequent passes must be no-ops: no re-arm, no edge churn.
-	for i := 0; i < 3; i++ {
-		test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
-		test.That(t, nodeB.hasUnresolvedDependencies(), test.ShouldBeFalse)
-		test.That(t, g.GetAllParentsOf(nameB), test.ShouldResemble, []Name{nameA})
-	}
 }

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -1289,10 +1289,12 @@ func TestResourceGraphReconcilesDroppedDependencyEdge(t *testing.T) {
 	g := NewGraph(logger)
 
 	nameA := NewName(apiA, "A") // dependency
-	nameB := NewName(apiA, "B") // dependent; declares A in its config
+	nameB := NewName(apiA, "B") // dependent; declares A as an implicit dep
 
 	test.That(t, g.AddNode(nameA, &GraphNode{}), test.ShouldBeNil)
-	bCfg := Config{API: apiA, Name: "B", DependsOn: []string{nameA.String()}}
+	// Declare the dependency the way modular resources do (via Validate ->
+	// ImplicitDependsOn), not the legacy explicit depends_on field.
+	bCfg := Config{API: apiA, Name: "B", ImplicitDependsOn: []string{nameA.String()}}
 	test.That(t, g.AddNode(nameB, NewUnconfiguredGraphNode(bCfg, bCfg.Dependencies())), test.ShouldBeNil)
 
 	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -1279,3 +1279,31 @@ func shouldMatchMultipleNodesErr(actual interface{}, expected ...interface{}) st
 	}
 	return ""
 }
+
+// TestResourceGraphReconcilesDroppedDependencyEdge verifies the core invariant: graph edges
+// are a reconciled projection of a node's durable declared dependencies. If a dependency's
+// node is removed (dropping the edge) and later re-added, ResolveDependencies rebuilds the
+// edge from the dependent's declared config deps — no re-arm bookkeeping required.
+func TestResourceGraphReconcilesDroppedDependencyEdge(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	g := NewGraph(logger)
+
+	nameA := NewName(apiA, "A") // dependency
+	nameB := NewName(apiA, "B") // dependent; declares A in its config
+
+	test.That(t, g.AddNode(nameA, &GraphNode{}), test.ShouldBeNil)
+	bCfg := Config{API: apiA, Name: "B", DependsOn: []string{nameA.String()}}
+	test.That(t, g.AddNode(nameB, NewUnconfiguredGraphNode(bCfg, bCfg.Dependencies())), test.ShouldBeNil)
+
+	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+	test.That(t, g.GetAllParentsOf(nameB), test.ShouldResemble, []Name{nameA})
+
+	// Remove the dependency's node -> edge is dropped.
+	g.remove(nameA)
+	test.That(t, g.GetAllParentsOf(nameB), test.ShouldBeEmpty)
+
+	// Re-add the dependency and resolve: the edge is reconciled back from B's declared deps.
+	test.That(t, g.AddNode(nameA, &GraphNode{}), test.ShouldBeNil)
+	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+	test.That(t, g.GetAllParentsOf(nameB), test.ShouldResemble, []Name{nameA})
+}

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -5714,51 +5714,83 @@ func TestReconfigureTracing(t *testing.T) {
 // is removed via a name collision while a surviving dependent has already resolved it, then it
 // is re-added. The reconcile design must rebuild the dependent's edge once the dependency is
 // healthy again. Asserts on the edge (a tolerant dependent can report Ready while disconnected).
+// TestDependentReconnectsAfterDependencyNodeReadded reproduces the incident: a modular
+// resource declares an *implicit* dependency (via Validate -> ImplicitDependsOn, the way
+// placemarker-ai depended on vision-predict-fish). When the dependency's node is removed and
+// later re-added while the dependent's own config is untouched (so it is never re-validated),
+// the dependency edge must be reconciled back from the dependent's retained implicit deps.
 func TestDependentReconnectsAfterDependencyNodeReadded(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
 
-	x := resource.Config{Name: "x", Model: fakeModel, API: base.API}
-	d := resource.Config{Name: "d", Model: fakeModel, API: base.API}
-	aSvc := resource.Config{Name: "a-svc", Model: fakeModel, API: slam.API}
-	bCmp := resource.Config{
-		Name: "b-cmp", Model: fakeModel, API: motor.API,
-		DependsOn: []string{"a-svc"}, ConvertedAttributes: &fakemotor.Config{},
-	}
-	bn := motor.Named("b-cmp")
+	// Precompile modules to avoid timeout issues when building takes too long.
+	testPath := rtestutils.BuildTempModule(t, "module/testmodule")
+	// Manually define models, as importing them can cause double registration.
+	sensorModel := resource.NewModel("rdk", "test", "sensordep")
 
-	r := setupLocalRobot(t, ctx, &config.Config{Components: []resource.Config{x}}, logger, WithDisableCompleteConfigWorker())
+	modCfg := config.Module{Name: "mod", ExePath: testPath}
+	filler := resource.Config{Name: "x", Model: fakeModel, API: base.API}
+	d := resource.Config{Name: "d", Model: fakeModel, API: base.API}
+	sCfg := resource.Config{Name: "s", Model: fakeModel, API: sensor.API}
+	// dep's Validate returns ["s"] as an implicit required dependency.
+	depCfg := resource.Config{
+		Name: "dep", Model: sensorModel, API: sensor.API,
+		Attributes: rutils.AttributeMap{"sensor": "s"},
+	}
+	depName := sensor.Named("dep")
+
+	r := setupLocalRobot(t, ctx,
+		&config.Config{Modules: []config.Module{modCfg}, Components: []resource.Config{filler}},
+		logger, WithDisableCompleteConfigWorker())
 	lr := r.(*localRobot)
 
-	r.Reconfigure(ctx, &config.Config{Components: []resource.Config{x, bCmp}, Services: []resource.Config{aSvc, aSvc}})
-	r.Reconfigure(ctx, &config.Config{Components: []resource.Config{x, d, bCmp}, Services: []resource.Config{aSvc, aSvc}})
-	r.Reconfigure(ctx, &config.Config{Components: []resource.Config{x, d, bCmp}, Services: []resource.Config{aSvc}})
+	// Duplicate "s" to force the name-collision removal path (which strips the dependency
+	// node and dep's edge to it without re-arming dep), then let the collision clear.
+	r.Reconfigure(ctx, &config.Config{Modules: []config.Module{modCfg}, Components: []resource.Config{filler, sCfg, sCfg, depCfg}})
+	r.Reconfigure(ctx, &config.Config{Modules: []config.Module{modCfg}, Components: []resource.Config{filler, d, sCfg, sCfg, depCfg}})
+	r.Reconfigure(ctx, &config.Config{Modules: []config.Module{modCfg}, Components: []resource.Config{filler, d, sCfg, depCfg}})
 
-	test.That(t, lr.manager.resources.GetAllParentsOf(bn), test.ShouldContain, slam.Named("a-svc"))
+	test.That(t, lr.manager.resources.GetAllParentsOf(depName), test.ShouldContain, sensor.Named("s"))
 }
 
 // TestReconcileDoesNotResurrectDroppedDependency ensures the reconcile only rebuilds edges for
-// dependencies a resource still declares: dropping B's dependency on A (and removing A) must not
-// leave B waiting on a stale A.
+// dependencies a resource still declares. When dep's implicit dependency is switched from "s"
+// to "s2", re-adding "s" must not resurrect the stale edge to "s".
 func TestReconcileDoesNotResurrectDroppedDependency(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
 
-	a := resource.Config{Name: "a", Model: fakeModel, API: base.API}
-	bDep := resource.Config{Name: "b", Model: fakeModel, API: motor.API, DependsOn: []string{"a"}, ConvertedAttributes: &fakemotor.Config{}}
-	bNoDep := resource.Config{Name: "b", Model: fakeModel, API: motor.API, DependsOn: []string{}, ConvertedAttributes: &fakemotor.Config{}}
-	bn := motor.Named("b")
+	testPath := rtestutils.BuildTempModule(t, "module/testmodule")
+	sensorModel := resource.NewModel("rdk", "test", "sensordep")
 
-	r := setupLocalRobot(t, ctx, &config.Config{Components: []resource.Config{a, bDep}}, logger, WithDisableCompleteConfigWorker())
+	modCfg := config.Module{Name: "mod", ExePath: testPath}
+	sCfg := resource.Config{Name: "s", Model: fakeModel, API: sensor.API}
+	s2Cfg := resource.Config{Name: "s2", Model: fakeModel, API: sensor.API}
+	depOnS := resource.Config{
+		Name: "dep", Model: sensorModel, API: sensor.API,
+		Attributes: rutils.AttributeMap{"sensor": "s"},
+	}
+	depOnS2 := resource.Config{
+		Name: "dep", Model: sensorModel, API: sensor.API,
+		Attributes: rutils.AttributeMap{"sensor": "s2"},
+	}
+	depName := sensor.Named("dep")
+
+	r := setupLocalRobot(t, ctx, &config.Config{
+		Modules: []config.Module{modCfg}, Components: []resource.Config{sCfg, s2Cfg, depOnS},
+	}, logger, WithDisableCompleteConfigWorker())
 	lr := r.(*localRobot)
+	test.That(t, lr.manager.resources.GetAllParentsOf(depName), test.ShouldContain, sensor.Named("s"))
 
-	r.Reconfigure(ctx, &config.Config{Components: []resource.Config{bNoDep}})
-	_, errB := r.ResourceByName(bn)
-	test.That(t, errB, test.ShouldBeNil)
-	test.That(t, lr.manager.resources.GetAllParentsOf(bn), test.ShouldBeEmpty)
+	// Switch dep's implicit dependency to "s2" and remove "s".
+	r.Reconfigure(ctx, &config.Config{
+		Modules: []config.Module{modCfg}, Components: []resource.Config{s2Cfg, depOnS2},
+	})
+	test.That(t, lr.manager.resources.GetAllParentsOf(depName), test.ShouldResemble, []resource.Name{sensor.Named("s2")})
 
-	r.Reconfigure(ctx, &config.Config{Components: []resource.Config{a, bNoDep}})
-	_, errB2 := r.ResourceByName(bn)
-	test.That(t, errB2, test.ShouldBeNil)
-	test.That(t, lr.manager.resources.GetAllParentsOf(bn), test.ShouldBeEmpty)
+	// Re-add "s". The reconcile must not resurrect the dropped edge to "s".
+	r.Reconfigure(ctx, &config.Config{
+		Modules: []config.Module{modCfg}, Components: []resource.Config{sCfg, s2Cfg, depOnS2},
+	})
+	test.That(t, lr.manager.resources.GetAllParentsOf(depName), test.ShouldResemble, []resource.Name{sensor.Named("s2")})
 }

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -5710,15 +5710,19 @@ func TestReconfigureTracing(t *testing.T) {
 	})
 }
 
-// TestDependentReconnectsAfterDependencyNodeReadded is a robot-level repro: a dependency's node
-// is removed via a name collision while a surviving dependent has already resolved it, then it
-// is re-added. The reconcile design must rebuild the dependent's edge once the dependency is
-// healthy again. Asserts on the edge (a tolerant dependent can report Ready while disconnected).
-// TestDependentReconnectsAfterDependencyNodeReadded reproduces the incident: a modular
-// resource declares an *implicit* dependency (via Validate -> ImplicitDependsOn, the way
-// placemarker-ai depended on vision-predict-fish). When the dependency's node is removed and
-// later re-added while the dependent's own config is untouched (so it is never re-validated),
-// the dependency edge must be reconciled back from the dependent's retained implicit deps.
+// TestDependentReconnectsAfterDependencyNodeReadded verifies that a dependent reconnects to a
+// dependency whose graph node is torn down and later re-added.
+//
+// The reader is a modular resource that declares an implicit dependency on sensor "s". Adding a
+// duplicate "s" triggers a name collision that removes the "s" node along with its dependents.
+// Because the reader is added in the same reconfigure, its edge to "s" has not been built yet
+// when the collision decides which dependents to remove, so the reader is not torn down; it goes
+// on to resolve "s" just before "s" is removed, and is left marked resolved with no edge to "s".
+//
+// Once the collision clears and "s" is healthy again, the reader is not re-resolved (it already
+// resolved "s" once), so nothing rebuilds the dropped edge: "s" is available but the reader stays
+// disconnected. This test guards that the edge is instead rebuilt from the reader's declared
+// dependencies.
 func TestDependentReconnectsAfterDependencyNodeReadded(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)
@@ -5729,68 +5733,30 @@ func TestDependentReconnectsAfterDependencyNodeReadded(t *testing.T) {
 	sensorModel := resource.NewModel("rdk", "test", "sensordep")
 
 	modCfg := config.Module{Name: "mod", ExePath: testPath}
-	filler := resource.Config{Name: "x", Model: fakeModel, API: base.API}
-	d := resource.Config{Name: "d", Model: fakeModel, API: base.API}
 	sCfg := resource.Config{Name: "s", Model: fakeModel, API: sensor.API}
-	// dep's Validate returns ["s"] as an implicit required dependency.
-	depCfg := resource.Config{
-		Name: "dep", Model: sensorModel, API: sensor.API,
+	// reader's Validate returns ["s"] as an implicit required dependency.
+	readerCfg := resource.Config{
+		Name: "reader", Model: sensorModel, API: sensor.API,
 		Attributes: rutils.AttributeMap{"sensor": "s"},
 	}
-	depName := sensor.Named("dep")
+	readerName := sensor.Named("reader")
 
 	r := setupLocalRobot(t, ctx,
-		&config.Config{Modules: []config.Module{modCfg}, Components: []resource.Config{filler}},
+		&config.Config{Modules: []config.Module{modCfg}},
 		logger, WithDisableCompleteConfigWorker())
 	lr := r.(*localRobot)
 
-	// Duplicate "s" to force the name-collision removal path (which strips the dependency
-	// node and dep's edge to it without re-arming dep), then let the collision clear.
-	r.Reconfigure(ctx, &config.Config{Modules: []config.Module{modCfg}, Components: []resource.Config{filler, sCfg, sCfg, depCfg}})
-	r.Reconfigure(ctx, &config.Config{Modules: []config.Module{modCfg}, Components: []resource.Config{filler, d, sCfg, sCfg, depCfg}})
-	r.Reconfigure(ctx, &config.Config{Modules: []config.Module{modCfg}, Components: []resource.Config{filler, d, sCfg, depCfg}})
+	// Add the reader together with a duplicate "s": the reader resolves an edge to "s" in the
+	// same reconfigure that the collision marks "s" for removal, so the reader is not in the
+	// collision's dependents snapshot and is left stranded when "s" is torn down.
+	r.Reconfigure(ctx, &config.Config{Modules: []config.Module{modCfg}, Components: []resource.Config{sCfg, sCfg, readerCfg}})
+	// The collision clears, leaving a single healthy "s".
+	r.Reconfigure(ctx, &config.Config{Modules: []config.Module{modCfg}, Components: []resource.Config{sCfg, readerCfg}})
 
-	test.That(t, lr.manager.resources.GetAllParentsOf(depName), test.ShouldContain, sensor.Named("s"))
-}
-
-// TestReconcileDoesNotResurrectDroppedDependency ensures the reconcile only rebuilds edges for
-// dependencies a resource still declares. When dep's implicit dependency is switched from "s"
-// to "s2", re-adding "s" must not resurrect the stale edge to "s".
-func TestReconcileDoesNotResurrectDroppedDependency(t *testing.T) {
-	ctx := context.Background()
-	logger := logging.NewTestLogger(t)
-
-	testPath := rtestutils.BuildTempModule(t, "module/testmodule")
-	sensorModel := resource.NewModel("rdk", "test", "sensordep")
-
-	modCfg := config.Module{Name: "mod", ExePath: testPath}
-	sCfg := resource.Config{Name: "s", Model: fakeModel, API: sensor.API}
-	s2Cfg := resource.Config{Name: "s2", Model: fakeModel, API: sensor.API}
-	depOnS := resource.Config{
-		Name: "dep", Model: sensorModel, API: sensor.API,
-		Attributes: rutils.AttributeMap{"sensor": "s"},
-	}
-	depOnS2 := resource.Config{
-		Name: "dep", Model: sensorModel, API: sensor.API,
-		Attributes: rutils.AttributeMap{"sensor": "s2"},
-	}
-	depName := sensor.Named("dep")
-
-	r := setupLocalRobot(t, ctx, &config.Config{
-		Modules: []config.Module{modCfg}, Components: []resource.Config{sCfg, s2Cfg, depOnS},
-	}, logger, WithDisableCompleteConfigWorker())
-	lr := r.(*localRobot)
-	test.That(t, lr.manager.resources.GetAllParentsOf(depName), test.ShouldContain, sensor.Named("s"))
-
-	// Switch dep's implicit dependency to "s2" and remove "s".
-	r.Reconfigure(ctx, &config.Config{
-		Modules: []config.Module{modCfg}, Components: []resource.Config{s2Cfg, depOnS2},
-	})
-	test.That(t, lr.manager.resources.GetAllParentsOf(depName), test.ShouldResemble, []resource.Name{sensor.Named("s2")})
-
-	// Re-add "s". The reconcile must not resurrect the dropped edge to "s".
-	r.Reconfigure(ctx, &config.Config{
-		Modules: []config.Module{modCfg}, Components: []resource.Config{sCfg, s2Cfg, depOnS2},
-	})
-	test.That(t, lr.manager.resources.GetAllParentsOf(depName), test.ShouldResemble, []resource.Name{sensor.Named("s2")})
+	// The dependency "s" is available again ...
+	_, err := r.ResourceByName(sensor.Named("s"))
+	test.That(t, err, test.ShouldBeNil)
+	// ... and the reader must be reconnected to it. Without the reconcile, "s" is available but
+	// the reader is left with no edge to it (available-but-disconnected).
+	test.That(t, lr.manager.resources.GetAllParentsOf(readerName), test.ShouldContain, sensor.Named("s"))
 }

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -5709,3 +5709,56 @@ func TestReconfigureTracing(t *testing.T) {
 		testReconfigureTracing(t, "fake-cloud-id")
 	})
 }
+
+// TestDependentReconnectsAfterDependencyNodeReadded is a robot-level repro: a dependency's node
+// is removed via a name collision while a surviving dependent has already resolved it, then it
+// is re-added. The reconcile design must rebuild the dependent's edge once the dependency is
+// healthy again. Asserts on the edge (a tolerant dependent can report Ready while disconnected).
+func TestDependentReconnectsAfterDependencyNodeReadded(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+
+	x := resource.Config{Name: "x", Model: fakeModel, API: base.API}
+	d := resource.Config{Name: "d", Model: fakeModel, API: base.API}
+	aSvc := resource.Config{Name: "a-svc", Model: fakeModel, API: slam.API}
+	bCmp := resource.Config{
+		Name: "b-cmp", Model: fakeModel, API: motor.API,
+		DependsOn: []string{"a-svc"}, ConvertedAttributes: &fakemotor.Config{},
+	}
+	bn := motor.Named("b-cmp")
+
+	r := setupLocalRobot(t, ctx, &config.Config{Components: []resource.Config{x}}, logger, WithDisableCompleteConfigWorker())
+	lr := r.(*localRobot)
+
+	r.Reconfigure(ctx, &config.Config{Components: []resource.Config{x, bCmp}, Services: []resource.Config{aSvc, aSvc}})
+	r.Reconfigure(ctx, &config.Config{Components: []resource.Config{x, d, bCmp}, Services: []resource.Config{aSvc, aSvc}})
+	r.Reconfigure(ctx, &config.Config{Components: []resource.Config{x, d, bCmp}, Services: []resource.Config{aSvc}})
+
+	test.That(t, lr.manager.resources.GetAllParentsOf(bn), test.ShouldContain, slam.Named("a-svc"))
+}
+
+// TestReconcileDoesNotResurrectDroppedDependency ensures the reconcile only rebuilds edges for
+// dependencies a resource still declares: dropping B's dependency on A (and removing A) must not
+// leave B waiting on a stale A.
+func TestReconcileDoesNotResurrectDroppedDependency(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+
+	a := resource.Config{Name: "a", Model: fakeModel, API: base.API}
+	bDep := resource.Config{Name: "b", Model: fakeModel, API: motor.API, DependsOn: []string{"a"}, ConvertedAttributes: &fakemotor.Config{}}
+	bNoDep := resource.Config{Name: "b", Model: fakeModel, API: motor.API, DependsOn: []string{}, ConvertedAttributes: &fakemotor.Config{}}
+	bn := motor.Named("b")
+
+	r := setupLocalRobot(t, ctx, &config.Config{Components: []resource.Config{a, bDep}}, logger, WithDisableCompleteConfigWorker())
+	lr := r.(*localRobot)
+
+	r.Reconfigure(ctx, &config.Config{Components: []resource.Config{bNoDep}})
+	_, errB := r.ResourceByName(bn)
+	test.That(t, errB, test.ShouldBeNil)
+	test.That(t, lr.manager.resources.GetAllParentsOf(bn), test.ShouldBeEmpty)
+
+	r.Reconfigure(ctx, &config.Config{Components: []resource.Config{a, bNoDep}})
+	_, errB2 := r.ResourceByName(bn)
+	test.That(t, errB2, test.ShouldBeNil)
+	test.That(t, lr.manager.resources.GetAllParentsOf(bn), test.ShouldBeEmpty)
+}


### PR DESCRIPTION
## Summary

Makes graph dependency edges a self-healing projection of a resource's durable declared dependencies, so a dependent can't be permanently severed from a dependency that is healthy and present.

## The bug

Once a resource resolves a dependency, the requirement is recorded **only as a graph edge** — the node's unresolved-dependency list is cleared and `ResolveDependencies` skips resolved nodes. `Graph.remove` strips a removed node out of every dependent's parent set but does not put the dependency back on the dependent's unresolved list, and the notify paths (`SetNeedsUpdate` / `SetNeedsRebuild` via `markChildrenForUpdate`) re-seed from the node's *runtime* unresolved list — empty for a resolved node — not from `config.Dependencies()`. So if a dependency's node is dropped (a name collision, module remove/re-add, remote churn), nothing re-derives the edge: the dependent looks fully resolved with no dependency and stays that way even after the dependency returns healthy.

Observed impact: two fragments defining the same resources by name collided and removed a shared vision service that a dependent in another module had already resolved; the dependent then looped on `Resource missing from dependencies` for ~35 min and only recovered when its module was manually restarted (a restart reprocesses its config, which re-seeds the full declared deps).

## History

Regressed in #2225 (Reconfiguration Refactor, Apr 2023), which introduced the lazy resolve-once model. Before it, `completeConfig` re-derived edges from `conf.Dependencies()` every pass, so a dependent re-wired on the next reconfigure. The `Graph.remove` edge-strip itself dates to #434 (2022) but was benign until #2225. This change restores that per-pass re-derivation, scoped to nodes actually missing an edge.

## Change

`ResolveDependencies` reconciles each node's edges against its durable declared deps: a dependency a node still declares (`DependsOn` + `ImplicitDependsOn`) but has no edge for is re-armed and re-resolved on that pass (`declaredDepsMissingEdges`). Edges become a projection of `(declared deps × existing nodes)` — a dropped edge rebuilds once the dependency reappears, a dropped *declared* dep is not resurrected, and optional deps (excluded from `Dependencies()`) stay fail-open. `config.Dependencies()` is durably retained across reconfigures, so this is reliable for the modular implicit deps that triggered the issue.

## Tests

- `resource/resource_graph_test.go::TestResourceGraphReconcilesDroppedDependencyEdge` — drop a dependency node under a resolved dependent, re-add, resolve → edge reconciled; subtests cover multiple dependents and optional-deps-ignored.
- `robot/impl/local_robot_test.go::TestDependentReconnectsAfterDependencyNodeReadded` — end-to-end repro through a modular implicit dep: a name collision strips the edge without re-arming the dependent, and once the dependency is healthy the dependent reconnects.

Both verified to fail without the change and pass with it. Also validated locally: the full `resource` package and the dependency/reconfigure/module-recovery suite in `robot/impl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
