### PR TITLE
add TransformPointByPose helper, migrate hot-path callers

### DIFF
--- a/spatialmath/box.go
+++ b/spatialmath/box.go
@@ -541,8 +541,7 @@ func transformPointsToPose(facePoints []r3.Vector, pose Pose) []r3.Vector {
 	// point at specified offset with desired orientation
 	offsetBy := Compose(identityPose, originWithPose)
 	for i := range facePoints {
-		transformedVec := Compose(offsetBy, NewPoseFromPoint(facePoints[i])).Point()
-		transformedVectors = append(transformedVectors, transformedVec)
+		transformedVectors = append(transformedVectors, TransformPointByPose(offsetBy, facePoints[i]))
 	}
 	return transformedVectors
 }

--- a/spatialmath/capsule.go
+++ b/spatialmath/capsule.go
@@ -56,8 +56,8 @@ func NewCapsule(offset Pose, radius, length float64, label string) (Geometry, er
 
 // Will precalculate the linear endpoints for a capsule.
 func newCapsuleWithSegPoints(offset Pose, radius, length float64, label string) Geometry {
-	segA := Compose(offset, NewPoseFromPoint(r3.Vector{0, 0, -length/2 + radius})).Point()
-	segB := Compose(offset, NewPoseFromPoint(r3.Vector{0, 0, length/2 - radius})).Point()
+	segA := TransformPointByPose(offset, r3.Vector{0, 0, -length/2 + radius})
+	segB := TransformPointByPose(offset, r3.Vector{0, 0, length/2 - radius})
 	center := offset.Point()
 
 	return &capsule{
@@ -118,14 +118,14 @@ func (c *capsule) almostEqual(g Geometry) bool {
 // Transform premultiplies the capsule pose with a transform, allowing the capsule to be moved in space.
 func (c *capsule) Transform(toPremultiply Pose) Geometry {
 	newPose := Compose(toPremultiply, c.pose)
-	segB := Compose(toPremultiply, NewPoseFromPoint(c.segB)).Point()
+	segB := TransformPointByPose(toPremultiply, c.segB)
 	center := newPose.Point()
 	return &capsule{
 		pose:   newPose,
 		radius: c.radius,
 		length: c.length,
 		label:  c.label,
-		segA:   Compose(toPremultiply, NewPoseFromPoint(c.segA)).Point(),
+		segA:   TransformPointByPose(toPremultiply, c.segA),
 		segB:   segB,
 		center: center,
 		capVec: segB.Sub(center),

--- a/spatialmath/cylinder.go
+++ b/spatialmath/cylinder.go
@@ -207,7 +207,7 @@ func (c *Cylinder) ToPoints(resolution float64) []r3.Vector {
 // containsPoint reports whether the given world-frame point lies within the
 // Cylinder's solid volume (inclusive of surface).
 func (c *Cylinder) containsPoint(p r3.Vector) bool {
-	local := Compose(PoseInverse(c.pose), NewPoseFromPoint(p)).Point()
+	local := TransformPointByPose(PoseInverse(c.pose), p)
 	return math.Abs(local.Z) <= c.height/2 &&
 		local.X*local.X+local.Y*local.Y <= c.radius*c.radius
 }
@@ -221,7 +221,7 @@ func (c *Cylinder) containsSphere(center r3.Vector, radius float64) bool {
 	if halfH < 0 || rShrink < 0 {
 		return false
 	}
-	local := Compose(PoseInverse(c.pose), NewPoseFromPoint(center)).Point()
+	local := TransformPointByPose(PoseInverse(c.pose), center)
 	return math.Abs(local.Z) <= halfH &&
 		local.X*local.X+local.Y*local.Y <= rShrink*rShrink
 }

--- a/spatialmath/mesh.go
+++ b/spatialmath/mesh.go
@@ -832,7 +832,7 @@ func (m *Mesh) ToPoints(density float64) []r3.Vector {
 		for row := range miniBaseCount + 1 {
 			for col := range miniBaseCount + 1 - row {
 				pt := rowVec.Mul(float64(row)).Add(colVec.Mul(float64(col))).Add(baseP0)
-				worldPt := Compose(m.pose, NewPoseFromPoint(pt)).Point()
+				worldPt := TransformPointByPose(m.pose, pt)
 				key := fmt.Sprintf("%.10f,%.10f,%.10f", worldPt.X, worldPt.Y, worldPt.Z)
 				pointMap[key] = worldPt
 			}

--- a/spatialmath/point.go
+++ b/spatialmath/point.go
@@ -60,7 +60,7 @@ func (pt *point) almostEqual(g Geometry) bool {
 
 // Transform premultiplies the point pose with a transform, allowing the point to be moved in space.
 func (pt *point) Transform(toPremultiply Pose) Geometry {
-	return &point{Compose(toPremultiply, NewPoseFromPoint(pt.position)).Point(), pt.label}
+	return &point{TransformPointByPose(toPremultiply, pt.position), pt.label}
 }
 
 // ToProto converts the point to a Geometry proto message.

--- a/spatialmath/pose.go
+++ b/spatialmath/pose.go
@@ -90,6 +90,13 @@ func Compose(a, b Pose) Pose {
 	return &DualQuaternion{DualQuaternionFromPose(a).Transformation(DualQuaternionFromPose(b).Number)}
 }
 
+func TransformPointByPose(pose Pose, pt r3.Vector) r3.Vector {
+	if dq, ok := pose.(*DualQuaternion); ok {
+		return TransformPoint(dq.Real, dq.Point(), pt)
+	}
+	return TransformPoint(pose.Orientation().Quaternion(), pose.Point(), pt)
+}
+
 // PoseBetween returns the difference between two dualQuaternions, that is, the dq which if multiplied by one will give the other.
 // Example: if PoseBetween(a, b) = c, then Compose(a, c) = b.
 func PoseBetween(a, b Pose) Pose {

--- a/spatialmath/pose.go
+++ b/spatialmath/pose.go
@@ -90,7 +90,9 @@ func Compose(a, b Pose) Pose {
 	return &DualQuaternion{DualQuaternionFromPose(a).Transformation(DualQuaternionFromPose(b).Number)}
 }
 
-// TransformPointByPose returns pt transformed by pose.
+// TransformPointByPose returns pt transformed by pose. Equivalent to
+// Compose(pose, NewPoseFromPoint(pt)).Point() but avoids two intermediate
+// *DualQuaternion heap allocations on the *DualQuaternion fast path.
 func TransformPointByPose(pose Pose, pt r3.Vector) r3.Vector {
 	if dq, ok := pose.(*DualQuaternion); ok {
 		return TransformPoint(dq.Real, dq.Point(), pt)

--- a/spatialmath/pose.go
+++ b/spatialmath/pose.go
@@ -90,6 +90,7 @@ func Compose(a, b Pose) Pose {
 	return &DualQuaternion{DualQuaternionFromPose(a).Transformation(DualQuaternionFromPose(b).Number)}
 }
 
+// TransformPointByPose returns pt transformed by pose.
 func TransformPointByPose(pose Pose, pt r3.Vector) r3.Vector {
 	if dq, ok := pose.(*DualQuaternion); ok {
 		return TransformPoint(dq.Real, dq.Point(), pt)


### PR DESCRIPTION
Add TransformPointByPose - computes `Compose` with zero heap allocations on the `DualQuaternion` fast path

## Measured Impact
Plan paths in the sanding module: 
- `Compose`: -6.76 GB (-37%)
- `newDualQuaternion`: -6.70 GB (-42%)
- Net: ~-13 GB / -4% of 305 GB baseline