### PR TITLE
Give shell service a controlling terminal on unix (viam machine part shell tunneling)

### DIFF
--- a/services/shell/builtin/builtin.go
+++ b/services/shell/builtin/builtin.go
@@ -74,6 +74,8 @@ func (svc *builtIn) Shell(ctx context.Context, extra map[string]interface{}) (
 		cancel()
 		return nil, nil, nil, err
 	}
+	// xpty.Start doesn't give the child a controlling terminal, so interactive shells lose job control on unix
+	setControllingTTY(cmd)
 	if err := f.Start(cmd); err != nil {
 		cancel()
 		utils.UncheckedError(f.Close())

--- a/services/shell/builtin/tty_posix.go
+++ b/services/shell/builtin/tty_posix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package builtin
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func setControllingTTY(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+	cmd.SysProcAttr.Setctty = true
+}

--- a/services/shell/builtin/tty_windows.go
+++ b/services/shell/builtin/tty_windows.go
@@ -1,0 +1,6 @@
+package builtin
+
+import "os/exec"
+
+// setControllingTTY is a no-op on Windows; ConPTY handles the console session.
+func setControllingTTY(_ *exec.Cmd) {}


### PR DESCRIPTION
I recently updated shell service on the viam-server side into a windows-friendly ptty, but it didn't automatically give job control over the opened shell. 

Testing shelling from linux into mac:
Before(see warning pop up about job control + ctrl-z does not work):
```
viam machine part shell --part-id=xxx
bash: no job control in this shell
bash-3.2$ sleep 30
^Z^Z^Z
```

After:
```
viam machine part shell --part-id=xxx
bash-3.2$ sleep 300
^Z
[2]+  Stopped
```
mac to linux:
```
➜  rdk git:(fix-shell-tunnel) ✗ viam machine part shell --part-id
Info: Ensure machine part has a valid shell type service
bash: cannot set terminal process group (15211): Inappropriate ioctl for device
bash: no job control in this shell
root@arduino:/opt/viam# sleep 30
^C^Z^Z                                  
➜  rdk git:(fix-shell-tunnel) ✗ viam machine part shell --part-id
Info: Ensure machine part has a valid shell type service
root@arduino:/home/arduino# sleep 30
^Z
[1]+  Stopped                 sleep 30
root@arduino:/home/arduino# 
```
Also confirmed that I can still shell into windows with no warnings popping up - no code was really changed on the windows side (added a no-op function) so makes sense

