### PR TITLE
armplanning: guard GetWorldState against nil ObstaclesInWorldFrame

### DIFF
--- a/motionplan/armplanning/api.go
+++ b/motionplan/armplanning/api.go
@@ -55,9 +55,11 @@ type PlanRequest struct {
 // GetWorldState is a backwards compatibility helper that turns the ObstaclesInWorldFrame back into
 // WorldState object. Presumably for interfacing/rendering with the viz-client.
 func (req *PlanRequest) GetWorldState() *referenceframe.WorldState {
-	return mustNewWorldState([]*referenceframe.GeometriesInFrame{
-		req.ObstaclesInWorldFrame,
-	}, nil)
+	var obstacles []*referenceframe.GeometriesInFrame
+	if req.ObstaclesInWorldFrame != nil {
+		obstacles = append(obstacles, req.ObstaclesInWorldFrame)
+	}
+	return mustNewWorldState(obstacles, nil)
 }
 
 // validatePlanRequest ensures PlanRequests are not malformed.


### PR DESCRIPTION
## Summary

`PlanRequest.GetWorldState()` panicked with a nil-pointer dereference for any request that has no obstacles. This makes it construct an empty `WorldState` instead, so obstacle-free plans can be visualized/rendered without crashing.

## Changes

- **motionplan/armplanning**: `GetWorldState` no longer wraps `req.ObstaclesInWorldFrame` in a slice unconditionally. When the field is nil (a request with no obstacles), the obstacles slice is left empty rather than containing a nil `*GeometriesInFrame`, which `referenceframe.NewWorldState` would dereference.

## Testing

- Manually reproduced via `go run motionplan/armplanning/cmd-plan/cmd-plan.go <plan.json>` on a modern-format plan file whose `obstacles_in_world_frame` is `null`. Before: `panic: runtime error: invalid memory address or nil pointer dereference` in the visualize step (`GetWorldState` → `NewWorldState` → `GeometriesInFrame.Geometries`). After: planning and rendering complete with exit code 0.
- No behavior change for requests that do have obstacles (the frame is still included).


🤖 Generated with [Claude Code](https://claude.com/claude-code)