### PR TITLE
[RSDK-14191]: Don't resolve a dependency that is marked for removal

### DIFF
--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -882,6 +882,16 @@ func (g *Graph) ResolveDependencies(logger logging.Logger) error {
 
 			resolvedName, resolved := tryResolve()
 			if resolved {
+				// Don't resolve a dependency whose node is already marked for removal. The node
+				// is still present (removal happens after this pass), but building an edge to it
+				// now would be stripped when it is removed, leaving this resource resolved with
+				// no edge and no way to notice. Instead, leave the dependency unresolved so it is
+				// re-resolved on a later pass once a live node with that name exists.
+				if depNode, ok := g.nodes.Get(resolvedName); ok && depNode.MarkedForRemoval() {
+					resolved = false
+				}
+			}
+			if resolved {
 				if err := g.addChild(nodeName, resolvedName); err != nil {
 					allErrs = multierr.Combine(allErrs, err)
 					logger.Errorw(

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -883,10 +883,10 @@ func (g *Graph) ResolveDependencies(logger logging.Logger) error {
 			resolvedName, resolved := tryResolve()
 			if resolved {
 				// Don't resolve a dependency whose node is already marked for removal. The node
-				// is still present (removal happens after this pass), but building an edge to it
-				// now would be stripped when it is removed, leaving this resource resolved with
-				// no edge and no way to notice. Instead, leave the dependency unresolved so it is
-				// re-resolved on a later pass once a live node with that name exists.
+				// is still present (removal happens later), but building an edge to it now would
+				// be stripped when it is removed, leaving this resource resolved with no edge and
+				// no way to notice. Instead, leave the dependency unresolved so it is re-resolved
+				// on a later pass once a live node with that name exists.
 				if depNode, ok := g.nodes.Get(resolvedName); ok && depNode.MarkedForRemoval() {
 					resolved = false
 				}

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -831,9 +831,11 @@ func (g *Graph) ReverseTopologicalSortInLevels() [][]Name {
 // node resolves a dependency, the requirement lives on solely as a graph edge, so
 // if that edge is later removed (e.g. the dependency is removed) without the dependent
 // being removed or re-marking the dependency as unresolved, this pass will not rebuild
-// the edge even if the dependency is later re-added. Every resource-removal path at the
-// robot level either cascades removal to the dependent or marks it to re-resolve the
-// dependency, so this gap is theoretical.
+// the edge even if the dependency is later re-added. We guard on resolving a dependency
+// whose node is already marked for removal, so that a dependent node will stay pending
+// instead of building an edge that is about to be stripped, which prevents the one
+// known way of reaching this state. Other unknown paths may still reach this state, and
+// this pass would not recover a dependent stranded that way.
 func (g *Graph) ResolveDependencies(logger logging.Logger) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -826,6 +826,14 @@ func (g *Graph) ReverseTopologicalSortInLevels() [][]Name {
 
 // ResolveDependencies attempts to link up unresolved dependencies after
 // new changes to the graph.
+//
+// Note: This only resolves dependencies a node still lists as unresolved. Once a
+// node resolves a dependency, the requirement lives on solely as a graph edge, so
+// if that edge is later removed (e.g. the dependency is removed) without the dependent
+// being removed or re-marking the dependency as unresolved, this pass will not rebuild
+// the edge even if the dependency is later re-added. Every resource-removal path at the
+// robot level either cascades removal to the dependent or marks it to re-resolve the
+// dependency, so this gap is theoretical.
 func (g *Graph) ResolveDependencies(logger logging.Logger) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -889,10 +897,7 @@ func (g *Graph) ResolveDependencies(logger logging.Logger) error {
 				// on a later pass once a live node with that name exists.
 				if depNode, ok := g.nodes.Get(resolvedName); ok && depNode.MarkedForRemoval() {
 					resolved = false
-				}
-			}
-			if resolved {
-				if err := g.addChild(nodeName, resolvedName); err != nil {
+				} else if err := g.addChild(nodeName, resolvedName); err != nil {
 					allErrs = multierr.Combine(allErrs, err)
 					logger.Errorw(
 						"error adding dependency for resource as a child to parent",

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -1279,3 +1279,33 @@ func shouldMatchMultipleNodesErr(actual interface{}, expected ...interface{}) st
 	}
 	return ""
 }
+
+// TestResolveDependenciesSkipsDependencyMarkedForRemoval verifies that ResolveDependencies does
+// not build an edge to a dependency whose node is already marked for removal. Doing so would
+// leave the dependent resolved with an edge that is stripped when the node is removed, and with
+// no way to notice. Instead the dependency stays unresolved and is re-resolved once a live node
+// with that name exists.
+func TestResolveDependenciesSkipsDependencyMarkedForRemoval(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	g := NewGraph(logger)
+
+	nameA := NewName(apiA, "A") // dependency, marked for removal
+	nameB := NewName(apiA, "B") // dependent declaring A
+
+	nodeA := &GraphNode{}
+	test.That(t, g.AddNode(nameA, nodeA), test.ShouldBeNil)
+	nodeA.MarkForRemoval()
+
+	bCfg := Config{API: apiA, Name: "B", ImplicitDependsOn: []string{nameA.String()}}
+	test.That(t, g.AddNode(nameB, NewUnconfiguredGraphNode(bCfg, bCfg.Dependencies())), test.ShouldBeNil)
+
+	// A is present but marked for removal, so B must not resolve it: no edge, stays pending.
+	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+	test.That(t, g.GetAllParentsOf(nameB), test.ShouldBeEmpty)
+
+	// Replace A with a live node; B now resolves it on the next pass.
+	g.remove(nameA)
+	test.That(t, g.AddNode(nameA, &GraphNode{}), test.ShouldBeNil)
+	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+	test.That(t, g.GetAllParentsOf(nameB), test.ShouldResemble, []Name{nameA})
+}

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -1281,10 +1281,7 @@ func shouldMatchMultipleNodesErr(actual interface{}, expected ...interface{}) st
 }
 
 // TestResolveDependenciesSkipsDependencyMarkedForRemoval verifies that ResolveDependencies does
-// not build an edge to a dependency whose node is already marked for removal. Doing so would
-// leave the dependent resolved with an edge that is stripped when the node is removed, and with
-// no way to notice. Instead the dependency stays unresolved and is re-resolved once a live node
-// with that name exists.
+// not build an edge to a dependency whose node is already marked for removal.
 func TestResolveDependenciesSkipsDependencyMarkedForRemoval(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	g := NewGraph(logger)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -5713,13 +5713,13 @@ func TestReconfigureTracing(t *testing.T) {
 // TestDependentReconnectsAfterDependencyNodeReadded verifies that a dependent stays connected to
 // a dependency whose graph node is torn down and re-added.
 //
-// The reader is a modular resource that declares an implicit dependency on sensor "s". Adding a
-// duplicate "s" triggers a name collision that removes the "s" node along with its dependents.
-// Because the reader is added in the same reconfigure, its edge to "s" is not built yet when the
-// collision snapshots which dependents to remove, so the reader is not torn down. Without care it
-// would then resolve "s" moments before "s" is removed and be left resolved with no edge; because
-// resolution skips a dependency that is already marked for removal, the reader instead stays
-// pending and links to the healthy "s" once the collision clears.
+// The reader is a modular resource that declares a dependency on sensor "s". Adding a duplicate
+// "s" triggers a name collision that removes the "s" node along with its dependents. The reader
+// is added in the same reconfigure, but its edge to "s" is not built yet when the collision
+// snapshots which dependents to remove, so the reader is not torn down. It would then resolve
+// "s" moments before "s" is removed and would then stay resolved with no edge, however resolution
+// skips a dependency that is already marked for removal, so the reader instead stays pending and
+// links to the healthy "s" once the collision clears.
 func TestDependentReconnectsAfterDependencyNodeReadded(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -5709,3 +5709,49 @@ func TestReconfigureTracing(t *testing.T) {
 		testReconfigureTracing(t, "fake-cloud-id")
 	})
 }
+
+// TestDependentReconnectsAfterDependencyNodeReadded verifies that a dependent stays connected to
+// a dependency whose graph node is torn down and re-added.
+//
+// The reader is a modular resource that declares an implicit dependency on sensor "s". Adding a
+// duplicate "s" triggers a name collision that removes the "s" node along with its dependents.
+// Because the reader is added in the same reconfigure, its edge to "s" is not built yet when the
+// collision snapshots which dependents to remove, so the reader is not torn down. Without care it
+// would then resolve "s" moments before "s" is removed and be left resolved with no edge; because
+// resolution skips a dependency that is already marked for removal, the reader instead stays
+// pending and links to the healthy "s" once the collision clears.
+func TestDependentReconnectsAfterDependencyNodeReadded(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+
+	// Precompile modules to avoid timeout issues when building takes too long.
+	testPath := rtestutils.BuildTempModule(t, "module/testmodule")
+	// Manually define models, as importing them can cause double registration.
+	sensorModel := resource.NewModel("rdk", "test", "sensordep")
+
+	modCfg := config.Module{Name: "mod", ExePath: testPath}
+	sCfg := resource.Config{Name: "s", Model: fakeModel, API: sensor.API}
+	// reader's Validate returns ["s"] as an implicit required dependency.
+	readerCfg := resource.Config{
+		Name: "reader", Model: sensorModel, API: sensor.API,
+		Attributes: rutils.AttributeMap{"sensor": "s"},
+	}
+	readerName := sensor.Named("reader")
+
+	r := setupLocalRobot(t, ctx,
+		&config.Config{Modules: []config.Module{modCfg}},
+		logger, WithDisableCompleteConfigWorker())
+	lr := r.(*localRobot)
+
+	// Add the reader together with a duplicate "s": the reader would resolve an edge to "s" in
+	// the same reconfigure that the collision marks "s" for removal.
+	r.Reconfigure(ctx, &config.Config{Modules: []config.Module{modCfg}, Components: []resource.Config{sCfg, sCfg, readerCfg}})
+	// The collision clears, leaving a single healthy "s".
+	r.Reconfigure(ctx, &config.Config{Modules: []config.Module{modCfg}, Components: []resource.Config{sCfg, readerCfg}})
+
+	// The dependency "s" is available ...
+	_, err := r.ResourceByName(sensor.Named("s"))
+	test.That(t, err, test.ShouldBeNil)
+	// ... and the reader is connected to it, rather than left available-but-disconnected.
+	test.That(t, lr.manager.resources.GetAllParentsOf(readerName), test.ShouldContain, sensor.Named("s"))
+}

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -5754,4 +5754,12 @@ func TestDependentReconnectsAfterDependencyNodeReadded(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	// ... and the reader is connected to it, rather than left available-but-disconnected.
 	test.That(t, lr.manager.resources.GetAllParentsOf(readerName), test.ShouldContain, sensor.Named("s"))
+	// ... and the edge is actually usable. The reader's Readings implementation just forwards
+	// the call to its sensor dependency "s" so this call travels test -> reader -> s (hop over
+	// the reader->s edge). If that edge existed in the graph but the underlying client was
+	// unusable, this would error even though the GetAllParentsOf check above passed.
+	reader, err := r.ResourceByName(readerName)
+	test.That(t, err, test.ShouldBeNil)
+	_, err = reader.(sensor.Sensor).Readings(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
 }

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -301,8 +301,7 @@ func TestModularResources(t *testing.T) {
 		_, err = r.ResourceByName(cfg2.ResourceName())
 		test.That(t, err, test.ShouldNotBeNil)
 		// The dependency was removed, so it is now unresolved. (Resolution skips a dependency
-		// marked for removal, so the dependent is never built against the doomed node and never
-		// caches a transient "pending removal" error.)
+		// marked for removal, so the dependent is never built against the doomed node.)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "unresolved dependencies")
 		_, err = r.ResourceByName(cfg3.ResourceName())
 		test.That(t, err, test.ShouldNotBeNil)

--- a/robot/impl/resource_manager_modular_test.go
+++ b/robot/impl/resource_manager_modular_test.go
@@ -300,7 +300,10 @@ func TestModularResources(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		_, err = r.ResourceByName(cfg2.ResourceName())
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "pending")
+		// The dependency was removed, so it is now unresolved. (Resolution skips a dependency
+		// marked for removal, so the dependent is never built against the doomed node and never
+		// caches a transient "pending removal" error.)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "unresolved dependencies")
 		_, err = r.ResourceByName(cfg3.ResourceName())
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err, test.ShouldBeError, nodeNotFoundErr(cfg3.ResourceName()))


### PR DESCRIPTION
## Description
[RSDK-14191](https://viam.atlassian.net/browse/RSDK-14191) Dependent resource loses edge to dependency when dependency's graph node is removed and re-added

Prevents a dependent from being permanently stranded from a healthy dependency, by refusing to build a graph edge to a dependency whose node is already marked for removal.

I also explored re-fetching dependencies from a nodes `conf.Dependencies` every call to `ResolveDependencies` (circumvents the `unresolvedDependecies` optimization) and re-populating a resource's dependents `unresolvedDependecies`  when it is removed (complicates low-level resource graph methods). 

## The bug

Once a resource resolves a dependency, the requirement is recorded only as a graph edge. We fetch dependencies from the module's `Validate` and store those in the graph node's `unresolvedDependencies` once at node creation. We construct each dependency and remove it from the `unresolvedDependencies` and `ResolveDependencies` skips resolved nodes thereafter. If a dependency node is torn down and the dependent isn't re-armed to re-resolve it, it ends up stranded with a missing dependency. It looks fully resolved (since `unresolvedDependencies` remains empty) but has no edge, and never reconnects even after the dependency is healthy again, until its config is reprocessed (e.g. a module restart).

The way we can end up in that state: a resource name collision marks a dependency's node for removal in `updateResources`, but the actual removal happens later in `removeMarkedAndClose`. A dependent added in the same reconfigure cycle has its edge built in between (during `completeConfig`), after the collision snapshotted which dependents to cascade-remove. So the dependent isn't torn down, resolves the doomed dependency, and is left resolved-with-no-edge once the node is removed.

## Change

In `ResolveDependencies`, after a dependency name resolves to a node, skip it if that node is `MarkedForRemoval` to leave the dependency unresolved instead of building an edge to a node that's about to disappear. The dependent stays pending and re-resolves on a later pass once a healthy node with that name exists. 

This does not rebuild an edge to a dependency that is torn down from a dependent that already successfully resolved once. I could not find a way to get into that state at the robot level. Every resource removal path re-arms the dependent with an unresolved dependency or cascades removal to the dependent, so this seems like a theoretical gap for now.

I verified the other edge-loss paths recover on their own: dependency removed from config (`markRemoved` cascades to dependents with `withDependents=true`), dependency's module removed, and remote disconnect/reconnect (`updateRemoteResourceNames` marks nodes unreachable rather than removing them, so edges persist).

## Tests

- `resource/resource_graph_test.go::TestResolveDependenciesSkipsDependencyMarkedForRemoval`: a dependency marked for removal is not resolved into an edge; the dependent stays pending and links to a live replacement.
- `robot/impl/local_robot_test.go::TestDependentReconnectsAfterDependencyNodeReadded`: a regression test for the collision scenario using a cross-modue implicit dependency: without the change the dependency comes back available but the dependent is left disconnected; with it the dependent stays connected.

Both fail without the change and pass with it.

[RSDK-14191]: https://viam.atlassian.net/browse/RSDK-14191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