### PR TITLE
spatialmath - use sentinel error for unsupported collision types

### DIFF
--- a/spatialmath/box.go
+++ b/spatialmath/box.go
@@ -196,7 +196,7 @@ func (b *box) CollidesWith(g Geometry, collisionBufferMM float64) (bool, float64
 		col, d := pointVsBoxCollision(other.position, b, collisionBufferMM)
 		return col, d, nil
 	default:
-		return true, collisionBufferMM, newCollisionTypeUnsupportedError(b, g)
+		return true, collisionBufferMM, errCollisionTypeUnsupported
 	}
 }
 
@@ -215,7 +215,7 @@ func (b *box) DistanceFrom(g Geometry) (float64, error) {
 	case *point:
 		return pointVsBoxDistance(other.position, b), nil
 	default:
-		return math.Inf(-1), newCollisionTypeUnsupportedError(b, g)
+		return math.Inf(-1), errCollisionTypeUnsupported
 	}
 }
 
@@ -234,7 +234,7 @@ func (b *box) EncompassedBy(g Geometry) (bool, error) {
 	case *point:
 		return false, nil
 	default:
-		return false, newCollisionTypeUnsupportedError(b, g)
+		return false, errCollisionTypeUnsupported
 	}
 }
 

--- a/spatialmath/capsule.go
+++ b/spatialmath/capsule.go
@@ -182,7 +182,7 @@ func (c *capsule) DistanceFrom(g Geometry) (float64, error) {
 	case *sphere:
 		return capsuleVsSphereDistance(c, other), nil
 	default:
-		return math.Inf(-1), newCollisionTypeUnsupportedError(c, g)
+		return math.Inf(-1), errCollisionTypeUnsupported
 	}
 }
 
@@ -201,7 +201,7 @@ func (c *capsule) EncompassedBy(g Geometry) (bool, error) {
 	case *point:
 		return false, nil
 	default:
-		return true, newCollisionTypeUnsupportedError(c, g)
+		return true, errCollisionTypeUnsupported
 	}
 }
 

--- a/spatialmath/errors.go
+++ b/spatialmath/errors.go
@@ -12,9 +12,7 @@ func newBadCapsuleLengthError(l, r float64) error {
 	return errors.Errorf("Capsule total length %f cannot be less than 2x radius %f", l, r)
 }
 
-func newCollisionTypeUnsupportedError(g1, g2 Geometry) error {
-	return errors.Errorf("Collisions between %T and %T are not supported", g1, g2)
-}
+var errCollisionTypeUnsupported = errors.New("unsupported collision between geometry types")
 
 func newOrientationTypeUnsupportedError(orientationType string) error {
 	return errors.Errorf("Orientation type %s unsupported in json configuration", orientationType)

--- a/spatialmath/mesh.go
+++ b/spatialmath/mesh.go
@@ -472,7 +472,7 @@ func (m *Mesh) CollidesWith(g Geometry, collisionBufferMM float64) (bool, float6
 		triMesh := NewMesh(NewZeroPose(), []*Triangle{other}, "")
 		return m.collidesWithMesh(triMesh, collisionBufferMM)
 	default:
-		return true, math.Inf(1), newCollisionTypeUnsupportedError(m, g)
+		return true, math.Inf(1), errCollisionTypeUnsupported
 	}
 }
 
@@ -533,7 +533,7 @@ func (m *Mesh) DistanceFrom(g Geometry) (float64, error) {
 	case *Cylinder:
 		return other.DistanceFrom(m)
 	default:
-		return math.Inf(-1), newCollisionTypeUnsupportedError(m, g)
+		return math.Inf(-1), errCollisionTypeUnsupported
 	}
 }
 

--- a/spatialmath/point.go
+++ b/spatialmath/point.go
@@ -110,7 +110,7 @@ func (pt *point) CollidesWith(g Geometry, collisionBufferMM float64) (bool, floa
 		}
 		return false, dist, nil
 	default:
-		return true, collisionBufferMM, newCollisionTypeUnsupportedError(pt, g)
+		return true, collisionBufferMM, errCollisionTypeUnsupported
 	}
 }
 
@@ -130,7 +130,7 @@ func (pt *point) DistanceFrom(g Geometry) (float64, error) {
 	case *point:
 		return pt.position.Sub(other.position).Norm(), nil
 	default:
-		return math.Inf(-1), newCollisionTypeUnsupportedError(pt, g)
+		return math.Inf(-1), errCollisionTypeUnsupported
 	}
 }
 

--- a/spatialmath/sphere.go
+++ b/spatialmath/sphere.go
@@ -130,7 +130,7 @@ func (s *sphere) CollidesWith(g Geometry, collisionBufferMM float64) (bool, floa
 		}
 		return false, dist, nil
 	default:
-		return true, collisionBufferMM, newCollisionTypeUnsupportedError(s, g)
+		return true, collisionBufferMM, errCollisionTypeUnsupported
 	}
 }
 
@@ -149,7 +149,7 @@ func (s *sphere) DistanceFrom(g Geometry) (float64, error) {
 	case *point:
 		return sphereVsPointDistance(s, other.position), nil
 	default:
-		return math.Inf(-1), newCollisionTypeUnsupportedError(s, g)
+		return math.Inf(-1), errCollisionTypeUnsupported
 	}
 }
 
@@ -168,7 +168,7 @@ func (s *sphere) EncompassedBy(g Geometry) (bool, error) {
 	case *point:
 		return false, nil
 	default:
-		return true, newCollisionTypeUnsupportedError(s, g)
+		return true, errCollisionTypeUnsupported
 	}
 }
 

--- a/spatialmath/triangle.go
+++ b/spatialmath/triangle.go
@@ -178,7 +178,7 @@ func (t *Triangle) CollidesWith(g Geometry, collisionBufferMM float64) (bool, fl
 	case *Cylinder:
 		return other.CollidesWith(t, collisionBufferMM)
 	default:
-		return true, collisionBufferMM, newCollisionTypeUnsupportedError(t, g)
+		return true, collisionBufferMM, errCollisionTypeUnsupported
 	}
 }
 
@@ -364,7 +364,7 @@ func (t *Triangle) DistanceFrom(g Geometry) (float64, error) {
 	case *Cylinder:
 		return other.DistanceFrom(t)
 	default:
-		return math.Inf(-1), newCollisionTypeUnsupportedError(t, g)
+		return math.Inf(-1), errCollisionTypeUnsupported
 	}
 }
 
@@ -398,7 +398,7 @@ func (t *Triangle) EncompassedBy(g Geometry) (bool, error) {
 		}
 		return true, nil
 	default:
-		return false, newCollisionTypeUnsupportedError(t, g)
+		return false, errCollisionTypeUnsupported
 	}
 }
 


### PR DESCRIPTION
Replace `newCollisionTypeUnsupportedError` (which called `errors.Errorf` on every invocation) with a package level sentinel `errCollisionTypeUnsupported` matching the existing `errGeometryTypeUnsupported` already used

## Motivation
Running against the sanding module: 
- 8.6 GB allocated (2.5% of total)
- 58 CPU seconds (2.5% of total)

## Why this is fine
The error is returned by several function on unsupported type combinations. Its only caller `checkCollisionsHinted` treats it as a "retry with reversed args" signal and discards it. It never uses the error's contents