### PR TITLE
appimage-test: fall back to extract-and-run when libfuse2 install fails

### DIFF
--- a/.github/workflows/appimage-build.yml
+++ b/.github/workflows/appimage-build.yml
@@ -136,8 +136,13 @@ jobs:
 
     - name: Test AppImage
       run: |
+        # Prefer real FUSE mount; fall back to extract-and-run if libfuse2
+        # can't be installed (e.g. ports.ubuntu.com outage).
         if echo "${{ matrix.arch[0] }}" | grep -q 'ubuntu'; then
-          sudo apt-get install -y libfuse2
+          if ! sudo apt-get install -y libfuse2; then
+            echo "::warning::libfuse2 install failed (ports.ubuntu.com outage?); running AppImage via APPIMAGE_EXTRACT_AND_RUN=1 — FUSE mount path NOT exercised this run"
+            export APPIMAGE_EXTRACT_AND_RUN=1
+          fi
         fi
         export TEST_DIR=`mktemp -d -t test-viam-server-XXXXXX`
         cd $TEST_DIR


### PR DESCRIPTION
## Problem

The `AppImage Test` job (arm targets) fails whenever `ports.ubuntu.com` is unreachable. The step installs `libfuse2` so the AppImage can self-mount via FUSE, but arm packages only come from `ports.ubuntu.com`, which periodically has outages — all of its IPs (`91.189.91.102/103/104`, `2620:2d:4002:1::10a-c`) time out. amd64 is unaffected because it pulls from the on-network `azure.archive.ubuntu.com` mirror; arm has no equivalent (`azure.ports.ubuntu.com` just CNAMEs back to the degraded origin).

The build and the binary are fine — only the runtime `apt-get` fails, so reruns don't help while the mirror is down.

Observed in: https://github.com/viamrobotics/rdk/actions/runs/29425566599/job/87392402371

## Fix

Keep testing the real FUSE mount path when `libfuse2` installs (the normal case, unchanged). If the install fails, emit a `::warning::` and run the AppImage with `APPIMAGE_EXTRACT_AND_RUN=1` (no FUSE) so a mirror outage **degrades fidelity instead of failing the run**. Self-healing: when the mirror recovers, it returns to the real path automatically.

Trade-off: during an outage the FUSE mount path isn't exercised — hence the loud warning annotation so a degraded pass is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)