### PR TITLE
Updating upload-artifact action

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -7,6 +7,9 @@
 name: run-htmltest
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - updating-jira-action
   schedule:
     # 10am UTC on Mondays
     - cron: "0 10 * * 1"

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           config: .htmltest.yml
       - name: Archive htmltest results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         # Note: Set ACTIONS_RUNTIME_TOKEN env variable to test with nektos/act
         with:
           name: htmltest-report

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -6,10 +6,6 @@
 #
 name: run-htmltest
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - updating-jira-action
   schedule:
     # 10am UTC on Mondays
     - cron: "0 10 * * 1"

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -6,6 +6,7 @@
 #
 name: run-htmltest
 on:
+  workflow_dispatch:
   schedule:
     # 10am UTC on Mondays
     - cron: "0 10 * * 1"


### PR DESCRIPTION
The V3 version of the file upload action has been deprecated: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

All other instances of this action have already been upgraded, so just bringing this one up to the supported version.