### PR TITLE
appimage-test: tolerate teardown exit in extract-and-run mode

### DIFF
--- a/.github/workflows/appimage-build.yml
+++ b/.github/workflows/appimage-build.yml
@@ -156,8 +156,10 @@ jobs:
         ./viam-server -config test.json &
         curl --retry 5 --retry-delay 5 --retry-connrefused localhost:$RAND_PORT
         export RET1=$?
-        kill %%
-        wait $!
-        export RET2=$?
+        # In extract-and-run mode the AppImage runtime wraps viam-server, so
+        # the background job exits non-zero (143/SIGTERM) on teardown. Tolerate
+        # it so the smoke test's verdict rests on RET1 (server came up).
+        kill %% || true
+        wait $! || true
         cd - && rm -rf $TEST_DIR
-        [ $RET1 == 0 ] && [ $RET1 == 0 ]
+        [ $RET1 == 0 ]


### PR DESCRIPTION
## Problem

Follow-up to the libfuse2 fallback (#6236). When `ports.ubuntu.com` is down and the AppImage runs via `APPIMAGE_EXTRACT_AND_RUN=1`, the smoke test **passes** (server boots and serves) but the job still fails with exit **143**.

Root cause (from [the failing run](https://github.com/viamrobotics/rdk/actions/runs/29435793677/job/87423232751)):
- Server came up and served — `serving {"url":"http://127.0.0.1:38746"}`, and the retried `curl` got a response (`RET1=0`).
- In extract-and-run mode the AppImage runtime wraps viam-server in a separate process. `kill %%` hits the **wrapper**, leaving viam-server orphaned (log: `Terminate orphan process: pid (1665) (viam-server)`), and `wait $!` returns **143** (SIGTERM).
- The step runs under `bash -e`, so `wait $!` returning 143 aborts the step **before** the `[ $RET1 == 0 ]` assertion.

In the FUSE path this never happened: viam-server *was* the job, caught SIGTERM, and exited 0.

## Fix

Make teardown tolerant so the verdict rests on `RET1` (did the server serve):

```bash
kill %% || true
wait $! || true
...
[ $RET1 == 0 ]
```

Also drops the dead `RET2` capture and the duplicated `[ $RET1 == 0 ] && [ $RET1 == 0 ]` (it checked `RET1` twice — a typo dating to #5818; `RET2` was never used). No-op in FUSE mode; unblocks the extract-and-run fallback during a mirror outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)