### PR TITLE
RSDK-14247: Shell copy should verify target directory exists before copying

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -3890,6 +3890,9 @@ func (c *viamClient) machinesPartCopyFilesAction(
 	attemptCount, err := doCopy()
 	if err != nil {
 		defer pm.Fail("copy", err) //nolint:errcheck
+		if errors.Is(err, errNoShellService) {
+			return err
+		}
 		if statusErr := status.Convert(err); statusErr != nil {
 			if statusErr.Code() == codes.InvalidArgument &&
 				statusErr.Message() == shell.ErrMsgDirectoryCopyRequestNoRecursion {
@@ -5683,6 +5686,14 @@ func (c *viamClient) retryableCopy(
 
 		// Handle error
 		hadPreviousFailure = true
+
+		// A machine without a shell service will not gain one by retrying; abort early.
+		if errors.Is(copyErr, errNoShellService) {
+			warningf(cmd.Root().ErrWriter, "Copy failed because the machine does not have the shell service enabled. "+
+				"Add the shell service to the machine part's configuration to enable file copying.")
+			_ = pm.Fail(attemptStepID, copyErr) //nolint:errcheck
+			return attempt, copyErr
+		}
 
 		// Print special warning for invalid argument and permission denied errors (in addition to regular error)
 		if s, ok := status.FromError(copyErr); ok {

--- a/cli/client.go
+++ b/cli/client.go
@@ -5695,7 +5695,7 @@ func (c *viamClient) retryableCopy(
 			return attempt, copyErr
 		}
 
-		// Print special warning for invalid argument and permission denied errors (in addition to regular error)
+		// Print special warning for invalid argument, permission denied, and not found errors (in addition to regular error)
 		if s, ok := status.FromError(copyErr); ok {
 			if s.Code() == codes.PermissionDenied {
 				if isFrom {

--- a/cli/client.go
+++ b/cli/client.go
@@ -3890,10 +3890,14 @@ func (c *viamClient) machinesPartCopyFilesAction(
 	attemptCount, err := doCopy()
 	if err != nil {
 		defer pm.Fail("copy", err) //nolint:errcheck
-		if statusErr := status.Convert(err); statusErr != nil &&
-			statusErr.Code() == codes.InvalidArgument &&
-			statusErr.Message() == shell.ErrMsgDirectoryCopyRequestNoRecursion {
-			return errDirectoryCopyRequestNoRecursion
+		if statusErr := status.Convert(err); statusErr != nil {
+			if statusErr.Code() == codes.InvalidArgument &&
+				statusErr.Message() == shell.ErrMsgDirectoryCopyRequestNoRecursion {
+				return errDirectoryCopyRequestNoRecursion
+			}
+			if statusErr.Code() == codes.NotFound {
+				return fmt.Errorf("copy aborted: %s", statusErr.Message())
+			}
 		}
 		return fmt.Errorf("all %d copy attempts failed, try again later", attemptCount)
 	}
@@ -5696,6 +5700,10 @@ func (c *viamClient) retryableCopy(
 				return attempt, copyErr
 			} else if s.Code() == codes.InvalidArgument {
 				warningf(cmd.Root().ErrWriter, "Copy failed with invalid argument: %s", copyErr.Error())
+				_ = pm.Fail(attemptStepID, copyErr) //nolint:errcheck
+				return attempt, copyErr
+			} else if s.Code() == codes.NotFound {
+				warningf(cmd.Root().ErrWriter, "Copy failed because the destination path does not exist: %s", s.Message())
 				_ = pm.Fail(attemptStepID, copyErr) //nolint:errcheck
 				return attempt, copyErr
 			}

--- a/cli/client.go
+++ b/cli/client.go
@@ -3899,7 +3899,7 @@ func (c *viamClient) machinesPartCopyFilesAction(
 				return errDirectoryCopyRequestNoRecursion
 			}
 			if statusErr.Code() == codes.NotFound {
-				return fmt.Errorf("copy aborted: %s", statusErr.Message())
+				return errors.WithMessage(err, "copy aborted")
 			}
 		}
 		return fmt.Errorf("all %d copy attempts failed, try again later", attemptCount)

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -2447,4 +2447,40 @@ func TestRetryableCopy(t *testing.T) {
 		test.That(t, errMsg, test.ShouldContainSubstring, "destination path does not exist")
 		test.That(t, errMsg, test.ShouldContainSubstring, `"/some/dir" does not exist or is not a directory`)
 	})
+
+	t.Run("NoShellServiceError", func(t *testing.T) {
+		cCtx, vc, _, errOut := setup(&inject.AppServiceClient{}, nil, &inject.BuildServiceClient{},
+			map[string]any{}, "token")
+
+		attemptCount := 0
+		mockCopyFunc := func() error {
+			attemptCount++
+			return errNoShellService
+		}
+
+		allSteps := []*Step{
+			{ID: "copy", Message: "Copying package...", CompletedMsg: "Package copied", IndentLevel: 0},
+		}
+		pm := NewProgressManager(allSteps, WithProgressOutput(false))
+		defer pm.Stop()
+
+		err := pm.Start("copy")
+		test.That(t, err, test.ShouldBeNil)
+
+		attempts, err := vc.retryableCopy(
+			cCtx,
+			pm,
+			mockCopyFunc,
+			false,
+		)
+
+		// Verify the copy was aborted after the first attempt instead of retrying
+		test.That(t, errors.Is(err, errNoShellService), test.ShouldBeTrue)
+		test.That(t, attempts, test.ShouldEqual, 1)
+		test.That(t, attemptCount, test.ShouldEqual, 1)
+
+		// Verify shell service specific warning appears
+		errMsg := strings.Join(errOut.messages, "")
+		test.That(t, errMsg, test.ShouldContainSubstring, "does not have the shell service enabled")
+	})
 }

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -2410,4 +2410,41 @@ func TestRetryableCopy(t *testing.T) {
 		errMsg = strings.Join(errOut.messages, "")
 		test.That(t, errMsg, test.ShouldContainSubstring, "RDK couldn't read the source files on the machine.")
 	})
+
+	t.Run("DestinationNotFoundError", func(t *testing.T) {
+		cCtx, vc, _, errOut := setup(&inject.AppServiceClient{}, nil, &inject.BuildServiceClient{},
+			map[string]any{}, "token")
+
+		attemptCount := 0
+		mockCopyFunc := func() error {
+			attemptCount++
+			return status.Error(codes.NotFound, `"/some/dir" does not exist or is not a directory`)
+		}
+
+		allSteps := []*Step{
+			{ID: "copy", Message: "Copying package...", CompletedMsg: "Package copied", IndentLevel: 0},
+		}
+		pm := NewProgressManager(allSteps, WithProgressOutput(false))
+		defer pm.Stop()
+
+		err := pm.Start("copy")
+		test.That(t, err, test.ShouldBeNil)
+
+		attempts, err := vc.retryableCopy(
+			cCtx,
+			pm,
+			mockCopyFunc,
+			false,
+		)
+
+		// Verify the copy was aborted after the first attempt instead of retrying
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, attempts, test.ShouldEqual, 1)
+		test.That(t, attemptCount, test.ShouldEqual, 1)
+
+		// Verify destination not found specific warning appears
+		errMsg := strings.Join(errOut.messages, "")
+		test.That(t, errMsg, test.ShouldContainSubstring, "destination path does not exist")
+		test.That(t, errMsg, test.ShouldContainSubstring, `"/some/dir" does not exist or is not a directory`)
+	})
 }

--- a/services/shell/client.go
+++ b/services/shell/client.go
@@ -201,7 +201,7 @@ func (c *client) CopyFilesToMachine(
 	// File->ShellRPCFileCopier->CopyFilesToMachineClient
 	// ShellRPCFileCopier does the heavy lifting for us by handling fragmentation
 	// and ordering.
-	return newShellRPCFileCopier(shellRPCCopyWriterTo{client}, preserve), nil
+	return newShellRPCFileCopier(newShellRPCCopyWriterTo(client), preserve), nil
 }
 
 // CopyFilesFromMachine is the client side RPC implementation of copying files from a machine.

--- a/services/shell/copy_local.go
+++ b/services/shell/copy_local.go
@@ -53,8 +53,12 @@ func (f *localFileCopyFactory) MakeFileCopier(ctx context.Context, sourceType Co
 		// for multiple files (a b c machine:~/some/dir), ~/some/dir needs to already exist
 		// as a directory
 		dstInfo, err := os.Stat(f.destination)
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
 		if err != nil || dstInfo == nil || !dstInfo.IsDir() {
-			return nil, fmt.Errorf("%q does not exist or is not a directory", f.destination)
+			// we use an error code here so the CLI can detect this case and abort early
+			return nil, status.Newf(codes.NotFound, "%q does not exist or is not a directory", f.destination).Err()
 		}
 		if err := os.MkdirAll(filepath.Dir(f.destination), 0o750); err != nil {
 			return nil, fmt.Errorf("MkdirAll all failed (%s): %w", f.destination, err)
@@ -95,6 +99,10 @@ func (f *localFileCopyFactory) MakeFileCopier(ctx context.Context, sourceType Co
 			parentInfo, err := os.Stat(parent)
 			if err != nil {
 				// the parent does not exist, then error
+				if errors.Is(err, fs.ErrNotExist) {
+					// we use an error code here so the CLI can detect this case and abort early
+					return nil, status.Newf(codes.NotFound, "destination %q: %s", f.destination, err).Err()
+				}
 				return nil, err
 			}
 			if parentInfo == nil {

--- a/services/shell/copy_local_test.go
+++ b/services/shell/copy_local_test.go
@@ -118,6 +118,20 @@ func TestLocalFileCopy(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, readCopier.Close(ctx), test.ShouldBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "is an existing file")
+
+		t.Log("parent does not exist")
+		factory, err = NewLocalFileCopyFactory(filepath.Join(tempDir, "notthere", "alsonotthere"), false, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		readCopier, err = NewLocalFileReadCopier([]string{tfs.SingleFileNested}, false, false, factory)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = readCopier.ReadAll(ctx)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, readCopier.Close(ctx), test.ShouldBeNil)
+		s, ok := status.FromError(err)
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, s.Code(), test.ShouldEqual, codes.NotFound)
 	})
 
 	t.Run("single file relative", func(t *testing.T) {
@@ -237,7 +251,10 @@ func TestLocalFileCopy(t *testing.T) {
 		err = readCopier.ReadAll(ctx)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, readCopier.Close(ctx), test.ShouldBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "does not exist or is not a directory")
+		s, ok := status.FromError(err)
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, s.Code(), test.ShouldEqual, codes.NotFound)
+		test.That(t, s.Message(), test.ShouldContainSubstring, "does not exist or is not a directory")
 	})
 
 	t.Run("preserve permissions on a nested file", func(t *testing.T) {

--- a/services/shell/copy_rpc.go
+++ b/services/shell/copy_rpc.go
@@ -351,33 +351,31 @@ type shellRPCCopyWriter interface {
 // A shellRPCCopyWriterTo is the To, Writer/Client side of a CopyTo. A background
 // receiver consumes the stream's responses so that a terminal error from the server
 // (e.g. the destination does not exist) is noticed while file data is still being
-// sent, rather than only after the whole file has been transferred.
+// sent, rather than only after the whole file has been transferred. The receiver
+// cancels ctx with the terminal stream error as its cause.
 type shellRPCCopyWriterTo struct {
 	rpcClient pb.ShellService_CopyFilesToMachineClient
+	ctx       context.Context
 	acks      chan struct{}
-	done      chan struct{}
-	recvErr   error
 }
 
 func newShellRPCCopyWriterTo(rpcClient pb.ShellService_CopyFilesToMachineClient) *shellRPCCopyWriterTo {
+	ctx, cancel := context.WithCancelCause(rpcClient.Context())
 	client := &shellRPCCopyWriterTo{
 		rpcClient: rpcClient,
+		ctx:       ctx,
 		// files are sent one at a time, so at most one un-awaited ACK is in flight
 		acks: make(chan struct{}, 1),
-		done: make(chan struct{}),
 	}
 	utils.PanicCapturingGo(func() {
 		for {
 			if _, err := rpcClient.Recv(); err != nil {
-				client.recvErr = err
-				close(client.done)
+				cancel(err)
 				return
 			}
 			select {
 			case client.acks <- struct{}{}:
-			case <-rpcClient.Context().Done():
-				client.recvErr = rpcClient.Context().Err()
-				close(client.done)
+			case <-ctx.Done():
 				return
 			}
 		}
@@ -386,12 +384,10 @@ func newShellRPCCopyWriterTo(rpcClient pb.ShellService_CopyFilesToMachineClient)
 }
 
 func (client *shellRPCCopyWriterTo) SendFile(fileDataProto *pb.FileData) error {
-	select {
-	case <-client.done:
+	if err := client.ctx.Err(); err != nil {
 		// the server already terminated the copy; fail fast instead of
 		// streaming the rest of the file data.
-		return client.recvErr
-	default:
+		return context.Cause(client.ctx)
 	}
 	if err := client.rpcClient.Send(&pb.CopyFilesToMachineRequest{
 		Request: &pb.CopyFilesToMachineRequest_FileData{
@@ -400,12 +396,8 @@ func (client *shellRPCCopyWriterTo) SendFile(fileDataProto *pb.FileData) error {
 	}); err != nil {
 		// a send error means the stream is dead (gRPC reports the reason via
 		// Recv); wait for the receiver to surface the actual error.
-		select {
-		case <-client.done:
-			return client.recvErr
-		case <-client.rpcClient.Context().Done():
-			return err
-		}
+		<-client.ctx.Done()
+		return context.Cause(client.ctx)
 	}
 	return nil
 }
@@ -414,14 +406,14 @@ func (client *shellRPCCopyWriterTo) WaitLastACK() error {
 	select {
 	case <-client.acks:
 		return nil
-	case <-client.done:
+	case <-client.ctx.Done():
 		// an ACK received before the stream ended is already buffered; prefer it
 		select {
 		case <-client.acks:
 			return nil
 		default:
 		}
-		return client.recvErr
+		return context.Cause(client.ctx)
 	}
 }
 

--- a/services/shell/copy_rpc.go
+++ b/services/shell/copy_rpc.go
@@ -348,25 +348,84 @@ type shellRPCCopyWriter interface {
 	Close() error
 }
 
-// A shellRPCCopyWriterTo is the To, Writer/Client side of a CopyTo.
+// A shellRPCCopyWriterTo is the To, Writer/Client side of a CopyTo. A background
+// receiver consumes the stream's responses so that a terminal error from the server
+// (e.g. the destination does not exist) is noticed while file data is still being
+// sent, rather than only after the whole file has been transferred.
 type shellRPCCopyWriterTo struct {
 	rpcClient pb.ShellService_CopyFilesToMachineClient
+	acks      chan struct{}
+	done      chan struct{}
+	recvErr   error
 }
 
-func (client shellRPCCopyWriterTo) SendFile(fileDataProto *pb.FileData) error {
-	return client.rpcClient.Send(&pb.CopyFilesToMachineRequest{
+func newShellRPCCopyWriterTo(rpcClient pb.ShellService_CopyFilesToMachineClient) *shellRPCCopyWriterTo {
+	client := &shellRPCCopyWriterTo{
+		rpcClient: rpcClient,
+		// files are sent one at a time, so at most one un-awaited ACK is in flight
+		acks: make(chan struct{}, 1),
+		done: make(chan struct{}),
+	}
+	utils.PanicCapturingGo(func() {
+		for {
+			if _, err := rpcClient.Recv(); err != nil {
+				client.recvErr = err
+				close(client.done)
+				return
+			}
+			select {
+			case client.acks <- struct{}{}:
+			case <-rpcClient.Context().Done():
+				client.recvErr = rpcClient.Context().Err()
+				close(client.done)
+				return
+			}
+		}
+	})
+	return client
+}
+
+func (client *shellRPCCopyWriterTo) SendFile(fileDataProto *pb.FileData) error {
+	select {
+	case <-client.done:
+		// the server already terminated the copy; fail fast instead of
+		// streaming the rest of the file data.
+		return client.recvErr
+	default:
+	}
+	if err := client.rpcClient.Send(&pb.CopyFilesToMachineRequest{
 		Request: &pb.CopyFilesToMachineRequest_FileData{
 			FileData: fileDataProto,
 		},
-	})
+	}); err != nil {
+		// a send error means the stream is dead (gRPC reports the reason via
+		// Recv); wait for the receiver to surface the actual error.
+		select {
+		case <-client.done:
+			return client.recvErr
+		case <-client.rpcClient.Context().Done():
+			return err
+		}
+	}
+	return nil
 }
 
-func (client shellRPCCopyWriterTo) WaitLastACK() error {
-	_, err := client.rpcClient.Recv()
-	return err
+func (client *shellRPCCopyWriterTo) WaitLastACK() error {
+	select {
+	case <-client.acks:
+		return nil
+	case <-client.done:
+		// an ACK received before the stream ended is already buffered; prefer it
+		select {
+		case <-client.acks:
+			return nil
+		default:
+		}
+		return client.recvErr
+	}
 }
 
-func (client shellRPCCopyWriterTo) Close() error {
+func (client *shellRPCCopyWriterTo) Close() error {
 	return client.rpcClient.CloseSend()
 }
 

--- a/services/shell/copy_rpc_test.go
+++ b/services/shell/copy_rpc_test.go
@@ -9,12 +9,16 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/pkg/errors"
 	pb "go.viam.com/api/service/shell/v1"
 	"go.viam.com/test"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	shelltestutils "go.viam.com/rdk/services/shell/testutils"
@@ -378,4 +382,96 @@ func (mem *inMemoryFileCopier) Copy(ctx context.Context, file File) error {
 
 func (mem *inMemoryFileCopier) Close(ctx context.Context) error {
 	return nil
+}
+
+type copyToMachineRecv struct {
+	resp *pb.CopyFilesToMachineResponse
+	err  error
+}
+
+// fakeCopyFilesToMachineClient is a fake pb.ShellService_CopyFilesToMachineClient
+// whose responses are fed through recvCh.
+type fakeCopyFilesToMachineClient struct {
+	ctx       context.Context
+	sendErr   error
+	sendCount atomic.Int32
+	recvCh    chan copyToMachineRecv
+}
+
+func newFakeCopyFilesToMachineClient() *fakeCopyFilesToMachineClient {
+	return &fakeCopyFilesToMachineClient{
+		ctx:    context.Background(),
+		recvCh: make(chan copyToMachineRecv),
+	}
+}
+
+func (f *fakeCopyFilesToMachineClient) Send(*pb.CopyFilesToMachineRequest) error {
+	f.sendCount.Add(1)
+	return f.sendErr
+}
+
+func (f *fakeCopyFilesToMachineClient) Recv() (*pb.CopyFilesToMachineResponse, error) {
+	next := <-f.recvCh
+	return next.resp, next.err
+}
+
+func (f *fakeCopyFilesToMachineClient) Context() context.Context     { return f.ctx }
+func (f *fakeCopyFilesToMachineClient) CloseSend() error             { return nil }
+func (f *fakeCopyFilesToMachineClient) Header() (metadata.MD, error) { return nil, nil }
+func (f *fakeCopyFilesToMachineClient) Trailer() metadata.MD         { return nil }
+func (f *fakeCopyFilesToMachineClient) SendMsg(any) error            { return nil }
+func (f *fakeCopyFilesToMachineClient) RecvMsg(any) error            { return nil }
+
+func TestShellRPCCopyWriterTo(t *testing.T) {
+	t.Run("SendFile fails fast once the server terminates the stream", func(t *testing.T) {
+		fake := newFakeCopyFilesToMachineClient()
+		writer := newShellRPCCopyWriterTo(fake)
+
+		terminalErr := status.Error(codes.NotFound, `"/some/dir" does not exist or is not a directory`)
+		fake.recvCh <- copyToMachineRecv{err: terminalErr}
+		<-writer.done
+
+		err := writer.SendFile(&pb.FileData{Name: "foo", Data: []byte("data")})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, status.Convert(err).Code(), test.ShouldEqual, codes.NotFound)
+		// no data should have been sent after the stream ended
+		test.That(t, fake.sendCount.Load(), test.ShouldEqual, 0)
+
+		err = writer.WaitLastACK()
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, status.Convert(err).Code(), test.ShouldEqual, codes.NotFound)
+	})
+
+	t.Run("SendFile surfaces the terminal error on send failure", func(t *testing.T) {
+		fake := newFakeCopyFilesToMachineClient()
+		writer := newShellRPCCopyWriterTo(fake)
+
+		// gRPC semantics: Send returns io.EOF and the real error comes from Recv
+		fake.sendErr = io.EOF
+		terminalErr := status.Error(codes.NotFound, `"/some/dir" does not exist or is not a directory`)
+		go func() {
+			fake.recvCh <- copyToMachineRecv{err: terminalErr}
+		}()
+
+		err := writer.SendFile(&pb.FileData{Name: "foo", Data: []byte("data")})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, status.Convert(err).Code(), test.ShouldEqual, codes.NotFound)
+	})
+
+	t.Run("WaitLastACK returns nil per ACK and prefers a buffered ACK over EOF", func(t *testing.T) {
+		fake := newFakeCopyFilesToMachineClient()
+		writer := newShellRPCCopyWriterTo(fake)
+
+		err := writer.SendFile(&pb.FileData{Name: "foo", Data: []byte("data"), Eof: true})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, fake.sendCount.Load(), test.ShouldEqual, 1)
+
+		fake.recvCh <- copyToMachineRecv{resp: &pb.CopyFilesToMachineResponse{AckLastFile: true}}
+		fake.recvCh <- copyToMachineRecv{err: io.EOF}
+		<-writer.done
+
+		test.That(t, writer.WaitLastACK(), test.ShouldBeNil)
+		test.That(t, writer.WaitLastACK(), test.ShouldBeError, io.EOF)
+		test.That(t, writer.Close(), test.ShouldBeNil)
+	})
 }

--- a/services/shell/copy_rpc_test.go
+++ b/services/shell/copy_rpc_test.go
@@ -429,7 +429,7 @@ func TestShellRPCCopyWriterTo(t *testing.T) {
 
 		terminalErr := status.Error(codes.NotFound, `"/some/dir" does not exist or is not a directory`)
 		fake.recvCh <- copyToMachineRecv{err: terminalErr}
-		<-writer.done
+		<-writer.ctx.Done()
 
 		err := writer.SendFile(&pb.FileData{Name: "foo", Data: []byte("data")})
 		test.That(t, err, test.ShouldNotBeNil)
@@ -468,7 +468,7 @@ func TestShellRPCCopyWriterTo(t *testing.T) {
 
 		fake.recvCh <- copyToMachineRecv{resp: &pb.CopyFilesToMachineResponse{AckLastFile: true}}
 		fake.recvCh <- copyToMachineRecv{err: io.EOF}
-		<-writer.done
+		<-writer.ctx.Done()
 
 		test.That(t, writer.WaitLastACK(), test.ShouldBeNil)
 		test.That(t, writer.WaitLastACK(), test.ShouldBeError, io.EOF)


### PR DESCRIPTION
Using the shell to copy a file would send the entire file over the wire before checking the server response to see there was an issue. With slow enough connections and/or large enough files this could mean waiting a long time just to find out the transfer failed due to an error that could have been detected almost immediately. This changes the behavior to have a background goroutine actively checking for any errors on `Recv` and cancelling a context if it finds one, and otherwise just managing the file received acks from the server. If it does get an error indicating the target path does not exist, the cli will break out of its 6 iteration retry loop early. Technically we could let the retry loop run but I don't think most users will race to create the target directory before the sixth retry fails. For similar reasons this also makes the retry loop exit early when the server reports that the shell service is not enabled.

Tested manually w/ a Linux iso and a slow network connection in addition to the automated tests.