### PR TITLE
[RSDK-14238][RSDK-14242][RSDK-14243] Cleanup static linking for cgo story

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ bin/$(GOOS)-$(GOARCH)/viam-cli: $(GO_FILES) Makefile go.mod go.sum
 	# no_cgo necessary here because of motionplan -> nlopt dependency.
 	# can be removed if you can run CGO_ENABLED=0 go build ./cli/viam on your local machine.
 	# CGO_ENABLED=0 is necessary after bedf954b to prevent go from sneakily doing a cgo build
-	CGO_ENABLED=0 go build $(GCFLAGS) $(LDFLAGS) -tags osusergo,netgo,no_cgo -o $@ ./cli/viam
+	CGO_ENABLED=0 go build $(GCFLAGS) $(LDFLAGS) -tags no_cgo -o $@ ./cli/viam
 
 .PHONY: cli
 cli: bin/$(GOOS)-$(GOARCH)/viam-cli
@@ -93,18 +93,20 @@ test-go-no-race: tool-install
 $(BIN_OUTPUT_PATH)/viam-server: $(GO_FILES) Makefile go.mod go.sum
 	go build $(GCFLAGS) $(LDFLAGS_WRAPPER) -o $@ ./web/cmd/server
 
+# NOTE: the `server` make target is referenced in file_utils.go
 .PHONY: server
 server: $(BIN_OUTPUT_PATH)/viam-server
 
 $(BIN_OUTPUT_PATH)/viam-server-static: $(GO_FILES) Makefile go.mod go.sum
 	VIAM_STATIC_BUILD=1 GOFLAGS=$(GOFLAGS) go build $(GCFLAGS) $(LDFLAGS_WRAPPER) -o $@ ./web/cmd/server
 
+# NOTE: the `server-static` make target is referenced in file_utils.go
 .PHONY: server-static
 server-static: $(BIN_OUTPUT_PATH)/viam-server-static
 
 bin/static/viam-server-$(GOARCH): $(GO_FILES) Makefile go.mod go.sum
 	mkdir -p $(dir $@)
