### PR TITLE
focal: build+publish on merge to main, and fix armhf summary links

### DIFF
--- a/.github/actions/focal-publish/action.yml
+++ b/.github/actions/focal-publish/action.yml
@@ -4,6 +4,9 @@ inputs:
   channel:
     description: viam-server channel name
     required: true
+  arch:
+    description: uname -m of the built binary, for the summary URL
+    required: true
   gcp-credentials:
     description: GCP service-account credentials JSON
     required: true
@@ -26,3 +29,10 @@ runs:
         destination: packages.viam.com/apps/viam-server/
         glob: 'viam-server-${{ inputs.channel }}-*'
         parent: false
+
+    - name: Summary
+      shell: bash
+      run: |
+        url="https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-${{ inputs.channel }}-${{ inputs.arch }}"
+        echo "### viam-server-${{ inputs.channel }}-${{ inputs.arch }}" >> "$GITHUB_STEP_SUMMARY"
+        echo "$url" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/focal-build.yml
+++ b/.github/workflows/focal-build.yml
@@ -108,14 +108,8 @@ jobs:
       uses: ./.github/actions/focal-publish
       with:
         channel: ${{ steps.meta.outputs.channel }}
+        arch: ${{ matrix.uname_m }}
         gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
-
-    - name: Summary
-      if: steps.meta.outputs.publish == 'true'
-      run: |
-        url="https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-${{ steps.meta.outputs.channel }}-${{ matrix.uname_m }}"
-        echo "### viam-server-${{ steps.meta.outputs.channel }}-${{ matrix.uname_m }}" >> "$GITHUB_STEP_SUMMARY"
-        echo "$url" >> "$GITHUB_STEP_SUMMARY"
 
   # Bare arm64 host + docker run: JS actions can't exec in a 32-bit-arm container.
   focal-static-armhf:
@@ -169,4 +163,5 @@ jobs:
       uses: ./.github/actions/focal-publish
       with:
         channel: ${{ steps.meta.outputs.channel }}
+        arch: armv7l
         gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,8 +109,9 @@ jobs:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  # Publish to the focal channel on merge to main (same gate as the deploy jobs);
-  # validate-only on PRs and staged/no-prod dispatches.
+  # "focal" is not an official release channel — just a dummy channel name used
+  # as the binary filename to unblock testing. Published on merge to main (same
+  # gate as the deploy jobs); PRs and staged/no-prod dispatches validate only.
   focal-build:
     needs: [changes, test]
     if: ${{ github.event_name != 'push' || needs.changes.outputs.release == 'true' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,6 +109,17 @@ jobs:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
+  # Publish to the focal channel on merge to main (same gate as the deploy jobs);
+  # validate-only on PRs and staged/no-prod dispatches.
+  focal-build:
+    needs: [changes, test]
+    if: ${{ github.event_name != 'push' || needs.changes.outputs.release == 'true' }}
+    uses: viamrobotics/rdk/.github/workflows/focal-build.yml@main
+    with:
+      release_type: ${{ (inputs.release_type != 'pr' && !inputs.no_prod_upload) && 'focal' || 'validate' }}
+    secrets:
+      GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+
   full-static-build:
     needs: changes
     if: ${{ github.event_name != 'push' || needs.changes.outputs.release == 'true' }}


### PR DESCRIPTION
Two focal-build improvements.

## 1. Build & publish focal on every merge to main

`main.yml` builds and publishes antique (`latest`), appimage, full-static, etc. on every merge, but not focal. This adds a `focal-build` job so focal is built and published to the **focal channel** on merge — keeping it current, the same way `latest` tracks main for antique.

- Publish is gated identically to the existing deploy jobs (`release_type != 'pr' && !no_prod_upload`), so PRs and staged/no-prod dispatches only **validate** (build+boot, no publish).
- `needs: [changes, test]` — a failing test suite won't publish focal.

## 2. Emit binary-link summary for armhf

On a published focal build the job summary listed download links for amd64/arm64 but not armv7l (the armhf job had no Summary step). The summary now lives in the `focal-publish` composite action (with an `arch` input), so both the matrix and armhf jobs emit their link; the matrix job's standalone Summary step is removed as redundant.

## Verify

- Push/merge path: focal-build runs after `test`, publishes `viam-server-focal-<arch>` (incl. armv7l) and lists all three links in the summary.
- PR / `no_prod_upload` dispatch: focal-build runs `validate` only — no publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)