### PR TITLE
RSDK-9565: Preserve permissions by default in viam machine part cp + fix copy resume bug

### DIFF
--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1180,12 +1180,12 @@ func TestShellFileCopy(t *testing.T) {
 					test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, filepath.Join(tempDir, filepath.Base(tfs.Root))), test.ShouldBeNil)
 					afterInfo, err := os.Stat(nestedCopy)
 					test.That(t, err, test.ShouldBeNil)
+					// mode follows the source with or without preserve (umask applies without)
+					test.That(t, afterInfo.Mode(), test.ShouldEqual, newMode)
 					if preserve {
 						test.That(t, afterInfo.ModTime().UTC().String(), test.ShouldEqual, modTime.String())
-						test.That(t, afterInfo.Mode(), test.ShouldEqual, newMode)
 					} else {
 						test.That(t, afterInfo.ModTime().UTC().String(), test.ShouldNotEqual, modTime.String())
-						test.That(t, afterInfo.Mode(), test.ShouldNotEqual, newMode)
 					}
 				})
 			}
@@ -1309,12 +1309,12 @@ func TestShellFileCopy(t *testing.T) {
 					test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, filepath.Join(tempDir, filepath.Base(tfs.Root))), test.ShouldBeNil)
 					afterInfo, err := os.Stat(nestedCopy)
 					test.That(t, err, test.ShouldBeNil)
+					// mode follows the source with or without preserve (umask applies without)
+					test.That(t, afterInfo.Mode(), test.ShouldEqual, newMode)
 					if preserve {
 						test.That(t, afterInfo.ModTime().UTC().String(), test.ShouldEqual, modTime.String())
-						test.That(t, afterInfo.Mode(), test.ShouldEqual, newMode)
 					} else {
 						test.That(t, afterInfo.ModTime().UTC().String(), test.ShouldNotEqual, modTime.String())
-						test.That(t, afterInfo.Mode(), test.ShouldNotEqual, newMode)
 					}
 				})
 			}

