### PR TITLE
ci: checkout repo before paths-filter in main.yml changes job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,9 @@ jobs:
     outputs:
       release: ${{ steps.decide.outputs.release }}
     steps:
+      # paths-filter needs the git history to diff against the previous commit on push events.
+      # actions/checkout@v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       # dorny/paths-filter@v4.0.1
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter


### PR DESCRIPTION
## Problem

The `changes` job added in #6083 to `.github/workflows/main.yml` runs `dorny/paths-filter` as its **first and only** step, with no `actions/checkout` before it. On `push` events `paths-filter` shells out to `git` to diff the current commit against the previous one, so with no `.git` in the workspace it fails:

```
[command]/usr/bin/git branch --show-current
fatal: not a git repository (or any of the parent directories): .git
##[error]The process '/usr/bin/git' failed with exit code 128
```

This failed the whole "Build and Publish Latest" run on main: https://github.com/viamrobotics/rdk/actions/runs/28911520451

(The `pull_request` path works because there `paths-filter` uses the GitHub API instead of local git, which is why this slipped through in #6083.)

## Fix

Add an `actions/checkout` step before the filter so the git history is available for the diff. `paths-filter`'s default `initial-fetch-depth: 100` fetches any additional history it needs, so a default shallow checkout is sufficient. `checkout` is SHA-pinned with a version comment to match the `paths-filter` line below it. `main.yml` is the only workflow using `paths-filter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)