### PR TITLE
Fix flaky TestDataCaptureUploadIntegration on loaded runners

### DIFF
--- a/services/datamanager/builtin/builtin_sync_test.go
+++ b/services/datamanager/builtin/builtin_sync_test.go
@@ -495,12 +495,12 @@ func TestDataCaptureUploadIntegration(t *testing.T) {
 			}
 
 			if tc.cloudConnectionErr == nil {
-				wait := time.After(waitTime)
 				var successfulReqs []*v1.DataCaptureUploadRequest
-				// Get the successful requests
+				// Reset the timeout per file so a scheduling stall extends the wait
+				// rather than failing the whole batch on one deadline.
 				for i := 0; i < numFiles; i++ {
 					select {
-					case <-wait:
+					case <-time.After(waitTime):
 						offline := tc.connStateConstructor == nil || tc.connStateConstructor(nil).(rgrpc.ConnectivityState).GetState() != connectivity.Ready
 						if offline && !tc.manualSync {
 							err = b2.Close(context.Background())


### PR DESCRIPTION
## Problem

`TestDataCaptureUploadIntegration` flakes on the macOS CI job (e.g. [run 29212323879](https://github.com/viamrobotics/rdk/actions/runs/29212323879), which passed on rerun of the identical commit).

The failure surfaces as:
```
builtin_sync_test.go:516: timed out waiting for sync request
```

## Root cause

The success-collection loop created a single `wait := time.After(waitTime)` (192ms) **before** the loop, so all `numFiles` (20) uploads shared one wall-clock deadline. When the runner stalled — the failing log shows a ~1s dead stretch between files mid-test, consistent with CPU starvation on an oversubscribed shared macOS runner (a GC/scheduling pause would look the same) — the timer expired before the retried uploads could drain from `successChan`, and the batch failed.

This is a timing flake, not a product regression: the same commit passed on rerun, and this suite has prior flaky-fix history (#5876).

## Fix

Reset the timeout **per received file** by moving `time.After(waitTime)` inside the loop. A scheduling stall now only extends the wait for the next file rather than failing the whole batch on one deadline. The offline early-return branch is unchanged.

## Testing

`go test ./services/datamanager/builtin/ -run TestDataCaptureUploadIntegration -count=1` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)