--- a/services/shell/copy_local.go
+++ b/services/shell/copy_local.go
@@ -196,10 +196,10 @@ func (copier *localFileCopier) Copy(ctx context.Context, file File) error {
 		modTime = fileInfo.ModTime()
 		fileMode = fileInfo.Mode()
 	case fileInfo.Mode().Perm() != 0:
-		// source permissions, masked by umask at creation; setuid/setgid/sticky need preserve
+		// even without preserve, pass through the file mode (if it exists)
+		// to match the behavior of scp
 		fileMode = fileInfo.Mode().Perm()
 	case fileInfo.IsDir():
-		// mode unavailable (older sender)
 		fileMode = 0o750
 	default:
 		fileMode = 0o640

--- a/services/shell/copy_local.go
+++ b/services/shell/copy_local.go
@@ -195,7 +195,11 @@ func (copier *localFileCopier) Copy(ctx context.Context, file File) error {
 	case copier.preserve:
 		modTime = fileInfo.ModTime()
 		fileMode = fileInfo.Mode()
+	case fileInfo.Mode().Perm() != 0:
+		// source permissions, masked by umask at creation; setuid/setgid/sticky need preserve
+		fileMode = fileInfo.Mode().Perm()
 	case fileInfo.IsDir():
+		// mode unavailable (older sender)
 		fileMode = 0o750
 	default:
 		fileMode = 0o640

--- a/services/shell/copy_local.go
+++ b/services/shell/copy_local.go
@@ -223,6 +223,11 @@ func (copier *localFileCopier) Copy(ctx context.Context, file File) error {
 		// Technically the temp file can be deleted upon any Copy error, but it will also be clobbered next time we retry.
 		fullPathTmp := fullPath + ".download"
 
+		// always delete a potential stale temp. if the temp is read-only, it can
+		// cause the following OpenFile call to fail on windows
+		if err := os.Remove(fullPathTmp); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
 		//nolint:gosec // this is from an authenticated/authorized connection
 		localFile, err := os.OpenFile(fullPathTmp, os.O_CREATE|os.O_WRONLY, fileMode)
 		if err != nil {
@@ -240,6 +245,13 @@ func (copier *localFileCopier) Copy(ctx context.Context, file File) error {
 		}
 		if closeErr != nil {
 			return closeErr
+		}
+		// if there is already a file at the destination path, we are going to overwrite it.
+		// make sure it's writable first so the overwrite doesn't fail on windows
+
+		// if this fails, we should still try and move the tmp file to the destination
+		if info, err := os.Stat(fullPath); err == nil && info.Mode().Perm()&0o200 == 0 {
+			utils.UncheckedError(os.Chmod(fullPath, info.Mode().Perm()|0o200))
 		}
 		if err := os.Rename(fullPathTmp, fullPath); err != nil {
 			return err

--- a/services/shell/copy_local_test.go
+++ b/services/shell/copy_local_test.go
@@ -294,7 +294,7 @@ func TestLocalFileCopy(t *testing.T) {
 
 		err = copier.Copy(ctx, File{
 			RelativeName: "legacy",
-			Data:         &modelessFile{Reader: strings.NewReader("data"), info: fileInfoData{name: "legacy", size: 4}},
+			Data:         &stubFile{Reader: strings.NewReader("data"), info: fileInfoData{name: "legacy", size: 4}},
 		})
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, copier.Close(ctx), test.ShouldBeNil)
@@ -329,14 +329,39 @@ func TestLocalFileCopy(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, info.Mode(), test.ShouldEqual, os.FileMode(0o640))
 	})
+
+	t.Run("stale read-only temp from an interrupted transfer", func(t *testing.T) {
+		tempDir := t.TempDir()
+		stalePath := filepath.Join(tempDir, "readonly.download")
+		test.That(t, os.WriteFile(stalePath, []byte("partial"), 0o444), test.ShouldBeNil)
+
+		factory, err := NewLocalFileCopyFactory(tempDir, false, false)
+		test.That(t, err, test.ShouldBeNil)
+		copier, err := factory.MakeFileCopier(ctx, CopyFilesSourceTypeSingleFile)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = copier.Copy(ctx, File{
+			RelativeName: "readonly",
+			Data:         &stubFile{Reader: strings.NewReader("data"), info: fileInfoData{name: "readonly", size: 4, mode: 0o444}},
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, copier.Close(ctx), test.ShouldBeNil)
+
+		rd, err := os.ReadFile(filepath.Join(tempDir, "readonly"))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, rd, test.ShouldResemble, []byte("data"))
+		_, err = os.Stat(stalePath)
+		test.That(t, errors.Is(err, fs.ErrNotExist), test.ShouldBeTrue)
+	})
 }
 
-// modelessFile mimics a stream from an older sender that omits the file mode.
-type modelessFile struct {
+// stubFile is an in-memory fs.File with arbitrary file info, e.g. for mimicking
+// an older sender that omits the file mode.
+type stubFile struct {
 	*strings.Reader
 	info fileInfoData
 }
 
-func (f *modelessFile) Stat() (fs.FileInfo, error) { return f.info, nil }
+func (f *stubFile) Stat() (fs.FileInfo, error) { return f.info, nil }
 
-func (f *modelessFile) Close() error { return nil }
+func (f *stubFile) Close() error { return nil }

--- a/services/shell/copy_local_test.go
+++ b/services/shell/copy_local_test.go
@@ -269,14 +269,67 @@ func TestLocalFileCopy(t *testing.T) {
 				test.That(t, shelltestutils.DirectoryContentsEqual(tfs.Root, filepath.Join(tempDir, filepath.Base(tfs.Root))), test.ShouldBeNil)
 				afterInfo, err := os.Stat(nestedCopy)
 				test.That(t, err, test.ShouldBeNil)
+				// mode follows the source with or without preserve (umask applies without)
+				test.That(t, afterInfo.Mode(), test.ShouldEqual, newMode)
 				if preserve {
 					test.That(t, afterInfo.ModTime().UTC().String(), test.ShouldEqual, modTime.String())
-					test.That(t, afterInfo.Mode(), test.ShouldEqual, newMode)
 				} else {
 					test.That(t, afterInfo.ModTime().UTC().String(), test.ShouldNotEqual, modTime.String())
-					test.That(t, afterInfo.Mode(), test.ShouldNotEqual, newMode)
 				}
 			})
 		}
 	})
+
+	t.Run("defaults applied when source mode unavailable", func(t *testing.T) {
+		tempDir := t.TempDir()
+
+		factory, err := NewLocalFileCopyFactory(tempDir, false, false)
+		test.That(t, err, test.ShouldBeNil)
+		copier, err := factory.MakeFileCopier(ctx, CopyFilesSourceTypeSingleFile)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = copier.Copy(ctx, File{
+			RelativeName: "legacy",
+			Data:         &modelessFile{Reader: strings.NewReader("data"), info: fileInfoData{name: "legacy", size: 4}},
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, copier.Close(ctx), test.ShouldBeNil)
+
+		info, err := os.Stat(filepath.Join(tempDir, "legacy"))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, info.Mode(), test.ShouldEqual, os.FileMode(0o640))
+	})
+
+	t.Run("mode 0o000 file gets default permissions", func(t *testing.T) {
+		srcDir := t.TempDir()
+		srcPath := filepath.Join(srcDir, "unreadable")
+		test.That(t, os.WriteFile(srcPath, []byte("data"), 0o644), test.ShouldBeNil)
+		// open before chmod so the read works without root
+		src, err := os.Open(srcPath)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, os.Chmod(srcPath, 0o000), test.ShouldBeNil)
+
+		tempDir := t.TempDir()
+		factory, err := NewLocalFileCopyFactory(tempDir, false, false)
+		test.That(t, err, test.ShouldBeNil)
+		copier, err := factory.MakeFileCopier(ctx, CopyFilesSourceTypeSingleFile)
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, copier.Copy(ctx, File{RelativeName: "unreadable", Data: src}), test.ShouldBeNil)
+		test.That(t, copier.Close(ctx), test.ShouldBeNil)
+
+		info, err := os.Stat(filepath.Join(tempDir, "unreadable"))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, info.Mode(), test.ShouldEqual, os.FileMode(0o640))
+	})
 }
