### PR TITLE
Focal build follow-ups: fix container shell, drop armhf, extract deps script, upx action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,11 +64,6 @@ jobs:
           platform: linux/arm64
           image: rdk-focal
           file: etc/Dockerfile.focal
-        - arch: ubuntu-small-arm
-          tag: armhf
-          platform: linux/arm/v7
-          image: rdk-focal
-          file: etc/Dockerfile.focal
     runs-on: ${{ matrix.arch }}
     timeout-minutes: 30
     steps:

--- a/.github/workflows/focal-build.yml
+++ b/.github/workflows/focal-build.yml
@@ -67,19 +67,14 @@ jobs:
       run: chown -R testbot:testbot .
 
     - name: Install upx
-      shell: bash
-      env:
-        UPX_VERSION: 5.2.0
-      run: |
-        set -euo pipefail
-        case "$(uname -m)" in
-          x86_64) upx_arch=amd64 ;;
-          aarch64) upx_arch=arm64 ;;
-          *) echo "unsupported arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL "https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-${upx_arch}_linux.tar.xz" \
-          | tar -C /usr/local/bin --strip-components=1 --wildcards -xJ '*/upx'
-        upx --version
+      # crazy-max/ghaction-upx@v4.0.0
+      uses: crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368
+      with:
+        version: v5.2.0
+        install-only: true
+
+    - name: Link upx into /usr/local/bin
+      run: ln -sf "$(command -v upx)" /usr/local/bin/upx
 
     - name: Resolve channel and arch
       id: meta

--- a/.github/workflows/focal-build.yml
+++ b/.github/workflows/focal-build.yml
@@ -67,6 +67,7 @@ jobs:
       run: chown -R testbot:testbot .
 
     - name: Install upx
+      shell: bash
       env:
         UPX_VERSION: 5.2.0
       run: |

--- a/etc/Dockerfile.focal
+++ b/etc/Dockerfile.focal
@@ -19,17 +19,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libjpeg-turbo8-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# cmake >= 3.18 is required by nlopt >= 2.11; focal apt ships 3.16. Kitware
-# prebuilt where available, pip wheel (manylinux_2_31 matches focal) on armhf.
+# cmake >= 3.18 is required by nlopt >= 2.11; focal apt ships 3.16.
 RUN set -eux; \
     case "$(dpkg --print-architecture)" in \
         amd64|arm64) \
             curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" \
                 | tar -xz --strip-components=1 -C /usr/local ;; \
-        armhf) \
-            apt-get update && apt-get install -y --no-install-recommends python3-pip \
-                && pip3 install "cmake==${CMAKE_VERSION}" \
-                && rm -rf /var/lib/apt/lists/* ;; \
         *) echo "unsupported arch" >&2; exit 1 ;; \
     esac; \
     cmake --version
@@ -64,7 +59,6 @@ RUN set -eux; \
     case "$(dpkg --print-architecture)" in \
         amd64) go_arch=amd64 ;; \
         arm64) go_arch=arm64 ;; \
-        armhf) go_arch=armv6l ;; \
         *) echo "unsupported arch" >&2; exit 1 ;; \
     esac; \
     curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${go_arch}.tar.gz" \

--- a/etc/Dockerfile.focal
+++ b/etc/Dockerfile.focal
@@ -1,70 +1,11 @@
 # Minimal Focal toolchain image for building RDK's semi-static viam-server.
 FROM ubuntu:focal
 
-# GO_VERSION tracks the `go` directive in go.mod.
-ARG GO_VERSION=1.25.9
-ARG NLOPT_VERSION=2.11.0
-ARG CMAKE_VERSION=4.3.4
-# x264 stable branch. Built from source: focal's prebuilt libx264.a references
-# __*_finite glibc symbols that fail to resolve when statically linked.
-ARG X264_COMMIT=b35605ace3ddf7c1a5d67a2eb553f034aef41d55
-
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH=/usr/local/go/bin:$PATH
 
