### PR TITLE
Bump focal-build actions to Node 24 releases

### DIFF
--- a/.github/workflows/focal-build.yml
+++ b/.github/workflows/focal-build.yml
@@ -51,15 +51,15 @@ jobs:
     steps:
     - name: Check out code
       if: github.event_name != 'pull_request_target'
-      # actions/checkout@v4.3.1
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         fetch-depth: 0 # needed for dev-version.sh to work
 
     - name: Check out PR branch code
       if: github.event_name == 'pull_request_target'
-      # actions/checkout@v4.3.1
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
@@ -113,16 +113,17 @@ jobs:
 
     - name: Authorize GCP upload
       if: steps.meta.outputs.publish == 'true'
-      # google-github-actions/auth@v2.1.13
-      uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed
+      # google-github-actions/auth@v3.0.0
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
       with:
         credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
     - name: Publish ${{ steps.meta.outputs.channel }} channel
       if: steps.meta.outputs.publish == 'true'
-      # google-github-actions/upload-cloud-storage@v2.2.4
-      uses: google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23
+      # google-github-actions/upload-cloud-storage@v3.0.0
+      uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a
       with:
+        process_gcloudignore: false
         headers: "cache-control: no-cache"
         path: etc/packaging/static/deploy/
         destination: packages.viam.com/apps/viam-server/


### PR DESCRIPTION
Clears the warnings emitted by the focal build workflow (see [this run](https://github.com/viamrobotics/rdk/actions/runs/29050427078)):

- **Node.js 20 deprecation** — bumps the three pinned actions to their latest Node 24-ready releases:
  - `actions/checkout` v4.3.1 → v7.0.0 (`9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`)
  - `google-github-actions/auth` v2.1.13 → v3.0.0 (`7c6bc770dae815cd3e89ee6cdf493a5fab2cc093`)
  - `google-github-actions/upload-cloud-storage` v2.2.4 → v3.0.0 (`6397bd7208e18d13ba2619ee21b9873edc94427a`)
- **`process_gcloudignore` notice** — sets `process_gcloudignore: false` on the upload step, as the warning suggests. The upload is already scoped by `path` + `glob`, so there is no `.gcloudignore` to process.

All pins remain full commit SHAs with version comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)