### PR TITLE
RSDK-14253: Disallow motion service API calls when the frame system is disconnected.

### DIFF
--- a/robot/framesystem/framesystem.go
+++ b/robot/framesystem/framesystem.go
@@ -190,8 +190,12 @@ type frameSystemService struct {
 	components map[string]resource.Resource
 	logger     logging.Logger
 
-	parts   []*referenceframe.FrameSystemPart
 	partsMu sync.RWMutex
+	parts   []*referenceframe.FrameSystemPart
+	// unlinkedParts represent frame system configuration errors (e.g: a frame's parent not
+	// existing). They are not currently returned over proto. This is consumed by the motion service
+	// to determine if a frame system configuration error is safe to ignore for specific actions.
+	unlinkedParts []*referenceframe.FrameSystemPart
 }
 
 // Reconfigure will rebuild the frame system from the newly updated robot.
@@ -226,6 +230,7 @@ func (svc *frameSystemService) BuiltInReconfigure(ctx context.Context, deps reso
 	}
 
 	svc.parts = sortedParts
+	svc.unlinkedParts = unlinkedParts
 	svc.logger.Debugf("reconfigured robot frame system: %v", (&Config{Parts: sortedParts}).String())
 	return nil
 }
@@ -361,6 +366,41 @@ func NewFromService(
 		return nil, err
 	}
 	return referenceframe.NewFrameSystem(service.Name().ShortName(), fsCfg.Parts, supplementalTransforms)
+}
+
+// NewFromService creates a referenceframe.FrameSystem from the given Service's FrameSystemConfig and returns it.
+// Supplemental transforms can be provided to augment the FrameSystemConfig.
+func NewFromServiceMustBeConnected(
+	ctx context.Context,
+	serviceI Service,
+	supplementalTransforms []*referenceframe.LinkInFrame,
+) (*referenceframe.FrameSystem, error) {
+	service, isLocalFSService := serviceI.(*frameSystemService)
+	if !isLocalFSService {
+		// Dan: This "must be connected" API is for RDK builtin motion service move requests. Which
+		// would be in the same process as this frame system service. I cannot imagine this code
+		// path being relevant, but being cautious and preserving what would be returned.
+		fsCfg, err := service.FrameSystemConfig(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return referenceframe.NewFrameSystem(service.Name().ShortName(), fsCfg.Parts, supplementalTransforms)
+	}
+
+	service.partsMu.RLock()
+	defer service.partsMu.RUnlock()
+
+	if len(service.unlinkedParts) > 0 {
+		strs := make([]string, len(service.unlinkedParts))
+		for idx, part := range service.unlinkedParts {
+			strs[idx] = part.FrameConfig.Name()
+		}
+
+		return nil, fmt.Errorf("Some frames are not linked to the world frame. Unlinked parts: %v", strs)
+	}
+
+	return referenceframe.NewFrameSystem(service.Name().ShortName(), service.parts, supplementalTransforms)
 }
 
 // PrefixRemoteParts applies prefixes to a list of FrameSystemParts appropriate to the remote they originate from.

--- a/robot/framesystem/framesystem.go
+++ b/robot/framesystem/framesystem.go
@@ -368,8 +368,10 @@ func NewFromService(
 	return referenceframe.NewFrameSystem(service.Name().ShortName(), fsCfg.Parts, supplementalTransforms)
 }
 
-// NewFromService creates a referenceframe.FrameSystem from the given Service's FrameSystemConfig and returns it.
-// Supplemental transforms can be provided to augment the FrameSystemConfig.
+// NewFromServiceMustBeConnected creates a referenceframe.FrameSystem from the given Service's
+// FrameSystemConfig and returns it. This will return an error if there are frame system parts that
+// are not rooted in the world frame (e.g: orphaned parents or some parent cycle). Supplemental
+// transforms can be provided to augment the FrameSystemConfig.
 func NewFromServiceMustBeConnected(
 	ctx context.Context,
 	serviceI Service,

--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -405,7 +405,7 @@ func (ms *builtIn) DoCommand(ctx context.Context, cmd map[string]interface{}) (m
 }
 
 func (ms *builtIn) getFrameSystem(ctx context.Context, transforms []*referenceframe.LinkInFrame) (*referenceframe.FrameSystem, error) {
-	frameSys, err := framesystem.NewFromService(ctx, ms.fsService, transforms)
+	frameSys, err := framesystem.NewFromServiceMustBeConnected(ctx, ms.fsService, transforms)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Putting out a feeler based on a collision with cooking bot. No mandate from me that we must enforce this policy/happy to just close. Simple story:
* robot config was good, gripper on arm, camera on arm
  * collision detection working fine
* the arm resource was renamed
* gripper/camera parents were not updated to reflect the arm resource
* gripper/camera were orphaned and the framesystem/motion planning were happy to ignore that fact
* resulted in a collision

There's a ticket for the frontend to validate this. But there were some strong opinions that the backend should also disallow this after a real world collision.

I'm not sure if this was an intentional decision to ignore orphaned frames. Or what I think is more likely (read: total guess), this might an artifact from back in the day where totally valid frame configs were stuck with orphans in the frame system because reconfigure was a joke.

I did check to what degree this would be backwards breaking for existing robots. I downloaded every instance of this [framesystem warning](https://github.com/viamrobotics/rdk/blob/edb0fed71b4d3be16cab8482c933b2d6535338ae/robot/framesystem/framesystem.go#L225) from a 24 hour span that clearly states which frames are being orphaned. This showed up in 36 machines. Every error message was about a camera/gripper/sander being disconnected. Looking at the config on every machine:
* the config was either clean (most cases) or
* the config did not have an arm enabled (e.g: erh-23big)
  * Meaning, no use in trying to motion plan anyways

For the cases of clean configs, every one had the "[input enabled resource is unavailable, omitting from frame system](https://github.com/viamrobotics/rdk/blob/edb0fed71b4d3be16cab8482c933b2d6535338ae/robot/impl/local_robot.go?plain=1#L1376)" log line firing. I've concluded that in all cases the log was transient due to the arm connection coming/going, temporarily breaking things at the end of the arm. And again -- can't motion plan for the arm if the robot can't connect.

The above is the motivation/justification that this is worthwhile and won't be backwards breaking. I decided to fix the problem in a way that ultimately assumes the motion service and frame system service are in the same viam-server process. Just to keep things simple.

Strictly speaking, we wouldn't need to change proto to solve this -- we can make sure we're returning disconnected parts when [returning the frame system config over the wire](https://github.com/viamrobotics/rdk/blob/edb0fed71b4d3be16cab8482c933b2d6535338ae/robot/server/server.go?plain=1#L321). But it would put the onus on every consumer of the frame system to solve graph connectivity if they wanted similar functionality. Not going to extrapolate every choice/detail about exposing this more official/publicly. Just wanted to give some shape about the choices that can be made here and let you drive if we should be doing more now.