-# Build/link deps. nasm builds x264.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        build-essential \
-        ca-certificates curl file git make nasm pkg-config sudo xz-utils \
-        libjpeg-turbo8-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# cmake >= 3.18 is required by nlopt >= 2.11; focal apt ships 3.16.
-RUN set -eux; \
-    case "$(dpkg --print-architecture)" in \
-        amd64|arm64) \
-            curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" \
-                | tar -xz --strip-components=1 -C /usr/local ;; \
-        *) echo "unsupported arch" >&2; exit 1 ;; \
-    esac; \
-    cmake --version
-
-# nlopt into /usr/local: headers + PIC static lib + pkg-config. NLOPT_CXX=OFF
-# skips the C++-only algorithms so the library stays plain C.
-RUN set -eux; \
-    curl -fsSL "https://github.com/stevengj/nlopt/archive/refs/tags/v${NLOPT_VERSION}.tar.gz" \
-        | tar -C /tmp -xz; \
-    cmake -S "/tmp/nlopt-${NLOPT_VERSION}" -B /tmp/nlopt-build \
-        -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-        -DNLOPT_CXX=OFF \
-        -DNLOPT_PYTHON=OFF -DNLOPT_OCTAVE=OFF -DNLOPT_MATLAB=OFF \
-        -DNLOPT_GUILE=OFF -DNLOPT_SWIG=OFF -DNLOPT_TESTS=OFF; \
-    cmake --build /tmp/nlopt-build -j "$(nproc)"; \
-    cmake --install /tmp/nlopt-build; \
-    rm -rf "/tmp/nlopt-${NLOPT_VERSION}" /tmp/nlopt-build
-
-# x264 into /usr/local: headers + shared + PIC static + pkg-config.
-RUN set -eux; \
-    curl -fsSL "https://code.videolan.org/videolan/x264/-/archive/${X264_COMMIT}/x264-${X264_COMMIT}.tar.gz" \
-        | tar -C /tmp -xz; \
-    cd "/tmp/x264-${X264_COMMIT}"; \
-    ./configure --prefix=/usr/local --enable-shared --enable-static --enable-pic --disable-cli --disable-opencl; \
-    make -j "$(nproc)"; \
-    make install; \
-    ldconfig; \
-    cd /; rm -rf "/tmp/x264-${X264_COMMIT}"
-
-# Go toolchain.
-RUN set -eux; \
-    case "$(dpkg --print-architecture)" in \
-        amd64) go_arch=amd64 ;; \
-        arm64) go_arch=arm64 ;; \
-        *) echo "unsupported arch" >&2; exit 1 ;; \
-    esac; \
-    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${go_arch}.tar.gz" \
-        | tar -C /usr/local -xz; \
-    ln -s /usr/local/go/bin/go /usr/local/bin/go; \
-    go version
+COPY etc/ensure-focal-deps.sh /tmp/ensure-focal-deps.sh
+RUN /tmp/ensure-focal-deps.sh && rm /tmp/ensure-focal-deps.sh
 
 # Unprivileged build user (uid/gid 1000) with passwordless sudo.
 RUN groupadd -g 1000 testbot \