+
+// modelessFile mimics a stream from an older sender that omits the file mode.
+type modelessFile struct {
+	*strings.Reader
+	info fileInfoData
+}
+
+func (f *modelessFile) Stat() (fs.FileInfo, error) { return f.info, nil }
+
+func (f *modelessFile) Close() error { return nil }

--- a/services/shell/copy_local_test.go
+++ b/services/shell/copy_local_test.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -281,6 +282,9 @@ func TestLocalFileCopy(t *testing.T) {
 	})
 
 	t.Run("defaults applied when source mode unavailable", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("expects unix file modes; Windows fabricates 0666/0444")
+		}
 		tempDir := t.TempDir()
 
 		factory, err := NewLocalFileCopyFactory(tempDir, false, false)
@@ -301,6 +305,9 @@ func TestLocalFileCopy(t *testing.T) {
 	})
 
 	t.Run("mode 0o000 file gets default permissions", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("chmod 0o000 becomes read-only 0444 on Windows; fallback branch unreachable")
+		}
 		srcDir := t.TempDir()
 		srcPath := filepath.Join(srcDir, "unreadable")
 		test.That(t, os.WriteFile(srcPath, []byte("data"), 0o644), test.ShouldBeNil)

--- a/services/shell/copy_rpc.go
+++ b/services/shell/copy_rpc.go
@@ -450,10 +450,11 @@ func (writer *shellFileCopyWriter) Copy(ctx context.Context, file File) error {
 			fileDataProto.Name = file.RelativeName
 			fileDataProto.IsDir = fileInfo.IsDir()
 			fileDataProto.Size = fileInfo.Size()
+			// mode is always sent so receivers can default to source permissions
+			mode := uint32(fileInfo.Mode())
+			fileDataProto.Mode = &mode
 			if writer.preserve {
 				// Note(erd): maybe support access time in the future if needed
-				mode := uint32(fileInfo.Mode())
-				fileDataProto.Mode = &mode
 				fileDataProto.ModTime = timestamppb.New(fileInfo.ModTime())
 			}
 		}

--- a/services/shell/copy_rpc.go
+++ b/services/shell/copy_rpc.go
@@ -450,7 +450,6 @@ func (writer *shellFileCopyWriter) Copy(ctx context.Context, file File) error {
 			fileDataProto.Name = file.RelativeName
 			fileDataProto.IsDir = fileInfo.IsDir()
 			fileDataProto.Size = fileInfo.Size()
-			// mode is always sent so receivers can default to source permissions
 			mode := uint32(fileInfo.Mode())
 			fileDataProto.Mode = &mode
 			if writer.preserve {

--- a/services/shell/copy_rpc_test.go
+++ b/services/shell/copy_rpc_test.go
@@ -239,14 +239,13 @@ func TestShellRPCFileCopier(t *testing.T) {
 				test.That(t, memWriter.fileDatas[0].Name, test.ShouldEqual, shellFile.RelativeName)
 				test.That(t, memWriter.fileDatas[0].Eof, test.ShouldBeFalse)
 
+				test.That(t, memWriter.fileDatas[0].Mode, test.ShouldNotBeNil)
+				test.That(t, fs.FileMode(*memWriter.fileDatas[0].Mode), test.ShouldEqual, newMode)
 				if preserve {
 					test.That(t, memWriter.fileDatas[0].ModTime, test.ShouldNotBeNil)
-					test.That(t, memWriter.fileDatas[0].Mode, test.ShouldNotBeNil)
 					test.That(t, memWriter.fileDatas[0].ModTime.AsTime().String(), test.ShouldEqual, modTime.String())
-					test.That(t, fs.FileMode(*memWriter.fileDatas[0].Mode), test.ShouldEqual, newMode)
 				} else {
 					test.That(t, memWriter.fileDatas[0].ModTime, test.ShouldBeNil)
-					test.That(t, memWriter.fileDatas[0].Mode, test.ShouldBeNil)
 				}
 
 				test.That(t, len(memWriter.fileDatas), test.ShouldEqual, 6)


### PR DESCRIPTION
`viam machine part cp` used to strip file permissions completely unless `--preserve` was passed. This was surprising for users, since file copy utilities like `scp` do tend to preserve permissions even when their `--preserve` flags are not passed.

This branch updates `viam machine part cp` to preserve permissions by default (by just always passing them through and setting them). The difference between `--preserve` and default are now:
- Without `--preserve`, the receiver's `umask` (default `022`) applies on top of the source permissions. `--preserve` actually runs `chmod` after the copy to force source permissions
- `--preserve` updates the modified time to match the source, default does not

Since there's no `umask` on Windows, this basically means permissions will always be preserved on Windows (as faithfully as they can be, based on the implementation of `os.Chmod()`).

This branch also fixes an edge case (which Claude pointed out) where some stages of the copy process can fail on Windows if the file being copied (or the file already existing at the destination) is read-only - because Windows disallows certain operations on read-only files (like opening for writing or overwriting by renaming). So I added some steps to defend against those failures.