-	CGO_ENABLED=0 go build -tags no_cgo,osusergo,netgo $(GCFLAGS) $(LDFLAGS) -o $@ ./web/cmd/server
+	CGO_ENABLED=0 go build -tags no_cgo $(GCFLAGS) $(LDFLAGS) -o $@ ./web/cmd/server
 
 .PHONY: full-static
 full-static: bin/static/viam-server-$(GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ ifdef BUILD_DEBUG
 else
 	COMMON_LDFLAGS += -s -w
 endif
-LDFLAGS = -ldflags "-extld=$(shell pwd)/etc/ld_wrapper.sh $(COMMON_LDFLAGS)"
+
+LDFLAGS = -ldflags "$(COMMON_LDFLAGS)"
+LDFLAGS_WRAPPER = -ldflags "-extld=$(shell pwd)/etc/ld_wrapper.sh $(COMMON_LDFLAGS)"
 
 default: build lint server
 
@@ -89,20 +91,20 @@ test-go-no-race: tool-install
 	PATH=$(PATH_WITH_TOOLS) ./etc/test.sh
 
 $(BIN_OUTPUT_PATH)/viam-server: $(GO_FILES) Makefile go.mod go.sum
-	go build $(GCFLAGS) $(LDFLAGS) -o $@ ./web/cmd/server
+	go build $(GCFLAGS) $(LDFLAGS_WRAPPER) -o $@ ./web/cmd/server
 
 .PHONY: server
 server: $(BIN_OUTPUT_PATH)/viam-server
 
 $(BIN_OUTPUT_PATH)/viam-server-static: $(GO_FILES) Makefile go.mod go.sum
-	VIAM_STATIC_BUILD=1 GOFLAGS=$(GOFLAGS) go build $(GCFLAGS) $(LDFLAGS) -o $@ ./web/cmd/server
+	VIAM_STATIC_BUILD=1 GOFLAGS=$(GOFLAGS) go build $(GCFLAGS) $(LDFLAGS_WRAPPER) -o $@ ./web/cmd/server
 
 .PHONY: server-static
 server-static: $(BIN_OUTPUT_PATH)/viam-server-static
 
 bin/static/viam-server-$(GOARCH): $(GO_FILES) Makefile go.mod go.sum
 	mkdir -p $(dir $@)
-	go build -tags no_cgo,osusergo,netgo $(GCFLAGS) -ldflags="-extldflags=-static $(COMMON_LDFLAGS)" -o $@ ./web/cmd/server
+	CGO_ENABLED=0 go build -tags no_cgo,osusergo,netgo $(GCFLAGS) $(LDFLAGS) -o $@ ./web/cmd/server
 
 .PHONY: full-static
 full-static: bin/static/viam-server-$(GOARCH)
@@ -110,7 +112,7 @@ full-static: bin/static/viam-server-$(GOARCH)
 # should be kept in sync with the windows build in the BuildViamServer helper in testutils/file_utils.go
 bin/windows/viam-server-amd64.exe: $(GO_FILES) Makefile go.mod go.sum
 	mkdir -p $(dir $@)
-	GOOS=windows GOARCH=amd64 go build -tags no_cgo $(GCFLAGS) -ldflags="-extldflags=-static $(COMMON_LDFLAGS)" -o $@ ./web/cmd/server
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -tags no_cgo $(GCFLAGS) $(LDFLAGS) -o $@ ./web/cmd/server
 
 .PHONY: windows
 windows: bin/windows/viam-server-amd64.exe

--- a/etc/ld_wrapper.sh
+++ b/etc/ld_wrapper.sh
@@ -1,24 +1,14 @@
 #!/bin/bash
 
-# find the real linker, from env or same defaults as go
-REAL_LD="${CC}"
+# Use the system selected C++ compiler as the linker. We want to pick up
+# a dynamic dependency on the system C++ runtime, just like the system C runtime.
+# If, for some reason, it isn't set, do our best with `c++` which is probably fine.
+REAL_LD="${CXX}"
 if [[ -z "${REAL_LD}" ]]; then
-	REAL_LD="$(which gcc)"
+	REAL_LD="$(which c++)"
 fi
-if [[ -z "${REAL_LD}" ]]; then
-	REAL_LD="$(which clang)"
-fi
-
 
 ARGS=("$@")
-
-# Always dynamically link in C++ on MacOS. For a semi-static release, we build viam-server
-# for MacOS with static libnlopt, which dynamically links to libc++. libc++ is not
-# otherwise dynamically linked to viam-server, so make sure it is here. Dynamically
-# linking in C++ for non-semi-static-release builds doesn't hurt anything.
-if [[ `uname` == "Darwin" ]]; then
-	ARGS+=("-lc++")
-fi
 
 # add for 32-bit arm builds
 if [[ `uname -m` =~ armv[6,7]l ]]; then
@@ -39,10 +29,10 @@ fi
 STRIPPED_ARGS="-g -O2"
 
 # list of arguments to prefix with -Bstatic
-STATIC_ARGS="-lx264 -lnlopt -lstdc++"
+STATIC_ARGS="-lx264 -lnlopt"
 
-# add explicit static standard library flags
-FILTERED=("-static-libgcc" "-static-libstdc++")
+FILTERED=()
+
 # Loop through the arguments and filter
 for ARG in "${ARGS[@]}"; do
 	if [[ "${STRIPPED_ARGS[@]}" =~ "${ARG}" ]]; then
@@ -50,15 +40,12 @@ for ARG in "${ARGS[@]}"; do
 		:
 	elif [[ "${STATIC_ARGS[@]}" =~ "${ARG}" ]]; then
 		# wrap the arg as a static one
-		FILTERED+=("-Wl,-Bstatic" "${ARG}" "-Wl,-Bdynamic")
+		FILTERED+=("-Wl,--push-state,-Bstatic" "${ARG}" "-Wl,--pop-state")
 	else
 		# pass through with no filtering
 		FILTERED+=("${ARG}")
 	fi
 done
-
-# add libstdc++ statically (and last)
-FILTERED+=("-Wl,-Bstatic" "-lstdc++" "-Wl,-Bdynamic")
 
 # call the real linker with the filtered arguments
 exec "$REAL_LD" "${FILTERED[@]}"

--- a/packaging.make
+++ b/packaging.make
@@ -48,7 +48,7 @@ static-release: $(BIN_OUTPUT_PATH)/viam-server-static-compressed
 
 static-release-win:
 	rm -f bin/static/viam-server-windows.exe
-	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -tags no_cgo,osusergo,netgo -ldflags="-extldflags=-static $(COMMON_LDFLAGS)" -o bin/static/viam-server-windows.exe ./web/cmd/server
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -tags no_cgo $(LDFLAGS) -o bin/static/viam-server-windows.exe ./web/cmd/server
 	upx --best --lzma bin/static/viam-server-windows.exe
 	test -z "$(SIGN_CMD)" || $(SIGN_CMD) bin/static/viam-server-windows.exe
 

--- a/packaging.make
+++ b/packaging.make
@@ -48,7 +48,7 @@ static-release: $(BIN_OUTPUT_PATH)/viam-server-static-compressed
 
 static-release-win:
 	rm -f bin/static/viam-server-windows.exe
-	GOOS=windows GOARCH=amd64 go build -tags no_cgo,osusergo,netgo -ldflags="-extldflags=-static $(COMMON_LDFLAGS)" -o bin/static/viam-server-windows.exe ./web/cmd/server
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -tags no_cgo,osusergo,netgo -ldflags="-extldflags=-static $(COMMON_LDFLAGS)" -o bin/static/viam-server-windows.exe ./web/cmd/server
 	upx --best --lzma bin/static/viam-server-windows.exe
 	test -z "$(SIGN_CMD)" || $(SIGN_CMD) bin/static/viam-server-windows.exe
 
@@ -61,7 +61,7 @@ static-release-win:
 	fi
 
 	# note: GOOS=windows would break this on a linux runner
-	go run -tags no_cgo ./web/cmd/server --dump-resources win-resources.json
+	CGO_ENABLED=0 go run -tags no_cgo ./web/cmd/server --dump-resources win-resources.json
 
 	rm -rf etc/packaging/static/manifest/
 	mkdir -p etc/packaging/static/manifest/

--- a/testutils/file_utils.go
+++ b/testutils/file_utils.go
@@ -69,7 +69,7 @@ func BuildViamServer(tb testing.TB) string {
 		//nolint:gosec
 		builder = exec.Command(
 			"go", "build", "-tags", "no_cgo",
-			"-s", "-w",
+			"-ldflags=-s -w",
 			"-o", serverPath,
 			"./web/cmd/server",
 		)

--- a/testutils/file_utils.go
+++ b/testutils/file_utils.go
@@ -68,11 +68,12 @@ func BuildViamServer(tb testing.TB) string {
 		serverPath += ".exe"
 		//nolint:gosec
 		builder = exec.Command(
-			"go", "build", "-tags", "no_cgo,osusergo,netgo",
-			"-ldflags=-extldflags=-static -s -w",
+			"go", "build", "-tags", "no_cgo",
+			"-s", "-w",
 			"-o", serverPath,
 			"./web/cmd/server",
 		)
+		builder.Env = append(os.Environ(), "CGO_ENABLED=0")
 	}
 	// set Dir to root of repo
 	builder.Dir = utils.ResolveFile(".")


### PR DESCRIPTION
- Only use the ld wrapper when cgo is in play
- Ensure GO_ENABLED=0 on all no_cgo builds to get pure go builds
- Always use the C++ compiler to drive the link when cgo is in play
- Bind to the dynamic system C++ runtime, not the static one.
- Use push/pop to manage linker flags

The net effect is pure go binaries when cgo is not in play. When cgo is in play, we bind to the system C++ runtime if any linked libraries have unresolved C++ symbols.