### PR TITLE
focal-build: emit binary-link summary for armhf too

### DIFF
--- a/.github/actions/focal-publish/action.yml
+++ b/.github/actions/focal-publish/action.yml
@@ -4,6 +4,9 @@ inputs:
   channel:
     description: viam-server channel name
     required: true
+  arch:
+    description: uname -m of the built binary, for the summary URL
+    required: true
   gcp-credentials:
     description: GCP service-account credentials JSON
     required: true
@@ -26,3 +29,10 @@ runs:
         destination: packages.viam.com/apps/viam-server/
         glob: 'viam-server-${{ inputs.channel }}-*'
         parent: false
+
+    - name: Summary
+      shell: bash
+      run: |
+        url="https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-${{ inputs.channel }}-${{ inputs.arch }}"
+        echo "### viam-server-${{ inputs.channel }}-${{ inputs.arch }}" >> "$GITHUB_STEP_SUMMARY"
+        echo "$url" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/focal-build.yml
+++ b/.github/workflows/focal-build.yml
@@ -108,14 +108,8 @@ jobs:
       uses: ./.github/actions/focal-publish
       with:
         channel: ${{ steps.meta.outputs.channel }}
+        arch: ${{ matrix.uname_m }}
         gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
-
-    - name: Summary
-      if: steps.meta.outputs.publish == 'true'
-      run: |
-        url="https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-${{ steps.meta.outputs.channel }}-${{ matrix.uname_m }}"
-        echo "### viam-server-${{ steps.meta.outputs.channel }}-${{ matrix.uname_m }}" >> "$GITHUB_STEP_SUMMARY"
-        echo "$url" >> "$GITHUB_STEP_SUMMARY"
 
   # Bare arm64 host + docker run: JS actions can't exec in a 32-bit-arm container.
   focal-static-armhf:
@@ -169,4 +163,5 @@ jobs:
       uses: ./.github/actions/focal-publish
       with:
         channel: ${{ steps.meta.outputs.channel }}
+        arch: armv7l
         gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
## Problem

On a published focal build, the job summary lists download links for the amd64/arm64 binaries but **not armv7l** — the armhf job never had a Summary step.

## Fix

Move the summary into the `focal-publish` composite action (which both jobs already call for publishing) and give it an `arch` input. Now both the matrix job and the armhf job emit their binary link, and the matrix job's standalone Summary step is removed as redundant.

Behavior-preserving for amd64/arm64; adds the missing armv7l link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)