### PR TITLE
Update docs.viam.com links: /dev/reference/ -> /reference/

### DIFF
--- a/app/app_client.go
+++ b/app/app_client.go
@@ -628,7 +628,7 @@ func newAppClient(conn rpc.ClientConn) *AppClient {
 //
 // For more information, see the [GetUserIDByEmail method docs].
 //
-// [GetUserIDByEmail method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getuseridbyemail
+// [GetUserIDByEmail method docs]: https://docs.viam.com/reference/apis/fleet/#getuseridbyemail
 func (c *AppClient) GetUserIDByEmail(ctx context.Context, email string) (string, error) {
 	resp, err := c.client.GetUserIDByEmail(ctx, &pb.GetUserIDByEmailRequest{
 		Email: email,
@@ -647,7 +647,7 @@ func (c *AppClient) GetUserIDByEmail(ctx context.Context, email string) (string,
 //
 // For more information, see the [CreateOrganization method docs].
 //
-// [CreateOrganization method docs]: https://docs.viam.com/dev/reference/apis/fleet/#createorganization
+// [CreateOrganization method docs]: https://docs.viam.com/reference/apis/fleet/#createorganization
 func (c *AppClient) CreateOrganization(ctx context.Context, name string) (*Organization, error) {
 	resp, err := c.client.CreateOrganization(ctx, &pb.CreateOrganizationRequest{
 		Name: name,
@@ -666,7 +666,7 @@ func (c *AppClient) CreateOrganization(ctx context.Context, name string) (*Organ
 //
 // For more information, see the [ListOrganizations method docs].
 //
-// [ListOrganizations method docs]: https://docs.viam.com/dev/reference/apis/fleet/#listorganizations
+// [ListOrganizations method docs]: https://docs.viam.com/reference/apis/fleet/#listorganizations
 func (c *AppClient) ListOrganizations(ctx context.Context) ([]*Organization, error) {
 	resp, err := c.client.ListOrganizations(ctx, &pb.ListOrganizationsRequest{})
 	if err != nil {
@@ -688,7 +688,7 @@ func (c *AppClient) ListOrganizations(ctx context.Context) ([]*Organization, err
 //
 // For more information, see the [GetOrganizationsWithAccessToLocation method docs].
 //
-// [GetOrganizationsWithAccessToLocation method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getorganizationswithaccesstolocation
+// [GetOrganizationsWithAccessToLocation method docs]: https://docs.viam.com/reference/apis/fleet/#getorganizationswithaccesstolocation
 func (c *AppClient) GetOrganizationsWithAccessToLocation(ctx context.Context, locationID string) ([]*OrganizationIdentity, error) {
 	resp, err := c.client.GetOrganizationsWithAccessToLocation(ctx, &pb.GetOrganizationsWithAccessToLocationRequest{
 		LocationId: locationID,
@@ -712,7 +712,7 @@ func (c *AppClient) GetOrganizationsWithAccessToLocation(ctx context.Context, lo
 //
 // For more information, see the [ListOrganizationsByUser method docs].
 //
-// [ListOrganizationsByUser method docs]: https://docs.viam.com/dev/reference/apis/fleet/#listorganizationsbyuser
+// [ListOrganizationsByUser method docs]: https://docs.viam.com/reference/apis/fleet/#listorganizationsbyuser
 func (c *AppClient) ListOrganizationsByUser(ctx context.Context, userID string) ([]*OrgDetails, error) {
 	resp, err := c.client.ListOrganizationsByUser(ctx, &pb.ListOrganizationsByUserRequest{
 		UserId: userID,
@@ -736,7 +736,7 @@ func (c *AppClient) ListOrganizationsByUser(ctx context.Context, userID string) 
 //
 // For more information, see the [GetOrganization method docs].
 //
-// [GetOrganization method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getorganization
+// [GetOrganization method docs]: https://docs.viam.com/reference/apis/fleet/#getorganization
 func (c *AppClient) GetOrganization(ctx context.Context, orgID string) (*Organization, error) {
 	resp, err := c.client.GetOrganization(ctx, &pb.GetOrganizationRequest{
 		OrganizationId: orgID,
@@ -755,7 +755,7 @@ func (c *AppClient) GetOrganization(ctx context.Context, orgID string) (*Organiz
 //
 // For more information, see the [GetOrganizationNamespaceAvailability method docs].
 //
-// [GetOrganizationNamespaceAvailability method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getorganizationnamespaceavailability
+// [GetOrganizationNamespaceAvailability method docs]: https://docs.viam.com/reference/apis/fleet/#getorganizationnamespaceavailability
 func (c *AppClient) GetOrganizationNamespaceAvailability(ctx context.Context, namespace string) (bool, error) {
 	resp, err := c.client.GetOrganizationNamespaceAvailability(ctx, &pb.GetOrganizationNamespaceAvailabilityRequest{
 		PublicNamespace: namespace,
@@ -780,7 +780,7 @@ func (c *AppClient) GetOrganizationNamespaceAvailability(ctx context.Context, na
 //
 // For more information, see the [UpdateOrganization method docs].
 //
-// [UpdateOrganization method docs]: https://docs.viam.com/dev/reference/apis/fleet/#updateorganization
+// [UpdateOrganization method docs]: https://docs.viam.com/reference/apis/fleet/#updateorganization
 func (c *AppClient) UpdateOrganization(ctx context.Context, orgID string, opts *UpdateOrganizationOptions) (*Organization, error) {
 	var name, namespace, region, cid *string
 	if opts != nil {
@@ -807,7 +807,7 @@ func (c *AppClient) UpdateOrganization(ctx context.Context, orgID string, opts *
 //
 // For more information, see the [DeleteOrganization method docs].
 //
-// [DeleteOrganization method docs]: https://docs.viam.com/dev/reference/apis/fleet/#deleteorganization
+// [DeleteOrganization method docs]: https://docs.viam.com/reference/apis/fleet/#deleteorganization
 func (c *AppClient) DeleteOrganization(ctx context.Context, orgID string) error {
 	_, err := c.client.DeleteOrganization(ctx, &pb.DeleteOrganizationRequest{
 		OrganizationId: orgID,
@@ -825,7 +825,7 @@ func (c *AppClient) DeleteOrganization(ctx context.Context, orgID string) error 
 //
 // For more information, see the [GetOrganizationMetadata method docs].
 //
-// [GetOrganizationMetadata method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getorganizationmetadata
+// [GetOrganizationMetadata method docs]: https://docs.viam.com/reference/apis/fleet/#getorganizationmetadata
 func (c *AppClient) GetOrganizationMetadata(ctx context.Context, organizationID string) (map[string]interface{}, error) {
 	resp, err := c.client.GetOrganizationMetadata(ctx, &pb.GetOrganizationMetadataRequest{
 		OrganizationId: organizationID,
@@ -850,7 +850,7 @@ func (c *AppClient) GetOrganizationMetadata(ctx context.Context, organizationID 
 //
 // For more information, see the [UpdateOrganizationMetadata method docs].
 //
-// [UpdateOrganizationMetadata method docs]: https://docs.viam.com/dev/reference/apis/fleet/#updateorganizationmetadata
+// [UpdateOrganizationMetadata method docs]: https://docs.viam.com/reference/apis/fleet/#updateorganizationmetadata
 func (c *AppClient) UpdateOrganizationMetadata(ctx context.Context, organizationID string, data interface{}) error {
 	d, err := protoutils.StructToStructPb(data)
 	if err != nil {
@@ -871,7 +871,7 @@ func (c *AppClient) UpdateOrganizationMetadata(ctx context.Context, organization
 //
 // For more information, see the [ListOrganizationMembers method docs].
 //
-// [ListOrganizationMembers method docs]: https://docs.viam.com/dev/reference/apis/fleet/#listorganizationmembers
+// [ListOrganizationMembers method docs]: https://docs.viam.com/reference/apis/fleet/#listorganizationmembers
 func (c *AppClient) ListOrganizationMembers(ctx context.Context, orgID string) ([]*OrganizationMember, []*OrganizationInvite, error) {
 	resp, err := c.client.ListOrganizationMembers(ctx, &pb.ListOrganizationMembersRequest{
 		OrganizationId: orgID,
@@ -910,7 +910,7 @@ func (c *AppClient) ListOrganizationMembers(ctx context.Context, orgID string) (
 //
 // For more information, see the [CreateOrganizationInvite method docs].
 //
-// [CreateOrganizationInvite method docs]: https://docs.viam.com/dev/reference/apis/fleet/#createorganizationinvite
+// [CreateOrganizationInvite method docs]: https://docs.viam.com/reference/apis/fleet/#createorganizationinvite
 func (c *AppClient) CreateOrganizationInvite(
 	ctx context.Context, orgID, email string, authorizations []*Authorization, opts *CreateOrganizationInviteOptions,
 ) (*OrganizationInvite, error) {
@@ -954,11 +954,9 @@ func (c *AppClient) CreateOrganizationInvite(
 //
 // For more information, see the [UpdateOrganizationInviteAuthorizations method docs].
 //
-// [UpdateOrganizationInviteAuthorizations method docs]: https://docs.viam.com/dev/reference/apis/fleet/#updateorganizationinviteauthorizations
+// [UpdateOrganizationInviteAuthorizations method docs]: https://docs.viam.com/reference/apis/fleet/#updateorganizationinviteauthorizations
 //
-// [UpdateOrganizationInviteAuthorizations method docs]: https://docs.viam.com/dev/reference/apis/fleet/#updateorganizationinviteauthorizations
-//
-//nolint:lll
+// [UpdateOrganizationInviteAuthorizations method docs]: https://docs.viam.com/reference/apis/fleet/#updateorganizationinviteauthorizations
 func (c *AppClient) UpdateOrganizationInviteAuthorizations(
 	ctx context.Context, orgID, email string, addAuthorizations, removeAuthorizations []*Authorization,
 ) (*OrganizationInvite, error) {
@@ -993,7 +991,7 @@ func (c *AppClient) UpdateOrganizationInviteAuthorizations(
 //
 // For more information, see the [DeleteOrganizationMember method docs].
 //
-// [DeleteOrganizationMember method docs]: https://docs.viam.com/dev/reference/apis/fleet/#deleteorganizationmember
+// [DeleteOrganizationMember method docs]: https://docs.viam.com/reference/apis/fleet/#deleteorganizationmember
 func (c *AppClient) DeleteOrganizationMember(ctx context.Context, orgID, userID string) error {
 	_, err := c.client.DeleteOrganizationMember(ctx, &pb.DeleteOrganizationMemberRequest{
 		OrganizationId: orgID,
@@ -1013,7 +1011,7 @@ func (c *AppClient) DeleteOrganizationMember(ctx context.Context, orgID, userID 
 //
 // For more information, see the [DeleteOrganizationInvite method docs].
 //
-// [DeleteOrganizationInvite method docs]: https://docs.viam.com/dev/reference/apis/fleet/#deleteorganizationinvite
+// [DeleteOrganizationInvite method docs]: https://docs.viam.com/reference/apis/fleet/#deleteorganizationinvite
 func (c *AppClient) DeleteOrganizationInvite(ctx context.Context, orgID, email string) error {
 	_, err := c.client.DeleteOrganizationInvite(ctx, &pb.DeleteOrganizationInviteRequest{
 		OrganizationId: orgID,
@@ -1030,7 +1028,7 @@ func (c *AppClient) DeleteOrganizationInvite(ctx context.Context, orgID, email s
 //
 // For more information, see the [ResendOrganizationInvite method docs].
 //
-// [ResendOrganizationInvite method docs]: https://docs.viam.com/dev/reference/apis/fleet/#resendorganizationinvite
+// [ResendOrganizationInvite method docs]: https://docs.viam.com/reference/apis/fleet/#resendorganizationinvite
 func (c *AppClient) ResendOrganizationInvite(ctx context.Context, orgID, email string) (*OrganizationInvite, error) {
 	resp, err := c.client.ResendOrganizationInvite(ctx, &pb.ResendOrganizationInviteRequest{
 		OrganizationId: orgID,
@@ -1059,7 +1057,7 @@ func (c *AppClient) EnableBillingService(ctx context.Context, orgID string, bill
 //
 // For more information, see the [DisableBillingService method docs].
 //
-// [DisableBillingService method docs]: https://docs.viam.com/dev/reference/apis/fleet/#disablebillingservice
+// [DisableBillingService method docs]: https://docs.viam.com/reference/apis/fleet/#disablebillingservice
 func (c *AppClient) DisableBillingService(ctx context.Context, orgID string) error {
 	_, err := c.client.DisableBillingService(ctx, &pb.DisableBillingServiceRequest{
 		OrgId: orgID,
@@ -1084,7 +1082,7 @@ func (c *AppClient) UpdateBillingService(ctx context.Context, orgID string, bill
 //
 // For more information, see the [OrganizationSetSupportEmail method docs].
 //
-// [OrganizationSetSupportEmail method docs]: https://docs.viam.com/dev/reference/apis/fleet/#organizationsetsupportemail
+// [OrganizationSetSupportEmail method docs]: https://docs.viam.com/reference/apis/fleet/#organizationsetsupportemail
 func (c *AppClient) OrganizationSetSupportEmail(ctx context.Context, orgID, email string) error {
 	_, err := c.client.OrganizationSetSupportEmail(ctx, &pb.OrganizationSetSupportEmailRequest{
 		OrgId: orgID,
@@ -1101,7 +1099,7 @@ func (c *AppClient) OrganizationSetSupportEmail(ctx context.Context, orgID, emai
 //
 // For more information, see the [OrganizationGetSupportEmail method docs].
 //
-// [OrganizationGetSupportEmail method docs]: https://docs.viam.com/dev/reference/apis/fleet/#organizationgetsupportemail
+// [OrganizationGetSupportEmail method docs]: https://docs.viam.com/reference/apis/fleet/#organizationgetsupportemail
 func (c *AppClient) OrganizationGetSupportEmail(ctx context.Context, orgID string) (string, error) {
 	resp, err := c.client.OrganizationGetSupportEmail(ctx, &pb.OrganizationGetSupportEmailRequest{
 		OrgId: orgID,
@@ -1122,7 +1120,7 @@ func (c *AppClient) OrganizationGetSupportEmail(ctx context.Context, orgID strin
 //
 // For more information, see the [GetBillingServiceConfig method docs].
 //
-// [GetBillingServiceConfig method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getbillingserviceconfig
+// [GetBillingServiceConfig method docs]: https://docs.viam.com/reference/apis/fleet/#getbillingserviceconfig
 func (c *AppClient) GetBillingServiceConfig(ctx context.Context, orgID string) (*pb.GetBillingServiceConfigResponse, error) {
 	resp, err := c.client.GetBillingServiceConfig(ctx, &pb.GetBillingServiceConfigRequest{
 		OrgId: orgID,
@@ -1146,7 +1144,7 @@ func (c *AppClient) GetBillingServiceConfig(ctx context.Context, orgID string) (
 //
 // For more information, see the [OrganizationSetLogo method docs].
 //
-// [OrganizationSetLogo method docs]: https://docs.viam.com/dev/reference/apis/fleet/#organizationsetlogo
+// [OrganizationSetLogo method docs]: https://docs.viam.com/reference/apis/fleet/#organizationsetlogo
 func (c *AppClient) OrganizationSetLogo(ctx context.Context, orgID string, logo []byte) error {
 	_, err := c.client.OrganizationSetLogo(ctx, &pb.OrganizationSetLogoRequest{
 		OrgId: orgID,
@@ -1166,7 +1164,7 @@ func (c *AppClient) OrganizationSetLogo(ctx context.Context, orgID string, logo 
 //
 // For more information, see the [OrganizationGetLogo method docs].
 //
-// [OrganizationGetLogo method docs]: https://docs.viam.com/dev/reference/apis/fleet/#organizationgetlogo
+// [OrganizationGetLogo method docs]: https://docs.viam.com/reference/apis/fleet/#organizationgetlogo
 func (c *AppClient) OrganizationGetLogo(ctx context.Context, orgID string) (string, error) {
 	resp, err := c.client.OrganizationGetLogo(ctx, &pb.OrganizationGetLogoRequest{
 		OrgId: orgID,
@@ -1188,7 +1186,7 @@ func (c *AppClient) OrganizationGetLogo(ctx context.Context, orgID string) (stri
 //
 // For more information, see the [ListOAuthApps method docs].
 //
-// [ListOAuthApps method docs]: https://docs.viam.com/dev/reference/apis/fleet/#listoauthapps
+// [ListOAuthApps method docs]: https://docs.viam.com/reference/apis/fleet/#listoauthapps
 func (c *AppClient) ListOAuthApps(ctx context.Context, orgID string) ([]string, error) {
 	resp, err := c.client.ListOAuthApps(ctx, &pb.ListOAuthAppsRequest{
 		OrgId: orgID,
@@ -1214,7 +1212,7 @@ func (c *AppClient) ListOAuthApps(ctx context.Context, orgID string) ([]string, 
 //
 // For more information, see the [CreateLocation method docs].
 //
-// [CreateLocation method docs]: https://docs.viam.com/dev/reference/apis/fleet/#createlocation
+// [CreateLocation method docs]: https://docs.viam.com/reference/apis/fleet/#createlocation
 func (c *AppClient) CreateLocation(ctx context.Context, orgID, name string, opts *CreateLocationOptions) (*Location, error) {
 	var parentID *string
 	if opts != nil {
@@ -1239,7 +1237,7 @@ func (c *AppClient) CreateLocation(ctx context.Context, orgID, name string, opts
 //
 // For more information, see the [GetLocation method docs].
 //
-// [GetLocation method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getlocation
+// [GetLocation method docs]: https://docs.viam.com/reference/apis/fleet/#getlocation
 func (c *AppClient) GetLocation(ctx context.Context, locationID string) (*Location, error) {
 	resp, err := c.client.GetLocation(ctx, &pb.GetLocationRequest{
 		LocationId: locationID,
@@ -1266,7 +1264,7 @@ func (c *AppClient) GetLocation(ctx context.Context, locationID string) (*Locati
 //
 // For more information, see the [UpdateLocation method docs].
 //
-// [UpdateLocation method docs]: https://docs.viam.com/dev/reference/apis/fleet/#updatelocation
+// [UpdateLocation method docs]: https://docs.viam.com/reference/apis/fleet/#updatelocation
 func (c *AppClient) UpdateLocation(ctx context.Context, locationID string, opts *UpdateLocationOptions) (*Location, error) {
 	var name, parentID, region *string
 	if opts != nil {
@@ -1292,7 +1290,7 @@ func (c *AppClient) UpdateLocation(ctx context.Context, locationID string, opts 
 //
 // For more information, see the [DeleteLocation method docs].
 //
-// [DeleteLocation method docs]: https://docs.viam.com/dev/reference/apis/fleet/#deletelocation
+// [DeleteLocation method docs]: https://docs.viam.com/reference/apis/fleet/#deletelocation
 func (c *AppClient) DeleteLocation(ctx context.Context, locationID string) error {
 	_, err := c.client.DeleteLocation(ctx, &pb.DeleteLocationRequest{
 		LocationId: locationID,
@@ -1308,7 +1306,7 @@ func (c *AppClient) DeleteLocation(ctx context.Context, locationID string) error
 //
 // For more information, see the [ListLocations method docs].
 //
-// [ListLocations method docs]: https://docs.viam.com/dev/reference/apis/fleet/#listlocations
+// [ListLocations method docs]: https://docs.viam.com/reference/apis/fleet/#listlocations
 func (c *AppClient) ListLocations(ctx context.Context, orgID string) ([]*Location, error) {
 	resp, err := c.client.ListLocations(ctx, &pb.ListLocationsRequest{
 		OrganizationId: orgID,
@@ -1332,7 +1330,7 @@ func (c *AppClient) ListLocations(ctx context.Context, orgID string) ([]*Locatio
 //
 // For more information, see the [ShareLocation method docs].
 //
-// [ShareLocation method docs]: https://docs.viam.com/dev/reference/apis/fleet/#sharelocation
+// [ShareLocation method docs]: https://docs.viam.com/reference/apis/fleet/#sharelocation
 func (c *AppClient) ShareLocation(ctx context.Context, locationID, orgID string) error {
 	_, err := c.client.ShareLocation(ctx, &pb.ShareLocationRequest{
 		LocationId:     locationID,
@@ -1349,7 +1347,7 @@ func (c *AppClient) ShareLocation(ctx context.Context, locationID, orgID string)
 //
 // For more information, see the [UnshareLocation method docs].
 //
-// [UnshareLocation method docs]: https://docs.viam.com/dev/reference/apis/fleet/#unsharelocation
+// [UnshareLocation method docs]: https://docs.viam.com/reference/apis/fleet/#unsharelocation
 func (c *AppClient) UnshareLocation(ctx context.Context, locationID, orgID string) error {
 	_, err := c.client.UnshareLocation(ctx, &pb.UnshareLocationRequest{
 		LocationId:     locationID,
@@ -1366,7 +1364,7 @@ func (c *AppClient) UnshareLocation(ctx context.Context, locationID, orgID strin
 //
 // For more information, see the [LocationAuth method docs].
 //
-// [LocationAuth method docs]: https://docs.viam.com/dev/reference/apis/fleet/#locationauth
+// [LocationAuth method docs]: https://docs.viam.com/reference/apis/fleet/#locationauth
 func (c *AppClient) LocationAuth(ctx context.Context, locationID string) (*LocationAuth, error) {
 	resp, err := c.client.LocationAuth(ctx, &pb.LocationAuthRequest{
 		LocationId: locationID,
@@ -1385,7 +1383,7 @@ func (c *AppClient) LocationAuth(ctx context.Context, locationID string) (*Locat
 //
 // For more information, see the [CreateLocationSecret method docs].
 //
-// [CreateLocationSecret method docs]: https://docs.viam.com/dev/reference/apis/fleet/#createlocationsecret
+// [CreateLocationSecret method docs]: https://docs.viam.com/reference/apis/fleet/#createlocationsecret
 func (c *AppClient) CreateLocationSecret(ctx context.Context, locationID string) (*LocationAuth, error) {
 	resp, err := c.client.CreateLocationSecret(ctx, &pb.CreateLocationSecretRequest{
 		LocationId: locationID,
@@ -1408,7 +1406,7 @@ func (c *AppClient) CreateLocationSecret(ctx context.Context, locationID string)
 //
 // For more information, see the [DeleteLocationSecret method docs].
 //
-// [DeleteLocationSecret method docs]: https://docs.viam.com/dev/reference/apis/fleet/#deletelocationsecret
+// [DeleteLocationSecret method docs]: https://docs.viam.com/reference/apis/fleet/#deletelocationsecret
 func (c *AppClient) DeleteLocationSecret(ctx context.Context, locationID, secretID string) error {
 	_, err := c.client.DeleteLocationSecret(ctx, &pb.DeleteLocationSecretRequest{
 		LocationId: locationID,
@@ -1425,7 +1423,7 @@ func (c *AppClient) DeleteLocationSecret(ctx context.Context, locationID, secret
 //
 // For more information, see the [GetLocationMetadata method docs].
 //
-// [GetLocationMetadata method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getlocationmetadata
+// [GetLocationMetadata method docs]: https://docs.viam.com/reference/apis/fleet/#getlocationmetadata
 func (c *AppClient) GetLocationMetadata(ctx context.Context, locationID string) (map[string]interface{}, error) {
 	resp, err := c.client.GetLocationMetadata(ctx, &pb.GetLocationMetadataRequest{
 		LocationId: locationID,
@@ -1450,7 +1448,7 @@ func (c *AppClient) GetLocationMetadata(ctx context.Context, locationID string) 
 //
 // For more information, see the [UpdateLocationMetadata method docs].
 //
-// [UpdateLocationMetadata method docs]: https://docs.viam.com/dev/reference/apis/fleet/#updatelocationmetadata
+// [UpdateLocationMetadata method docs]: https://docs.viam.com/reference/apis/fleet/#updatelocationmetadata
 func (c *AppClient) UpdateLocationMetadata(ctx context.Context, locationID string, data interface{}) error {
 	d, err := protoutils.StructToStructPb(data)
 	if err != nil {
@@ -1471,7 +1469,7 @@ func (c *AppClient) UpdateLocationMetadata(ctx context.Context, locationID strin
 //
 // For more information, see the [GetRobot method docs].
 //
-// [GetRobot method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getrobot
+// [GetRobot method docs]: https://docs.viam.com/reference/apis/fleet/#getrobot
 func (c *AppClient) GetRobot(ctx context.Context, id string) (*Robot, error) {
 	resp, err := c.client.GetRobot(ctx, &pb.GetRobotRequest{
 		Id: id,
@@ -1492,7 +1490,7 @@ func (c *AppClient) GetRobot(ctx context.Context, id string) (*Robot, error) {
 //
 // For more information, see the [GetRobotMetadata method docs].
 //
-// [GetRobotMetadata method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getrobotmetadata
+// [GetRobotMetadata method docs]: https://docs.viam.com/reference/apis/fleet/#getrobotmetadata
 func (c *AppClient) GetRobotMetadata(ctx context.Context, robotID string) (map[string]interface{}, error) {
 	resp, err := c.client.GetRobotMetadata(ctx, &pb.GetRobotMetadataRequest{
 		Id: robotID,
@@ -1517,7 +1515,7 @@ func (c *AppClient) GetRobotMetadata(ctx context.Context, robotID string) (map[s
 //
 // For more information, see the [UpdateRobotMetadata method docs].
 //
-// [UpdateRobotMetadata method docs]: https://docs.viam.com/dev/reference/apis/fleet/#updaterobotmetadata
+// [UpdateRobotMetadata method docs]: https://docs.viam.com/reference/apis/fleet/#updaterobotmetadata
 func (c *AppClient) UpdateRobotMetadata(ctx context.Context, robotID string, data interface{}) error {
 	d, err := protoutils.StructToStructPb(data)
 	if err != nil {
@@ -1553,7 +1551,7 @@ func (c *AppClient) GetRoverRentalRobots(ctx context.Context, orgID string) ([]*
 //
 // For more information, see the [GetRobotParts method docs].
 //
-// [GetRobotParts method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getrobotparts
+// [GetRobotParts method docs]: https://docs.viam.com/reference/apis/fleet/#getrobotparts
 func (c *AppClient) GetRobotParts(ctx context.Context, robotID string) ([]*RobotPart, error) {
 	resp, err := c.client.GetRobotParts(ctx, &pb.GetRobotPartsRequest{
 		RobotId: robotID,
@@ -1579,7 +1577,7 @@ func (c *AppClient) GetRobotParts(ctx context.Context, robotID string) ([]*Robot
 //
 // For more information, see the [GetRobotPart method docs].
 //
-// [GetRobotPart method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getrobotpart
+// [GetRobotPart method docs]: https://docs.viam.com/reference/apis/fleet/#getrobotpart
 func (c *AppClient) GetRobotPart(ctx context.Context, id string) (*RobotPart, string, error) {
 	resp, err := c.client.GetRobotPart(ctx, &pb.GetRobotPartRequest{
 		Id: id,
@@ -1616,7 +1614,7 @@ func (c *AppClient) GetRobotPart(ctx context.Context, id string) (*RobotPart, st
 //
 // For more information, see the [GetRobotPartLogs method docs].
 //
-// [GetRobotPartLogs method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getrobotpartlogs
+// [GetRobotPartLogs method docs]: https://docs.viam.com/reference/apis/fleet/#getrobotpartlogs
 func (c *AppClient) GetRobotPartLogs(ctx context.Context, id string, opts *GetRobotPartLogsOptions) ([]*LogEntry, string, error) {
 	var filter, token, source *string
 	var levels []string
@@ -1690,7 +1688,7 @@ func (s *RobotPartLogStream) Next() ([]*LogEntry, error) {
 //
 // For more information, see the [TailRobotPartLogs method docs].
 //
-// [TailRobotPartLogs method docs]: https://docs.viam.com/dev/reference/apis/fleet/#tailrobotpartlogs
+// [TailRobotPartLogs method docs]: https://docs.viam.com/reference/apis/fleet/#tailrobotpartlogs
 func (c *AppClient) TailRobotPartLogs(
 	ctx context.Context, id string, errorsOnly bool, opts *TailRobotPartLogsOptions,
 ) (*RobotPartLogStream, error) {
@@ -1719,7 +1717,7 @@ func (c *AppClient) TailRobotPartLogs(
 //
 // For more information, see the [GetRobotPartHistory method docs].
 //
-// [GetRobotPartHistory method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getrobotparthistory
+// [GetRobotPartHistory method docs]: https://docs.viam.com/reference/apis/fleet/#getrobotparthistory
 func (c *AppClient) GetRobotPartHistory(ctx context.Context, id string) ([]*RobotPartHistoryEntry, error) {
 	resp, err := c.client.GetRobotPartHistory(ctx, &pb.GetRobotPartHistoryRequest{
 		Id: id,
@@ -1760,7 +1758,7 @@ func (c *AppClient) GetRobotPartHistory(ctx context.Context, id string) ([]*Robo
 //
 // For more information, see the [UpdateRobotPart method docs].
 //
-// [UpdateRobotPart method docs]: https://docs.viam.com/dev/reference/apis/fleet/#updaterobotpart
+// [UpdateRobotPart method docs]: https://docs.viam.com/reference/apis/fleet/#updaterobotpart
 func (c *AppClient) UpdateRobotPart(ctx context.Context, id, name string, robotConfig interface{}) (*RobotPart, error) {
 	config, err := protoutils.StructToStructPb(robotConfig)
 	if err != nil {
@@ -1788,7 +1786,7 @@ func (c *AppClient) UpdateRobotPart(ctx context.Context, id, name string, robotC
 //
 // For more information, see the [NewRobotPart method docs].
 //
-// [NewRobotPart method docs]: https://docs.viam.com/dev/reference/apis/fleet/#newrobotpart
+// [NewRobotPart method docs]: https://docs.viam.com/reference/apis/fleet/#newrobotpart
 func (c *AppClient) NewRobotPart(ctx context.Context, robotID, partName string) (string, error) {
 	resp, err := c.client.NewRobotPart(ctx, &pb.NewRobotPartRequest{
 		RobotId:  robotID,
@@ -1808,7 +1806,7 @@ func (c *AppClient) NewRobotPart(ctx context.Context, robotID, partName string) 
 //
 // For more information, see the [DeleteRobotPart method docs].
 //
-// [DeleteRobotPart method docs]: https://docs.viam.com/dev/reference/apis/fleet/#deleterobotpart
+// [DeleteRobotPart method docs]: https://docs.viam.com/reference/apis/fleet/#deleterobotpart
 func (c *AppClient) DeleteRobotPart(ctx context.Context, partID string) error {
 	_, err := c.client.DeleteRobotPart(ctx, &pb.DeleteRobotPartRequest{
 		PartId: partID,
@@ -1826,7 +1824,7 @@ func (c *AppClient) DeleteRobotPart(ctx context.Context, partID string) error {
 //
 // For more information, see the [GetRobotPartMetadata method docs].
 //
-// [GetRobotPartMetadata method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getrobotpartmetadata
+// [GetRobotPartMetadata method docs]: https://docs.viam.com/reference/apis/fleet/#getrobotpartmetadata
 func (c *AppClient) GetRobotPartMetadata(ctx context.Context, robotID string) (map[string]interface{}, error) {
 	resp, err := c.client.GetRobotPartMetadata(ctx, &pb.GetRobotPartMetadataRequest{
 		Id: robotID,
@@ -1851,7 +1849,7 @@ func (c *AppClient) GetRobotPartMetadata(ctx context.Context, robotID string) (m
 //
 // For more information, see the [UpdateRobotPartMetadata method docs].
 //
-// [UpdateRobotPartMetadata method docs]: https://docs.viam.com/dev/reference/apis/fleet/#updaterobotpartmetadata
+// [UpdateRobotPartMetadata method docs]: https://docs.viam.com/reference/apis/fleet/#updaterobotpartmetadata
 func (c *AppClient) UpdateRobotPartMetadata(ctx context.Context, robotID string, data interface{}) error {
 	d, err := protoutils.StructToStructPb(data)
 	if err != nil {
@@ -1872,7 +1870,7 @@ func (c *AppClient) UpdateRobotPartMetadata(ctx context.Context, robotID string,
 //
 // For more information, see the [GetRobotAPIKeys method docs].
 //
-// [GetRobotAPIKeys method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getrobotapikeys
+// [GetRobotAPIKeys method docs]: https://docs.viam.com/reference/apis/fleet/#getrobotapikeys
 func (c *AppClient) GetRobotAPIKeys(ctx context.Context, robotID string) ([]*APIKeyWithAuthorizations, error) {
 	resp, err := c.client.GetRobotAPIKeys(ctx, &pb.GetRobotAPIKeysRequest{
 		RobotId: robotID,
@@ -1895,7 +1893,7 @@ func (c *AppClient) GetRobotAPIKeys(ctx context.Context, robotID string) ([]*API
 //
 // For more information, see the [MarkPartAsMain method docs].
 //
-// [MarkPartAsMain method docs]: https://docs.viam.com/dev/reference/apis/fleet/#markpartasmain
+// [MarkPartAsMain method docs]: https://docs.viam.com/reference/apis/fleet/#markpartasmain
 func (c *AppClient) MarkPartAsMain(ctx context.Context, partID string) error {
 	_, err := c.client.MarkPartAsMain(ctx, &pb.MarkPartAsMainRequest{
 		PartId: partID,
@@ -1913,7 +1911,7 @@ func (c *AppClient) MarkPartAsMain(ctx context.Context, partID string) error {
 //
 // For more information, see the [MarkPartForRestart method docs].
 //
-// [MarkPartForRestart method docs]: https://docs.viam.com/dev/reference/apis/fleet/#markpartforrestart
+// [MarkPartForRestart method docs]: https://docs.viam.com/reference/apis/fleet/#markpartforrestart
 func (c *AppClient) MarkPartForRestart(ctx context.Context, partID string) error {
 	_, err := c.client.MarkPartForRestart(ctx, &pb.MarkPartForRestartRequest{
 		PartId: partID,
@@ -1932,7 +1930,7 @@ func (c *AppClient) MarkPartForRestart(ctx context.Context, partID string) error
 //
 // For more information, see the [CreateRobotPartSecret method docs].
 //
-// [CreateRobotPartSecret method docs]: https://docs.viam.com/dev/reference/apis/fleet/#createrobotpartsecret
+// [CreateRobotPartSecret method docs]: https://docs.viam.com/reference/apis/fleet/#createrobotpartsecret
 func (c *AppClient) CreateRobotPartSecret(ctx context.Context, partID string) (*RobotPart, error) {
 	resp, err := c.client.CreateRobotPartSecret(ctx, &pb.CreateRobotPartSecretRequest{
 		PartId: partID,
@@ -1954,7 +1952,7 @@ func (c *AppClient) CreateRobotPartSecret(ctx context.Context, partID string) (*
 //
 // For more information, see the [DeleteRobotPartSecret method docs].
 //
-// [DeleteRobotPartSecret method docs]: https://docs.viam.com/dev/reference/apis/fleet/#deleterobotpartsecret
+// [DeleteRobotPartSecret method docs]: https://docs.viam.com/reference/apis/fleet/#deleterobotpartsecret
 func (c *AppClient) DeleteRobotPartSecret(ctx context.Context, partID, secretID string) error {
 	_, err := c.client.DeleteRobotPartSecret(ctx, &pb.DeleteRobotPartSecretRequest{
 		PartId:   partID,
@@ -1971,7 +1969,7 @@ func (c *AppClient) DeleteRobotPartSecret(ctx context.Context, partID, secretID 
 //
 // For more information, see the [ListRobots method docs].
 //
-// [ListRobots method docs]: https://docs.viam.com/dev/reference/apis/fleet/#listrobots
+// [ListRobots method docs]: https://docs.viam.com/reference/apis/fleet/#listrobots
 func (c *AppClient) ListRobots(ctx context.Context, locationID string) ([]*Robot, error) {
 	resp, err := c.client.ListRobots(ctx, &pb.ListRobotsRequest{
 		LocationId: locationID,
@@ -1994,7 +1992,7 @@ func (c *AppClient) ListRobots(ctx context.Context, locationID string) ([]*Robot
 //
 // For more information, see the [NewRobot method docs].
 //
-// [NewRobot method docs]: https://docs.viam.com/dev/reference/apis/fleet/#newrobot
+// [NewRobot method docs]: https://docs.viam.com/reference/apis/fleet/#newrobot
 func (c *AppClient) NewRobot(ctx context.Context, name, location string) (string, error) {
 	resp, err := c.client.NewRobot(ctx, &pb.NewRobotRequest{
 		Name:     name,
@@ -2014,7 +2012,7 @@ func (c *AppClient) NewRobot(ctx context.Context, name, location string) (string
 //
 // For more information, see the [UpdateRobot method docs].
 //
-// [UpdateRobot method docs]: https://docs.viam.com/dev/reference/apis/fleet/#updaterobot
+// [UpdateRobot method docs]: https://docs.viam.com/reference/apis/fleet/#updaterobot
 func (c *AppClient) UpdateRobot(ctx context.Context, id, name, location string) (*Robot, error) {
 	resp, err := c.client.UpdateRobot(ctx, &pb.UpdateRobotRequest{
 		Id:       id,
@@ -2035,7 +2033,7 @@ func (c *AppClient) UpdateRobot(ctx context.Context, id, name, location string) 
 //
 // For more information, see the [DeleteRobot method docs].
 //
-// [DeleteRobot method docs]: https://docs.viam.com/dev/reference/apis/fleet/#deleterobot
+// [DeleteRobot method docs]: https://docs.viam.com/reference/apis/fleet/#deleterobot
 func (c *AppClient) DeleteRobot(ctx context.Context, id string) error {
 	_, err := c.client.DeleteRobot(ctx, &pb.DeleteRobotRequest{
 		Id: id,
@@ -2056,7 +2054,7 @@ func (c *AppClient) DeleteRobot(ctx context.Context, id string) error {
 //
 // For more information, see the [ListFragments method docs].
 //
-// [ListFragments method docs]: https://docs.viam.com/dev/reference/apis/fleet/#listfragments
+// [ListFragments method docs]: https://docs.viam.com/reference/apis/fleet/#listfragments
 func (c *AppClient) ListFragments(
 	ctx context.Context, orgID string, showPublic bool, fragmentVisibility []FragmentVisibility,
 ) ([]*Fragment, error) {
@@ -2088,7 +2086,7 @@ func (c *AppClient) ListFragments(
 //
 // For more information, see the [GetFragment method docs].
 //
-// [GetFragment method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getfragment
+// [GetFragment method docs]: https://docs.viam.com/reference/apis/fleet/#getfragment
 func (c *AppClient) GetFragment(ctx context.Context, id, version string) (*Fragment, error) {
 	req := &pb.GetFragmentRequest{
 		Id: id,
@@ -2129,7 +2127,7 @@ func (c *AppClient) GetFragment(ctx context.Context, id, version string) (*Fragm
 //
 // For more information, see the [CreateFragment method docs].
 //
-// [CreateFragment method docs]: https://docs.viam.com/dev/reference/apis/fleet/#createfragment
+// [CreateFragment method docs]: https://docs.viam.com/reference/apis/fleet/#createfragment
 func (c *AppClient) CreateFragment(
 	ctx context.Context, orgID, name string, config map[string]interface{}, opts *CreateFragmentOptions,
 ) (*Fragment, error) {
@@ -2177,7 +2175,7 @@ func (c *AppClient) CreateFragment(
 //
 // For more information, see the [UpdateFragment method docs].
 //
-// [UpdateFragment method docs]: https://docs.viam.com/dev/reference/apis/fleet/#updatefragment
+// [UpdateFragment method docs]: https://docs.viam.com/reference/apis/fleet/#updatefragment
 func (c *AppClient) UpdateFragment(
 	ctx context.Context, id, name string, config map[string]interface{}, opts *UpdateFragmentOptions,
 ) (*Fragment, error) {
@@ -2214,7 +2212,7 @@ func (c *AppClient) UpdateFragment(
 //
 // For more information, see the [DeleteFragment method docs].
 //
-// [DeleteFragment method docs]: https://docs.viam.com/dev/reference/apis/fleet/#deletefragment
+// [DeleteFragment method docs]: https://docs.viam.com/reference/apis/fleet/#deletefragment
 func (c *AppClient) DeleteFragment(ctx context.Context, id string) error {
 	_, err := c.client.DeleteFragment(ctx, &pb.DeleteFragmentRequest{
 		Id: id,
@@ -2231,7 +2229,7 @@ func (c *AppClient) DeleteFragment(ctx context.Context, id string) error {
 //
 // For more information, see the [ListMachineFragments method docs].
 //
-// [ListMachineFragments method docs]: https://docs.viam.com/dev/reference/apis/fleet/#listmachinefragments
+// [ListMachineFragments method docs]: https://docs.viam.com/reference/apis/fleet/#listmachinefragments
 func (c *AppClient) ListMachineFragments(ctx context.Context, machineID string, additionalIDs []string) ([]*Fragment, error) {
 	resp, err := c.client.ListMachineFragments(ctx, &pb.ListMachineFragmentsRequest{
 		MachineId:             machineID,
@@ -2259,7 +2257,7 @@ func (c *AppClient) ListMachineFragments(ctx context.Context, machineID string, 
 //
 // For more information, see the [GetFragmentHistory method docs].
 //
-// [GetFragmentHistory method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getfragmenthistory
+// [GetFragmentHistory method docs]: https://docs.viam.com/reference/apis/fleet/#getfragmenthistory
 func (c *AppClient) GetFragmentHistory(
 	ctx context.Context, id string, opts *GetFragmentHistoryOptions,
 ) ([]*FragmentHistoryEntry, string, error) {
@@ -2336,7 +2334,7 @@ func (c *AppClient) ChangeRole(
 //
 // For more information, see the [ListAuthorizations method docs].
 //
-// [ListAuthorizations method docs]: https://docs.viam.com/dev/reference/apis/fleet/#listauthorizations
+// [ListAuthorizations method docs]: https://docs.viam.com/reference/apis/fleet/#listauthorizations
 func (c *AppClient) ListAuthorizations(ctx context.Context, orgID string, resourceIDs []string) ([]*Authorization, error) {
 	resp, err := c.client.ListAuthorizations(ctx, &pb.ListAuthorizationsRequest{
 		OrganizationId: orgID,
@@ -2369,7 +2367,7 @@ func (c *AppClient) ListAuthorizations(ctx context.Context, orgID string, resour
 //
 // For more information, see the [CheckPermissions method docs].
 //
-// [CheckPermissions method docs]: https://docs.viam.com/dev/reference/apis/fleet/#checkpermissions
+// [CheckPermissions method docs]: https://docs.viam.com/reference/apis/fleet/#checkpermissions
 func (c *AppClient) CheckPermissions(ctx context.Context, permissions []*AuthorizedPermissions) ([]*AuthorizedPermissions, error) {
 	var pbPermissions []*pb.AuthorizedPermissions
 	for _, permission := range permissions {
@@ -2398,7 +2396,7 @@ func (c *AppClient) CheckPermissions(ctx context.Context, permissions []*Authori
 //
 // For more information, see the [GetRegistryItem method docs].
 //
-// [GetRegistryItem method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getregistryitem
+// [GetRegistryItem method docs]: https://docs.viam.com/reference/apis/fleet/#getregistryitem
 func (c *AppClient) GetRegistryItem(ctx context.Context, itemID string) (*RegistryItem, error) {
 	resp, err := c.client.GetRegistryItem(ctx, &pb.GetRegistryItemRequest{
 		ItemId: itemID,
@@ -2425,7 +2423,7 @@ func (c *AppClient) GetRegistryItem(ctx context.Context, itemID string) (*Regist
 //
 // For more information, see the [CreateRegistryItem method docs].
 //
-// [CreateRegistryItem method docs]: https://docs.viam.com/dev/reference/apis/fleet/#createregistryitem
+// [CreateRegistryItem method docs]: https://docs.viam.com/reference/apis/fleet/#createregistryitem
 func (c *AppClient) CreateRegistryItem(ctx context.Context, orgID, name string, packageType PackageType) error {
 	_, err := c.client.CreateRegistryItem(ctx, &pb.CreateRegistryItemRequest{
 		OrganizationId: orgID,
@@ -2451,7 +2449,7 @@ func (c *AppClient) CreateRegistryItem(ctx context.Context, orgID, name string, 
 //
 // For more information, see the [UpdateRegistryItem method docs].
 //
-// [UpdateRegistryItem method docs]: https://docs.viam.com/dev/reference/apis/fleet/#updateregistryitem
+// [UpdateRegistryItem method docs]: https://docs.viam.com/reference/apis/fleet/#updateregistryitem
 func (c *AppClient) UpdateRegistryItem(
 	ctx context.Context, itemID string, packageType PackageType, description string, visibility Visibility, opts *UpdateRegistryItemOptions,
 ) error {
@@ -2493,7 +2491,7 @@ func (c *AppClient) UpdateRegistryItem(
 //
 // For more information, see the [ListRegistryItems method docs].
 //
-// [ListRegistryItems method docs]: https://docs.viam.com/dev/reference/apis/fleet/#listregistryitems
+// [ListRegistryItems method docs]: https://docs.viam.com/reference/apis/fleet/#listregistryitems
 func (c *AppClient) ListRegistryItems(
 	ctx context.Context,
 	orgID *string,
@@ -2555,7 +2553,7 @@ func (c *AppClient) ListRegistryItems(
 //
 // For more information, see the [DeleteRegistryItem method docs].
 //
-// [DeleteRegistryItem method docs]: https://docs.viam.com/dev/reference/apis/fleet/#deleteregistryitem
+// [DeleteRegistryItem method docs]: https://docs.viam.com/reference/apis/fleet/#deleteregistryitem
 func (c *AppClient) DeleteRegistryItem(ctx context.Context, itemID string) error {
 	_, err := c.client.DeleteRegistryItem(ctx, &pb.DeleteRegistryItemRequest{
 		ItemId: itemID,
@@ -2571,7 +2569,7 @@ func (c *AppClient) DeleteRegistryItem(ctx context.Context, itemID string) error
 //
 // For more information, see the [TransferRegistryItem method docs].
 //
-// [TransferRegistryItem method docs]: https://docs.viam.com/dev/reference/apis/fleet/#transferregistryitem
+// [TransferRegistryItem method docs]: https://docs.viam.com/reference/apis/fleet/#transferregistryitem
 func (c *AppClient) TransferRegistryItem(ctx context.Context, itemID, newPublicNamespace string) error {
 	_, err := c.client.TransferRegistryItem(ctx, &pb.TransferRegistryItemRequest{
 		ItemId:             itemID,
@@ -2592,7 +2590,7 @@ func (c *AppClient) TransferRegistryItem(ctx context.Context, itemID, newPublicN
 //
 // For more information, see the [CreateModule method docs].
 //
-// [CreateModule method docs]: https://docs.viam.com/dev/reference/apis/fleet/#createmodule
+// [CreateModule method docs]: https://docs.viam.com/reference/apis/fleet/#createmodule
 func (c *AppClient) CreateModule(ctx context.Context, orgID, name string) (string, string, error) {
 	resp, err := c.client.CreateModule(ctx, &pb.CreateModuleRequest{
 		OrganizationId: orgID,
@@ -2633,7 +2631,7 @@ func (c *AppClient) CreateModule(ctx context.Context, orgID, name string) (strin
 //
 // For more information, see the [UpdateModule method docs].
 //
-// [UpdateModule method docs]: https://docs.viam.com/dev/reference/apis/fleet/#updatemodule
+// [UpdateModule method docs]: https://docs.viam.com/reference/apis/fleet/#updatemodule
 func (c *AppClient) UpdateModule(
 	ctx context.Context,
 	moduleID string,
@@ -2686,7 +2684,7 @@ func (c *AppClient) UpdateModule(
 //
 // For more information, see the [UploadModuleFile method docs].
 //
-// [UploadModuleFile method docs]: https://docs.viam.com/dev/reference/apis/fleet/#uploadmodulefile
+// [UploadModuleFile method docs]: https://docs.viam.com/reference/apis/fleet/#uploadmodulefile
 func (c *AppClient) UploadModuleFile(ctx context.Context, fileInfo ModuleFileInfo, file []byte) (string, error) {
 	stream, err := c.client.UploadModuleFile(ctx)
 	if err != nil {
@@ -2738,7 +2736,7 @@ func (c *AppClient) UploadModuleFile(ctx context.Context, fileInfo ModuleFileInf
 //
 // For more information, see the [GetModule method docs].
 //
-// [GetModule method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getmodule
+// [GetModule method docs]: https://docs.viam.com/reference/apis/fleet/#getmodule
 func (c *AppClient) GetModule(ctx context.Context, moduleID string) (*Module, error) {
 	resp, err := c.client.GetModule(ctx, &pb.GetModuleRequest{
 		ModuleId: moduleID,
@@ -2758,7 +2756,7 @@ func (c *AppClient) GetModule(ctx context.Context, moduleID string) (*Module, er
 //
 // For more information, see the [ListModules method docs].
 //
-// [ListModules method docs]: https://docs.viam.com/dev/reference/apis/fleet/#listmodules
+// [ListModules method docs]: https://docs.viam.com/reference/apis/fleet/#listmodules
 func (c *AppClient) ListModules(ctx context.Context, opts *ListModulesOptions) ([]*Module, error) {
 	var orgID *string
 	if opts != nil {
@@ -2806,7 +2804,7 @@ func (c *AppClient) CreateKey(
 //
 // For more information, see the [DeleteKey method docs].
 //
-// [DeleteKey method docs]: https://docs.viam.com/dev/reference/apis/fleet/#deletekey
+// [DeleteKey method docs]: https://docs.viam.com/reference/apis/fleet/#deletekey
 func (c *AppClient) DeleteKey(ctx context.Context, id string) error {
 	_, err := c.client.DeleteKey(ctx, &pb.DeleteKeyRequest{
 		Id: id,
@@ -2820,7 +2818,7 @@ func (c *AppClient) DeleteKey(ctx context.Context, id string) error {
 //
 // For more information, see the [ListKeys method docs].
 //
-// [ListKeys method docs]: https://docs.viam.com/dev/reference/apis/fleet/#listkeys
+// [ListKeys method docs]: https://docs.viam.com/reference/apis/fleet/#listkeys
 // ListKeys lists all the keys for the organization.
 func (c *AppClient) ListKeys(ctx context.Context, orgID string) ([]*APIKeyWithAuthorizations, error) {
 	resp, err := c.client.ListKeys(ctx, &pb.ListKeysRequest{
@@ -2844,7 +2842,7 @@ func (c *AppClient) ListKeys(ctx context.Context, orgID string) ([]*APIKeyWithAu
 //
 // For more information, see the [RenameKey method docs].
 //
-// [RenameKey method docs]: https://docs.viam.com/dev/reference/apis/fleet/#renamekey
+// [RenameKey method docs]: https://docs.viam.com/reference/apis/fleet/#renamekey
 func (c *AppClient) RenameKey(ctx context.Context, id, name string) (string, string, error) {
 	resp, err := c.client.RenameKey(ctx, &pb.RenameKeyRequest{
 		Id:   id,
@@ -2864,7 +2862,7 @@ func (c *AppClient) RenameKey(ctx context.Context, id, name string) (string, str
 //
 // For more information, see the [RotateKey method docs].
 //
-// [RotateKey method docs]: https://docs.viam.com/dev/reference/apis/fleet/#rotatekey
+// [RotateKey method docs]: https://docs.viam.com/reference/apis/fleet/#rotatekey
 func (c *AppClient) RotateKey(ctx context.Context, id string) (string, string, error) {
 	resp, err := c.client.RotateKey(ctx, &pb.RotateKeyRequest{
 		Id: id,
@@ -2883,9 +2881,7 @@ func (c *AppClient) RotateKey(ctx context.Context, id string) (string, string, e
 //
 // For more information, see the [CreateKeyFromExistingKeyAuthorizations method docs].
 //
-// [CreateKeyFromExistingKeyAuthorizations method docs]: https://docs.viam.com/dev/reference/apis/fleet/#createkeyfromexistingkeyauthorizations
-//
-//nolint:lll
+// [CreateKeyFromExistingKeyAuthorizations method docs]: https://docs.viam.com/reference/apis/fleet/#createkeyfromexistingkeyauthorizations
 func (c *AppClient) CreateKeyFromExistingKeyAuthorizations(ctx context.Context, id string) (string, string, error) {
 	resp, err := c.client.CreateKeyFromExistingKeyAuthorizations(ctx, &pb.CreateKeyFromExistingKeyAuthorizationsRequest{
 		Id: id,
@@ -2910,7 +2906,7 @@ func (c *AppClient) CreateKeyFromExistingKeyAuthorizations(ctx context.Context, 
 //
 // For more information, see the [ListMachineSummaries method docs].
 //
-// [ListMachineSummaries method docs]: https://docs.viam.com/dev/reference/apis/fleet/#listmachinesummaries
+// [ListMachineSummaries method docs]: https://docs.viam.com/reference/apis/fleet/#listmachinesummaries
 func (c *AppClient) ListMachineSummaries(
 	ctx context.Context,
 	organizationID string,
@@ -2945,7 +2941,7 @@ func (c *AppClient) ListMachineSummaries(
 //
 // For more information, see the [GetAppBranding method docs].
 //
-// [GetAppBranding method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getappbranding
+// [GetAppBranding method docs]: https://docs.viam.com/reference/apis/fleet/#getappbranding
 func (c *AppClient) GetAppBranding(ctx context.Context, orgPublicNamespace, appName string) (*AppBranding, error) {
 	req := &pb.GetAppBrandingRequest{
 		PublicNamespace: orgPublicNamespace,
@@ -2968,7 +2964,7 @@ func (c *AppClient) GetAppBranding(ctx context.Context, orgPublicNamespace, appN
 //
 // For more information, see the [GetAppContent method docs].
 //
-// [GetAppContent method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getappcontent
+// [GetAppContent method docs]: https://docs.viam.com/reference/apis/fleet/#getappcontent
 func (c *AppClient) GetAppContent(ctx context.Context, orgPublicNamespace, appName string) (*AppContent, error) {
 	req := &pb.GetAppContentRequest{
 		PublicNamespace: orgPublicNamespace,
@@ -2991,7 +2987,7 @@ func (c *AppClient) GetAppContent(ctx context.Context, orgPublicNamespace, appNa
 //
 // For more information, see the [GetRobotPartByNameAndLocation method docs].
 //
-// [GetRobotPartByNameAndLocation method docs]: https://docs.viam.com/dev/reference/apis/fleet/#getrobotpartbynameandlocation
+// [GetRobotPartByNameAndLocation method docs]: https://docs.viam.com/reference/apis/fleet/#getrobotpartbynameandlocation
 func (c *AppClient) GetRobotPartByNameAndLocation(ctx context.Context, name, locationID string) (*RobotPart, error) {
 	req := &pb.GetRobotPartByNameAndLocationRequest{
 		Name:       name,

--- a/cli/app.go
+++ b/cli/app.go
@@ -3657,7 +3657,7 @@ Run this command from within the module directory.`,
 						&cli.StringFlag{
 							Name: generalFlagResourceSubtype,
 							Usage: "(module only) resource subtype to use in module, for example arm, camera, or motion. see " +
-								"https://docs.viam.com/dev/reference/glossary/#term-subtype for more details",
+								"https://docs.viam.com/reference/glossary/#term-subtype for more details",
 						},
 						// This is unnecessary and creates a gotcha for users. Kept here
 						// because it's technically breaking to remove it, but it's hidden

--- a/cli/mock_resource_arm.txt
+++ b/cli/mock_resource_arm.txt
@@ -114,11 +114,11 @@ func Named(name string) resource.Name {
 // For more information, see the [JointPositions method docs].
 //
 // [arm component docs]: https://docs.viam.com/components/arm/
-// [EndPosition method docs]: https://docs.viam.com/dev/reference/apis/components/arm/#getendposition
-// [MoveToPosition method docs]: https://docs.viam.com/dev/reference/apis/components/arm/#movetoposition
-// [MoveToJointPositions method docs]: https://docs.viam.com/dev/reference/apis/components/arm/#movetojointpositions
-// [MoveThroughJointPositions method docs]: https://docs.viam.com/dev/reference/apis/components/arm/#movethroughjointpositions
-// [JointPositions method docs]: https://docs.viam.com/dev/reference/apis/components/arm/#getjointpositions
+// [EndPosition method docs]: https://docs.viam.com/reference/apis/components/arm/#getendposition
+// [MoveToPosition method docs]: https://docs.viam.com/reference/apis/components/arm/#movetoposition
+// [MoveToJointPositions method docs]: https://docs.viam.com/reference/apis/components/arm/#movetojointpositions
+// [MoveThroughJointPositions method docs]: https://docs.viam.com/reference/apis/components/arm/#movethroughjointpositions
+// [JointPositions method docs]: https://docs.viam.com/reference/apis/components/arm/#getjointpositions
 type Arm interface {
 	resource.Resource
 	resource.Shaped

--- a/components/arm/arm.go
+++ b/components/arm/arm.go
@@ -119,11 +119,11 @@ func Named(name string) resource.Name {
 // For more information, see the [JointPositions method docs].
 //
 // [arm component docs]: https://docs.viam.com/components/arm/
-// [EndPosition method docs]: https://docs.viam.com/dev/reference/apis/components/arm/#getendposition
-// [MoveToPosition method docs]: https://docs.viam.com/dev/reference/apis/components/arm/#movetoposition
-// [MoveToJointPositions method docs]: https://docs.viam.com/dev/reference/apis/components/arm/#movetojointpositions
-// [MoveThroughJointPositions method docs]: https://docs.viam.com/dev/reference/apis/components/arm/#movethroughjointpositions
-// [JointPositions method docs]: https://docs.viam.com/dev/reference/apis/components/arm/#getjointpositions
+// [EndPosition method docs]: https://docs.viam.com/reference/apis/components/arm/#getendposition
+// [MoveToPosition method docs]: https://docs.viam.com/reference/apis/components/arm/#movetoposition
+// [MoveToJointPositions method docs]: https://docs.viam.com/reference/apis/components/arm/#movetojointpositions
+// [MoveThroughJointPositions method docs]: https://docs.viam.com/reference/apis/components/arm/#movethroughjointpositions
+// [JointPositions method docs]: https://docs.viam.com/reference/apis/components/arm/#getjointpositions
 type Arm interface {
 	resource.Resource
 	resource.Shaped

--- a/components/base/base.go
+++ b/components/base/base.go
@@ -116,11 +116,11 @@ func Named(name string) resource.Name {
 // For more information, see the [Properties method docs].
 //
 // [base component docs]: https://docs.viam.com/components/base/
-// [Properties method docs]: https://docs.viam.com/dev/reference/apis/components/base/#getproperties
-// [SetVelocity method docs]: https://docs.viam.com/dev/reference/apis/components/base/#setvelocity
-// [SetPower method docs]: https://docs.viam.com/dev/reference/apis/components/base/#setpower
-// [Spin method docs]: https://docs.viam.com/dev/reference/apis/components/base/#spin
-// [MoveStraight method docs]: https://docs.viam.com/dev/reference/apis/components/base/#movestraight
+// [Properties method docs]: https://docs.viam.com/reference/apis/components/base/#getproperties
+// [SetVelocity method docs]: https://docs.viam.com/reference/apis/components/base/#setvelocity
+// [SetPower method docs]: https://docs.viam.com/reference/apis/components/base/#setpower
+// [Spin method docs]: https://docs.viam.com/reference/apis/components/base/#spin
+// [MoveStraight method docs]: https://docs.viam.com/reference/apis/components/base/#movestraight
 type Base interface {
 	resource.Resource
 	resource.Actuator

--- a/components/board/board.go
+++ b/components/board/board.go
@@ -116,11 +116,11 @@ func Named(name string) resource.Name {
 // For more information, see the [StreamTicks method docs].
 //
 // [board component docs]: https://docs.viam.com/operate/reference/components/board/
-// [AnalogByName method docs]: https://docs.viam.com/dev/reference/apis/components/board/#analogbyname
-// [DigitalInterruptByName method docs]: https://docs.viam.com/dev/reference/apis/components/board/#digitalinterruptbyname
-// [GPIOPinByName method docs]: https://docs.viam.com/dev/reference/apis/components/board/#gpiopinbyname
-// [SetPowerMode method docs]: https://docs.viam.com/dev/reference/apis/components/board/#setpowermode
-// [StreamTicks method docs]: https://docs.viam.com/dev/reference/apis/components/board/#streamticks
+// [AnalogByName method docs]: https://docs.viam.com/reference/apis/components/board/#analogbyname
+// [DigitalInterruptByName method docs]: https://docs.viam.com/reference/apis/components/board/#digitalinterruptbyname
+// [GPIOPinByName method docs]: https://docs.viam.com/reference/apis/components/board/#gpiopinbyname
+// [SetPowerMode method docs]: https://docs.viam.com/reference/apis/components/board/#setpowermode
+// [StreamTicks method docs]: https://docs.viam.com/reference/apis/components/board/#streamticks
 type Board interface {
 	resource.Resource
 
@@ -171,8 +171,8 @@ type Board interface {
 //
 // For more information, see the [Write method docs].
 //
-// [Read method docs]: https://docs.viam.com/dev/reference/apis/components/board/#readanalogreader
-// [Write method docs]: https://docs.viam.com/dev/reference/apis/components/board/#writeanalog
+// [Read method docs]: https://docs.viam.com/reference/apis/components/board/#readanalogreader
+// [Write method docs]: https://docs.viam.com/reference/apis/components/board/#writeanalog
 type Analog interface {
 	// Read reads off the current value.
 	Read(ctx context.Context, extra map[string]interface{}) (AnalogValue, error)

--- a/components/board/digital_interrupts.go
+++ b/components/board/digital_interrupts.go
@@ -31,7 +31,7 @@ type Tick struct {
 //
 // For more information, see the [Value method docs].
 //
-// [Value method docs]: https://docs.viam.com/dev/reference/apis/components/board/#getdigitalinterruptvalue
+// [Value method docs]: https://docs.viam.com/reference/apis/components/board/#getdigitalinterruptvalue
 type DigitalInterrupt interface {
 	// Name returns the name of the interrupt.
 	Name() string

--- a/components/board/gpio_pin.go
+++ b/components/board/gpio_pin.go
@@ -81,12 +81,12 @@ import (
 //
 // For more information, see the [SetPWMFreq method docs].
 //
-// [Set method docs]: https://docs.viam.com/dev/reference/apis/components/board/#setgpio
-// [Get method docs]: https://docs.viam.com/dev/reference/apis/components/board/#getgpio
-// [PWM method docs]: https://docs.viam.com/dev/reference/apis/components/board/#getpwm
-// [SetPWM method docs]: https://docs.viam.com/dev/reference/apis/components/board/#setpwm
-// [PWMFreq method docs]: https://docs.viam.com/dev/reference/apis/components/board/#pwmfrequency
-// [SetPWMFreq method docs]: https://docs.viam.com/dev/reference/apis/components/board/#setpwmfrequency
+// [Set method docs]: https://docs.viam.com/reference/apis/components/board/#setgpio
+// [Get method docs]: https://docs.viam.com/reference/apis/components/board/#getgpio
+// [PWM method docs]: https://docs.viam.com/reference/apis/components/board/#getpwm
+// [SetPWM method docs]: https://docs.viam.com/reference/apis/components/board/#setpwm
+// [PWMFreq method docs]: https://docs.viam.com/reference/apis/components/board/#pwmfrequency
+// [SetPWMFreq method docs]: https://docs.viam.com/reference/apis/components/board/#setpwmfrequency
 type GPIOPin interface {
 	// Set sets the pin to either low or high.
 	Set(ctx context.Context, high bool, extra map[string]interface{}) error

--- a/components/button/button.go
+++ b/components/button/button.go
@@ -50,8 +50,8 @@ func Named(name string) resource.Name {
 //
 // For more information, see the [Push method docs].
 //
-// [Button component docs]: https://docs.viam.com/dev/reference/apis/components/button/
-// [Push method docs]: https://docs.viam.com/dev/reference/apis/components/button/#push
+// [Button component docs]: https://docs.viam.com/reference/apis/components/button/
+// [Push method docs]: https://docs.viam.com/reference/apis/components/button/#push
 type Button interface {
 	resource.Resource
 

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -257,10 +257,10 @@ func (ni *NamedImage) Bounds() (image.Rectangle, error) {
 //
 // For more information, see the [Close method docs].
 //
-// [camera component docs]: https://docs.viam.com/dev/reference/apis/components/camera/
-// [Images method docs]: https://docs.viam.com/dev/reference/apis/components/camera/#getimages
-// [NextPointCloud method docs]: https://docs.viam.com/dev/reference/apis/components/camera/#getpointcloud
-// [Close method docs]: https://docs.viam.com/dev/reference/apis/components/camera/#close
+// [camera component docs]: https://docs.viam.com/reference/apis/components/camera/
+// [Images method docs]: https://docs.viam.com/reference/apis/components/camera/#getimages
+// [NextPointCloud method docs]: https://docs.viam.com/reference/apis/components/camera/#getpointcloud
+// [Close method docs]: https://docs.viam.com/reference/apis/components/camera/#close
 type Camera interface {
 	resource.Resource
 	resource.Shaped

--- a/components/encoder/encoder.go
+++ b/components/encoder/encoder.go
@@ -103,10 +103,10 @@ func (t PositionType) String() string {
 //
 // For more information, see the [Properties methods docs].
 //
-// [encoder component docs]: https://docs.viam.com/dev/reference/apis/components/encoder/
-// [Position method docs]: https://docs.viam.com/dev/reference/apis/components/encoder/#getposition
-// [ResetPosition method docs]: https://docs.viam.com/dev/reference/apis/components/encoder/#resetposition
-// [Properties methods docs]: https://docs.viam.com/dev/reference/apis/components/encoder/#getproperties
+// [encoder component docs]: https://docs.viam.com/reference/apis/components/encoder/
+// [Position method docs]: https://docs.viam.com/reference/apis/components/encoder/#getposition
+// [ResetPosition method docs]: https://docs.viam.com/reference/apis/components/encoder/#resetposition
+// [Properties methods docs]: https://docs.viam.com/reference/apis/components/encoder/#getproperties
 type Encoder interface {
 	resource.Resource
 

--- a/components/gantry/gantry.go
+++ b/components/gantry/gantry.go
@@ -95,11 +95,11 @@ func Named(name string) resource.Name {
 //
 // For more information, see the [Home method docs].
 //
-// [gantry component docs]: https://docs.viam.com/dev/reference/apis/components/gantry/
-// [Position method docs]: https://docs.viam.com/dev/reference/apis/components/gantry/#getposition
-// [MoveToPosition method docs]: https://docs.viam.com/dev/reference/apis/components/gantry/#movetoposition
-// [Lengths method docs]: https://docs.viam.com/dev/reference/apis/components/gantry/#getlengths
-// [Home method docs]: https://docs.viam.com/dev/reference/apis/components/gantry/#home
+// [gantry component docs]: https://docs.viam.com/reference/apis/components/gantry/
+// [Position method docs]: https://docs.viam.com/reference/apis/components/gantry/#getposition
+// [MoveToPosition method docs]: https://docs.viam.com/reference/apis/components/gantry/#movetoposition
+// [Lengths method docs]: https://docs.viam.com/reference/apis/components/gantry/#getlengths
+// [Home method docs]: https://docs.viam.com/reference/apis/components/gantry/#home
 type Gantry interface {
 	resource.Resource
 	resource.Shaped

--- a/components/gripper/gripper.go
+++ b/components/gripper/gripper.go
@@ -73,9 +73,9 @@ type HoldingStatus struct {
 //
 // For more information, see the [Grab method docs].
 //
-// [gripper component docs]: https://docs.viam.com/dev/reference/apis/components/gripper/
-// [Open method docs]: https://docs.viam.com/dev/reference/apis/components/gripper/#open
-// [Grab method docs]: https://docs.viam.com/dev/reference/apis/components/gripper/#grab
+// [gripper component docs]: https://docs.viam.com/reference/apis/components/gripper/
+// [Open method docs]: https://docs.viam.com/reference/apis/components/gripper/#open
+// [Grab method docs]: https://docs.viam.com/reference/apis/components/gripper/#grab
 type Gripper interface {
 	resource.Resource
 	resource.Shaped

--- a/components/input/input.go
+++ b/components/input/input.go
@@ -90,10 +90,10 @@ func Named(name string) resource.Name {
 //
 // For more information, see the [RegisterControlCallback method docs].
 //
-// [input controller component docs]: https://docs.viam.com/dev/reference/apis/components/input-controller/
-// [Controls method docs]: https://docs.viam.com/dev/reference/apis/components/input-controller/#getcontrols
-// [Events method docs]: https://docs.viam.com/dev/reference/apis/components/input-controller/#getevents
-// [RegisterControlCallback method docs]: https://docs.viam.com/dev/reference/apis/components/input-controller/#registercontrolcallback
+// [input controller component docs]: https://docs.viam.com/reference/apis/components/input-controller/
+// [Controls method docs]: https://docs.viam.com/reference/apis/components/input-controller/#getcontrols
+// [Events method docs]: https://docs.viam.com/reference/apis/components/input-controller/#getevents
+// [RegisterControlCallback method docs]: https://docs.viam.com/reference/apis/components/input-controller/#registercontrolcallback
 type Controller interface {
 	resource.Resource
 

--- a/components/motor/motor.go
+++ b/components/motor/motor.go
@@ -121,15 +121,15 @@ var API = resource.APINamespaceRDK.WithComponentType(SubtypeName)
 //
 // For more information, see the [IsPowered method docs].
 //
-// [motor component docs]: https://docs.viam.com/dev/reference/apis/components/motor/
-// [SetPower method docs]: https://docs.viam.com/dev/reference/apis/components/motor/#setpower
-// [GoFor method docs]: https://docs.viam.com/dev/reference/apis/components/motor/#gofor
-// [GoTo method docs]: https://docs.viam.com/dev/reference/apis/components/motor/#goto
-// [SetRPM method docs]: https://docs.viam.com/dev/reference/apis/components/motor/#setrpm
-// [ResetZeroPosition method docs]: https://docs.viam.com/dev/reference/apis/components/motor/#resetzeroposition
-// [Position method docs]: https://docs.viam.com/dev/reference/apis/components/motor/#getposition
-// [Properties method docs]: https://docs.viam.com/dev/reference/apis/components/motor/#getproperties
-// [IsPowered method docs]: https://docs.viam.com/dev/reference/apis/components/motor/#ispowered
+// [motor component docs]: https://docs.viam.com/reference/apis/components/motor/
+// [SetPower method docs]: https://docs.viam.com/reference/apis/components/motor/#setpower
+// [GoFor method docs]: https://docs.viam.com/reference/apis/components/motor/#gofor
+// [GoTo method docs]: https://docs.viam.com/reference/apis/components/motor/#goto
+// [SetRPM method docs]: https://docs.viam.com/reference/apis/components/motor/#setrpm
+// [ResetZeroPosition method docs]: https://docs.viam.com/reference/apis/components/motor/#resetzeroposition
+// [Position method docs]: https://docs.viam.com/reference/apis/components/motor/#getposition
+// [Properties method docs]: https://docs.viam.com/reference/apis/components/motor/#getproperties
+// [IsPowered method docs]: https://docs.viam.com/reference/apis/components/motor/#ispowered
 type Motor interface {
 	resource.Resource
 	resource.Actuator

--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -146,15 +146,15 @@ func Named(name string) resource.Name {
 //
 // For more information, see the [Accuracy method docs].
 //
-// [movement sensor component docs]: https://docs.viam.com/dev/reference/apis/components/movement-sensor/
-// [Position method docs]: https://docs.viam.com/dev/reference/apis/components/movement-sensor/#getposition
-// [LinearVelocity method docs]: https://docs.viam.com/dev/reference/apis/components/movement-sensor/#getlinearvelocity
-// [AngularVelocity method docs]: https://docs.viam.com/dev/reference/apis/components/movement-sensor/#getangularvelocity
-// [LinearAcceleration method docs]: https://docs.viam.com/dev/reference/apis/components/movement-sensor/#getlinearacceleration
-// [CompassHeading method docs]: https://docs.viam.com/dev/reference/apis/components/movement-sensor/#getcompassheading
-// [Orientation method docs]: https://docs.viam.com/dev/reference/apis/components/movement-sensor/#getorientation
-// [Properties method docs]: https://docs.viam.com/dev/reference/apis/components/movement-sensor/#getproperties
-// [Accuracy method docs]: https://docs.viam.com/dev/reference/apis/components/movement-sensor/#getaccuracy
+// [movement sensor component docs]: https://docs.viam.com/reference/apis/components/movement-sensor/
+// [Position method docs]: https://docs.viam.com/reference/apis/components/movement-sensor/#getposition
+// [LinearVelocity method docs]: https://docs.viam.com/reference/apis/components/movement-sensor/#getlinearvelocity
+// [AngularVelocity method docs]: https://docs.viam.com/reference/apis/components/movement-sensor/#getangularvelocity
+// [LinearAcceleration method docs]: https://docs.viam.com/reference/apis/components/movement-sensor/#getlinearacceleration
+// [CompassHeading method docs]: https://docs.viam.com/reference/apis/components/movement-sensor/#getcompassheading
+// [Orientation method docs]: https://docs.viam.com/reference/apis/components/movement-sensor/#getorientation
+// [Properties method docs]: https://docs.viam.com/reference/apis/components/movement-sensor/#getproperties
+// [Accuracy method docs]: https://docs.viam.com/reference/apis/components/movement-sensor/#getaccuracy
 type MovementSensor interface {
 	resource.Sensor
 	resource.Resource

--- a/components/powersensor/powersensor.go
+++ b/components/powersensor/powersensor.go
@@ -82,10 +82,10 @@ func Named(name string) resource.Name {
 //
 // For more information, see the [Power method docs].
 //
-// [power sensor component docs]: https://docs.viam.com/dev/reference/apis/components/power-sensor/
-// [Voltage method docs]: https://docs.viam.com/dev/reference/apis/components/power-sensor/#getvoltage
-// [Current method docs]: https://docs.viam.com/dev/reference/apis/components/power-sensor/#getcurrent
-// [Power method docs]: https://docs.viam.com/dev/reference/apis/components/power-sensor/#getpower
+// [power sensor component docs]: https://docs.viam.com/reference/apis/components/power-sensor/
+// [Voltage method docs]: https://docs.viam.com/reference/apis/components/power-sensor/#getvoltage
+// [Current method docs]: https://docs.viam.com/reference/apis/components/power-sensor/#getcurrent
+// [Power method docs]: https://docs.viam.com/reference/apis/components/power-sensor/#getpower
 type PowerSensor interface {
 	resource.Sensor
 	resource.Resource

--- a/components/sensor/sensor.go
+++ b/components/sensor/sensor.go
@@ -1,7 +1,7 @@
 // Package sensor defines an abstract sensing device that can provide measurement readings.
 // For more information, see the [sensor component docs].
 //
-// [sensor component docs]: https://docs.viam.com/dev/reference/apis/components/sensor/
+// [sensor component docs]: https://docs.viam.com/reference/apis/components/sensor/
 package sensor
 
 import (

--- a/components/servo/servo.go
+++ b/components/servo/servo.go
@@ -67,9 +67,9 @@ var API = resource.APINamespaceRDK.WithComponentType(SubtypeName)
 //
 // For more information, see the [Position method docs].
 //
-// [servo component docs]: https://docs.viam.com/dev/reference/apis/components/servo/
-// [Move method docs]: https://docs.viam.com/dev/reference/apis/components/servo/#move
-// [Position method docs]: https://docs.viam.com/dev/reference/apis/components/servo/#getposition
+// [servo component docs]: https://docs.viam.com/reference/apis/components/servo/
+// [Move method docs]: https://docs.viam.com/reference/apis/components/servo/#move
+// [Position method docs]: https://docs.viam.com/reference/apis/components/servo/#getposition
 type Servo interface {
 	resource.Resource
 	resource.Actuator

--- a/components/switch/switch.go
+++ b/components/switch/switch.go
@@ -66,10 +66,10 @@ func Named(name string) resource.Name {
 //
 // For more information, see the [GetNumberOfPositions method docs].
 //
-// [Switch component docs]: https://docs.viam.com/dev/reference/apis/components/switch/
-// [SetPosition method docs]: https://docs.viam.com/dev/reference/apis/components/switch/#setposition
-// [GetPosition method docs]: https://docs.viam.com/dev/reference/apis/components/switch/#getposition
-// [GetNumberOfPositions method docs]: https://docs.viam.com/dev/reference/apis/components/switch/#getnumberofpositions
+// [Switch component docs]: https://docs.viam.com/reference/apis/components/switch/
+// [SetPosition method docs]: https://docs.viam.com/reference/apis/components/switch/#setposition
+// [GetPosition method docs]: https://docs.viam.com/reference/apis/components/switch/#getposition
+// [GetNumberOfPositions method docs]: https://docs.viam.com/reference/apis/components/switch/#getnumberofpositions
 type Switch interface {
 	resource.Resource
 

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -186,8 +186,8 @@ func ContainsReservedCharacter(val string) error {
 //
 // For more information, see the [Readings method docs].
 //
-// [sensor component docs]: https://docs.viam.com/dev/reference/apis/components/sensor/
-// [Readings method docs]: https://docs.viam.com/dev/reference/apis/components/sensor/#getreadings
+// [sensor component docs]: https://docs.viam.com/reference/apis/components/sensor/
+// [Readings method docs]: https://docs.viam.com/reference/apis/components/sensor/#getreadings
 type Sensor interface {
 	// Readings return data specific to the type of sensor and can be of any type.
 	Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error)

--- a/services/baseremotecontrol/base_remote_control.go
+++ b/services/baseremotecontrol/base_remote_control.go
@@ -64,8 +64,8 @@ func init() {
 // For more information, see the [ControllerInputs method docs].
 //
 // [base remote control service docs]: https://docs.viam.com/operate/reference/services/base-rc/
-// [Close method docs]: https://docs.viam.com/dev/reference/apis/services/base-rc/#close
-// [ControllerInputs method docs]: https://docs.viam.com/dev/reference/apis/services/base-rc/#controllerinputs
+// [Close method docs]: https://docs.viam.com/reference/apis/services/base-rc/#close
+// [ControllerInputs method docs]: https://docs.viam.com/reference/apis/services/base-rc/#controllerinputs
 type Service interface {
 	resource.Resource
 	// Close out of all remote control related systems.

--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -47,7 +47,7 @@ func init() {
 // For more information, see the [Sync method docs].
 //
 // [data management service docs]: https://docs.viam.com/data-ai/capture-data/capture-sync/
-// [Sync method docs]: https://docs.viam.com/dev/reference/apis/services/data/#sync
+// [Sync method docs]: https://docs.viam.com/reference/apis/services/data/#sync
 type Service interface {
 	resource.Resource
 	// Sync will sync data stored on the machine to the cloud.

--- a/services/discovery/discovery.go
+++ b/services/discovery/discovery.go
@@ -1,7 +1,7 @@
 // Package discovery implements the discovery service, which lets users surface resource configs for their machines to use.
 // For more information, see the [Discovery service docs].
 //
-// [Discovery service docs]: https://docs.viam.com/dev/reference/apis/services/discovery/
+// [Discovery service docs]: https://docs.viam.com/reference/apis/services/discovery/
 package discovery
 
 import (
@@ -81,8 +81,8 @@ func FromProvider(provider resource.Provider, name string) (Service, error) {
 //
 // For more information, see the [discover resources method docs].
 //
-// [Discovery service docs]: https://docs.viam.com/dev/reference/apis/services/discovery/
-// [discover resources method docs]: https://docs.viam.com/dev/reference/apis/services/discovery/#discoverresources
+// [Discovery service docs]: https://docs.viam.com/reference/apis/services/discovery/
+// [discover resources method docs]: https://docs.viam.com/reference/apis/services/discovery/#discoverresources
 type Service interface {
 	resource.Resource
 	DiscoverResources(ctx context.Context, extra map[string]any) ([]resource.Config, error)

--- a/services/generic/generic.go
+++ b/services/generic/generic.go
@@ -1,7 +1,7 @@
 // Package generic defines an abstract generic service and DoCommand() method.
 // For more information, see the [generic service docs].
 //
-// [generic service docs]: https://docs.viam.com/dev/reference/apis/services/generic/
+// [generic service docs]: https://docs.viam.com/reference/apis/services/generic/
 package generic
 
 import (

--- a/services/mlmodel/mlmodel.go
+++ b/services/mlmodel/mlmodel.go
@@ -62,8 +62,8 @@ func init() {
 // For more information, see the [Metadata method docs].
 //
 // [ML model service docs]: https://docs.viam.com/data-ai/ai/deploy/
-// [Infer method docs]: https://docs.viam.com/dev/reference/apis/services/ml/#infer
-// [Metadata method docs]: https://docs.viam.com/dev/reference/apis/services/ml/#metadata
+// [Infer method docs]: https://docs.viam.com/reference/apis/services/ml/#infer
+// [Metadata method docs]: https://docs.viam.com/reference/apis/services/ml/#metadata
 type Service interface {
 	resource.Resource
 	// Infer returns an output tensor map after running an input tensor map through an interface model.

--- a/services/motion/motion.go
+++ b/services/motion/motion.go
@@ -343,14 +343,14 @@ type PlanWithStatus struct {
 // For more information, see the [PlanHistory method docs].
 //
 // [motion service docs]: https://docs.viam.com/operate/reference/services/motion/
-// [Move method docs]: https://docs.viam.com/dev/reference/apis/services/motion/#move
-// [MoveOnMap method docs]: https://docs.viam.com/dev/reference/apis/services/motion/#moveonmap
-// [MoveOnGlobe method docs]: https://docs.viam.com/dev/reference/apis/services/motion/#moveonglobe
-// [StopPlan method docs]: https://docs.viam.com/dev/reference/apis/services/motion/#stopplan
-// [ListPlanStatuses method docs]: https://docs.viam.com/dev/reference/apis/services/motion/#listplanstatuses
-// [PlanHistory method docs]: https://docs.viam.com/dev/reference/apis/services/motion/#getplan
+// [Move method docs]: https://docs.viam.com/reference/apis/services/motion/#move
+// [MoveOnMap method docs]: https://docs.viam.com/reference/apis/services/motion/#moveonmap
+// [MoveOnGlobe method docs]: https://docs.viam.com/reference/apis/services/motion/#moveonglobe
+// [StopPlan method docs]: https://docs.viam.com/reference/apis/services/motion/#stopplan
+// [ListPlanStatuses method docs]: https://docs.viam.com/reference/apis/services/motion/#listplanstatuses
+// [PlanHistory method docs]: https://docs.viam.com/reference/apis/services/motion/#getplan
 //
-// [GetPose method docs]: https://docs.viam.com/dev/reference/apis/services/motion/#getpose
+// [GetPose method docs]: https://docs.viam.com/reference/apis/services/motion/#getpose
 type Service interface {
 	resource.Resource
 

--- a/services/navigation/navigation.go
+++ b/services/navigation/navigation.go
@@ -165,15 +165,15 @@ type Properties struct {
 // For more information, see the [Properties method docs].
 //
 // [navigation service docs]: https://docs.viam.com/operate/reference/services/navigation/
-// [Mode method docs]: https://docs.viam.com/dev/reference/apis/services/navigation/#getmode
-// [SetMode method docs]: https://docs.viam.com/dev/reference/apis/services/navigation/#setmode
-// [Location method docs]: https://docs.viam.com/dev/reference/apis/services/navigation/#getlocation
-// [Waypoints method docs]: https://docs.viam.com/dev/reference/apis/services/navigation/#getwaypoints
-// [AddWaypoint method docs]: https://docs.viam.com/dev/reference/apis/services/navigation/#addwaypoint
-// [RemoveWaypoint method docs]: https://docs.viam.com/dev/reference/apis/services/navigation/#removewaypoint
-// [Paths method docs]: https://docs.viam.com/dev/reference/apis/services/navigation/#getpaths
-// [Properties method docs]: https://docs.viam.com/dev/reference/apis/services/navigation/#getproperties
-// [Obstacles method docs]: https://docs.viam.com/dev/reference/apis/services/navigation/#getobstacles
+// [Mode method docs]: https://docs.viam.com/reference/apis/services/navigation/#getmode
+// [SetMode method docs]: https://docs.viam.com/reference/apis/services/navigation/#setmode
+// [Location method docs]: https://docs.viam.com/reference/apis/services/navigation/#getlocation
+// [Waypoints method docs]: https://docs.viam.com/reference/apis/services/navigation/#getwaypoints
+// [AddWaypoint method docs]: https://docs.viam.com/reference/apis/services/navigation/#addwaypoint
+// [RemoveWaypoint method docs]: https://docs.viam.com/reference/apis/services/navigation/#removewaypoint
+// [Paths method docs]: https://docs.viam.com/reference/apis/services/navigation/#getpaths
+// [Properties method docs]: https://docs.viam.com/reference/apis/services/navigation/#getproperties
+// [Obstacles method docs]: https://docs.viam.com/reference/apis/services/navigation/#getobstacles
 type Service interface {
 	resource.Resource
 

--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -175,10 +175,10 @@ func FromProvider(provider resource.Provider, name string) (Service, error) {
 // For more information, see the [Properties method docs].
 //
 // [SLAM service docs]: https://docs.viam.com/operate/reference/services/slam/
-// [Position method docs]: https://docs.viam.com/dev/reference/apis/services/slam/#getposition
-// [PointCloudMap method docs]: https://docs.viam.com/dev/reference/apis/services/slam/#getpointcloudmap
-// [InternalState method docs]: https://docs.viam.com/dev/reference/apis/services/slam/#getinternalstate
-// [Properties method docs]: https://docs.viam.com/dev/reference/apis/services/slam/#getproperties
+// [Position method docs]: https://docs.viam.com/reference/apis/services/slam/#getposition
+// [PointCloudMap method docs]: https://docs.viam.com/reference/apis/services/slam/#getpointcloudmap
+// [InternalState method docs]: https://docs.viam.com/reference/apis/services/slam/#getinternalstate
+// [Properties method docs]: https://docs.viam.com/reference/apis/services/slam/#getproperties
 type Service interface {
 	resource.Resource
 	Position(ctx context.Context) (spatialmath.Pose, error)

--- a/services/vision/vision.go
+++ b/services/vision/vision.go
@@ -170,13 +170,13 @@ func init() {
 //
 // For more information, see the [CaptureAllFromCamera method docs].
 //
-// [vision service docs]: https://docs.viam.com/dev/reference/apis/services/vision/
-// [DetectionsFromCamera method docs]: https://docs.viam.com/dev/reference/apis/services/vision/#getdetectionsfromcamera
-// [Detections method docs]: https://docs.viam.com/dev/reference/apis/services/vision/#getdetections
-// [ClassificationsFromCamera method docs]: https://docs.viam.com/dev/reference/apis/services/vision/#getclassificationsfromcamera
-// [Classifications method docs]: https://docs.viam.com/dev/reference/apis/services/vision/#getclassifications
-// [GetObjectPointClouds method docs]: https://docs.viam.com/dev/reference/apis/services/vision/#getobjectpointclouds
-// [CaptureAllFromCamera method docs]: https://docs.viam.com/dev/reference/apis/services/vision/#captureallfromcamera
+// [vision service docs]: https://docs.viam.com/reference/apis/services/vision/
+// [DetectionsFromCamera method docs]: https://docs.viam.com/reference/apis/services/vision/#getdetectionsfromcamera
+// [Detections method docs]: https://docs.viam.com/reference/apis/services/vision/#getdetections
+// [ClassificationsFromCamera method docs]: https://docs.viam.com/reference/apis/services/vision/#getclassificationsfromcamera
+// [Classifications method docs]: https://docs.viam.com/reference/apis/services/vision/#getclassifications
+// [GetObjectPointClouds method docs]: https://docs.viam.com/reference/apis/services/vision/#getobjectpointclouds
+// [CaptureAllFromCamera method docs]: https://docs.viam.com/reference/apis/services/vision/#captureallfromcamera
 type Service interface {
 	resource.Resource
 	// DetectionsFromCamera returns a list of detections from the next image from a specified camera using a configured detector.

--- a/services/worldstatestore/world_state_store.go
+++ b/services/worldstatestore/world_state_store.go
@@ -2,7 +2,7 @@
 // create custom visualizers to be rendered in the client.
 // For more information, see the [WorldStateStore service docs].
 //
-// [WorldStateStore service docs]: https://docs.viam.com/dev/reference/apis/services/world-state-store/
+// [WorldStateStore service docs]: https://docs.viam.com/reference/apis/services/world-state-store/
 package worldstatestore
 
 import (
@@ -107,10 +107,10 @@ func FromProvider(provider resource.Provider, name string) (Service, error) {
 //
 // For more information, see the [stream transform changes method docs].
 //
-// [WorldStateStore service docs]: https://docs.viam.com/dev/reference/apis/services/world-state-store/
-// [list uuids method docs]: https://docs.viam.com/dev/reference/apis/services/world-state-store/#listuuids
-// [get transform method docs]: https://docs.viam.com/dev/reference/apis/services/world-state-store/#gettransform
-// [stream transform changes method docs]: https://docs.viam.com/dev/reference/apis/services/world-state-store/#streamtransformchanges
+// [WorldStateStore service docs]: https://docs.viam.com/reference/apis/services/world-state-store/
+// [list uuids method docs]: https://docs.viam.com/reference/apis/services/world-state-store/#listuuids
+// [get transform method docs]: https://docs.viam.com/reference/apis/services/world-state-store/#gettransform
+// [stream transform changes method docs]: https://docs.viam.com/reference/apis/services/world-state-store/#streamtransformchanges
 type Service interface {
 	resource.Resource
 	ListUUIDs(ctx context.Context, extra map[string]any) ([][]byte, error)


### PR DESCRIPTION
## What

The docs update broke some RDK links, and the link check job broke a few months ago, so some links need to be updated. This fixes the easy ones. Repoints all `docs.viam.com/dev/reference/…` links to their current canonical `docs.viam.com/reference/…` paths (213 links across 31 files, `#anchors` preserved). 

A lot of the links technically still work, as the docs have a redirect, but then it drops the anchor portion of the link, this should fix both.

## Why

The docs site moved its API reference out from under `/dev/reference/` to `/reference/`, leaving the old paths as redirect aliases. RDK's godoc doc-comment and error/CLI-string links still point at the old aliased paths, so they resolve only via a redirect rather than the canonical URL.

## How

Mechanical find/replace, no semantic changes:

```
s|docs.viam.com/dev/reference/|docs.viam.com/reference/|
```

## Validation

A link checker run against the tree **after** this change drops RDK's `docs.viam.com` findings from 239 → 56: the 188 systematic `/dev/reference/` stale links are resolved. The residual 56 will be fixed in a different PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
