### PR TITLE
ci: allow fork PR checkout behind the 'safe to test' label

### DIFF
--- a/.github/workflows/appimage-build.yml
+++ b/.github/workflows/appimage-build.yml
@@ -55,6 +55,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pullrequest-trusted.yml).
+        allow-unsafe-pr-checkout: true
 
     - name: Clean and Fix Permissions
       run: |

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -32,6 +32,8 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
+        # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pullrequest-trusted.yml).
+        allow-unsafe-pr-checkout: true
 
     - uses: actions/setup-go@v5
       with:

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -32,6 +32,8 @@ jobs:
       if: github.event_name == 'pull_request_target'
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pullrequest-trusted.yml).
+        allow-unsafe-pr-checkout: true
 
     - uses: actions/setup-go@v5
       with:

--- a/.github/workflows/focal-build.yml
+++ b/.github/workflows/focal-build.yml
@@ -64,6 +64,8 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pullrequest-trusted.yml).
+        allow-unsafe-pr-checkout: true
 
     - name: Fix permissions
       run: chown -R testbot:testbot .
@@ -137,6 +139,7 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        allow-unsafe-pr-checkout: true
 
     - name: Resolve channel
       id: meta

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -23,6 +23,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pullrequest-trusted.yml).
+        allow-unsafe-pr-checkout: true
 
     - name: Run license finder
       run: |

--- a/.github/workflows/motion-benchmarks.yml
+++ b/.github/workflows/motion-benchmarks.yml
@@ -26,6 +26,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see motion-pull-request-trusted.yml).
+        allow-unsafe-pr-checkout: true
 
     - name: Check out code in motion-testing repository
       uses: actions/checkout@v4

--- a/.github/workflows/motion-tests.yml
+++ b/.github/workflows/motion-tests.yml
@@ -23,6 +23,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pullrequest-trusted.yml).
+        allow-unsafe-pr-checkout: true
 
     - name: Check out code in motion-testing repository
       uses: actions/checkout@v4

--- a/.github/workflows/pullrequest-trusted.yml
+++ b/.github/workflows/pullrequest-trusted.yml
@@ -15,7 +15,9 @@ on:
 
 jobs:
   test:
-    if: (github.event.label.name == 'safe to test' || github.event.label.name == 'appimage')
+    if: |
+      (github.event.label.name == 'safe to test' || github.event.label.name == 'appimage') &&
+      contains(github.event.pull_request.labels.*.name, 'safe to test')
     uses: viamrobotics/rdk/.github/workflows/test.yml@main
     secrets:
       MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
@@ -138,9 +140,15 @@ jobs:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
   license_finder:
+    if: |
+      (github.event.label.name == 'safe to test' || github.event.label.name == 'appimage') &&
+      contains(github.event.pull_request.labels.*.name, 'safe to test')
     uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
 
   cli:
+    if: |
+      (github.event.label.name == 'safe to test' || github.event.label.name == 'appimage') &&
+      contains(github.event.pull_request.labels.*.name, 'safe to test')
     uses: viamrobotics/rdk/.github/workflows/cli.yml@main
     with:
       release_type: pr

--- a/.github/workflows/staticbuild-build.yml
+++ b/.github/workflows/staticbuild-build.yml
@@ -84,6 +84,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pullrequest-trusted.yml).
+        allow-unsafe-pr-checkout: true
 
     - name: Clean and Fix Permissions
       run: |
@@ -214,6 +216,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        allow-unsafe-pr-checkout: true
 
     - name: Authorize GCP Upload
       uses: google-github-actions/auth@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
+          # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pullrequest-trusted.yml).
+          allow-unsafe-pr-checkout: true
 
       - uses: actions/setup-go@v5
         with:
@@ -251,6 +253,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.event.ref }}
+          allow-unsafe-pr-checkout: true
 
       - name: Set main env vars
         if: github.event_name != 'pull_request_target'
@@ -315,6 +318,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.event.ref }}
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -343,6 +347,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+        allow-unsafe-pr-checkout: true
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
@@ -403,6 +408,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+        allow-unsafe-pr-checkout: true
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
@@ -453,6 +459,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+          allow-unsafe-pr-checkout: true
 
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## What

actions/checkout added a guard that refuses to fetch fork PR code in `pull_request_target` workflows unless the step opts in with `allow-unsafe-pr-checkout: true`. Since the guard shipped, every check on fork PRs dies at the checkout step in under 10 seconds — see #6192, where all six checks failed this way.

This PR:

- sets `allow-unsafe-pr-checkout: true` on the 15 PR-head checkout steps across the reusable workflows (`test`, `cli`, `license_finder`, `motion-benchmarks`, `motion-tests`, `staticbuild-build`, `focal-build`, `appimage-build`, `droid`);
- closes the two spots where a job ran fork code without the `safe to test` label:
  - `license_finder` and `cli` in `pullrequest-trusted.yml` ran on any label event; they now require `safe to test`;
  - `test` ran when the `appimage` label alone was applied; it now also requires `safe to test` to be present, matching `motion-pull-request-trusted.yml`.

## Why the opt-in is safe here

The trust decision is the `safe to test` label, managed by `pr-labeler.yml`: it strips the label on every push and re-adds it only when the PR author is a viamrobotics org member. For outside contributors, a maintainer must apply the label by hand after reading the diff. Fork code therefore never reaches a `pull_request_target` run with secrets until someone we trust has approved it — which is the review the checkout guard asks for.

`code-samples-check.yml`, `pr-labeler.yml`, and `pullrequestclose.yml` also use `pull_request_target` but never check out fork code, so they are untouched.

## Verification

- All ten files pass YAML parsing.
- actionlint flags `allow-unsafe-pr-checkout` as unknown, but that is a stale bundled schema: the failing run's log on #6192 lists the input (default `false`) on the current `v4` tag, and the `v7.0.0` SHA pinned in `focal-build.yml` defines it in its `action.yml`.
- Real proof needs a fork PR: after merge, re-apply `safe to test` to #6192 and the checks should get past checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)