### PR TITLE
guard against TargetFrameRate values that panic NewTicker

### DIFF
--- a/gostream/stream.go
+++ b/gostream/stream.go
@@ -23,6 +23,9 @@ import (
 
 const (
 	defaultTargetFrameRate = 20
+	// Anything above this is almost certainly garbage input.
+	// If a use case emerges, we can raise this value.
+	maxTargetFrameRate = 500
 )
 
 // A Stream is sink that accepts any image frames for the purpose
@@ -65,7 +68,16 @@ func NewStream(config StreamConfig, logger logging.Logger) (Stream, error) {
 	if config.VideoEncoderFactory == nil {
 		return nil, errors.New("video encoder factory must be set")
 	}
-	if config.TargetFrameRate == 0 {
+	// NewTicker panics on non-positive durations.
+	// Arbitrarily large values result in integer division to 0 - which cause panics as well
+	if config.TargetFrameRate <= 0 || config.TargetFrameRate > maxTargetFrameRate {
+		if config.TargetFrameRate != 0 {
+			logger.Warnw("TargetFrameRate out of valid range, using default",
+				"received", config.TargetFrameRate,
+				"min", 1,
+				"max", maxTargetFrameRate,
+				"default", defaultTargetFrameRate)
+		}
 		config.TargetFrameRate = defaultTargetFrameRate
 	}
 

--- a/gostream/stream.go
+++ b/gostream/stream.go
@@ -69,7 +69,7 @@ func NewStream(config StreamConfig, logger logging.Logger) (Stream, error) {
 		return nil, errors.New("video encoder factory must be set")
 	}
 	// NewTicker panics on non-positive durations.
-	// Arbitrarily large values result in integer division to 0 - which cause panics as well
+	// Arbitrarily large values result in integer division to 0 - which cause panics as well.
 	if config.TargetFrameRate <= 0 || config.TargetFrameRate > maxTargetFrameRate {
 		if config.TargetFrameRate != 0 {
 			logger.Warnw("TargetFrameRate out of valid range, using default",

--- a/gostream/stream_test.go
+++ b/gostream/stream_test.go
@@ -9,6 +9,9 @@ import (
 
 	"go.viam.com/test"
 	"golang.org/x/time/rate"
+
+	"go.viam.com/rdk/gostream/codec"
+	"go.viam.com/rdk/logging"
 )
 
 func init() {
@@ -158,4 +161,45 @@ func BenchmarkStream_30FPS_3Streams(b *testing.B) {
 
 	cancel()
 	b.ReportMetric(SecondNs/avgNs, "fps")
+}
+
+type fakeEncoder struct{}
+
+func (f *fakeEncoder) Encode(_ context.Context, _ image.Image) ([]byte, error) { return nil, nil }
+func (f *fakeEncoder) Close() error                                            { return nil }
+
+type fakeEncoderFactory struct{}
+
+func (f *fakeEncoderFactory) New(_, _, _ int, _ logging.Logger) (codec.VideoEncoder, error) {
+	return &fakeEncoder{}, nil
+}
+func (f *fakeEncoderFactory) MIMEType() string { return "test/fake" }
+
+func TestNewStream_TargetFrameRateGuard(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	factory := &fakeEncoderFactory{}
+
+	tests := []struct {
+		name       string
+		input      int
+		wantResult int
+	}{
+		{"unset (zero)", 0, defaultTargetFrameRate},
+		{"negative", -5, defaultTargetFrameRate},
+		{"in range", 60, 60},
+		{"at max", maxTargetFrameRate, maxTargetFrameRate},
+		{"above max", maxTargetFrameRate + 1, defaultTargetFrameRate},
+		{"garbage huge", 144524206401388544, defaultTargetFrameRate},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := NewStream(StreamConfig{
+				VideoEncoderFactory: factory,
+				TargetFrameRate:     tc.input,
+			}, logger)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, s.(*basicStream).config.TargetFrameRate, test.ShouldEqual, tc.wantResult)
+		})
+	}
 }

--- a/gostream/stream_test.go
+++ b/gostream/stream_test.go
@@ -189,7 +189,7 @@ func TestNewStream_TargetFrameRateGuard(t *testing.T) {
 		{"in range", 60, 60},
 		{"at max", maxTargetFrameRate, maxTargetFrameRate},
 		{"above max", maxTargetFrameRate + 1, defaultTargetFrameRate},
-		{"garbage huge", 144524206401388544, defaultTargetFrameRate},
+		{"garbage huge", 1_000_000_000, defaultTargetFrameRate},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## What happened
A camera C++ module returned an uninitialized `Camera::properties::frame_rate` field - [link](https://github.com/viam-labs/ensenso/blob/a5e6e505b727aa2071fce1d70f2c0ee38ca8a856/src/module/ensenso_camera.cpp#L690) to relevant piece of code in that module

In C++ declaring a POD struct with `props;` (not `props{};`) leaves primitive fields holding whatever bytes were previously on the stack

**The garbage travelled through gRPC into `StreamConfig.TargetFrameRate` as`144524206401388544`**

**The existing `== 0` guard didn't catch it so processInputFrames computed `time.Second / 144524206401388544 = 0` and `time.NewTicker(0)` panicked**

The result? **ManagedGo restarted the goroutine every 3s, panicking again and again, so on and so forth.** The WebRTC video track never received frames on app.viam.com just showed a blank screen (which is a separate UX issue I'll look into)
  
## Fix
Reject <= 0 or > 500 and fallback to `defaultTargetFrameRate`

## Upstream fixes
1. Ensenso module 
2. viam-cpp-sdk: add in class initializers to `Camera::properties` which should prevent the entire bug class for every current and future C++ camera module. Looking into this but I believe this fix needs to be enforced throughout the repo bc they have the footgun everywhere. **It's extremely well documented that primitive types should have in-class initializers**. I plan to ship a sequence of fixes in the sdk - this is the first one https://github.com/viamrobotics/viam-cpp-sdk/pull/687

The reason to ship this fix in addition to those upstream fixes is that it protects against any module - not just C++

## Alternative fix I'm unsure if I prefer
Returning an error from `NewStream` on invalid input would be more principled since silent fallback hides upstream bugs

Not doing it here because AddNewStreams treats any NewStream error as fatal for its entire loop. Map iteration is random so if a buggy camera got picked first every OTHER camera on the machine would silently fail to register too - worse UX than the bug we're fixing.

I can return an error from NewStream but it would require prior work first. 
1. change `AddNewStreams` to log and continue per camera
2. only then flip `NewStream` to return errors on invalid input

Let me know if you think that's worthwhile. 

## Manual testing
Rebuilt viam-server against this branch and ran against the unfixed ensenso module:
```
  WARN rdk gostream/stream.go:75 TargetFrameRate out of valid range, using default
    {"received":-9223372036854775808,"min":1,"max":500,"default":20}
```