### PR TITLE
focal: fix armhf image build (cmake wheel + x264 asm)

### DIFF
--- a/etc/ensure-focal-deps.sh
+++ b/etc/ensure-focal-deps.sh
@@ -35,7 +35,9 @@ case "$deb_arch" in
         apt-get update
         apt-get install -y --no-install-recommends python3-pip
         rm -rf /var/lib/apt/lists/*
-        pip3 install "cmake==${CMAKE_VERSION}"
+        # upgrade pip so it finds the manylinux_2_31_armv7l wheel (else source build)
+        python3 -m pip install --upgrade pip
+        python3 -m pip install "cmake==${CMAKE_VERSION}"
         ;;
     *)
         curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" \

--- a/etc/ensure-focal-deps.sh
+++ b/etc/ensure-focal-deps.sh
@@ -60,11 +60,13 @@ cmake --install /tmp/nlopt-build
 rm -rf "/tmp/nlopt-${NLOPT_VERSION}" /tmp/nlopt-build
 
 # x264 into /usr/local: headers + shared + PIC static + pkg-config.
+# armhf targets armv6l (no NEON); drop asm so it doesn't emit NEON and crash there.
+case "$deb_arch" in armhf) x264_asm=--disable-asm ;; *) x264_asm= ;; esac
 curl -fsSL "https://code.videolan.org/videolan/x264/-/archive/${X264_COMMIT}/x264-${X264_COMMIT}.tar.gz" \
     | tar -C /tmp -xz
 (
     cd "/tmp/x264-${X264_COMMIT}"
-    ./configure --prefix=/usr/local --enable-shared --enable-static --enable-pic --disable-cli --disable-opencl
+    ./configure --prefix=/usr/local --enable-shared --enable-static --enable-pic --disable-cli --disable-opencl $x264_asm
     make -j "$(nproc)"
     make install
 )


### PR DESCRIPTION
## Problem

The `rdk-focal:armhf-cache` image build has failed every day since it was added — so the image never publishes, and `focal-build.yml`'s armhf leg fails at *Initialize containers* with `manifest unknown`. Two separate armhf-only breakages in `ensure-focal-deps.sh`, one hidden behind the other:

1. **cmake:** `pip install cmake==4.3.4` builds cmake from source (Focal's pip 20.0.2 predates PEP 600 and can't see the prebuilt `manylinux_2_31_armv7l` wheel), and the compile **segfaults under qemu** (`exit 11`). (Apt's cmake 3.16 can't be used — nlopt 2.11 needs ≥ 3.18.)
2. **x264:** once cmake is fixed the build reaches x264, whose `./configure` aborts with *"no NEON support"*. armhf targets `armv6l`, which has no NEON.

## Fix

1. Upgrade pip so it picks the prebuilt `cmake-4.3.4-py3-none-manylinux_2_31_armv7l.whl` (glibc 2.31 == Focal, `requires-python >=3.8`) instead of compiling.
2. Build x264 with `--disable-asm` **on armhf only** — forcing NEON (the alternative) would emit instructions that SIGILL on the ARMv6 devices armhf ships to. amd64/arm64 keep their asm.

```diff
-        pip3 install "cmake==${CMAKE_VERSION}"
+        python3 -m pip install --upgrade pip
+        python3 -m pip install "cmake==${CMAKE_VERSION}"
```
```diff
+case "$deb_arch" in armhf) x264_asm=--disable-asm ;; *) x264_asm= ;; esac
-    ./configure ... --disable-cli --disable-opencl
+    ./configure ... --disable-cli --disable-opencl $x264_asm
```

## Verify

Dispatched `docker.yml` on this branch: confirmed it now builds **past** cmake (nlopt compiles and installs via cmake) — validating fix 1 — then hit the x264 wall, which fix 2 addresses. Re-running to confirm the armhf leg goes fully green and pushes `ghcr.io/viamrobotics/rdk-focal:armhf-cache`.

## Not fixed here (pre-existing)

Ubuntu armhf gcc defaults to ARMv7-A codegen, so the C libs' *compiled* code may still exceed the `armv6l` baseline — a latent mismatch that also affects the already-building nlopt. Out of scope for this PR, which just gets x264 to the same baseline as nlopt so the image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)