### PR TITLE
focal-build: add armhf leg (compressed)

### DIFF
--- a/.github/workflows/focal-build.yml
+++ b/.github/workflows/focal-build.yml
@@ -39,9 +39,15 @@ jobs:
           - arch: ubuntu-large
             image: ghcr.io/viamrobotics/rdk-focal:amd64-cache
             platform: linux/amd64
+            uname_m: x86_64
           - arch: ubuntu-large-arm
             image: ghcr.io/viamrobotics/rdk-focal:arm64-cache
             platform: linux/arm64
+            uname_m: aarch64
+          - arch: ubuntu-small-arm
+            image: ghcr.io/viamrobotics/rdk-focal:armhf-cache
+            platform: linux/arm/v7
+            uname_m: armv7l
     runs-on: ${{ matrix.arch }}
     container:
       image: ${{ matrix.image }}
@@ -90,11 +96,12 @@ jobs:
             echo "channel=focal" >> "$GITHUB_OUTPUT"
             echo "publish=false" >> "$GITHUB_OUTPUT" ;;
         esac
-        echo "arch=$(uname -m)" >> "$GITHUB_OUTPUT"
+        echo "arch=${{ matrix.uname_m }}" >> "$GITHUB_OUTPUT"
 
+    # UNAME_M override: uname -m can report aarch64 inside a 32-bit arm container.
     - name: Build viam-server-${{ steps.meta.outputs.channel }}
       run: |
-        sudo -Hu testbot bash -lc 'make BUILD_CHANNEL=${{ steps.meta.outputs.channel }} static-release'
+        sudo -Hu testbot bash -lc 'make BUILD_CHANNEL=${{ steps.meta.outputs.channel }} UNAME_M=${{ matrix.uname_m }} static-release'
 
     - name: Boot smoke test
       run: |


### PR DESCRIPTION
Adds an armhf leg to the Focal build so we publish a compressed `viam-server-focal-armv7l`. Follows up #6217 (the `rdk-focal:armhf-cache` image, already on main).

## Change (`.github/workflows/focal-build.yml`)
- Add the `ubuntu-small-arm` / `linux/arm/v7` / `rdk-focal:armhf-cache` matrix leg. armhf uses the **same** steps as amd64/arm64 — install upx + `make static-release` (compressed). No special-casing.
- Pass `UNAME_M=<uname_m>` (per matrix leg) to `make`, because `uname -m` can report the host `aarch64` inside a 32-bit arm container. `packaging.make` already honors this override, so the artifact is named `viam-server-focal-armv7l`.

## Sequencing / notes
- Needs `rdk-focal:armhf-cache` — merged in #6217, so run **docker.yml** (or wait for the daily cron) to build the image before the first armhf publish. `fail-fast: false` keeps a missing image from failing amd64/arm64.
- First run confirms whether upx + checkout run inside the 32-bit arm container; if not, fall back to the `test32` `docker run` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)