### PR TITLE
RSDK-10491: Disable robot connectivity checks in the cli by default

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -28,6 +28,8 @@ const (
 	disableProfilesFlag = "disable-profiles"
 	profileFlagName     = "profile-name"
 
+	checkConnectedEveryFlag = "check-connected-every"
+
 	// TODO: RSDK-6683.
 	quietFlag = "quiet"
 
@@ -328,12 +330,13 @@ var dataTagByFilterFlags = append([]cli.Flag{
 type emptyArgs struct{}
 
 type globalArgs struct {
-	BaseURL         string
-	Config          string
-	Debug           bool
-	Quiet           bool
-	Profile         string
-	DisableProfiles bool
+	BaseURL             string
+	Config              string
+	Debug               bool
+	Quiet               bool
+	Profile             string
+	DisableProfiles     bool
+	CheckConnectedEvery time.Duration
 }
 
 func (ga *globalArgs) createLogger() logging.Logger {
@@ -508,6 +511,10 @@ var app = &cli.Command{
 			Name:    disableProfilesFlag,
 			Aliases: []string{"disable-profile"}, // for ease of use; not backwards compatibility related
 			Usage:   "disable usage of profiles, falling back to default behavior",
+		},
+		&cli.DurationFlag{
+			Name:  checkConnectedEveryFlag,
+			Usage: "how often the robot client should check its connection to the machine (0 disables the check)",
 		},
 	},
 	Commands: []*cli.Command{

--- a/cli/app.go
+++ b/cli/app.go
@@ -21,14 +21,13 @@ import (
 const (
 	flagAll = "all"
 
-	baseURLFlag         = "base-url"
-	configFlag          = "config"
-	debugFlag           = "debug"
-	profileFlag         = "profile"
-	disableProfilesFlag = "disable-profiles"
-	profileFlagName     = "profile-name"
-
-	checkConnectedEveryFlag = "check-connected-every"
+	baseURLFlag                 = "base-url"
+	configFlag                  = "config"
+	debugFlag                   = "debug"
+	profileFlag                 = "profile"
+	disableProfilesFlag         = "disable-profiles"
+	profileFlagName             = "profile-name"
+	checkConnectionIntervalFlag = "check-connection-interval"
 
 	// TODO: RSDK-6683.
 	quietFlag = "quiet"
@@ -513,8 +512,8 @@ var app = &cli.Command{
 			Usage:   "disable usage of profiles, falling back to default behavior",
 		},
 		&cli.DurationFlag{
-			Name:  checkConnectedEveryFlag,
-			Usage: "how often the robot client should check its connection to the machine (0 disables the check)",
+			Name:  checkConnectionIntervalFlag,
+			Usage: "check robot connection on this interval and close the client if a faulty connection cannot be repaired",
 		},
 	},
 	Commands: []*cli.Command{

--- a/cli/client.go
+++ b/cli/client.go
@@ -5296,7 +5296,15 @@ func (c *viamClient) connectToRobot(
 	if c.dialOverride != nil {
 		return c.dialOverride(dialCtx, fqdn, rpcOpts, logger)
 	}
-	robotClient, err := client.New(dialCtx, fqdn, logger, client.WithDialOptions(rpcOpts...))
+	globalArgs, err := getGlobalArgs(c.c)
+	if err != nil {
+		return nil, err
+	}
+	clientOpts := []client.RobotClientOption{
+		client.WithDialOptions(rpcOpts...),
+		client.WithCheckConnectedEvery(globalArgs.CheckConnectedEvery),
+	}
+	robotClient, err := client.New(dialCtx, fqdn, logger, clientOpts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not connect to machine part")
 	}


### PR DESCRIPTION
# What

Allows configuring how frequently the robot client checks the connection status via a global cli flag, with a default of 0 (disable the check).

# Why

Using the shell copy service to transfer large files to or from robots on unreliable internet connections like boats at sea or clients on our office wifi would often fail when [this retry loop][1] hit its 3 attempt limit during an intermittent network issue. Disabling the background connection check allowed the transfers to succeed. I am unaware of any use cases within the cli that require this background connection check, so just changed it to be disabled by default everywhere in the cli.

[1]: https://github.com/viamrobotics/rdk/blob/97e1c25f771582507d273cd62f498729bcbbf8b3/robot/client/client.go#L685-L699