### PR TITLE
[RSDK-14248] Disable cgo for 32 bit arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,15 +92,20 @@ test-go: tool-install
 test-go-no-race: tool-install
 	PATH=$(PATH_WITH_TOOLS) ./etc/test.sh
 
+# CGO is only supported on amd64/arm64; elsewhere build pure-Go with the no_cgo tag.
+SERVER_TARGETS := $(BIN_OUTPUT_PATH)/viam-server $(BIN_OUTPUT_PATH)/viam-server-static
+$(SERVER_TARGETS): CGO_ENABLED := $(if $(filter amd64 arm64,$(GOARCH)),1,0)
+$(SERVER_TARGETS): CGO_TAGS := $(if $(filter amd64 arm64,$(GOARCH)),,-tags no_cgo)
+
 $(BIN_OUTPUT_PATH)/viam-server: $(GO_FILES) Makefile go.mod go.sum
-	go build $(GCFLAGS) $(LDFLAGS_WRAPPER) -o $@ ./web/cmd/server
+	CGO_ENABLED=$(CGO_ENABLED) go build $(CGO_TAGS) $(GCFLAGS) $(LDFLAGS_WRAPPER) -o $@ ./web/cmd/server
 
 # NOTE: the `server` make target is referenced in file_utils.go
 .PHONY: server
 server: $(BIN_OUTPUT_PATH)/viam-server
 
 $(BIN_OUTPUT_PATH)/viam-server-static: $(GO_FILES) Makefile go.mod go.sum
-	VIAM_STATIC_BUILD=1 GOFLAGS=$(GOFLAGS) go build $(GCFLAGS) $(LDFLAGS_WRAPPER) -o $@ ./web/cmd/server
+	CGO_ENABLED=$(CGO_ENABLED) VIAM_STATIC_BUILD=1 GOFLAGS=$(GOFLAGS) go build $(CGO_TAGS) $(GCFLAGS) $(LDFLAGS_WRAPPER) -o $@ ./web/cmd/server
 
 # NOTE: the `server-static` make target is referenced in file_utils.go
 .PHONY: server-static

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -42,6 +42,12 @@ import (
 	"go.viam.com/rdk/web/server"
 )
 
+// cgoBuiltinsExcluded reports whether the built viam-server drops cgo-only
+// builtins. cgo is only enabled on amd64/arm64.
+func cgoBuiltinsExcluded() bool {
+	return runtime.GOOS == "windows" || (runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64")
+}
+
 func TestEntrypoint(t *testing.T) {
 	ctx := context.Background()
 	t.Run("number of resources", func(t *testing.T) {
@@ -89,9 +95,7 @@ func TestEntrypoint(t *testing.T) {
 		// numResources is the # of resources in /etc/configs/fake.json + the 1
 		// expected builtin resources.
 		numResources := 21
-		if runtime.GOOS == "windows" {
-			// windows build excludes builtin models that use cgo,
-			// including builtin motion, fake arm, and builtin navigation.
+		if cgoBuiltinsExcluded() {
 			numResources = 18
 		}
 
@@ -116,8 +120,7 @@ func TestEntrypoint(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		numReg := 53
-		if runtime.GOOS == "windows" {
-			// windows build excludes builtin models that use cgo
+		if cgoBuiltinsExcluded() {
 			numReg = 45
 		}
 		test.That(t, registrations, test.ShouldHaveLength, numReg)
@@ -140,9 +143,8 @@ func TestEntrypoint(t *testing.T) {
 			"rdk:service:vision/rdk:builtin:mlmodel",
 		}
 
-		// windows build excludes builtin models that use cgo, so add more if not
-		// on windows
-		if runtime.GOOS != "windows" {
+		// cgo builds register additional builtin models that use cgo.
+		if !cgoBuiltinsExcluded() {
 			expectedReg = append(
 				expectedReg,
 				"rdk:component:camera/rdk:builtin:webcam",


### PR DESCRIPTION
I sort of dislike this, but I haven't found a better way. I tried pretty hard to get trajex armhf builds going, but it was a nightmare due to the 32-bit vs 64-bit time ABI split.

We got permission to drop cgo supported features on armhf, so, instead, just do that.

As written, it happens using the Makefile. I'm open to suggestions on more graceful ways to achieve this.