### PR TITLE
APP-16177 Disallow SetStreamOptions to invalid resolutions

### DIFF
--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -401,7 +401,7 @@ func validateSetStreamOptionsRequest(req *streampb.SetStreamOptionsRequest) (int
 func (server *Server) resizeVideoSource(ctx context.Context, name string, width, height int) error {
 	if width > 1000 && height > 600 {
 		// TODO - this should be smarter, ideally knowing what the original stream is
-		server.logger.Debugf("not resizing (%s) to %d, %d because it's probable a bad idea as it's too big",
+		server.logger.Debugf("not resizing (%s) to %d, %d because it's probably a bad idea as it's too big",
 			name, width, height)
 		return nil
 	}

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -310,7 +310,26 @@ func (server *Server) GetStreamOptions(
 	if req.Name == "" {
 		return nil, errors.New("stream name is required")
 	}
-	cam, err := camera.FromProvider(server.robot, req.Name)
+	scaledResolutions, err := server.availableResolutions(ctx, req.Name)
+	if err != nil {
+		return nil, err
+	}
+	resolutions := make([]*streampb.Resolution, 0, len(scaledResolutions))
+	for _, res := range scaledResolutions {
+		resolutions = append(resolutions, &streampb.Resolution{
+			Height: res.Height,
+			Width:  res.Width,
+		})
+	}
+	return &streampb.GetStreamOptionsResponse{
+		Resolutions: resolutions,
+	}, nil
+}
+
+// availableResolutions returns the resolutions that GetStreamOptions would report for the
+// named camera: the original resolution plus scaled-down variants.
+func (server *Server) availableResolutions(ctx context.Context, name string) ([]Resolution, error) {
+	cam, err := camera.FromProvider(server.robot, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get camera from robot: %w", err)
 	}
@@ -330,17 +349,7 @@ func (server *Server) GetStreamOptions(
 	} else {
 		width, height = camProps.IntrinsicParams.Width, camProps.IntrinsicParams.Height
 	}
-	scaledResolutions := GenerateResolutions(int32(width), int32(height), server.logger)
-	resolutions := make([]*streampb.Resolution, 0, len(scaledResolutions))
-	for _, res := range scaledResolutions {
-		resolutions = append(resolutions, &streampb.Resolution{
-			Height: res.Height,
-			Width:  res.Width,
-		})
-	}
-	return &streampb.GetStreamOptionsResponse{
-		Resolutions: resolutions,
-	}, nil
+	return GenerateResolutions(int32(width), int32(height), server.logger), nil
 }
 
 // SetStreamOptions implements part of the StreamServiceServer. It sets the resolution of the stream
@@ -349,7 +358,7 @@ func (server *Server) SetStreamOptions(
 	ctx context.Context,
 	req *streampb.SetStreamOptionsRequest,
 ) (*streampb.SetStreamOptionsResponse, error) {
-	cmd, err := validateSetStreamOptionsRequest(req)
+	cmd, err := server.validateSetStreamOptionsRequest(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +382,7 @@ func (server *Server) SetStreamOptions(
 }
 
 // validateSetStreamOptionsRequest validates the request to set the stream options.
-func validateSetStreamOptionsRequest(req *streampb.SetStreamOptionsRequest) (int, error) {
+func (server *Server) validateSetStreamOptionsRequest(ctx context.Context, req *streampb.SetStreamOptionsRequest) (int, error) {
 	if req.Name == "" {
 		return optionsCommandUnknown, errors.New("stream name is required in request")
 	}
@@ -394,17 +403,25 @@ func validateSetStreamOptionsRequest(req *streampb.SetStreamOptionsRequest) (int
 				req.Name, req.Resolution.Width, req.Resolution.Height,
 			)
 	}
-	return optionsCommandResize, nil
+	// Only allow resizing to a resolution reported as usable by GetStreamOptions.
+	resolutions, err := server.availableResolutions(ctx, req.Name)
+	if err != nil {
+		return optionsCommandUnknown, err
+	}
+	for _, res := range resolutions {
+		if req.Resolution.Width == res.Width && req.Resolution.Height == res.Height {
+			return optionsCommandResize, nil
+		}
+	}
+	return optionsCommandUnknown,
+		fmt.Errorf(
+			"invalid resolution to resize stream %q: width (%d) and height (%d) do not match a resolution returned by GetStreamOptions",
+			req.Name, req.Resolution.Width, req.Resolution.Height,
+		)
 }
 
 // resizeVideoSource resizes the video source with the given name.
 func (server *Server) resizeVideoSource(ctx context.Context, name string, width, height int) error {
-	if width > 1000 && height > 600 {
-		// TODO - this should be smarter, ideally knowing what the original stream is
-		server.logger.Debugf("not resizing (%s) to %d, %d because it's probably a bad idea as it's too big",
-			name, width, height)
-		return nil
-	}
 	existing, ok := server.videoSources[name]
 	if !ok {
 		return fmt.Errorf("video source %q not found", name)

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -401,7 +401,7 @@ func validateSetStreamOptionsRequest(req *streampb.SetStreamOptionsRequest) (int
 func (server *Server) resizeVideoSource(ctx context.Context, name string, width, height int) error {
 	if width > 1000 && height > 600 {
 		// TODO - this should be smarter, ideally knowing what the original stream is
-		server.logger.Infof("not resizing (%s) to %d, %d because it's probable a bad idea as it's too big",
+		server.logger.Debugf("not resizing (%s) to %d, %d because it's probable a bad idea as it's too big",
 			name, width, height)
 		return nil
 	}

--- a/robot/web/stream/state/state.go
+++ b/robot/web/stream/state/state.go
@@ -301,7 +301,8 @@ func (state *StreamState) tick() {
 	// If we are currently using passthrough, and the stream state changes to resized
 	// we need to stop the passthrough stream and restart it through gostream.
 	case state.streamSource == streamSourcePassthrough && state.isResized:
-		state.logger.Info("stream resized, stopping passthrough stream")
+		state.logger.Warn("stream resized; falling back from rtp_passthrough to GoStream, which will increase CPU utilization. " +
+			"Reset the stream to its original resolution to restore rtp_passthrough")
 		state.stopInputStream()
 		state.Stream.Start()
 		state.streamSource = streamSourceGoStream

--- a/robot/web/stream/stream_test.go
+++ b/robot/web/stream/stream_test.go
@@ -427,7 +427,7 @@ func TestSetStreamOptions(t *testing.T) {
 		})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, setStreamOptionsResp, test.ShouldBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "not found")
+		test.That(t, err.Error(), test.ShouldContainSubstring, "failed to get camera")
 	})
 
 	t.Run("SetStreamOptions without name", func(t *testing.T) {
@@ -457,6 +457,17 @@ func TestSetStreamOptions(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, setStreamOptionsResp, test.ShouldBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "invalid resolution")
+	})
+
+	// Test setting stream options with a resolution not reported by GetStreamOptions
+	t.Run("SetStreamOptions with unavailable resolution", func(t *testing.T) {
+		setStreamOptionsResp, err := livestreamClient.SetStreamOptions(ctx, &streampb.SetStreamOptionsRequest{
+			Name:       "fake-cam-0-0",
+			Resolution: &streampb.Resolution{Width: 300, Height: 200},
+		})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, setStreamOptionsResp, test.ShouldBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "do not match a resolution returned by GetStreamOptions")
 	})
 
 	t.Run("AddStream creates video track", func(t *testing.T) {
@@ -509,9 +520,16 @@ func TestSetStreamOptions(t *testing.T) {
 	})
 
 	t.Run("SetStreamOptions with RTPPassthrough enabled", func(t *testing.T) {
+		// The RTP passthrough fake camera ignores the configured width and height, so ask
+		// GetStreamOptions which resolutions are actually available and pick a scaled one.
+		getStreamOptionsResp, err := livestreamClient.GetStreamOptions(ctx, &streampb.GetStreamOptionsRequest{
+			Name: "fake-cam-0-1",
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(getStreamOptionsResp.Resolutions), test.ShouldBeGreaterThan, 1)
 		setStreamOptionsResp, err := livestreamClient.SetStreamOptions(ctx, &streampb.SetStreamOptionsRequest{
 			Name:       "fake-cam-0-1",
-			Resolution: &streampb.Resolution{Width: 320, Height: 240},
+			Resolution: getStreamOptionsResp.Resolutions[1],
 		})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, setStreamOptionsResp, test.ShouldNotBeNil)


### PR DESCRIPTION
APP-16177

## What

Removes the "probably too big" guard in `resizeVideoSource` that silently ignored resize requests larger than 1000x600, and instead validates `SetStreamOptions` resize requests against the set of resolutions reported by `GetStreamOptions`. Also adds a warning log when a resize forces a stream off of RTP passthrough.

## Why

The old guard had two problems: it silently returned success without resizing (originally logging at INFO, which was noisy), and its hardcoded 1000x600 threshold had no relationship to the actual camera. Validating against `GetStreamOptions` does exactly that: clients can only set the stream to a resolution the server itself advertises as usable (the original resolution or a scaled-down variant), and invalid requests now fail loudly with an error instead of silently doing nothing. This also means resizing to the camera's original resolution is now permitted for large cameras, where the old guard silently ignored it.

The warning log addresses a review comment: resizing a stream that is using RTP passthrough automatically swaps it to the `GetImages`/`GoStream` source (and a reset swaps it back), but that swap has significant CPU utilization consequences that previously surfaced only as an Info log.

## Testing

  - Adds a `SetStreamOptions` with unavailable resolution subtest verifying that a resolution not reported by `GetStreamOptions` (300x200 on a 640x480 camera) is rejected with an error
  - Updates the `SetStreamOptions` with invalid stream name subtest: validation now fails earlier with failed to get camera rather than the old video source not found path.
  - Updates the `SetStreamOptions` with RTPPassthrough enabled subtest to pick a resolution from a live `GetStreamOptions` call

  [Description generated by Claude 🤖]
