### PR TITLE
Add device_id field to webcam config for stable device selection

### DIFF
--- a/components/camera/videosource/query.go
+++ b/components/camera/videosource/query.go
@@ -91,6 +91,22 @@ func findReaderAndDriver(
 
 	constraints := makeConstraints(conf, logger)
 
+	// Prefer the stable device_id when set. Unlike video_path it is matched verbatim
+	// against the driver label parts (no symlink/base resolution), so it survives
+	// reboots and device-node reshuffles. labelFilter compares against every label
+	// part, so the by-id/by-path half of a Linux "<id>;<node>" label matches here.
+	if conf.DeviceID != "" {
+		if path != "" {
+			logger.Debugw("both device_id and video_path set; selecting by device_id",
+				"device_id", conf.DeviceID, "video_path", path)
+		}
+		reader, driver, err := getReaderAndDriver(conf.DeviceID, constraints, logger)
+		if err != nil {
+			return nil, nil, "", err
+		}
+		return reader, driver, conf.DeviceID, nil
+	}
+
 	// Handle specific path
 	if path != "" {
 		resolvedPath, err := filepath.EvalSymlinks(path)

--- a/components/camera/videosource/query_internal_test.go
+++ b/components/camera/videosource/query_internal_test.go
@@ -1,0 +1,52 @@
+package videosource
+
+import (
+	"testing"
+
+	"github.com/pion/mediadevices/pkg/driver"
+	"github.com/pion/mediadevices/pkg/prop"
+	"go.viam.com/test"
+)
+
+// fakeDriver is a minimal driver.Driver used to exercise label matching.
+type fakeDriver struct {
+	label string
+}
+
+func (d *fakeDriver) Open() error              { return nil }
+func (d *fakeDriver) Close() error             { return nil }
+func (d *fakeDriver) Properties() []prop.Media { return nil }
+func (d *fakeDriver) ID() string               { return d.label }
+func (d *fakeDriver) Info() driver.Info        { return driver.Info{Label: d.label} }
+func (d *fakeDriver) Status() driver.State     { return driver.StateClosed }
+
+// TestLabelFilterMatchesDeviceIDAndPath documents that both halves of a Linux
+// "<stable device_id>;<device node>" label are matchable. device_id selection
+// relies on the by-id/by-path half (labels[0]) matching here; video_path
+// selection relies on the device-node half (labels[1]).
+func TestLabelFilterMatchesDeviceIDAndPath(t *testing.T) {
+	// Linux-style label: stable id ; device node.
+	linux := &fakeDriver{label: "usb-046d_webcam-video-index0;video4"}
+	// macOS/Windows-style label: a single identifier, no separator.
+	single := &fakeDriver{label: "0x14200000046d0825"}
+
+	t.Run("device_id half matches", func(t *testing.T) {
+		f := labelFilter("usb-046d_webcam-video-index0", true)
+		test.That(t, f(linux), test.ShouldBeTrue)
+	})
+
+	t.Run("video_path half matches", func(t *testing.T) {
+		f := labelFilter("video4", true)
+		test.That(t, f(linux), test.ShouldBeTrue)
+	})
+
+	t.Run("non-matching target is rejected", func(t *testing.T) {
+		f := labelFilter("video9", true)
+		test.That(t, f(linux), test.ShouldBeFalse)
+	})
+
+	t.Run("single-part label (macOS/windows) matches device_id", func(t *testing.T) {
+		f := labelFilter("0x14200000046d0825", true)
+		test.That(t, f(single), test.ShouldBeTrue)
+	})
+}

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -54,9 +54,15 @@ type WebcamConfig struct {
 	DistortionParameters *transform.BrownConrady            `json:"distortion_parameters,omitempty"`
 	Format               string                             `json:"format,omitempty"`
 	Path                 string                             `json:"video_path,omitempty"`
-	Width                int                                `json:"width_px,omitempty"`
-	Height               int                                `json:"height_px,omitempty"`
-	FrameRate            float32                            `json:"frame_rate,omitempty"`
+	// DeviceID is the OS-provided stable identifier for the device (the by-id/by-path
+	// name on Linux, the single label on macOS/Windows). When set it takes precedence
+	// over Path for device selection: unlike video_path it is matched verbatim against
+	// the driver label, so it stays valid across reboots and device-node reshuffles.
+	// It is surfaced by the find-webcams discovery service.
+	DeviceID  string  `json:"device_id,omitempty"`
+	Width     int     `json:"width_px,omitempty"`
+	Height    int     `json:"height_px,omitempty"`
+	FrameRate float32 `json:"frame_rate,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid.

--- a/components/camera/videosource/webcam_test.go
+++ b/components/camera/videosource/webcam_test.go
@@ -6,7 +6,28 @@ import (
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/camera/videosource"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/utils"
 )
+
+// TestWebcamConfigDeviceID ensures the discovery-surfaced device_id attribute
+// decodes into the native WebcamConfig instead of being silently dropped.
+func TestWebcamConfigDeviceID(t *testing.T) {
+	attrs := utils.AttributeMap{
+		"device_id":  "usb-046d_webcam-video-index0",
+		"video_path": "video4",
+		"format":     "MJPEG",
+		"width_px":   1920,
+		"height_px":  1080,
+	}
+
+	native, err := resource.TransformAttributeMap[*videosource.WebcamConfig](attrs)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, native.DeviceID, test.ShouldEqual, "usb-046d_webcam-video-index0")
+	test.That(t, native.Path, test.ShouldEqual, "video4")
+	test.That(t, native.Format, test.ShouldEqual, "MJPEG")
+	test.That(t, native.Width, test.ShouldEqual, 1920)
+}
 
 func TestWebcamValidation(t *testing.T) {
 	webCfg := &videosource.WebcamConfig{


### PR DESCRIPTION
The find-webcams discovery service surfaces a `device_id` attribute (the OS-provided stable identifier — the by-id/by-path label half on Linux, the single label on macOS/Windows), but the webcam component's WebcamConfig had no matching field, so it was silently dropped on decode and had no effect: devices were only ever selected by video_path, which is not reboot-stable on Linux.

- Add WebcamConfig.DeviceID (`device_id`).
- Prefer DeviceID over Path in findReaderAndDriver when set, matching it verbatim against driver label parts (no symlink/base munging).
- Tests: device_id decodes into the native config; labelFilter matches both the stable-id and device-node halves of a Linux label.