### PR TITLE
Tag full motion plan JSON for data manager filtering

### DIFF
--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -817,14 +817,14 @@ func (ms *builtIn) writePlanRequest(
 	// Full plans (request + response) get tag=motion-plan so data manager can infer a
 	// stable type tag on arbitrary-file upload.
 	const motionPlanTypeTag = "motion-plan"
-	parts := []string{ms.conf.PlanFilePath}
+	tags := []string{}
 	if plan != nil {
-		parts = append(parts, "tag="+motionPlanTypeTag)
+		tags = append(tags, "tag="+motionPlanTypeTag)
 	}
 	if ms.conf.PlanDirectoryIncludeTraceID && traceID != "" {
-		parts = append(parts, "tag="+traceID)
+		tags = append(tags, "tag="+traceID)
 	}
-	fn = filepath.Join(append(parts, fn)...)
+	fn = filepath.Join(ms.conf.PlanFilePath, append(tags, fn)...)
 
 	dir := filepath.Dir(fn)
 	if err := os.MkdirAll(dir, 0o700); err != nil {

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -824,7 +824,8 @@ func (ms *builtIn) writePlanRequest(
 	if ms.conf.PlanDirectoryIncludeTraceID && traceID != "" {
 		tags = append(tags, "tag="+traceID)
 	}
-	fn = filepath.Join(ms.conf.PlanFilePath, append(tags, fn)...)
+	parts := append([]string{ms.conf.PlanFilePath}, tags...)
+	fn = filepath.Join(append(parts, fn)...)
 
 	dir := filepath.Dir(fn)
 	if err := os.MkdirAll(dir, 0o700); err != nil {

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -813,11 +813,18 @@ func (ms *builtIn) writePlanRequest(
 
 	fn := fmt.Sprintf("plan-%s-ms-%d-%s.json",
 		time.Now().Format(time.RFC3339), int(time.Since(start).Milliseconds()), planExtra)
-	if ms.conf.PlanDirectoryIncludeTraceID && traceID != "" {
-		fn = filepath.Join(ms.conf.PlanFilePath, fmt.Sprint("tag=", traceID), fn)
-	} else {
-		fn = filepath.Join(ms.conf.PlanFilePath, fn)
+
+	// Full plans (request + response) get tag=motion-plan so data manager can infer a
+	// stable type tag on arbitrary-file upload. 
+	const motionPlanTypeTag = "motion-plan"
+	parts := []string{ms.conf.PlanFilePath}
+	if plan != nil {
+		parts = append(parts, "tag="+motionPlanTypeTag)
 	}
+	if ms.conf.PlanDirectoryIncludeTraceID && traceID != "" {
+		parts = append(parts, "tag="+traceID)
+	}
+	fn = filepath.Join(append(parts, fn)...)
 
 	dir := filepath.Dir(fn)
 	if err := os.MkdirAll(dir, 0o700); err != nil {

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -815,7 +815,7 @@ func (ms *builtIn) writePlanRequest(
 		time.Now().Format(time.RFC3339), int(time.Since(start).Milliseconds()), planExtra)
 
 	// Full plans (request + response) get tag=motion-plan so data manager can infer a
-	// stable type tag on arbitrary-file upload. 
+	// stable type tag on arbitrary-file upload.
 	const motionPlanTypeTag = "motion-plan"
 	parts := []string{ms.conf.PlanFilePath}
 	if plan != nil {

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -666,7 +666,7 @@ func TestWritePlanRequest(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	msBuiltin := msBuiltinI.(*builtIn)
 
-	// First case, do not include a TraceID.
+	// First case: full plan, no TraceID → under tag=motion-plan only.
 	err = msBuiltin.writePlanRequest(
 		&armplanning.PlanRequest{},
 		&motionplan.SimplePlan{},
@@ -680,22 +680,26 @@ func TestWritePlanRequest(t *testing.T) {
 		nil)
 	test.That(t, err, test.ShouldBeNil)
 
-	// Assert we now have a file in our `PlanFilePath`.
 	planDirEntries, err = os.ReadDir(planDir)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, planDirEntries, test.ShouldHaveLength, 1)
+	test.That(t, planDirEntries[0].IsDir(), test.ShouldBeTrue)
+	test.That(t, planDirEntries[0].Name(), test.ShouldEqual, "tag=motion-plan")
+
+	typeTagDir := filepath.Join(planDir, planDirEntries[0].Name())
+	planDirEntries, err = os.ReadDir(typeTagDir)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, planDirEntries, test.ShouldHaveLength, 1)
 	test.That(t, planDirEntries[0].IsDir(), test.ShouldBeFalse)
 	test.That(t, filepath.Ext(planDirEntries[0].Name()), test.ShouldEqual, ".json")
 
-	// For test simplicity, remove the file so we can run a second test. And let that second test
-	// assume things in an empty state.
-	filePath := filepath.Join(planDir, planDirEntries[0].Name())
-	test.That(t, os.Remove(filePath), test.ShouldBeNil)
+	// For test simplicity, remove so later cases assume an empty PlanFilePath.
+	test.That(t, os.RemoveAll(typeTagDir), test.ShouldBeNil)
 	planDirEntries, err = os.ReadDir(planDir)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, planDirEntries, test.ShouldHaveLength, 0)
 
-	// Second case, include a TraceID.
+	// Second case: full plan with TraceID → tag=motion-plan/tag=<traceID>/.
 	err = msBuiltin.writePlanRequest(
 		// The contents of the plan request file are not interesting to this test. So long as the
 		// plan request and plan are non-nil, we ought to get a file placed in the right location.
@@ -711,31 +715,33 @@ func TestWritePlanRequest(t *testing.T) {
 		nil)
 	test.That(t, err, test.ShouldBeNil)
 
-	// Again, there should be one entry in the `PlanFilePath`.
 	planDirEntries, err = os.ReadDir(planDir)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, planDirEntries, test.ShouldHaveLength, 1)
+	typeTagDirEntry := planDirEntries[0]
+	test.That(t, typeTagDirEntry.IsDir(), test.ShouldBeTrue)
+	test.That(t, typeTagDirEntry.Name(), test.ShouldEqual, "tag=motion-plan")
 
-	// This time though, that entry is a directory with the "trace ID" name.
+	typeTagDir = filepath.Join(planDir, typeTagDirEntry.Name())
+	planDirEntries, err = os.ReadDir(typeTagDir)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, planDirEntries, test.ShouldHaveLength, 1)
 	traceIDDirEntry := planDirEntries[0]
 	test.That(t, traceIDDirEntry.IsDir(), test.ShouldBeTrue)
 	test.That(t, traceIDDirEntry.Name(), test.ShouldEqual, "tag=1234-abc-56-no-78")
 
-	// The directory constructed under the trace ID path also has one entry.
-	traceIDDir := filepath.Join(planDir, traceIDDirEntry.Name())
+	traceIDDir := filepath.Join(typeTagDir, traceIDDirEntry.Name())
 	planDirEntries, err = os.ReadDir(traceIDDir)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, planDirEntries, test.ShouldHaveLength, 1)
-	// Which is our plan request file.
 	planFile := planDirEntries[0]
 	test.That(t, planFile.IsDir(), test.ShouldBeFalse)
 	test.That(t, filepath.Ext(planFile.Name()), test.ShouldEqual, ".json")
 	test.That(t, planFile.Name(), test.ShouldNotContainSubstring, "cbirrt")
 
-	// Clean up for third test
-	test.That(t, os.RemoveAll(traceIDDir), test.ShouldBeNil)
+	test.That(t, os.RemoveAll(typeTagDir), test.ShouldBeNil)
 
-	// Third case: include a custom plan tag in the filename
+	// Third case: full plan with custom plan tag in the filename (still under tag=motion-plan).
 	err = msBuiltin.writePlanRequest(
 		&armplanning.PlanRequest{},
 		&motionplan.SimplePlan{},
@@ -746,16 +752,48 @@ func TestWritePlanRequest(t *testing.T) {
 		nil)
 	test.That(t, err, test.ShouldBeNil)
 
-	// Verify the file was created with the custom tag in the filename
 	planDirEntries, err = os.ReadDir(planDir)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, planDirEntries, test.ShouldHaveLength, 1)
+	test.That(t, planDirEntries[0].IsDir(), test.ShouldBeTrue)
+	test.That(t, planDirEntries[0].Name(), test.ShouldEqual, "tag=motion-plan")
+
+	typeTagDir = filepath.Join(planDir, planDirEntries[0].Name())
+	planDirEntries, err = os.ReadDir(typeTagDir)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, planDirEntries, test.ShouldHaveLength, 1)
 	planFile = planDirEntries[0]
 	test.That(t, planFile.IsDir(), test.ShouldBeFalse)
 	test.That(t, filepath.Ext(planFile.Name()), test.ShouldEqual, ".json")
-	// Verify the filename contains the custom tag
 	test.That(t, planFile.Name(), test.ShouldContainSubstring, "custom-test-tag")
 	test.That(t, planFile.Name(), test.ShouldContainSubstring, "cbirrt")
+
+	test.That(t, os.RemoveAll(typeTagDir), test.ShouldBeNil)
+
+	// Fourth case: request-only error dump (plan == nil) must NOT get tag=motion-plan.
+	err = msBuiltin.writePlanRequest(
+		&armplanning.PlanRequest{},
+		nil,
+		&armplanning.PlanMeta{},
+		time.Now(),
+		"1234-abc-56-no-78",
+		"",
+		errors.New("planning failed"))
+	test.That(t, err, test.ShouldBeNil)
+
+	planDirEntries, err = os.ReadDir(planDir)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, planDirEntries, test.ShouldHaveLength, 1)
+	test.That(t, planDirEntries[0].IsDir(), test.ShouldBeTrue)
+	test.That(t, planDirEntries[0].Name(), test.ShouldEqual, "tag=1234-abc-56-no-78")
+
+	traceIDDir = filepath.Join(planDir, planDirEntries[0].Name())
+	planDirEntries, err = os.ReadDir(traceIDDir)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, planDirEntries, test.ShouldHaveLength, 1)
+	planFile = planDirEntries[0]
+	test.That(t, planFile.IsDir(), test.ShouldBeFalse)
+	test.That(t, planFile.Name(), test.ShouldContainSubstring, "-err")
 }
 
 func TestErrorMessageContext(t *testing.T) {


### PR DESCRIPTION
## Issue
Full motion plan JSON synced via data manager only carried identity tags (trace/pass ID), so replay could not filter “is a motion plan.” We need stable tagging of full motion plan JSON for [motion plan replay](https://viam.atlassian.net/browse/APP-9316) in the visualizer, where we will want users to easily lookup their motion plans from data manager. 

## Changes
- **TLDR:** `writePlanRequest` now nests successful request+response dumps under `tag=motion-plan/` so arbitrary-file upload (APP-15102) attaches a stable type tag.
- Updates writePlanRequest to place full plans (plan != nil) under `tag=motion-plan/`, keeps optional` tag=<traceID>` when `plan_directory_include_trace_id` is set, leaves request-only error dumps untyped
- Tests: Extends `TestWritePlanRequest` for the new path layout and asserts error dumps omit `tag=motion-plan`

## Manual verification
1. Built and ran a local viam-server build on a machine with arm/fake, and a motion service configured as such:
```
{
  "log_planner_errors": true,
  "log_slow_plan_threshold_ms": 1,
  "plan_file_path": "/tmp/viam-plans",
  "plan_directory_include_trace_id": true
}
```
This is to enable the stable tagging, and writing all motion plans (since the slow plan threshold is low) to the directory. Additionally, configured data-manager to cloud-sync the indicated directory, "/tmp/viam-plans". 
2. Call on the motion service via an armPositionSaver. 
3. File produced under `…/tag=motion-plan/tag=<traceID>/plan-…-traj-….json` with cloud tags `motion-plan` plus the trace ID.