### PR TITLE
Allow configuring robot client reconnect attempts

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -27,6 +27,7 @@ const (
 	profileFlag         = "profile"
 	disableProfilesFlag = "disable-profiles"
 	profileFlagName     = "profile-name"
+	reconnectLimitFlag  = "reconnect-limit"
 
 	// TODO: RSDK-6683.
 	quietFlag = "quiet"
@@ -334,6 +335,7 @@ type globalArgs struct {
 	Quiet           bool
 	Profile         string
 	DisableProfiles bool
+	ReconnectLimit  int
 }
 
 func (ga *globalArgs) createLogger() logging.Logger {
@@ -365,14 +367,12 @@ func getValFromContext(name string, cmd *cli.Command) any {
 	return cmd.Value(camelFormatName(name))
 }
 
-// (erodkin) We don't support pointers in structs here. The problem is that when getting a value
-// from a context for a supported flag, the context will default to populating with the zero value.
-// When getting a value from the context, though, we currently have no way of know if that's going
-// to a concrete value, going to a pointer and should be a nil value, or going to a pointer but should
-// be a pointer to that default value.
-func parseStructFromCtx[T any](cmd *cli.Command) T {
-	var t T
-	tValue := reflect.ValueOf(&t).Elem()
+// same as [parseStructFromCtx], but merges changes into the struct in the
+// provided pointer. This allows for setting default values by pre-populating
+// the struct before calling this function. Panics if the defaults is not a
+// pointer to a struct.
+func mergeStructFromCtx(cmd *cli.Command, defaults any) {
+	tValue := reflect.ValueOf(defaults).Elem()
 	tType := tValue.Type()
 	for i := 0; i < tType.NumField(); i++ {
 		field := tType.Field(i)
@@ -404,7 +404,16 @@ func parseStructFromCtx[T any](cmd *cli.Command) T {
 			}
 		}
 	}
+}
 
+// (erodkin) We don't support pointers in structs here. The problem is that when getting a value
+// from a context for a supported flag, the context will default to populating with the zero value.
+// When getting a value from the context, though, we currently have no way of know if that's going
+// to a concrete value, going to a pointer and should be a nil value, or going to a pointer but should
+// be a pointer to that default value.
+func parseStructFromCtx[T any](cmd *cli.Command) T {
+	var t T
+	mergeStructFromCtx(cmd, &t)
 	return t
 }
 
@@ -412,7 +421,10 @@ func getGlobalArgs(cmd *cli.Command) (*globalArgs, error) {
 	if cmd == nil {
 		return &globalArgs{}, nil
 	}
-	gArgs := parseStructFromCtx[globalArgs](cmd)
+	gArgs := &globalArgs{
+		ReconnectLimit: -1,
+	}
+	mergeStructFromCtx(cmd, gArgs)
 	// TODO(RSDK-9361) - currently nothing prevents a developer from creating globalArgs directly
 	// and thereby bypassing this check. We should find a way to prevent direct creation and thereby
 	// programmatically enforce compliance here.
@@ -420,7 +432,7 @@ func getGlobalArgs(cmd *cli.Command) (*globalArgs, error) {
 		return nil, errors.New("profile specified with disable-profiles flag set")
 	}
 
-	return &gArgs, nil
+	return gArgs, nil
 }
 
 func createActionCommandWithT[T any](f func(context.Context, *cli.Command, T) error) func(context.Context, *cli.Command) error {
@@ -508,6 +520,10 @@ var app = &cli.Command{
 			Name:    disableProfilesFlag,
 			Aliases: []string{"disable-profile"}, // for ease of use; not backwards compatibility related
 			Usage:   "disable usage of profiles, falling back to default behavior",
+		},
+		&cli.IntFlag{
+			Name:  reconnectLimitFlag,
+			Usage: "maximum number of reconnect attempts. unlimited by default",
 		},
 	},
 	Commands: []*cli.Command{

--- a/cli/client.go
+++ b/cli/client.go
@@ -3606,7 +3606,7 @@ func MachinesPartRunAction(ctx context.Context, cmd *cli.Command, args machinesP
 			return err
 		}
 
-		robotClient, err := viamClient.connectToRobot(dialCtx, fqdn, rpcOpts, globalArgs.Debug, logger)
+		robotClient, err := viamClient.connectToRobot(dialCtx, fqdn, rpcOpts, globalArgs.Debug, globalArgs.ReconnectLimit, logger)
 		if err != nil {
 			return err
 		}
@@ -3690,6 +3690,7 @@ func RobotsPartShellAction(ctx context.Context, cmd *cli.Command, args robotsPar
 		args.Machine,
 		args.Part,
 		globalArgs.Debug,
+		globalArgs.ReconnectLimit,
 		logger,
 	)
 }
@@ -3850,6 +3851,7 @@ func (c *viamClient) machinesPartCopyFilesAction(
 					flagArgs.Machine,
 					flagArgs.Part,
 					globalArgs.Debug,
+					globalArgs.ReconnectLimit,
 					flagArgs.Recursive,
 					flagArgs.Preserve,
 					paths,
@@ -3866,6 +3868,7 @@ func (c *viamClient) machinesPartCopyFilesAction(
 					flagArgs.Machine,
 					flagArgs.Part,
 					globalArgs.Debug,
+					globalArgs.ReconnectLimit,
 					flagArgs.Recursive,
 					flagArgs.Preserve,
 					paths,
@@ -3947,6 +3950,7 @@ func (c *viamClient) machinesPartGetFTDCAction(
 		flagArgs.Machine,
 		flagArgs.Part,
 		debug,
+		gArgs.ReconnectLimit,
 		true,
 		false,
 		[]string{src},
@@ -4068,7 +4072,7 @@ func (c *viamClient) robotPartTunnel(ctx context.Context, cmd *cli.Command, args
 		return err
 	}
 
-	robotClient, err := c.connectToRobot(dialCtx, fqdn, rpcOpts, globalArgs.Debug, logger)
+	robotClient, err := c.connectToRobot(dialCtx, fqdn, rpcOpts, globalArgs.Debug, globalArgs.ReconnectLimit, logger)
 	if err != nil {
 		return err
 	}
@@ -5259,14 +5263,14 @@ func (c *viamClient) runRobotPartCommand(
 }
 
 func (c *viamClient) connectToShellService(ctx context.Context, orgStr, locStr, robotStr, partStr string,
-	debug bool,
+	debug bool, reconnectLimit int,
 	logger logging.Logger,
 ) (shell.Service, func(ctx context.Context) error, error) {
 	dialCtx, fqdn, rpcOpts, err := c.prepareDial(ctx, orgStr, locStr, robotStr, partStr, debug)
 	if err != nil {
 		return nil, nil, err
 	}
-	return c.connectToShellServiceInner(ctx, dialCtx, fqdn, rpcOpts, debug, logger)
+	return c.connectToShellServiceInner(ctx, dialCtx, fqdn, rpcOpts, debug, reconnectLimit, logger)
 }
 
 // connectToShellServiceFqdn is a shell service dialer that doesn't check org or re-fetch the part.
@@ -5274,13 +5278,14 @@ func (c *viamClient) connectToShellServiceFqdn(
 	ctx context.Context,
 	partFqdn string,
 	debug bool,
+	reconnectLimit int,
 	logger logging.Logger,
 ) (shell.Service, func(ctx context.Context) error, error) {
 	dialCtx, fqdn, rpcOpts, err := c.prepareDialInner(ctx, partFqdn, debug)
 	if err != nil {
 		return nil, nil, err
 	}
-	return c.connectToShellServiceInner(ctx, dialCtx, fqdn, rpcOpts, debug, logger)
+	return c.connectToShellServiceInner(ctx, dialCtx, fqdn, rpcOpts, debug, reconnectLimit, logger)
 }
 
 func (c *viamClient) connectToRobot(
@@ -5288,6 +5293,7 @@ func (c *viamClient) connectToRobot(
 	fqdn string,
 	rpcOpts []rpc.DialOption,
 	debug bool,
+	reconnectLimit int,
 	logger logging.Logger,
 ) (*client.RobotClient, error) {
 	if debug {
@@ -5296,7 +5302,8 @@ func (c *viamClient) connectToRobot(
 	if c.dialOverride != nil {
 		return c.dialOverride(dialCtx, fqdn, rpcOpts, logger)
 	}
-	robotClient, err := client.New(dialCtx, fqdn, logger, client.WithDialOptions(rpcOpts...))
+	robotClient, err := client.New(dialCtx, fqdn, logger,
+		client.WithDialOptions(rpcOpts...), client.WithReconnectAttempts(reconnectLimit))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not connect to machine part")
 	}
@@ -5309,9 +5316,10 @@ func (c *viamClient) connectToShellServiceInner(
 	fqdn string,
 	rpcOpts []rpc.DialOption,
 	debug bool,
+	reconnectLimit int,
 	logger logging.Logger,
 ) (shell.Service, func(ctx context.Context) error, error) {
-	robotClient, err := c.connectToRobot(dialCtx, fqdn, rpcOpts, debug, logger)
+	robotClient, err := c.connectToRobot(dialCtx, fqdn, rpcOpts, debug, reconnectLimit, logger)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -5353,9 +5361,10 @@ func (c *viamClient) startRobotPartShell(
 	ctx context.Context,
 	orgStr, locStr, robotStr, partStr string,
 	debug bool,
+	reconnectLimit int,
 	logger logging.Logger,
 ) error {
-	shellSvc, closeClient, err := c.connectToShellService(ctx, orgStr, locStr, robotStr, partStr, debug, logger)
+	shellSvc, closeClient, err := c.connectToShellService(ctx, orgStr, locStr, robotStr, partStr, debug, reconnectLimit, logger)
 	if err != nil {
 		return err
 	}
@@ -5559,6 +5568,7 @@ func (c *viamClient) copyFilesToMachine(
 	ctx context.Context,
 	orgStr, locStr, robotStr, partStr string,
 	debug bool,
+	reconnectLimit int,
 	allowRecursion bool,
 	preserve bool,
 	paths []string,
@@ -5566,7 +5576,7 @@ func (c *viamClient) copyFilesToMachine(
 	logger logging.Logger,
 	noProgress bool,
 ) error {
-	shellSvc, closeClient, err := c.connectToShellService(ctx, orgStr, locStr, robotStr, partStr, debug, logger)
+	shellSvc, closeClient, err := c.connectToShellService(ctx, orgStr, locStr, robotStr, partStr, debug, reconnectLimit, logger)
 	if err != nil {
 		return err
 	}
@@ -5578,6 +5588,7 @@ func (c *viamClient) copyFilesToFqdn(
 	ctx context.Context,
 	fqdn string,
 	debug bool,
+	reconnectLimit int,
 	allowRecursion bool,
 	preserve bool,
 	paths []string,
@@ -5585,7 +5596,7 @@ func (c *viamClient) copyFilesToFqdn(
 	logger logging.Logger,
 	noProgress bool,
 ) error {
-	shellSvc, closeClient, err := c.connectToShellServiceFqdn(ctx, fqdn, debug, logger)
+	shellSvc, closeClient, err := c.connectToShellServiceFqdn(ctx, fqdn, debug, reconnectLimit, logger)
 	if err != nil {
 		return err
 	}
@@ -5774,13 +5785,14 @@ func (c *viamClient) copyFilesFromMachine(
 	ctx context.Context,
 	orgStr, locStr, robotStr, partStr string,
 	debug bool,
+	reconnectLimit int,
 	allowRecursion bool,
 	preserve bool,
 	paths []string,
 	destination string,
 	logger logging.Logger,
 ) error {
-	shellSvc, closeClient, err := c.connectToShellService(ctx, orgStr, locStr, robotStr, partStr, debug, logger)
+	shellSvc, closeClient, err := c.connectToShellService(ctx, orgStr, locStr, robotStr, partStr, debug, reconnectLimit, logger)
 	if err != nil {
 		return err
 	}

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -1685,6 +1685,7 @@ func reloadModuleActionInner(
 				ctx,
 				part.Part.Fqdn,
 				globalArgs.Debug,
+				globalArgs.ReconnectLimit,
 				false, // allowRecursion
 				false, // preserve
 				[]string{buildPath},

--- a/cli/module_reload.go
+++ b/cli/module_reload.go
@@ -268,7 +268,7 @@ func addShellService(
 	// If we don't wait, the reload command will usually fail on first run.
 	for i := 0; i < 11; i++ {
 		time.Sleep(time.Second)
-		_, closeClient, err := vc.connectToShellServiceFqdn(ctx, part.Fqdn, args.Debug, logger)
+		_, closeClient, err := vc.connectToShellServiceFqdn(ctx, part.Fqdn, args.Debug, args.ReconnectLimit, logger)
 		if err == nil {
 			goutils.UncheckedError(closeClient(ctx))
 			return true, nil

--- a/cli/motion.go
+++ b/cli/motion.go
@@ -46,7 +46,7 @@ func motionPrintConfigAction(ctx context.Context, cmd *cli.Command, args motionP
 
 	logger := globalArgs.createLogger()
 
-	robotClient, err := client.connectToRobot(dialCtx, fqdn, rpcOpts, globalArgs.Debug, logger)
+	robotClient, err := client.connectToRobot(dialCtx, fqdn, rpcOpts, globalArgs.Debug, globalArgs.ReconnectLimit, logger)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func motionPrintStatusAction(ctx context.Context, cmd *cli.Command, args motionP
 
 	logger := globalArgs.createLogger()
 
-	robotClient, err := client.connectToRobot(dialCtx, fqdn, rpcOpts, globalArgs.Debug, logger)
+	robotClient, err := client.connectToRobot(dialCtx, fqdn, rpcOpts, globalArgs.Debug, globalArgs.ReconnectLimit, logger)
 	if err != nil {
 		return err
 	}
@@ -141,7 +141,7 @@ func motionGetPoseAction(ctx context.Context, cmd *cli.Command, args motionGetPo
 
 	logger := globalArgs.createLogger()
 
-	robotClient, err := client.connectToRobot(dialCtx, fqdn, rpcOpts, globalArgs.Debug, logger)
+	robotClient, err := client.connectToRobot(dialCtx, fqdn, rpcOpts, globalArgs.Debug, globalArgs.ReconnectLimit, logger)
 	if err != nil {
 		return err
 	}
@@ -193,7 +193,14 @@ func motionSetPoseAction(ctx context.Context, cmd *cli.Command, args motionSetPo
 
 	logger := globalArgs.createLogger()
 
-	robotClient, err := client.connectToRobot(dialCtx, fqdn, rpcOpts, globalArgs.Debug, logger)
+	robotClient, err := client.connectToRobot(
+		dialCtx,
+		fqdn,
+		rpcOpts,
+		globalArgs.Debug,
+		globalArgs.ReconnectLimit,
+		logger,
+	)
 	if err != nil {
 		return err
 	}

--- a/cli/traces.go
+++ b/cli/traces.go
@@ -131,6 +131,7 @@ func (c *viamClient) tracesGetRemoteAction(
 		flagArgs.Machine,
 		flagArgs.Part,
 		debug,
+		gArgs.ReconnectLimit,
 		true,
 		false,
 		[]string{src},

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -16,6 +16,7 @@ import (
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/grpcreflect"
+	errw "github.com/pkg/errors"
 	"github.com/samber/lo"
 	"github.com/viamrobotics/webrtc/v3"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -131,6 +132,10 @@ type RobotClient struct {
 	// webrtc. We don't want a network disconnect to result in reconnecting over tcp such that
 	// performance would be impacted.
 	serverIsWebrtcEnabled bool
+
+	// maxReconnectAttempts is how many times we will attempt to reconnect to a
+	// robot. <0 means retry forever.
+	maxReconnectAttempts int
 
 	pc         *webrtc.PeerConnection
 	sharedConn *grpc.SharedConn
@@ -299,20 +304,24 @@ func New(ctx context.Context, address string, clientLogger logging.ZapCompatible
 	heartbeatCtx, heartbeatCtxCancel := context.WithCancel(context.Background())
 
 	rc := &RobotClient{
-		Named:               resource.NewName(RemoteAPI, rOpts.remoteName).AsNamed(),
-		remoteName:          rOpts.remoteName,
-		address:             address,
-		backgroundCtx:       backgroundCtx,
-		backgroundCtxCancel: backgroundCtxCancel,
-		logger:              logger,
-		dialOptions:         rOpts.dialOptions,
-		notifyParent:        nil,
-		conn:                grpc.ReconfigurableClientConn{Logger: logger},
-		resourceClients:     make(map[resource.Name]resource.Resource),
-		remoteNameMap:       make(map[resource.Name]resource.Name),
-		sessionsDisabled:    rOpts.disableSessions,
-		heartbeatCtx:        heartbeatCtx,
-		heartbeatCtxCancel:  heartbeatCtxCancel,
+		Named:                resource.NewName(RemoteAPI, rOpts.remoteName).AsNamed(),
+		remoteName:           rOpts.remoteName,
+		address:              address,
+		backgroundCtx:        backgroundCtx,
+		backgroundCtxCancel:  backgroundCtxCancel,
+		logger:               logger,
+		dialOptions:          rOpts.dialOptions,
+		notifyParent:         nil,
+		conn:                 grpc.ReconfigurableClientConn{Logger: logger},
+		resourceClients:      make(map[resource.Name]resource.Resource),
+		remoteNameMap:        make(map[resource.Name]resource.Name),
+		sessionsDisabled:     rOpts.disableSessions,
+		heartbeatCtx:         heartbeatCtx,
+		heartbeatCtxCancel:   heartbeatCtxCancel,
+		maxReconnectAttempts: 3,
+	}
+	if attempts := rOpts.reconnectAttempts; attempts != nil {
+		rc.maxReconnectAttempts = *attempts
 	}
 
 	otelStatsHandler := otelgrpc.NewClientHandler(
@@ -682,13 +691,19 @@ func (rc *RobotClient) checkConnection(ctx context.Context, checkEvery, reconnec
 				return nil
 			}
 			var outerError error
-			for attempt := 0; attempt < 3; attempt++ {
+			for attempt := 0; rc.maxReconnectAttempts < 0 || attempt < rc.maxReconnectAttempts; attempt++ {
+				if err := ctx.Err(); err != nil {
+					outerError = errw.Wrap(err, "context cancelled during reconnect attempt")
+					break
+				}
+				rc.logger.CWarnw(ctx, "attempting to reconnect to remote", "attempt", attempt)
 				err := check()
 				if err != nil {
 					outerError = err
 					// A disconnect is terminal for this cycle, and immediately retrying a
 					// rate-limited request would only add load, so stop early in both cases.
 					if isDisconnectedError(err) || isResourceExhaustedError(err) {
+						rc.logger.Errorw("encountered terminal error, aborting reconniction attempts", "err", err)
 						break
 					}
 					// otherwise retry

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -696,7 +696,7 @@ func (rc *RobotClient) checkConnection(ctx context.Context, checkEvery, reconnec
 					outerError = errw.Wrap(err, "context cancelled during reconnect attempt")
 					break
 				}
-				rc.logger.CWarnw(ctx, "attempting to reconnect to remote", "attempt", attempt)
+				rc.logger.CWarnw(ctx, "attempting to reconnect to remote", "attempt", attempt, "limit", rc.maxReconnectAttempts)
 				err := check()
 				if err != nil {
 					outerError = err

--- a/robot/client/client_options.go
+++ b/robot/client/client_options.go
@@ -24,6 +24,11 @@ type robotClientOpts struct {
 	// it will automatically refresh every 1s
 	reconnectEvery *time.Duration
 
+	// reconnectAttempts is how many times we will attempt to reestablish a
+	// broken connection to a robot. <0 means retry infinitely, 0 means no
+	// attempts. Defaults to 3.
+	reconnectAttempts *int
+
 	// dialOptions are options using for clients dialing gRPC servers.
 	dialOptions []rpc.DialOption
 
@@ -70,6 +75,15 @@ func newFuncRobotClientOption(f func(*robotClientOpts)) *funcRobotClientOption {
 	return &funcRobotClientOption{
 		f: f,
 	}
+}
+
+// WithReconnectAttempts sets how many times we will attempt to repair a broken
+// robot connection before returning an error. <0 means retry infinitely.
+// Defaults to 3.
+func WithReconnectAttempts(attempts int) RobotClientOption {
+	return newFuncRobotClientOption(func(o *robotClientOpts) {
+		o.reconnectAttempts = &attempts
+	})
 }
 
 // WithModName attaches a unary interceptor that attaches the module name for each outgoing gRPC


### PR DESCRIPTION
# What

- Allows configuring how many times a robot client will attempt to reconnect when it detects an issue with the connection. Defaults to 3 to match the previous behavior. Context cancellation or the channel closing still cause the retry loop to abort with an error.
- Adds a global option to the cli to configure the above. Unlike the robot client code, this option defaults to an unlimited number of retries.

# Why

Using the shell copy service to transfer large files to or from robots on unreliable internet connections like boats at sea or clients our office wifi would often fail when [this retry loop][1] hit its 3 attempt limit during an intermittent network issue. Removing this limit allows these connections to succeed, albiet with many warning log lines along the way. During one test transferring a large file to a boat the loop ran for 50 iterations before the connection became healthy.

[1]: https://github.com/viamrobotics/rdk/blob/97e1c25f771582507d273cd62f498729bcbbf8b3/robot/client/client.go#L685-L699