### PR TITLE
[APP-17104] Preserve robot config field order when reloading a module

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -1786,7 +1786,7 @@ func machinesPartAddTriggerAction(ctx context.Context, cmd *cli.Command, args ma
 		return err
 	}
 
-	if err := client.updateRobotPart(ctx, part, config, nil); err != nil {
+	if err := client.updateRobotPartFromMap(ctx, part, config, nil); err != nil {
 		return err
 	}
 
@@ -2927,7 +2927,7 @@ func machinesPartAddJobAction(ctx context.Context, cmd *cli.Command, args machin
 	jobs = append(jobs, jobConfig)
 	config["jobs"] = jobs
 
-	if err := client.updateRobotPart(ctx, part, config, nil); err != nil {
+	if err := client.updateRobotPartFromMap(ctx, part, config, nil); err != nil {
 		return err
 	}
 
@@ -2995,7 +2995,7 @@ func machinesPartUpdateJobAction(ctx context.Context, cmd *cli.Command, args mac
 
 	config["jobs"] = jobs
 
-	if err := client.updateRobotPart(ctx, part, config, nil); err != nil {
+	if err := client.updateRobotPartFromMap(ctx, part, config, nil); err != nil {
 		return err
 	}
 
@@ -3052,7 +3052,7 @@ func machinesPartDeleteJobAction(ctx context.Context, cmd *cli.Command, args mac
 
 	config["jobs"] = newJobs
 
-	if err := client.updateRobotPart(ctx, part, config, nil); err != nil {
+	if err := client.updateRobotPartFromMap(ctx, part, config, nil); err != nil {
 		return err
 	}
 
@@ -5173,21 +5173,34 @@ func (c *viamClient) getRobotPart(ctx context.Context, partID string) (*apppb.Ge
 	return c.client.GetRobotPart(ctx, &apppb.GetRobotPartRequest{Id: partID})
 }
 
+// updateRobotPart sends a robot config to the app backend as a raw JSON string.
+// Passing the config as JSON (rather than a structpb.Struct) preserves field order,
+// which matters because the config is stored and displayed as-is.
 func (c *viamClient) updateRobotPart(
-	ctx context.Context, part *apppb.RobotPart, confMap map[string]any, lastKnownUpdate *timestamppb.Timestamp,
+	ctx context.Context, part *apppb.RobotPart, confJSON string, lastKnownUpdate *timestamppb.Timestamp,
 ) error {
-	confStruct, err := structpb.NewStruct(confMap)
-	if err != nil {
-		return errors.Wrap(err, "in NewStruct")
-	}
 	req := apppb.UpdateRobotPartRequest{
 		Id:              part.Id,
 		Name:            part.Name,
-		RobotConfig:     confStruct,
+		RobotConfigJson: &confJSON,
 		LastKnownUpdate: lastKnownUpdate,
 	}
-	_, err = c.client.UpdateRobotPart(ctx, &req)
+	_, err := c.client.UpdateRobotPart(ctx, &req)
 	return err
+}
+
+// updateRobotPartFromMap is a compatibility shim for callers that still build the config
+// as a map[string]any. It marshals the map to JSON and delegates to updateRobotPart.
+// Note: field order is not preserved through the map; prefer updateRobotPart for flows
+// where order matters (e.g. module reload).
+func (c *viamClient) updateRobotPartFromMap(
+	ctx context.Context, part *apppb.RobotPart, confMap map[string]any, lastKnownUpdate *timestamppb.Timestamp,
+) error {
+	confJSON, err := json.Marshal(confMap)
+	if err != nil {
+		return errors.Wrap(err, "marshaling robot config")
+	}
+	return c.updateRobotPart(ctx, part, string(confJSON), lastKnownUpdate)
 }
 
 func (c *viamClient) robotPartLogs(ctx context.Context, orgStr, locStr, robotStr, partStr string, errorsOnly bool,

--- a/cli/module_reload.go
+++ b/cli/module_reload.go
@@ -2,20 +2,21 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 	"github.com/urfave/cli/v3"
 	apppb "go.viam.com/api/app/v1"
 	goutils "go.viam.com/utils"
-	"google.golang.org/protobuf/types/known/structpb"
 
 	rdkConfig "go.viam.com/rdk/config"
 	"go.viam.com/rdk/logging"
-	rutils "go.viam.com/rdk/utils"
 )
 
 const (
@@ -23,31 +24,240 @@ const (
 	reloadSourceVersionPrefix = "reload-source"
 )
 
-// reloadUser returns the identity string to stamp on reload configs.
-// For token-based auth this is the user's email; for API keys it's the key ID.
-func reloadUser(conf *Config) string {
-	// let reload succeed even if the auth is nil, lets monitor to see if this case ever happens.
-	if conf == nil || conf.Auth == nil {
-		return ""
+// configureModule is the configuration step of module reloading. Returns (updated robotPart, needsRestart, error).
+// Mutates the passed part.RobotConfigJson.
+// Uses optimistic concurrency control with last_known_update to avoid overwriting concurrent changes.
+func configureModule(
+	ctx context.Context, cmd *cli.Command, vc *viamClient, manifest *ModuleManifest, part *apppb.RobotPart,
+	local, cloudReload bool, reloadUser, annotation string, reloadUnixTS int64,
+) (*apppb.RobotPart, bool, error) {
+	if manifest == nil {
+		return part, false, fmt.Errorf("reconfiguration requires valid manifest json passed to --%s", moduleFlagPath)
 	}
-	return conf.Auth.String()
+	args, err := getGlobalArgs(cmd)
+	if err != nil {
+		return part, false, err
+	}
+
+	// needsRestart reflects the config actually written; on an OCC retry it is recomputed from the
+	// re-fetched config, which is what we want the caller to act on.
+	var needsRestart bool
+	attempt := func(p *apppb.RobotPart) error {
+		cfgJSON, err := partConfigJSON(p)
+		if err != nil {
+			return err
+		}
+		cfgJSON, needsRestart, err = mutateModuleConfig(
+			cmd, cfgJSON, *manifest, local, cloudReload, reloadUser, annotation, reloadUnixTS)
+		if err != nil {
+			return err
+		}
+		writeBackConfig(p, cfgJSON)
+		debugf(cmd.Root().Writer, args.Debug, "writing back config changes")
+		return vc.updateRobotPart(ctx, p, cfgJSON, p.LastUpdated)
+	}
+
+	if err := vc.updateWithOCCRetry(ctx, part, attempt); err != nil {
+		return part, false, errors.Wrap(err, "configureModule")
+	}
+
+	// there is an issue whereby mutations are getting lost or not properly reflected in the
+	// robotPart config after the robot part is updated. To address this, we query the part again
+	// to get the most up-to-date version, and return it for further use.
+	partResponse, err := vc.getRobotPart(ctx, part.Id)
+	if err != nil {
+		return part, false, err
+	}
+	return partResponse.Part, needsRestart, nil
 }
 
-// ModuleMap is a type alias to indicate where a map represents a module config.
-// We don't convert to rdkConfig.Module because it can get out of date with what's in the db.
-// Using maps directly also saves a lot of high-maintenance ser/des work.
-type ModuleMap map[string]any
+// mutateModuleConfig edits the modules list in the config JSON string to hot-reload with the
+// given manifest. reloadUser is the email/identity of the user performing the reload.
+// Returns (updatedConfigJSON, needsRestart, error).
+// needsRestart means the module binary needs an explicit restart (the reload path/enabled were already correct).
+func mutateModuleConfig(
+	cmd *cli.Command,
+	cfgJSON string,
+	manifest ModuleManifest,
+	local bool,
+	cloudReload bool,
+	reloadUser string,
+	annotation string,
+	reloadUnixTS int64,
+) (string, bool, error) {
+	var needsRestart bool
 
-// ResourceMap is the same kind of thing as ModuleMap (see above), a map representing a single resource.
-type ResourceMap map[string]any
+	modules := gjson.Get(cfgJSON, "modules").Array()
+	foundIdx := -1
+	for i, mod := range modules {
+		if mod.Get("module_id").String() == manifest.ModuleID {
+			foundIdx = i
+			break
+		}
+	}
 
-// applyResourceToPartMap adds a resource to the components or services slice if missing. Mutates the partMap.
-// Returns an error if the modelName isn't in the manifest, or if the specified resourceName already exists.
-func applyResourceToPartMap(
-	partMap map[string]any, manifest *ModuleManifest, modelName, resourceName string,
-) (string, error) {
+	var absEntrypoint string
+	var err error
+	if local {
+		// This flag means that viam server is running on the same machine running the CLI
+		// Does not indicate module type (registry vs local)
+		absEntrypoint, err = filepath.Abs(manifest.Entrypoint)
+		if err != nil {
+			return "", false, err
+		}
+	} else {
+		absEntrypoint = reloadingDestination(cmd, &manifest)
+	}
+
+	args, err := getGlobalArgs(cmd)
+	if err != nil {
+		return "", false, err
+	}
+
+	reloadTime := time.Unix(reloadUnixTS, 0).UTC().Format(time.RFC3339)
+
+	editor := &jsonEditor{json: cfgJSON}
+	if foundIdx >= 0 && modules[foundIdx].Get("type").String() == string(rdkConfig.ModuleTypeRegistry) {
+		foundMod := modules[foundIdx]
+		prefix := fmt.Sprintf("modules.%d.", foundIdx)
+		same, err := samePath(foundMod.Get("reload_path").String(), absEntrypoint)
+		if err != nil {
+			return "", false, err
+		}
+		switch {
+		case same && foundMod.Get("reload_enabled").Bool():
+			debugf(cmd.Root().Writer, args.Debug, "ReloadPath is up to date and ReloadEnabled, updating user and time")
+			needsRestart = true
+		case same:
+			debugf(cmd.Root().Writer, args.Debug, "ReloadPath is up to date, setting ReloadEnabled true")
+			editor.set(prefix+"reload_enabled", true)
+		default:
+			debugf(cmd.Root().Writer, args.Debug, "updating ReloadPath and ReloadEnabled")
+			if cloudReload {
+				editor.del(prefix + "reload_path")
+			} else {
+				editor.set(prefix+"reload_path", absEntrypoint)
+			}
+			editor.set(prefix+"reload_enabled", true)
+		}
+		editor.set(prefix+"reload_user", reloadUser)
+		editor.set(prefix+"reload_time", reloadTime)
+		if annotation != "" {
+			editor.set(prefix+"reload_annotation", annotation)
+		}
+	} else {
+		if foundIdx < 0 {
+			debugf(cmd.Root().Writer, args.Debug, "module not found, inserting")
+		} else {
+			debugf(cmd.Root().Writer, args.Debug, "found local module, inserting registry module")
+		}
+		editor.appendObject("modules", len(modules),
+			newModulePairs(manifest.ModuleID, absEntrypoint, reloadUser, reloadTime, annotation, cloudReload))
+	}
+	if editor.err != nil {
+		return "", false, editor.err
+	}
+	return editor.json, needsRestart, nil
+}
+
+// addResourceFromModule adds a resource to the components or services array if missing.
+// Uses optimistic concurrency control with last_known_update to avoid overwriting concurrent changes.
+func (c *viamClient) addResourceFromModule(
+	cmd *cli.Command, part *apppb.RobotPart, manifest *ModuleManifest, modelName, resourceName string,
+) error {
+	var resolvedName string
+	attempt := func(p *apppb.RobotPart) error {
+		cfgJSON, err := partConfigJSON(p)
+		if err != nil {
+			return err
+		}
+		cfgJSON, resolvedName, err = applyResourceToJSON(cfgJSON, manifest, modelName, resourceName)
+		if err != nil {
+			return err
+		}
+		writeBackConfig(p, cfgJSON)
+		return c.updateRobotPart(context.Background(), p, cfgJSON, p.LastUpdated)
+	}
+
+	if err := c.updateWithOCCRetry(context.Background(), part, attempt); err != nil {
+		return errors.Wrap(err, "addResourceFromModule")
+	}
+	infof(cmd.Root().Writer, "installing %s model with name %s on target machine", modelName, resolvedName)
+	return nil
+}
+
+// jsonEditor threads an error through a sequence of sjson mutations so call sites don't have to
+// error-check every Set/Delete. The first failure is retained and short-circuits the rest; check
+// err once when done. (sjson only errors on malformed path syntax, never on the data itself.)
+type jsonEditor struct {
+	json string
+	err  error
+}
+
+func (e *jsonEditor) set(path string, val any) {
+	if e.err == nil {
+		e.json, e.err = sjson.Set(e.json, path, val)
+	}
+}
+
+func (e *jsonEditor) del(path string) {
+	if e.err == nil {
+		e.json, e.err = sjson.Delete(e.json, path)
+	}
+}
+
+// kvPair is an ordered key/value used to build JSON objects with a deterministic field order.
+type kvPair struct {
+	key   string
+	value any
+}
+
+// appendObject appends a new object with the given ordered fields to the array at arrayPath.
+// idx must be the current length of that array. Setting fields one-by-one (rather than passing a
+// map) guarantees a deterministic key order.
+func (e *jsonEditor) appendObject(arrayPath string, idx int, pairs []kvPair) {
+	e.set(arrayPath+".-1", map[string]any{})
+	prefix := fmt.Sprintf("%s.%d.", arrayPath, idx)
+	for _, p := range pairs {
+		e.set(prefix+p.key, p.value)
+	}
+}
+
+// partConfigJSON returns the robot config of a part as a raw JSON string. It prefers the
+// RobotConfigJson field (which preserves field order); if that is empty it falls back to
+// serializing the RobotConfig struct (e.g. for older responses).
+func partConfigJSON(part *apppb.RobotPart) (string, error) {
+	if j := part.GetRobotConfigJson(); j != "" {
+		return j, nil
+	}
+	if part.RobotConfig == nil {
+		return "{}", nil
+	}
+	raw, err := part.RobotConfig.MarshalJSON()
+	if err != nil {
+		return "", errors.Wrap(err, "marshaling robot config")
+	}
+	return string(raw), nil
+}
+
+// writeBackConfig stores an edited config JSON string back on part.RobotConfigJson; this is
+// necessary so that changes aren't lost when we make multiple updateRobotPart calls. It also clears
+// the legacy RobotConfig struct so no stale copy of the config is left behind: partConfigJSON and
+// the app backend both read RobotConfigJson.
+func writeBackConfig(part *apppb.RobotPart, cfgJSON string) {
+	part.RobotConfig = nil
+	part.RobotConfigJson = &cfgJSON
+}
+
+// applyResourceToJSON adds a resource to the components or services array if missing, mutating
+// the config JSON string. Returns the updated config JSON and the resolved resource name.
+// Returns an error if the modelName isn't in the manifest, or if the specified resourceName
+// already exists.
+func applyResourceToJSON(
+	cfgJSON string, manifest *ModuleManifest, modelName, resourceName string,
+) (string, string, error) {
 	if manifest == nil {
-		return "", errors.New("unable to add resource from config without a meta.json")
+		return "", "", errors.New("unable to add resource from config without a meta.json")
 	}
 
 	var modelAPI string
@@ -59,90 +269,141 @@ func applyResourceToPartMap(
 	}
 
 	if len(modelAPI) == 0 {
-		return "", errors.New("provided model name was not found in the meta.json")
+		return "", "", errors.New("provided model name was not found in the meta.json")
 	}
 
 	APISlice := strings.Split(modelAPI, ":")
 	if len(APISlice) != 3 {
-		return "", errors.New("the provided model's API is malformed; unable to determine resource type")
+		return "", "", errors.New("the provided model's API is malformed; unable to determine resource type")
 	}
 
 	resourceType := APISlice[1] + "s" // `components`, not `component`
 
-	if _, ok := partMap[resourceType]; !ok {
-		partMap[resourceType] = make([]any, 0, 1)
-	}
-	resources, _ := rutils.MapOver(partMap[resourceType].([]any), //nolint:errcheck
-		func(raw any) (ResourceMap, error) { return ResourceMap(raw.(map[string]any)), nil },
-	)
-
-	resourceNameAlreadyExists := func(name string) bool {
-		match := rutils.FindInSlice(partMap[resourceType].([]any),
-			func(raw any) bool { return raw.(map[string]any)["name"].(string) == name })
-
-		return match != nil
+	existing := gjson.Get(cfgJSON, resourceType).Array()
+	nameExists := func(name string) bool {
+		for _, r := range existing {
+			if r.Get("name").String() == name {
+				return true
+			}
+		}
+		return false
 	}
 
 	// if the user provides a resource name but it's already in the config, alert the user and return
 	if resourceName != "" {
-		if resourceNameAlreadyExists(resourceName) {
-			return "", errors.Errorf("resource name %s already exists in part config", resourceName)
+		if nameExists(resourceName) {
+			return "", "", errors.Errorf("resource name %s already exists in part config", resourceName)
 		}
 	} else { // if the user doesn't provide a resource name, find a valid one
-		resourceNum := 1
 		resourceSubtype := APISlice[2]
-		for {
+		for resourceNum := 1; ; resourceNum++ {
 			name := fmt.Sprintf("%s-%d", resourceSubtype, resourceNum)
-			if resourceNameAlreadyExists(name) {
-				resourceNum++
-			} else {
+			if !nameExists(name) {
 				resourceName = name
 				break
 			}
 		}
 	}
 
-	resources = append(resources, ResourceMap{"name": resourceName, "api": modelAPI, "model": modelName})
-	asAny, _ := rutils.MapOver(resources, func(resource ResourceMap) (any, error) { //nolint:errcheck
-		return map[string]any(resource), nil
+	editor := &jsonEditor{json: cfgJSON}
+	editor.appendObject(resourceType, len(existing), []kvPair{
+		{"name", resourceName},
+		{"api", modelAPI},
+		{"model", modelName},
 	})
-	partMap[resourceType] = asAny
-	return resourceName, nil
+	if editor.err != nil {
+		return "", "", editor.err
+	}
+	return editor.json, resourceName, nil
 }
 
-// addResourceFromModule adds a resource to the components or services slice if missing.
+// addShellService adds a shell service to the services array if missing. Mutates part.RobotConfigJson.
+// Returns (wasAdded, error) where wasAdded indicates if the shell service was newly added.
 // Uses optimistic concurrency control with last_known_update to avoid overwriting concurrent changes.
-func (c *viamClient) addResourceFromModule(
-	cmd *cli.Command, part *apppb.RobotPart, manifest *ModuleManifest, modelName, resourceName string,
-) error {
-	partMap := part.RobotConfig.AsMap()
-	resolvedName, err := applyResourceToPartMap(partMap, manifest, modelName, resourceName)
+func addShellService(
+	ctx context.Context, cmd *cli.Command, vc *viamClient, logger logging.Logger, part *apppb.RobotPart, wait bool,
+) (bool, error) {
+	args, err := getGlobalArgs(cmd)
 	if err != nil {
-		return err
+		return false, err
 	}
-	if err := writeBackConfig(part, partMap); err != nil {
-		return err
+	var added bool
+	attempt := func(p *apppb.RobotPart) error {
+		cfgJSON, err := partConfigJSON(p)
+		if err != nil {
+			return err
+		}
+		has, err := hasShellService(ctx, vc, cfgJSON)
+		if err != nil {
+			debugf(cmd.Root().Writer, args.Debug, "could not check for existing shell service: %v; installing one anyway", err)
+		} else if has {
+			debugf(cmd.Root().Writer, args.Debug, "shell service found on target machine, not installing")
+			added = false
+			return nil
+		}
+		cfgJSON, err = appendShellServiceToJSON(cfgJSON)
+		if err != nil {
+			return err
+		}
+		writeBackConfig(p, cfgJSON)
+		if err := vc.updateRobotPart(ctx, p, cfgJSON, p.LastUpdated); err != nil {
+			return err
+		}
+		added = true
+		return nil
 	}
-	infof(cmd.Root().Writer, "installing %s model with name %s on target machine", modelName, resolvedName)
 
-	if err := c.updateRobotPart(context.Background(), part, partMap, part.LastUpdated); err != nil {
-		partResp, refetchErr := c.getRobotPart(context.Background(), part.Id)
-		if refetchErr != nil {
-			return errors.Wrap(err, "update failed and could not re-fetch part config")
+	if err := vc.updateWithOCCRetry(ctx, part, attempt); err != nil {
+		return false, errors.Wrap(err, "addShellService")
+	}
+	if !added {
+		// shell service already present on the part (or a fragment); nothing to wait for.
+		return false, nil
+	}
+	if !wait {
+		return true, nil
+	}
+	// note: we wait up to 11 seconds; that's the 10 second default Cloud.RefreshInterval plus padding.
+	// If we don't wait, the reload command will usually fail on first run.
+	for i := 0; i < 11; i++ {
+		time.Sleep(time.Second)
+		_, closeClient, err := vc.connectToShellServiceFqdn(ctx, part.Fqdn, args.Debug, logger)
+		if err == nil {
+			goutils.UncheckedError(closeClient(ctx))
+			return true, nil
 		}
-		retryPart := partResp.Part
-		retryMap := retryPart.RobotConfig.AsMap()
-		if _, retryErr := applyResourceToPartMap(retryMap, manifest, modelName, resourceName); retryErr != nil {
-			return retryErr
-		}
-		if retryErr := writeBackConfig(retryPart, retryMap); retryErr != nil {
-			return retryErr
-		}
-		if retryErr := c.updateRobotPart(context.Background(), retryPart, retryMap, retryPart.LastUpdated); retryErr != nil {
-			return errors.Wrap(retryErr, "retry of addResourceFromModule also failed")
+		if !errors.Is(err, errNoShellService) {
+			return false, err
 		}
 	}
-	return nil
+	return false, errors.New("timed out waiting for shell service to start")
+}
+
+// appendShellServiceToJSON appends a shell service entry to the services array in the config JSON.
+func appendShellServiceToJSON(cfgJSON string) (string, error) {
+	editor := &jsonEditor{json: cfgJSON}
+	editor.appendObject("services", len(gjson.Get(cfgJSON, "services").Array()), []kvPair{
+		{"name", "shell"},
+		{"api", "rdk:service:shell"},
+	})
+	return editor.json, editor.err
+}
+
+// hasShellService checks if a part or any of its fragments (recursively) already has a shell
+// service configured. Field order is irrelevant for a presence check, so the config JSON is
+// decoded to a map for the recursive walk.
+func hasShellService(ctx context.Context, vc *viamClient, cfgJSON string) (bool, error) {
+	var cfgMap map[string]any
+	if err := json.Unmarshal([]byte(cfgJSON), &cfgMap); err != nil {
+		return false, errors.Wrap(err, "parsing robot config")
+	}
+	return vc.findResourceInPartOrFragments(ctx, cfgMap, isShellService, map[string]bool{})
+}
+
+// isShellService matches a resource config entry for the shell service, tolerating
+// both the modern `api` key and the legacy `type` key.
+func isShellService(resource map[string]any) bool {
+	return resource["type"] == "shell" || resource["api"] == "rdk:service:shell"
 }
 
 // findResourceInPartOrFragments returns true if predicate matches any resource in
@@ -190,199 +451,45 @@ func (c *viamClient) findResourceInPartOrFragments(
 	return false, nil
 }
 
-// hasShellService checks if a part or any of its fragments (recursively) already has a shell service configured
-func hasShellService(ctx context.Context, vc *viamClient, partMap map[string]any) (bool, error) {
-	return vc.findResourceInPartOrFragments(ctx, partMap, isShellService, map[string]bool{})
-}
-
-// appendShellServiceToPartMap appends a shell service entry to partMap["services"].
-func appendShellServiceToPartMap(partMap map[string]any) {
-	if _, ok := partMap["services"]; !ok {
-		partMap["services"] = make([]any, 0, 1)
+// updateWithOCCRetry runs attempt against part; if it fails, it re-fetches the part (picking up the
+// latest last_known_update and config) and runs attempt once more. This handles the
+// optimistic-concurrency-control conflict where a concurrent edit bumped last_known_update between
+// our fetch and our write. attempt must be safe to run twice: it re-derives the config from the
+// part it is given on each call.
+func (c *viamClient) updateWithOCCRetry(
+	ctx context.Context, part *apppb.RobotPart, attempt func(*apppb.RobotPart) error,
+) error {
+	if err := attempt(part); err == nil {
+		return nil
 	}
-	services, _ := rutils.MapOver(partMap["services"].([]any), //nolint:errcheck
-		func(raw any) (ResourceMap, error) { return ResourceMap(raw.(map[string]any)), nil },
-	)
-	services = append(services, ResourceMap{"name": "shell", "api": "rdk:service:shell"})
-	asAny, _ := rutils.MapOver(services, func(service ResourceMap) (any, error) { //nolint:errcheck
-		return map[string]any(service), nil
-	})
-	partMap["services"] = asAny
-}
-
-// isShellService matches a resource config entry for the shell service, tolerating
-// both the modern `api` key and the legacy `type` key.
-func isShellService(resource map[string]any) bool {
-	return resource["type"] == "shell" || resource["api"] == "rdk:service:shell"
-}
-
-// addShellService adds a shell service to the services slice if missing. Mutates part.RobotConfig.
-// Returns (wasAdded, error) where wasAdded indicates if the shell service was newly added.
-// Uses optimistic concurrency control with last_known_update to avoid overwriting concurrent changes.
-func addShellService(
-	ctx context.Context, cmd *cli.Command, vc *viamClient, logger logging.Logger, part *apppb.RobotPart, wait bool,
-) (bool, error) {
-	args, err := getGlobalArgs(cmd)
-	if err != nil {
-		return false, err
+	partResp, refetchErr := c.getRobotPart(ctx, part.Id)
+	if refetchErr != nil {
+		return errors.Wrap(refetchErr, "update failed and could not re-fetch part config")
 	}
-	partMap := part.RobotConfig.AsMap()
-	has, err := hasShellService(ctx, vc, partMap)
-	if err != nil {
-		debugf(cmd.Root().Writer, args.Debug, "could not check for existing shell service: %v; installing one anyway", err)
-	} else if has {
-		debugf(cmd.Root().Writer, args.Debug, "shell service found on target machine, not installing")
-		return false, nil
+	if err := attempt(partResp.Part); err != nil {
+		return errors.Wrap(err, "retry also failed")
 	}
-	appendShellServiceToPartMap(partMap)
-	if err := writeBackConfig(part, partMap); err != nil {
-		return false, err
-	}
-	if err := vc.updateRobotPart(ctx, part, partMap, part.LastUpdated); err != nil {
-		partResp, refetchErr := vc.getRobotPart(ctx, part.Id)
-		if refetchErr != nil {
-			return false, errors.Wrap(err, "update failed and could not re-fetch part config")
-		}
-		retryPart := partResp.Part
-		retryMap := retryPart.RobotConfig.AsMap()
-		retryHas, err := hasShellService(ctx, vc, retryMap)
-		if err != nil {
-			debugf(cmd.Root().Writer, args.Debug,
-				"could not check for existing shell service after re-fetch: %v; installing one anyway", err)
-		} else if retryHas {
-			debugf(cmd.Root().Writer, args.Debug, "shell service found on target machine after re-fetch, not installing")
-			return false, nil
-		}
-		appendShellServiceToPartMap(retryMap)
-		if retryErr := writeBackConfig(retryPart, retryMap); retryErr != nil {
-			return false, retryErr
-		}
-		if retryErr := vc.updateRobotPart(ctx, retryPart, retryMap, retryPart.LastUpdated); retryErr != nil {
-			return false, errors.Wrap(retryErr, "retry of addShellService also failed")
-		}
-	}
-	if !wait {
-		return true, nil
-	}
-	// note: we wait up to 11 seconds; that's the 10 second default Cloud.RefreshInterval plus padding.
-	// If we don't wait, the reload command will usually fail on first run.
-	for i := 0; i < 11; i++ {
-		time.Sleep(time.Second)
-		_, closeClient, err := vc.connectToShellServiceFqdn(ctx, part.Fqdn, args.Debug, logger)
-		if err == nil {
-			goutils.UncheckedError(closeClient(ctx))
-			return true, nil
-		}
-		if !errors.Is(err, errNoShellService) {
-			return false, err
-		}
-	}
-	return false, errors.New("timed out waiting for shell service to start")
-}
-
-// writeBackConfig mutates part.RobotConfig with an edited config; this is necessary so that changes
-// aren't lost when we make multiple updateRobotPart calls.
-func writeBackConfig(part *apppb.RobotPart, configAsMap map[string]any) error {
-	modifiedConfig, err := structpb.NewStruct(configAsMap)
-	if err != nil {
-		return err
-	}
-	part.RobotConfig = modifiedConfig
 	return nil
 }
 
-// applyModuleConfigToPartMap applies the module reload configuration changes to a partMap.
-// Returns (modules, dirty, needsRestart, error).
-// dirty means config was changed and needs to be written back.
-// needsRestart means the module needs an explicit restart (the reload path was already correct).
-func applyModuleConfigToPartMap(
-	cmd *cli.Command,
-	partMap map[string]any,
-	manifest ModuleManifest,
-	local,
-	cloudReload bool,
-	reloadUser,
-	annotation string,
-	reloadUnixTS int64,
-) ([]ModuleMap, bool, bool, error) {
-	if _, ok := partMap["modules"]; !ok {
-		partMap["modules"] = make([]any, 0, 1)
+// newModulePairs returns the ordered fields for a new registry module entry configured for hot reload.
+func newModulePairs(moduleID, entryPoint, reloadUser, reloadTime, annotation string, cloudReload bool) []kvPair {
+	pairs := []kvPair{
+		{"type", string(rdkConfig.ModuleTypeRegistry)},
+		{"module_id", moduleID},
+		{"name", localizeModuleID(moduleID)},
+		{"reload_enabled", true},
+		{"version", "latest-with-prerelease"},
+		{"reload_user", reloadUser},
+		{"reload_time", reloadTime},
 	}
-	modules, err := rutils.MapOver(
-		partMap["modules"].([]any),
-		func(raw any) (ModuleMap, error) { return ModuleMap(raw.(map[string]any)), nil },
-	)
-	if err != nil {
-		return nil, false, false, err
+	if annotation != "" {
+		pairs = append(pairs, kvPair{"reload_annotation", annotation})
 	}
-
-	modules, dirty, needsRestart, err := mutateModuleConfig(cmd, modules, manifest, local, cloudReload, reloadUser, annotation, reloadUnixTS)
-	if err != nil {
-		return nil, false, false, err
+	if !cloudReload {
+		pairs = append(pairs, kvPair{"reload_path", entryPoint})
 	}
-	modulesAsInterfaces, err := rutils.MapOver(modules, func(mod ModuleMap) (any, error) {
-		return map[string]any(mod), nil
-	})
-	if err != nil {
-		return nil, false, false, err
-	}
-	partMap["modules"] = modulesAsInterfaces
-	return modules, dirty, needsRestart, nil
-}
-
-// configureModule is the configuration step of module reloading. Returns (updated robotPartpart, needsRestart, error).
-// Mutates the passed part.RobotConfig.
-// Uses optimistic concurrency control with last_known_update to avoid overwriting concurrent changes.
-func configureModule(
-	ctx context.Context, cmd *cli.Command, vc *viamClient, manifest *ModuleManifest, part *apppb.RobotPart,
-	local, cloudReload bool, reloadUser, annotation string, reloadUnixTS int64,
-) (*apppb.RobotPart, bool, error) {
-	if manifest == nil {
-		return part, false, fmt.Errorf("reconfiguration requires valid manifest json passed to --%s", moduleFlagPath)
-	}
-	partMap := part.RobotConfig.AsMap()
-	_, dirty, needsRestart, err := applyModuleConfigToPartMap(
-		cmd, partMap, *manifest, local, cloudReload, reloadUser, annotation, reloadUnixTS)
-	if err != nil {
-		return part, false, err
-	}
-	if err := writeBackConfig(part, partMap); err != nil {
-		return part, false, err
-	}
-	if dirty {
-		args, err := getGlobalArgs(cmd)
-		if err != nil {
-			return part, false, err
-		}
-		debugf(cmd.Root().Writer, args.Debug, "writing back config changes")
-		if err := vc.updateRobotPart(ctx, part, partMap, part.LastUpdated); err != nil {
-			partResp, refetchErr := vc.getRobotPart(ctx, part.Id)
-			if refetchErr != nil {
-				return part, false, errors.Wrap(err, "update failed and could not re-fetch part config")
-			}
-			retryPart := partResp.Part
-			retryMap := retryPart.RobotConfig.AsMap()
-			_, _, _, retryErr := applyModuleConfigToPartMap(cmd, retryMap, *manifest, local, cloudReload, reloadUser, annotation, reloadUnixTS)
-			if retryErr != nil {
-				return part, false, retryErr
-			}
-			if retryErr = writeBackConfig(retryPart, retryMap); retryErr != nil {
-				return part, false, retryErr
-			}
-			if retryErr = vc.updateRobotPart(ctx, retryPart, retryMap, retryPart.LastUpdated); retryErr != nil {
-				return part, false, errors.Wrap(retryErr, "retry of configureModule also failed")
-			}
-		}
-	}
-
-	// there is an issue whereby mutations are getting lost or not properly reflected in the
-	// robotPart config after the robot part is updated. To address this, we query the part again
-	// to get the most up-to-date version, and return it for further use.
-	partResponse, err := vc.getRobotPart(ctx, part.Id)
-	if err != nil {
-		return part, false, err
-	}
-	return partResponse.Part, needsRestart, nil
+	return pairs
 }
 
 // localizeModuleID converts a module ID of the form "<namespace>:<moduleName>"
@@ -393,109 +500,12 @@ func localizeModuleID(moduleID string) string {
 	return strings.ReplaceAll(moduleID, ":", "_")
 }
 
-// mutateModuleConfig edits the modules list to hot-reload with the given manifest.
-// reloadUser is the email/identity of the user performing the reload.
-// Returns (modules, dirty, needsRestart, error).
-// dirty means config was changed and needs to be written back.
-// needsRestart means the module binary needs an explicit restart (the reload path/enabled were already correct).
-func mutateModuleConfig(
-	cmd *cli.Command,
-	modules []ModuleMap,
-	manifest ModuleManifest,
-	local bool,
-	cloudReload bool,
-	reloadUser string,
-	annotation string,
-	reloadUnixTS int64,
-) ([]ModuleMap, bool, bool, error) {
-	var dirty bool
-	var needsRestart bool
-	var foundMod ModuleMap
-	for _, mod := range modules {
-		if mod["module_id"] == manifest.ModuleID {
-			foundMod = mod
-			break
-		}
+// reloadUser returns the identity string to stamp on reload configs.
+// For token-based auth this is the user's email; for API keys it's the key ID.
+func reloadUser(conf *Config) string {
+	// let reload succeed even if the auth is nil, lets monitor to see if this case ever happens.
+	if conf == nil || conf.Auth == nil {
+		return ""
 	}
-
-	var absEntrypoint string
-	var err error
-	if local {
-		// This flag means that viam server is running on the same machine running the CLI
-		// Does not indicate module type (registry vs local)
-		absEntrypoint, err = filepath.Abs(manifest.Entrypoint)
-		if err != nil {
-			return nil, dirty, false, err
-		}
-	} else {
-		absEntrypoint = reloadingDestination(cmd, &manifest)
-	}
-
-	args, err := getGlobalArgs(cmd)
-	if err != nil {
-		return nil, false, false, err
-	}
-
-	reloadTime := time.Unix(reloadUnixTS, 0).UTC().Format(time.RFC3339)
-
-	if foundMod != nil && getMapString(foundMod, "type") == string(rdkConfig.ModuleTypeRegistry) {
-		samePath, err := samePath(getMapString(foundMod, "reload_path"), absEntrypoint)
-		if err != nil {
-			return nil, dirty, false, err
-		}
-		reloadFlag := foundMod["reload_enabled"]
-		if samePath && reloadFlag == true {
-			debugf(cmd.Root().Writer, args.Debug, "ReloadPath is up to date and ReloadEnabled, updating user and time")
-			needsRestart = true
-		} else {
-			if samePath {
-				debugf(cmd.Root().Writer, args.Debug, "ReloadPath is up to date, setting ReloadEnabled true")
-				foundMod["reload_enabled"] = true
-			} else {
-				debugf(cmd.Root().Writer, args.Debug, "updating ReloadPath and ReloadEnabled")
-				if cloudReload {
-					delete(foundMod, "reload_path")
-				} else {
-					foundMod["reload_path"] = absEntrypoint
-				}
-				foundMod["reload_enabled"] = true
-			}
-		}
-		dirty = true
-		foundMod["reload_user"] = reloadUser
-		foundMod["reload_time"] = reloadTime
-		if annotation != "" {
-			foundMod["reload_annotation"] = annotation
-		}
-	} else {
-		dirty = true
-		if foundMod == nil {
-			debugf(cmd.Root().Writer, args.Debug, "module not found, inserting")
-		} else {
-			debugf(cmd.Root().Writer, args.Debug, "found local module, inserting registry module")
-		}
-		newMod := createNewModuleMap(manifest.ModuleID, absEntrypoint, reloadUser, reloadTime, annotation, cloudReload)
-		modules = append(modules, newMod)
-	}
-	return modules, dirty, needsRestart, nil
-}
-
-func createNewModuleMap(moduleID, entryPoint, reloadUser, reloadTime, annotation string, cloudReload bool) ModuleMap {
-	localName := localizeModuleID(moduleID)
-	newMod := ModuleMap(map[string]any{
-		"type":           string(rdkConfig.ModuleTypeRegistry),
-		"module_id":      moduleID,
-		"name":           localName,
-		"reload_enabled": true,
-		"version":        "latest-with-prerelease",
-		"reload_user":    reloadUser,
-		"reload_time":    reloadTime,
-	})
-	if annotation != "" {
-		newMod["reload_annotation"] = annotation
-	}
-	if !cloudReload {
-		newMod["reload_path"] = entryPoint
-	}
-	return newMod
+	return conf.Auth.String()
 }

--- a/cli/module_reload_test.go
+++ b/cli/module_reload_test.go
@@ -2,12 +2,15 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/tidwall/gjson"
 	v1 "go.viam.com/api/app/build/v1"
 	apppb "go.viam.com/api/app/v1"
 	"go.viam.com/test"
@@ -47,16 +50,23 @@ func TestConfigureModule(t *testing.T) {
 func mockAppServiceClientWithRobotPart(
 	robotConfig, userSuppliedInfo *structpb.Struct,
 ) *inject.AppServiceClient {
+	configJSON := ""
+	if robotConfig != nil {
+		if raw, err := robotConfig.MarshalJSON(); err == nil {
+			configJSON = string(raw)
+		}
+	}
 	return &inject.AppServiceClient{
 		GetRobotPartFunc: func(ctx context.Context, req *apppb.GetRobotPartRequest,
 			opts ...grpc.CallOption,
 		) (*apppb.GetRobotPartResponse, error) {
 			return &apppb.GetRobotPartResponse{Part: &apppb.RobotPart{
 				RobotConfig:      robotConfig,
+				RobotConfigJson:  &configJSON,
 				Fqdn:             "test-robot.local",
 				UserSuppliedInfo: userSuppliedInfo,
 				LastUpdated:      timestamppb.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
-			}, ConfigJson: ``}, nil
+			}, ConfigJson: configJSON}, nil
 		},
 	}
 }
@@ -142,13 +152,10 @@ func TestFullReloadFlow(t *testing.T) {
 			part, _ := vc.getRobotPart(context.Background(), "id")
 			_, err := addShellService(context.Background(), cCtx, vc, logging.NewTestLogger(t), part.Part, false)
 			test.That(t, err, test.ShouldBeNil)
-			services, ok := part.Part.RobotConfig.AsMap()["services"].([]any)
-			test.That(t, ok, test.ShouldBeTrue)
-			test.That(t, services, test.ShouldNotBeNil)
+			services := gjson.Get(part.Part.GetRobotConfigJson(), "services").Array()
 			test.That(t, len(services), test.ShouldEqual, 1)
-			service := services[0].(map[string]any)
-			test.That(t, service["name"], test.ShouldEqual, "shell")
-			test.That(t, service["api"], test.ShouldEqual, "rdk:service:shell")
+			test.That(t, services[0].Get("name").String(), test.ShouldEqual, "shell")
+			test.That(t, services[0].Get("api").String(), test.ShouldEqual, "rdk:service:shell")
 		})
 
 		// Helper function to test detection of existing shell service
@@ -171,8 +178,7 @@ func TestFullReloadFlow(t *testing.T) {
 			part, _ := vc2.getRobotPart(context.Background(), "id")
 			_, err = addShellService(context.Background(), cCtx2, vc2, logging.NewTestLogger(t), part.Part, false)
 			test.That(t, err, test.ShouldBeNil)
-			services, ok := part.Part.RobotConfig.AsMap()["services"].([]any)
-			test.That(t, ok, test.ShouldBeTrue)
+			services := gjson.Get(part.Part.GetRobotConfigJson(), "services").Array()
 			// Should still have only 1 service (not added again)
 			test.That(t, len(services), test.ShouldEqual, 1)
 		}
@@ -230,7 +236,7 @@ func TestFullReloadFlow(t *testing.T) {
 			added, err := addShellService(context.Background(), cCtx2, vc2, logging.NewTestLogger(t), part.Part, false)
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, added, test.ShouldBeFalse)
-			services, _ := part.Part.RobotConfig.AsMap()["services"].([]any)
+			services := gjson.Get(part.Part.GetRobotConfigJson(), "services").Array()
 			test.That(t, len(services), test.ShouldEqual, 0)
 		})
 	})
@@ -391,6 +397,14 @@ func TestResolvePartId(t *testing.T) {
 	test.That(t, partID, test.ShouldEqual, "FLAG-PART")
 }
 
+// cfgWithModules builds a robot config JSON string containing the given modules array.
+func cfgWithModules(t *testing.T, modules []map[string]any) string {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{"modules": modules})
+	test.That(t, err, test.ShouldBeNil)
+	return string(raw)
+}
+
 func TestMutateModuleConfig(t *testing.T) {
 	c := newTestContext(t, map[string]any{"local": true})
 	manifest := ModuleManifest{
@@ -406,110 +420,140 @@ func TestMutateModuleConfig(t *testing.T) {
 	testUser := "test@viam.com"
 	testReloadUnixTS := time.Date(2024, 3, 18, 12, 0, 0, 0, time.UTC).Unix()
 
+	// mod is a shorthand to read modules.<i> from a returned config JSON string.
+	mod := func(cfgJSON string, i int) gjson.Result {
+		return gjson.Get(cfgJSON, fmt.Sprintf("modules.%d", i))
+	}
+
+	// assertInsertedModule checks the fields of a freshly inserted registry module at modules.<i>.
+	assertInsertedModule := func(t *testing.T, cfgJSON string, i int, expectedReloadPath string) {
+		t.Helper()
+		test.That(t, mod(cfgJSON, i).Get("module_id").String(), test.ShouldEqual, manifest.ModuleID)
+		test.That(t, mod(cfgJSON, i).Get("name").String(), test.ShouldEqual, expectedName)
+		test.That(t, mod(cfgJSON, i).Get("reload_path").String(), test.ShouldEqual, expectedReloadPath)
+		test.That(t, mod(cfgJSON, i).Get("reload_enabled").Bool(), test.ShouldBeTrue)
+		test.That(t, mod(cfgJSON, i).Get("version").String(), test.ShouldEqual, expectedVersion)
+		test.That(t, mod(cfgJSON, i).Get("reload_user").String(), test.ShouldEqual, testUser)
+		test.That(t, mod(cfgJSON, i).Get("reload_time").String(), test.ShouldNotBeEmpty)
+	}
+
 	t.Run("correct_reload_path_and_enabled", func(t *testing.T) {
-		// correct ReloadPath and ReloadEnabled -- still dirty because user/time are always updated
-		modules := []ModuleMap{{
+		// correct ReloadPath and ReloadEnabled -- user/time are still updated, and needsRestart is set
+		cfg := cfgWithModules(t, []map[string]any{{
 			"type":           string(rdkConfig.ModuleTypeRegistry),
 			"module_id":      manifest.ModuleID,
 			"reload_path":    manifest.Entrypoint,
 			"reload_enabled": true,
-		}}
-		_, dirty, needsRestart, err := mutateModuleConfig(c, modules, manifest, true, false, testUser, "", testReloadUnixTS)
+		}})
+		cfg, needsRestart, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, dirty, test.ShouldBeTrue)
 		test.That(t, needsRestart, test.ShouldBeTrue)
-		test.That(t, modules[0]["reload_user"], test.ShouldEqual, testUser)
-		test.That(t, modules[0]["reload_time"], test.ShouldNotBeEmpty)
+		test.That(t, mod(cfg, 0).Get("reload_user").String(), test.ShouldEqual, testUser)
+		test.That(t, mod(cfg, 0).Get("reload_time").String(), test.ShouldNotBeEmpty)
 	})
 
 	t.Run("correct_reload_path_and_disabled", func(t *testing.T) {
 		// correct ReloadPath, but ReloadEnabled is false in registry module
-		modules := []ModuleMap{{
+		cfg := cfgWithModules(t, []map[string]any{{
 			"type":           string(rdkConfig.ModuleTypeRegistry),
 			"module_id":      manifest.ModuleID,
 			"reload_path":    manifest.Entrypoint,
 			"reload_enabled": false,
-		}}
-		_, dirty, needsRestart, err := mutateModuleConfig(c, modules, manifest, true, false, testUser, "", testReloadUnixTS)
+		}})
+		cfg, needsRestart, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, dirty, test.ShouldBeTrue)
 		test.That(t, needsRestart, test.ShouldBeFalse)
-		test.That(t, modules[0]["reload_enabled"], test.ShouldBeTrue)
-		test.That(t, modules[0]["reload_user"], test.ShouldEqual, testUser)
-		test.That(t, modules[0]["reload_time"], test.ShouldNotBeEmpty)
+		test.That(t, mod(cfg, 0).Get("reload_enabled").Bool(), test.ShouldBeTrue)
+		test.That(t, mod(cfg, 0).Get("reload_user").String(), test.ShouldEqual, testUser)
+		test.That(t, mod(cfg, 0).Get("reload_time").String(), test.ShouldNotBeEmpty)
 	})
 
 	t.Run("incorrect_reload_path_and_disabled", func(t *testing.T) {
 		// incorrect ReloadPath and ReloadEnabled is false in registry module
-		modules := []ModuleMap{{
+		cfg := cfgWithModules(t, []map[string]any{{
 			"type":           string(rdkConfig.ModuleTypeRegistry),
 			"module_id":      manifest.ModuleID,
 			"reload_path":    "incorrect/path",
 			"reload_enabled": false,
-		}}
-		_, dirty, needsRestart, err := mutateModuleConfig(c, modules, manifest, true, false, testUser, "", testReloadUnixTS)
+		}})
+		cfg, needsRestart, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, dirty, test.ShouldBeTrue)
 		test.That(t, needsRestart, test.ShouldBeFalse)
-		test.That(t, modules[0]["reload_path"], test.ShouldEqual, expectedEntrypoint)
-		test.That(t, modules[0]["reload_enabled"], test.ShouldBeTrue)
-		test.That(t, modules[0]["reload_user"], test.ShouldEqual, testUser)
-		test.That(t, modules[0]["reload_time"], test.ShouldNotBeEmpty)
+		test.That(t, mod(cfg, 0).Get("reload_path").String(), test.ShouldEqual, expectedEntrypoint)
+		test.That(t, mod(cfg, 0).Get("reload_enabled").Bool(), test.ShouldBeTrue)
+		test.That(t, mod(cfg, 0).Get("reload_user").String(), test.ShouldEqual, testUser)
+		test.That(t, mod(cfg, 0).Get("reload_time").String(), test.ShouldNotBeEmpty)
 	})
 
 	t.Run("reload_fields_missing", func(t *testing.T) {
 		// ReloadPath and ReloadEnabled are both missing from the module map in registry module
-		modules := []ModuleMap{{
+		cfg := cfgWithModules(t, []map[string]any{{
 			"type":      string(rdkConfig.ModuleTypeRegistry),
 			"module_id": manifest.ModuleID,
-		}}
-		_, dirty, needsRestart, err := mutateModuleConfig(c, modules, manifest, true, false, testUser, "", testReloadUnixTS)
+		}})
+		cfg, needsRestart, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, dirty, test.ShouldBeTrue)
 		test.That(t, needsRestart, test.ShouldBeFalse)
-		test.That(t, modules[0]["reload_path"], test.ShouldEqual, expectedEntrypoint)
-		test.That(t, modules[0]["reload_enabled"], test.ShouldBeTrue)
-		test.That(t, modules[0]["reload_user"], test.ShouldEqual, testUser)
-		test.That(t, modules[0]["reload_time"], test.ShouldNotBeEmpty)
+		test.That(t, mod(cfg, 0).Get("reload_path").String(), test.ShouldEqual, expectedEntrypoint)
+		test.That(t, mod(cfg, 0).Get("reload_enabled").Bool(), test.ShouldBeTrue)
+		test.That(t, mod(cfg, 0).Get("reload_user").String(), test.ShouldEqual, testUser)
+		test.That(t, mod(cfg, 0).Get("reload_time").String(), test.ShouldNotBeEmpty)
 	})
 
 	t.Run("insert_when_missing", func(t *testing.T) {
-		modules := []ModuleMap{}
-		modules, _, _, _ = mutateModuleConfig(c, modules, manifest, true, false, testUser, "", testReloadUnixTS)
-		test.That(t, modules[0]["module_id"], test.ShouldEqual, manifest.ModuleID)
-		test.That(t, modules[0]["name"], test.ShouldEqual, expectedName)
-		test.That(t, modules[0]["reload_path"], test.ShouldEqual, expectedEntrypoint)
-		test.That(t, modules[0]["reload_enabled"], test.ShouldBeTrue)
-		test.That(t, modules[0]["version"], test.ShouldEqual, expectedVersion)
-		test.That(t, modules[0]["reload_user"], test.ShouldEqual, testUser)
-		test.That(t, modules[0]["reload_time"], test.ShouldNotBeEmpty)
+		cfg := cfgWithModules(t, []map[string]any{})
+		cfg, _, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS)
+		test.That(t, err, test.ShouldBeNil)
+		assertInsertedModule(t, cfg, 0, expectedEntrypoint)
 	})
 
 	t.Run("insert_when_local_module_found", func(t *testing.T) {
-		// ReloadPath and ReloadEnabled are both missing from the module map in registry module
-		modules := []ModuleMap{{
+		// A local module with the same ID exists; a new registry module should be appended.
+		cfg := cfgWithModules(t, []map[string]any{{
 			"type":      string(rdkConfig.ModuleTypeLocal),
 			"module_id": manifest.ModuleID,
-		}}
-		updatedModules, _, _, _ := mutateModuleConfig(c, modules, manifest, true, false, testUser, "", testReloadUnixTS)
-		test.That(t, len(updatedModules), test.ShouldEqual, 2)
-		test.That(t, updatedModules[1]["reload_path"], test.ShouldEqual, expectedEntrypoint)
-		test.That(t, updatedModules[1]["reload_enabled"], test.ShouldBeTrue)
-		test.That(t, updatedModules[1]["version"], test.ShouldEqual, expectedVersion)
-		test.That(t, updatedModules[1]["reload_user"], test.ShouldEqual, testUser)
-		test.That(t, updatedModules[1]["reload_time"], test.ShouldNotBeEmpty)
+		}})
+		cfg, _, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(gjson.Get(cfg, "modules").Array()), test.ShouldEqual, 2)
+		assertInsertedModule(t, cfg, 1, expectedEntrypoint)
 	})
 
 	c = newTestContext(t, map[string]any{})
 	t.Run("remote_insert", func(t *testing.T) {
-		modules, _, _, _ := mutateModuleConfig(c, []ModuleMap{}, manifest, false, false, testUser, "", testReloadUnixTS)
-		test.That(t, modules[0]["module_id"], test.ShouldEqual, manifest.ModuleID)
-		test.That(t, modules[0]["name"], test.ShouldEqual, expectedName)
-		test.That(t, modules[0]["reload_path"], test.ShouldEqual, remoteReloadPath)
-		test.That(t, modules[0]["reload_enabled"], test.ShouldBeTrue)
-		test.That(t, modules[0]["version"], test.ShouldEqual, expectedVersion)
-		test.That(t, modules[0]["reload_user"], test.ShouldEqual, testUser)
-		test.That(t, modules[0]["reload_time"], test.ShouldNotBeEmpty)
+		cfg := cfgWithModules(t, []map[string]any{})
+		cfg, _, err := mutateModuleConfig(c, cfg, manifest, false, false, testUser, "", testReloadUnixTS)
+		test.That(t, err, test.ShouldBeNil)
+		assertInsertedModule(t, cfg, 0, remoteReloadPath)
+	})
+
+	t.Run("preserves_field_order", func(t *testing.T) {
+		// A reload must only touch the reload_* keys and leave every other key (and its position)
+		// intact. Start from a config whose keys are in a deliberately non-alphabetical order.
+		cfg := `{"network":{"fqdn":"x"},"components":[{"name":"c1"}],` +
+			`"modules":[{"type":"registry","module_id":"viam-labs:test-module",` +
+			`"name":"viam-labs_test-module","version":"1.2.3","reload_path":"/bin/mod","reload_enabled":true}]}`
+		got, _, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS)
+		test.That(t, err, test.ShouldBeNil)
+		// Top-level key order is unchanged.
+		var topKeys []string
+		gjson.Parse(got).ForEach(func(key, _ gjson.Result) bool {
+			topKeys = append(topKeys, key.String())
+			return true
+		})
+		test.That(t, topKeys, test.ShouldResemble, []string{"network", "components", "modules"})
+		// Pre-existing module keys keep their order; reload_user/reload_time are appended after.
+		var modKeys []string
+		mod(got, 0).ForEach(func(key, _ gjson.Result) bool {
+			modKeys = append(modKeys, key.String())
+			return true
+		})
+		test.That(t, modKeys, test.ShouldResemble, []string{
+			"type", "module_id", "name", "version", "reload_path", "reload_enabled", "reload_user", "reload_time",
+		})
+		// Untouched values are preserved.
+		test.That(t, gjson.Get(got, "network.fqdn").String(), test.ShouldEqual, "x")
+		test.That(t, gjson.Get(got, "components.0.name").String(), test.ShouldEqual, "c1")
 	})
 }
 
@@ -887,32 +931,31 @@ func TestRepeatedReloadNeedsRestart(t *testing.T) {
 	testUser := "test@viam.com"
 	testReloadUnixTS := time.Date(2024, 3, 18, 12, 0, 0, 0, time.UTC).Unix()
 
-	initialConf, err := structpb.NewStruct(map[string]any{"modules": []any{}})
-	test.That(t, err, test.ShouldBeNil)
-
 	// Track the latest config written by UpdateRobotPart so subsequent GetRobotPart
 	// calls reflect the changes (simulating server persistence).
-	latestConfig := initialConf
+	latestConfig := `{"modules":[]}`
 	latestTimestamp := timestamppb.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	client := &inject.AppServiceClient{
 		GetRobotPartFunc: func(ctx context.Context, req *apppb.GetRobotPartRequest,
 			opts ...grpc.CallOption,
 		) (*apppb.GetRobotPartResponse, error) {
+			cfg := latestConfig
 			return &apppb.GetRobotPartResponse{Part: &apppb.RobotPart{
-				Id:          "part-123",
-				Name:        "test-part",
-				RobotConfig: latestConfig,
-				LastUpdated: latestTimestamp,
+				Id:              "part-123",
+				Name:            "test-part",
+				RobotConfigJson: &cfg,
+				LastUpdated:     latestTimestamp,
 			}}, nil
 		},
 		UpdateRobotPartFunc: func(ctx context.Context, req *apppb.UpdateRobotPartRequest,
 			opts ...grpc.CallOption,
 		) (*apppb.UpdateRobotPartResponse, error) {
-			latestConfig = req.RobotConfig
+			latestConfig = req.GetRobotConfigJson()
 			latestTimestamp = timestamppb.Now()
+			cfg := latestConfig
 			return &apppb.UpdateRobotPartResponse{Part: &apppb.RobotPart{
-				RobotConfig: latestConfig,
-				LastUpdated: latestTimestamp,
+				RobotConfigJson: &cfg,
+				LastUpdated:     latestTimestamp,
 			}}, nil
 		},
 	}
@@ -943,14 +986,14 @@ func TestReloadUserAndTimeInModuleConfig(t *testing.T) {
 	})
 	test.That(t, err, test.ShouldBeNil)
 
-	var capturedConfig *structpb.Struct
+	var capturedConfig string
 	updateCount := 0
 	client := mockAppServiceClientWithRobotPart(confStruct, nil)
 	client.UpdateRobotPartFunc = func(ctx context.Context, req *apppb.UpdateRobotPartRequest,
 		opts ...grpc.CallOption,
 	) (*apppb.UpdateRobotPartResponse, error) {
 		updateCount++
-		capturedConfig = req.RobotConfig
+		capturedConfig = req.GetRobotConfigJson()
 		return &apppb.UpdateRobotPartResponse{Part: &apppb.RobotPart{}}, nil
 	}
 	client.GetRobotAPIKeysFunc = func(ctx context.Context, in *apppb.GetRobotAPIKeysRequest,
@@ -976,12 +1019,10 @@ func TestReloadUserAndTimeInModuleConfig(t *testing.T) {
 	err = reloadModuleActionInner(context.Background(), cmd, vc, parseStructFromCtx[reloadModuleArgs](cmd), logger, false)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, updateCount, test.ShouldEqual, 1)
-	test.That(t, capturedConfig, test.ShouldNotBeNil)
+	test.That(t, capturedConfig, test.ShouldNotBeEmpty)
 
-	configMap := capturedConfig.AsMap()
-	modules := configMap["modules"].([]any)
+	modules := gjson.Get(capturedConfig, "modules").Array()
 	test.That(t, len(modules), test.ShouldBeGreaterThan, 0)
-	mod := modules[0].(map[string]any)
-	test.That(t, mod["reload_user"], test.ShouldEqual, testEmail)
-	test.That(t, mod["reload_time"], test.ShouldNotBeEmpty)
+	test.That(t, modules[0].Get("reload_user").String(), test.ShouldEqual, testEmail)
+	test.That(t, modules[0].Get("reload_time").String(), test.ShouldNotBeEmpty)
 }

--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,8 @@ require (
 	github.com/sergi/go-diff v1.4.0
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/spf13/cast v1.5.0
+	github.com/tidwall/gjson v1.19.0
+	github.com/tidwall/sjson v1.2.5
 	github.com/u2takey/ffmpeg-go v0.4.1
 	github.com/urfave/cli/v3 v3.7.0
 	github.com/viam-labs/motion-tools v1.35.1
@@ -328,6 +330,8 @@ require (
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tetratelabs/wazero v1.12.0 // indirect
 	github.com/tidwall/btree v1.8.1 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/u2takey/go-utils v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1053,6 +1053,15 @@ github.com/tetratelabs/wazero v1.12.0 h1:DuWcpNu/FzgEXgGBDp8J1Spc+CWOvvtvVyjKlaZ
 github.com/tetratelabs/wazero v1.12.0/go.mod h1:LvKtzl2RqO4gyF27BiXU+nKAjcV8f38U+kP/q2vgxh0=
 github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
 github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.19.0 h1:xwxm7n691Uf3u5OFjzngavjGTh55KX5q/9w9xHW88JU=
+github.com/tidwall/gjson v1.19.0/go.mod h1:V37/opeE/JbLUOfH0QTXiNez2l0RUjYUhpT4szFQAfc=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=


### PR DESCRIPTION
https://viam.atlassian.net/browse/APP-17104

## Problem

`viam module reload` / `reload-local` (and the shell-service and resource edits in that flow) mutated a machine's config by round-tripping it through `part.RobotConfig.AsMap()` — editing the resulting `map[string]any` and writing it back as a `structpb.Struct`. Because Go maps are unordered, **every reload reshuffled the field order of the entire robot config** in the cloud, producing large, noisy diffs for users viewing or versioning their config.

## Fix

Stop going through maps in the reload flow. Read the config as the raw JSON string the API now provides (`RobotPart.RobotConfigJson` / `GetRobotPartResponse.ConfigJson`), mutate it in place with `tidwall/sjson` (+ `gjson` for reads) so only the keys we actually change are touched, and send it back on `UpdateRobotPartRequest.RobotConfigJson`, which the app backend stores order-preserved.

New objects (a new module entry, an added resource, the shell service) are built with sequential `sjson.Set` calls rather than from a map, so their keys land in a deterministic order too.

### Scope
- Reload flow in `cli/module_reload.go`: `configureModule`, `addShellService`, `addResourceFromModule`, and `mutateModuleConfig`.
- Shared plumbing: `updateRobotPart` is now JSON-string based and sets `RobotConfigJson` **only**. An `updateRobotPartFromMap` shim keeps the remaining map-based callers (triggers, jobs) compiling; they can migrate later.

## Also in this change (cleanup)

- **Deduplicated the optimistic-concurrency retry** into one helper, `updateWithOCCRetry`, shared by all three writers (each mutation is expressed as a single `attempt` closure).
- **`jsonEditor`** accumulator threads the sjson error through a sequence of mutations, removing ~7 repetitive per-`Set` error checks in `mutateModuleConfig`.
- **Dropped the always-true `dirty` return** from `mutateModuleConfig` and the dead `if !dirty` guard.
- `writeBackConfig` now clears the legacy `RobotConfig` struct so no stale copy is left on a mutated part.

## Behavior notes

- `updateRobotPart` sends `RobotConfigJson` only (no `RobotConfig`); relies on the backend reading the JSON field, which is what preserves order.
- `needsRestart` is recomputed from the re-fetched config on an OCC-retry (reflects what was actually written); the non-conflict path is unchanged.

## Manual testing

See this robot part history for a clean hot reload diff on `2026-07-16`: https://app.viam.com/machine/e848dc38-e8c8-4907-8e4d-12426198130b/history

If you want to test yourself:

1. Pull these changes and build the RDK locally following the **Development** section here: https://github.com/viamrobotics/rdk/blob/main/cli/README.md#development
2. Clone the repo for the test module and `cd` into it: https://github.com/edobranov/evgeni-test-module-for-hot-reload
3. Run `viam module reload --part-id da041ddb-0e45-4d02-bfa5-8455fcf6be0f` to reload it on my machine (or feel free to use your own).