### PR TITLE
linkcheck: drop broken Jira ticketing, keep pass/fail

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -49,24 +49,3 @@ jobs:
           name: htmltest-report
           path: tmp/.htmltest/htmltest.log
           retention-days: 7 # Default is 90 days
-      - name: Login to Jira
-        if: failure()
-        uses: atlassian/gajira-login@v3
-        env:
-          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-      - name: Create Jira ticket
-        if: failure()
-        id: create
-        uses: atlassian/gajira-create@v3
-        env:
-          GITHUB_RUN_ID: ${{ github.run_id }}
-        with:
-          project: DOCS
-          issuetype: Bug
-          summary: Broken link detected in RDK
-          description: "For more info see https://github.com/viamrobotics/rdk/actions/runs/${{ env.GITHUB_RUN_ID }}."
-      - name: Log created Jira issue
-        if: failure()
-        run: echo "Issue ${{ steps.create.outputs.issue }} was created"


### PR DESCRIPTION
## What

Removes the three dead **Jira** steps (`Login to Jira` / `Create Jira ticket` / `Log created Jira issue`) from the weekly `linkcheck` workflow.

## Why

Do not merge, this was more here to be a talking point on the Job, currently the Jira connection appears to be broken
