### PR TITLE
Keep armhf in the Focal build image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,6 +64,11 @@ jobs:
           platform: linux/arm64
           image: rdk-focal
           file: etc/Dockerfile.focal
+        - arch: ubuntu-small-arm
+          tag: armhf
+          platform: linux/arm/v7
+          image: rdk-focal
+          file: etc/Dockerfile.focal
     runs-on: ${{ matrix.arch }}
     timeout-minutes: 30
     steps:

--- a/etc/ensure-focal-deps.sh
+++ b/etc/ensure-focal-deps.sh
@@ -11,9 +11,11 @@ CMAKE_VERSION=4.3.4
 # __*_finite glibc symbols that fail to resolve when statically linked.
 X264_COMMIT=b35605ace3ddf7c1a5d67a2eb553f034aef41d55
 
-case "$(dpkg --print-architecture)" in
+deb_arch="$(dpkg --print-architecture)"
+case "$deb_arch" in
     amd64) go_arch=amd64 ;;
     arm64) go_arch=arm64 ;;
+    armhf) go_arch=armv6l ;;
     *) echo "unsupported arch" >&2; exit 1 ;;
 esac
 
@@ -25,9 +27,21 @@ apt-get install -y --no-install-recommends \
     libjpeg-turbo8-dev
 rm -rf /var/lib/apt/lists/*
 
-# cmake >= 3.18 is required by nlopt >= 2.11; focal apt ships 3.16.
-curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" \
-    | tar -xz --strip-components=1 -C /usr/local
+# cmake >= 3.18 is required by nlopt >= 2.11; focal apt ships 3.16. Kitware
+# ships prebuilt tarballs for amd64/arm64; on armhf use the pip wheel
+# (manylinux_2_31 matches focal) since Kitware has no 32-bit arm build.
+case "$deb_arch" in
+    armhf)
+        apt-get update
+        apt-get install -y --no-install-recommends python3-pip
+        rm -rf /var/lib/apt/lists/*
+        pip3 install "cmake==${CMAKE_VERSION}"
+        ;;
+    *)
+        curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" \
+            | tar -xz --strip-components=1 -C /usr/local
+        ;;
+esac
 cmake --version
 
 # nlopt into /usr/local: headers + PIC static lib + pkg-config. NLOPT_CXX=OFF


### PR DESCRIPTION
## What
Restores the armhf leg to the `rdk-focal` cache image (removed in #6213), per the team-sre-dx decision to keep 32-bit armhf support.

## Changes
- **`.github/workflows/docker.yml`**: add the `rdk-focal` armhf (`linux/arm/v7`) matrix leg → builds `ghcr.io/viamrobotics/rdk-focal:armhf-cache`, matching the `rdk-devenv`/`antique2` image families.
- **`etc/ensure-focal-deps.sh`**: restore armhf toolchain handling — Go `armv6l`, and cmake via the pip wheel (`manylinux_2_31` matches Focal) since Kitware ships no 32-bit-arm prebuilt tarball. nlopt/x264 build from source as before.

## Notes
- `focal-build.yml` is intentionally unchanged: it only builds amd64/arm64 viam-server binaries and never had an armhf leg. This PR restores the **image**, not a binary build.
- Validated locally: `bash -n` + `shellcheck` clean on the script; `docker.yml` YAML parses and the `rdk-focal` legs are now `[amd64, arm64, armhf]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)