--- a/etc/ensure-focal-deps.sh
+++ b/etc/ensure-focal-deps.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Installs the Focal toolchain for building RDK's semi-static viam-server.
+# Used by etc/Dockerfile.focal.
+set -euxo pipefail
+
+# GO_VERSION tracks the `go` directive in go.mod.
+GO_VERSION=1.25.9
+NLOPT_VERSION=2.11.0
+CMAKE_VERSION=4.3.4
+# x264 stable branch. Built from source: focal's prebuilt libx264.a references
+# __*_finite glibc symbols that fail to resolve when statically linked.
+X264_COMMIT=b35605ace3ddf7c1a5d67a2eb553f034aef41d55
+
+case "$(dpkg --print-architecture)" in
+    amd64) go_arch=amd64 ;;
+    arm64) go_arch=arm64 ;;
+    *) echo "unsupported arch" >&2; exit 1 ;;
+esac
+
+# Build/link deps. nasm builds x264.
+apt-get update
+apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates curl file git make nasm pkg-config sudo xz-utils \
+    libjpeg-turbo8-dev
+rm -rf /var/lib/apt/lists/*
+
+# cmake >= 3.18 is required by nlopt >= 2.11; focal apt ships 3.16.
+curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" \
+    | tar -xz --strip-components=1 -C /usr/local
+cmake --version
+
+# nlopt into /usr/local: headers + PIC static lib + pkg-config. NLOPT_CXX=OFF
+# skips the C++-only algorithms so the library stays plain C.
+curl -fsSL "https://github.com/stevengj/nlopt/archive/refs/tags/v${NLOPT_VERSION}.tar.gz" \
+    | tar -C /tmp -xz
+cmake -S "/tmp/nlopt-${NLOPT_VERSION}" -B /tmp/nlopt-build \
+    -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DNLOPT_CXX=OFF \
+    -DNLOPT_PYTHON=OFF -DNLOPT_OCTAVE=OFF -DNLOPT_MATLAB=OFF \
+    -DNLOPT_GUILE=OFF -DNLOPT_SWIG=OFF -DNLOPT_TESTS=OFF
+cmake --build /tmp/nlopt-build -j "$(nproc)"
+cmake --install /tmp/nlopt-build
+rm -rf "/tmp/nlopt-${NLOPT_VERSION}" /tmp/nlopt-build
+
+# x264 into /usr/local: headers + shared + PIC static + pkg-config.
+curl -fsSL "https://code.videolan.org/videolan/x264/-/archive/${X264_COMMIT}/x264-${X264_COMMIT}.tar.gz" \
+    | tar -C /tmp -xz
+(
+    cd "/tmp/x264-${X264_COMMIT}"
+    ./configure --prefix=/usr/local --enable-shared --enable-static --enable-pic --disable-cli --disable-opencl
+    make -j "$(nproc)"
+    make install
+)
+ldconfig
+rm -rf "/tmp/x264-${X264_COMMIT}"
+
+# Go toolchain, symlinked into /usr/local/bin so it resolves under sudo's
+# secure_path (the sudo -Hu testbot build path).
+curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${go_arch}.tar.gz" \
+    | tar -C /usr/local -xz
+ln -s /usr/local/go/bin/go /usr/local/bin/go
+go version


### PR DESCRIPTION
Follow-ups to #6206, one commit each:

- **Fix `Install upx` failing in the job container.** Container run steps default to `sh`, which rejects `set -o pipefail`; set `shell: bash`.
- **Drop the armhf `rdk-focal` image.** 32-bit ARM support is planned for removal and nothing consumes it. Its build was also broken: focal's pip 20.0.2 predates PEP 600 wheel tags, so it fell back to compiling cmake from source under qemu and segfaulted.
- **Extract Dockerfile.focal toolchain installs into `etc/ensure-focal-deps.sh`** ([review follow-up](https://github.com/viamrobotics/rdk/pull/6206#discussion_r3545030281)). Versions live in the script; nothing overrode them as build args.
- **Install upx via `crazy-max/ghaction-upx`** ([review follow-up](https://github.com/viamrobotics/rdk/pull/6206#discussion_r3547447847)), pinned to the v4.0.0 SHA. The action only amends the step PATH, so upx is symlinked into `/usr/local/bin` where sudo's `secure_path` finds it.

## Verification

- Workflow changes: focal-build dispatched from this branch in validate mode — [green on both arches](https://github.com/viamrobotics/rdk/actions/runs/29041002954) (build, upx compression, boot smoke test).
- Dockerfile/script: local arm64 `docker build` succeeds; image has cmake 4.3.4, Go 1.25.9, nlopt 2.11.0 + static lib, x264 + static lib, and `go` resolves under `sudo -Hu testbot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)