### PR TITLE
[RSDK-14227] fix orphaned resource after validate fails

### DIFF
--- a/module/validatecycle/main.go
+++ b/module/validatecycle/main.go
@@ -1,0 +1,77 @@
+// Package main is a test-only module used to prove that a modular resource
+// recovers from a config cycle whose middle step fails module validation
+// (valid -> invalid -> valid). Its single generic model constructs trivially;
+// Validate fails iff the `bad` attribute is true.
+package main
+
+import (
+	"context"
+	"fmt"
+
+	goutils "go.viam.com/utils"
+
+	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/module"
+	"go.viam.com/rdk/resource"
+)
+
+var model = resource.NewModel("rdk", "test", "validatecycle")
+
+type conf struct {
+	Bad bool `json:"bad"`
+}
+
+// Validate fails iff bad==true. No dependencies.
+func (c *conf) Validate(path string) ([]string, []string, error) {
+	if c.Bad {
+		return nil, nil, fmt.Errorf("validatecycle: config is invalid (bad=true) at %q", path)
+	}
+	return nil, nil, nil
+}
+
+func main() {
+	goutils.ContextualMainWithSIGPIPE(mainWithArgs, module.NewLoggerFromArgs("ValidateCycleModule"))
+}
+
+func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) error {
+	myMod, err := module.NewModuleFromArgs(ctx)
+	if err != nil {
+		return err
+	}
+
+	resource.RegisterComponent(generic.API, model,
+		resource.Registration[resource.Resource, *conf]{Constructor: newThing})
+	if err := myMod.AddModelFromRegistry(ctx, generic.API, model); err != nil {
+		return err
+	}
+
+	if err := myMod.Start(ctx); err != nil {
+		return err
+	}
+	defer myMod.Close(ctx)
+	<-ctx.Done()
+	return nil
+}
+
+func newThing(
+	ctx context.Context,
+	deps resource.Dependencies,
+	c resource.Config,
+	logger logging.Logger,
+) (resource.Resource, error) {
+	return &thing{Named: c.ResourceName().AsNamed()}, nil
+}
+
+type thing struct {
+	resource.Named
+	resource.AlwaysRebuild
+}
+
+func (t *thing) DoCommand(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
+	return map[string]interface{}{"ok": true}, nil
+}
+
+func (t *thing) Close(ctx context.Context) error {
+	return nil
+}

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -610,7 +610,7 @@ func (manager *resourceManager) closeResource(ctx context.Context, res resource.
 // closeAndUnsetResource attempts to close and unset the resource from the graph node. Should only be called within
 // resourceGraphLock.
 func (manager *resourceManager) closeAndUnsetResource(ctx context.Context, gNode *resource.GraphNode) error {
-	res, err := gNode.Resource()
+	res, err := gNode.UnsafeResource()
 	if err != nil {
 		return err
 	}

--- a/robot/impl/validate_cycle_regression_test.go
+++ b/robot/impl/validate_cycle_regression_test.go
@@ -1,0 +1,60 @@
+package robotimpl
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	rtestutils "go.viam.com/rdk/testutils"
+	rutils "go.viam.com/rdk/utils"
+)
+
+// TestModularValidateFailureThenRecovery drives a modular resource through a
+// valid -> invalid -> valid config cycle, where the middle config fails the
+// module's Validate.
+func TestModularValidateFailureThenRecovery(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+
+	modPath := rtestutils.BuildTempModule(t, "module/validatecycle")
+	model := resource.NewModel("rdk", "test", "validatecycle")
+
+	mkCfg := func(bad bool) *config.Config {
+		return &config.Config{
+			Modules: []config.Module{{Name: "vcmod", ExePath: modPath}},
+			Components: []resource.Config{{
+				Name:       "thingy",
+				API:        generic.API,
+				Model:      model,
+				Attributes: rutils.AttributeMap{"bad": bad},
+			}},
+		}
+	}
+	r := setupLocalRobot(t, ctx, mkCfg(false), logger, WithDisableCompleteConfigWorker())
+
+	// Healthy start.
+	_, err := r.ResourceByName(generic.Named("thingy"))
+	test.That(t, err, test.ShouldBeNil)
+
+	// Push a config that fails the module's Validate: the resource becomes
+	// unavailable
+	r.Reconfigure(ctx, mkCfg(true))
+	_, err = r.ResourceByName(generic.Named("thingy"))
+	test.That(t, err, test.ShouldNotBeNil)
+
+	// Push the corrected config: the resource must come back.
+	r.Reconfigure(ctx, mkCfg(false))
+	res, err := r.ResourceByName(generic.Named("thingy"))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, res, test.ShouldNotBeNil)
+
+	// The recovered resource must actually work.
+	resp, err := res.DoCommand(ctx, map[string]interface{}{"ping": true})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, resp["ok"], test.ShouldEqual, true)
+}


### PR DESCRIPTION
The main branch of RDK I believe has a bug where if a call to a module `Validate` fails on a healthy resource the resource becomes orphaned. Even after fixing the configuration error the resource would be created again (because it is left dangling in the resource graph) Only a module restart can fix it.

I added a test covering this issue and what i think the fix should be