### PR TITLE
RSDK-14184: Recover from capture file close failures

### DIFF
--- a/data/capture_buffer.go
+++ b/data/capture_buffer.go
@@ -128,11 +128,12 @@ func (b *CaptureBuffer) Flush() error {
 	if b.nextFile == nil {
 		return nil
 	}
-	if err := b.nextFile.Close(); err != nil {
-		return err
-	}
+	// Clear nextFile even when Close fails so a transient close failure doesn't
+	// leave the buffer permanently stuck on a broken file (RSDK-14184). Any data
+	// left behind in a .prog file is picked up by sync on the next restart.
+	err := b.nextFile.Close()
 	b.nextFile = nil
-	return nil
+	return err
 }
 
 // Path returns the path to the directory containing the backing data capture files.

--- a/data/capture_buffer.go
+++ b/data/capture_buffer.go
@@ -91,7 +91,7 @@ func (b *CaptureBuffer) WriteTabular(item *v1.SensorData) error {
 		}
 		b.nextFile = nextFile
 	} else if b.nextFile.Size() > b.maxCaptureFileSize {
-		if err := b.nextFile.Close(); err != nil {
+		if err := b.flushInternal(); err != nil {
 			return err
 		}
 		nextFile, err := NewCaptureFile(b.Directory, b.MetaData)
@@ -121,10 +121,8 @@ func IsBinary(item *v1.SensorData) bool {
 	}
 }
 
-// Flush flushes all buffered data to disk and marks any in progress file as complete.
-func (b *CaptureBuffer) Flush() error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
+// flushInternal closes out nextFile; the caller must hold b.lock.
+func (b *CaptureBuffer) flushInternal() error {
 	if b.nextFile == nil {
 		return nil
 	}
@@ -134,6 +132,13 @@ func (b *CaptureBuffer) Flush() error {
 	err := b.nextFile.Close()
 	b.nextFile = nil
 	return err
+}
+
+// Flush flushes all buffered data to disk and marks any in progress file as complete.
+func (b *CaptureBuffer) Flush() error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	return b.flushInternal()
 }
 
 // Path returns the path to the directory containing the backing data capture files.

--- a/data/capture_buffer_test.go
+++ b/data/capture_buffer_test.go
@@ -782,12 +782,13 @@ func getCaptureFiles(dir string) (dcFiles, progFiles []string) {
 	return dcFiles, progFiles
 }
 
-// TestFlushFailsAfterProgRenamedExternally reproduces the APP-16267 regression:
+// TestFlushRecoversAfterProgRenamedExternally reproduces the APP-16267 regression:
 // renameProgFilesToCapture() is called during Reconfigure while collectors are still
 // running. On Linux, renaming a file doesn't invalidate open fds, so writes continue
 // normally — but when the collector eventually calls Flush it tries to rename the .prog
-// path which no longer exists, producing ENOENT.
-func TestFlushFailsAfterProgRenamedExternally(t *testing.T) {
+// path which no longer exists, producing ENOENT. Per RSDK-14184, that failure must be
+// transient: subsequent writes and flushes should succeed with a fresh file.
+func TestFlushRecoversAfterProgRenamedExternally(t *testing.T) {
 	dir := t.TempDir()
 	md := &v1.DataCaptureMetadata{Type: CaptureTypeTabular.ToProto()}
 	buf := NewCaptureBuffer(dir, md, 1<<20)
@@ -810,6 +811,15 @@ func TestFlushFailsAfterProgRenamedExternally(t *testing.T) {
 	err = buf.Flush()
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "no such file or directory")
+
+	// The failed close must not leave the buffer stuck: the next write should go
+	// to a fresh file, and the next flush should complete it successfully.
+	test.That(t, buf.WriteTabular(structSensorData), test.ShouldBeNil)
+	test.That(t, buf.Flush(), test.ShouldBeNil)
+
+	dcFiles, progFiles := getCaptureFiles(dir)
+	test.That(t, len(dcFiles), test.ShouldEqual, 2)
+	test.That(t, len(progFiles), test.ShouldEqual, 0)
 }
 
 func TestIsBinary(t *testing.T) {

--- a/data/capture_buffer_test.go
+++ b/data/capture_buffer_test.go
@@ -822,6 +822,44 @@ func TestFlushRecoversAfterProgRenamedExternally(t *testing.T) {
 	test.That(t, len(progFiles), test.ShouldEqual, 0)
 }
 
+// TestWriteTabularRecoversAfterRotationCloseFails covers the size-rotation path of
+// RSDK-14184: when WriteTabular rotates to a new file, a failed Close() leaves
+// nextFile in place and the close is retried on the next write. Because Close() is
+// idempotent, that retry succeeds and capture continues with a fresh file instead
+// of failing with "file already closed" forever.
+func TestWriteTabularRecoversAfterRotationCloseFails(t *testing.T) {
+	dir := t.TempDir()
+	md := &v1.DataCaptureMetadata{Type: CaptureTypeTabular.ToProto()}
+	// A 1-byte max file size forces a rotation on every write.
+	buf := NewCaptureBuffer(dir, md, 1)
+
+	test.That(t, buf.WriteTabular(structSensorData), test.ShouldBeNil)
+
+	// Simulate renameProgFilesToCapture() running mid-capture: rename every .prog → .capture.
+	entries, err := os.ReadDir(dir)
+	test.That(t, err, test.ShouldBeNil)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == InProgressCaptureFileExt {
+			src := filepath.Join(dir, e.Name())
+			dst := src[:len(src)-len(InProgressCaptureFileExt)] + CompletedCaptureFileExt
+			test.That(t, os.Rename(src, dst), test.ShouldBeNil)
+		}
+	}
+
+	// This write triggers a rotation whose Close() fails renaming the (gone) .prog path.
+	err = buf.WriteTabular(structSensorData)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "no such file or directory")
+
+	// The retried Close() is a no-op, so the next write rotates to a fresh file.
+	test.That(t, buf.WriteTabular(structSensorData), test.ShouldBeNil)
+	test.That(t, buf.Flush(), test.ShouldBeNil)
+
+	dcFiles, progFiles := getCaptureFiles(dir)
+	test.That(t, len(dcFiles), test.ShouldEqual, 2)
+	test.That(t, len(progFiles), test.ShouldEqual, 0)
+}
+
 func TestIsBinary(t *testing.T) {
 	test.That(t, IsBinary(nil), test.ShouldBeFalse)
 	test.That(t, IsBinary(&v1.SensorData{Data: &v1.SensorData_Struct{}}), test.ShouldBeFalse)

--- a/data/capture_file.go
+++ b/data/capture_file.go
@@ -72,6 +72,7 @@ type CaptureFile struct {
 	writer   *bufio.Writer
 	size     int64
 	metadata *v1.DataCaptureMetadata
+	closed   bool
 
 	initialReadOffset int64
 	readOffset        int64
@@ -204,10 +205,15 @@ func (f *CaptureFile) GetPath() string {
 	return f.path
 }
 
-// Close closes the file.
+// Close closes the file. It is idempotent: calls after the underlying file has
+// been closed return nil, so callers retrying after a failure (e.g. a failed
+// rename) don't hit "file already closed" errors forever (RSDK-14184).
 func (f *CaptureFile) Close() error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
+	if f.closed {
+		return nil
+	}
 	if err := f.writer.Flush(); err != nil {
 		return err
 	}
@@ -218,6 +224,7 @@ func (f *CaptureFile) Close() error {
 	if err := f.file.Close(); err != nil {
 		return err
 	}
+	f.closed = true
 	return os.Rename(f.file.Name(), newName)
 }
 

--- a/data/capture_file.go
+++ b/data/capture_file.go
@@ -69,14 +69,6 @@ const (
 // CaptureFile is the data structure containing data captured by collectors. It is backed by a file on disk containing
 // length delimited protobuf messages, where the first message is the CaptureMetadata for the file, and ensuing
 // messages contain the captured data.
-//
-// Lifecycle contract: a CaptureFile is open from construction until Close or
-// Delete. Close flushes buffered writes, releases the file descriptor, and
-// renames the file from .prog to .capture; Delete releases the descriptor and
-// removes the file from disk. Both are idempotent with respect to the
-// descriptor and may be called in either order. Once the file is closed,
-// read and write methods fail with ErrFileClosed, and GetPath reflects the
-// file's current on-disk name.
 type CaptureFile struct {
 	path     string
 	lock     sync.Mutex
@@ -231,9 +223,11 @@ func (f *CaptureFile) GetPath() string {
 	return f.path
 }
 
-// Close closes the file. It is idempotent: calls after the underlying file has
-// been closed return nil, so callers retrying after a failure (e.g. a failed
-// rename) don't hit "file already closed" errors forever (RSDK-14184).
+// Close flushes buffered writes, closes the underlying file, and renames it
+// from .prog to .capture to mark it complete. It is idempotent: calls after the
+// underlying file has been closed (by Close or Delete) return nil, so callers
+// retrying after a failure (e.g. a failed rename) don't hit "file already
+// closed" errors forever (RSDK-14184).
 func (f *CaptureFile) Close() error {
 	f.lock.Lock()
 	defer f.lock.Unlock()

--- a/data/capture_file.go
+++ b/data/capture_file.go
@@ -128,6 +128,7 @@ func NewCaptureFile(dir string, md *v1.DataCaptureMetadata) (*CaptureFile, error
 		path:              f.Name(),
 		writer:            bufio.NewWriter(f),
 		file:              f,
+		metadata:          md,
 		size:              int64(n),
 		initialReadOffset: int64(n),
 		readOffset:        int64(n),

--- a/data/capture_file.go
+++ b/data/capture_file.go
@@ -34,6 +34,10 @@ var ErrSensorMetadataTooLarge = errors.New("SensorMetadata field exceeds size li
 // be streamed due to an unexpected wire format (e.g. unknown wire type).
 var ErrUnparsableBinaryCapture = errors.New("capture file cannot be streamed due to unexpected wire format")
 
+// ErrFileClosed is returned by read and write methods called after the capture
+// file has been closed (via Close or Delete). It matches errors.Is(err, os.ErrClosed).
+var ErrFileClosed = fmt.Errorf("capture file already closed: %w", os.ErrClosed)
+
 // TODO Data-343: Reorganize this into a more standard interface/package, and add tests.
 
 const (
@@ -65,6 +69,14 @@ const (
 // CaptureFile is the data structure containing data captured by collectors. It is backed by a file on disk containing
 // length delimited protobuf messages, where the first message is the CaptureMetadata for the file, and ensuing
 // messages contain the captured data.
+//
+// Lifecycle contract: a CaptureFile is open from construction until Close or
+// Delete. Close flushes buffered writes, releases the file descriptor, and
+// renames the file from .prog to .capture; Delete releases the descriptor and
+// removes the file from disk. Both are idempotent with respect to the
+// descriptor and may be called in either order. Once the file is closed,
+// read and write methods fail with ErrFileClosed, and GetPath reflects the
+// file's current on-disk name.
 type CaptureFile struct {
 	path     string
 	lock     sync.Mutex
@@ -145,6 +157,9 @@ func (f *CaptureFile) ReadMetadata() *v1.DataCaptureMetadata {
 func (f *CaptureFile) ReadNext() (*v1.SensorData, error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
+	if f.closed {
+		return nil, ErrFileClosed
+	}
 
 	if err := f.writer.Flush(); err != nil {
 		return nil, err
@@ -167,6 +182,9 @@ func (f *CaptureFile) ReadNext() (*v1.SensorData, error) {
 func (f *CaptureFile) WriteNext(data *v1.SensorData) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
+	if f.closed {
+		return ErrFileClosed
+	}
 
 	if _, err := f.file.Seek(f.writeOffset, 0); err != nil {
 		return err
@@ -180,10 +198,14 @@ func (f *CaptureFile) WriteNext(data *v1.SensorData) error {
 	return nil
 }
 
-// Flush flushes any buffered writes to disk.
+// Flush flushes any buffered writes to disk. A closed file has no buffered
+// writes, so flushing it is a no-op rather than an error.
 func (f *CaptureFile) Flush() error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
+	if f.closed {
+		return nil
+	}
 	return f.writer.Flush()
 }
 
@@ -201,8 +223,11 @@ func (f *CaptureFile) Size() int64 {
 	return f.size
 }
 
-// GetPath returns the path of the underlying os.File.
+// GetPath returns the file's current on-disk path, accounting for the
+// .prog → .capture rename performed by a successful Close.
 func (f *CaptureFile) GetPath() string {
+	f.lock.Lock()
+	defer f.lock.Unlock()
 	return f.path
 }
 
@@ -226,17 +251,25 @@ func (f *CaptureFile) Close() error {
 		return err
 	}
 	f.closed = true
-	return os.Rename(f.file.Name(), newName)
+	if err := os.Rename(f.file.Name(), newName); err != nil {
+		return err
+	}
+	f.path = newName
+	return nil
 }
 
-// Delete deletes the file.
+// Delete deletes the file. It closes the underlying file descriptor if Close
+// has not already done so, then removes the file at its current on-disk path.
 func (f *CaptureFile) Delete() error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
-	if err := f.file.Close(); err != nil {
-		return err
+	if !f.closed {
+		if err := f.file.Close(); err != nil {
+			return err
+		}
+		f.closed = true
 	}
-	return os.Remove(f.GetPath())
+	return os.Remove(f.path)
 }
 
 // BuildCaptureMetadata builds a DataCaptureMetadata object and returns error if
@@ -326,6 +359,9 @@ func SensorDataFromCaptureFile(f *CaptureFile) ([]*v1.SensorData, error) {
 func (f *CaptureFile) BinaryPayloadReader() (*v1.SensorMetadata, int64, io.Reader, error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
+	if f.closed {
+		return nil, 0, nil, ErrFileClosed
+	}
 
 	// Seek to where we left off. seekOffset is captured before the seek so we can
 	// compute absolute file positions for the SectionReader later.

--- a/data/capture_file_test.go
+++ b/data/capture_file_test.go
@@ -316,3 +316,34 @@ func TestReadCorruptedFile(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(sd), test.ShouldEqual, numReadings)
 }
+
+// TestCloseIsIdempotent ensures repeated Close calls return nil rather than
+// "file already closed" errors, so callers retrying after a transient failure
+// can recover (RSDK-14184).
+func TestCloseIsIdempotent(t *testing.T) {
+	t.Run("close after successful close returns nil", func(t *testing.T) {
+		dir := t.TempDir()
+		f, err := NewCaptureFile(dir, &v1.DataCaptureMetadata{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, f.Close(), test.ShouldBeNil)
+		test.That(t, f.Close(), test.ShouldBeNil)
+	})
+
+	t.Run("close after failed rename returns nil", func(t *testing.T) {
+		dir := t.TempDir()
+		f, err := NewCaptureFile(dir, &v1.DataCaptureMetadata{})
+		test.That(t, err, test.ShouldBeNil)
+
+		// Rename the .prog file externally so Close's os.Rename fails with ENOENT.
+		src := f.GetPath()
+		dst := src[:len(src)-len(InProgressCaptureFileExt)] + CompletedCaptureFileExt
+		test.That(t, os.Rename(src, dst), test.ShouldBeNil)
+
+		err = f.Close()
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "no such file or directory")
+
+		// The underlying file is already closed; repeated calls are no-ops.
+		test.That(t, f.Close(), test.ShouldBeNil)
+	})
+}

--- a/data/capture_file_test.go
+++ b/data/capture_file_test.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -325,6 +326,65 @@ func TestNewCaptureFileSetsMetadata(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, f.ReadMetadata(), test.ShouldEqual, md)
 	test.That(t, f.Close(), test.ShouldBeNil)
+}
+
+// TestCaptureFileLifecycle covers the CaptureFile close contract: Close and
+// Delete are idempotent with respect to the file descriptor and valid in either
+// order, post-close I/O fails with ErrFileClosed, and GetPath tracks the
+// .prog → .capture rename.
+func TestCaptureFileLifecycle(t *testing.T) {
+	md := &v1.DataCaptureMetadata{Type: CaptureTypeTabular.ToProto()}
+	newFileWithReading := func(t *testing.T) *CaptureFile {
+		t.Helper()
+		f, err := NewCaptureFile(t.TempDir(), md)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, f.WriteNext(&v1.SensorData{
+			Metadata: &v1.SensorMetadata{},
+			Data:     &v1.SensorData_Struct{Struct: &structpb.Struct{}},
+		}), test.ShouldBeNil)
+		return f
+	}
+
+	t.Run("Close renames the file and updates GetPath", func(t *testing.T) {
+		f := newFileWithReading(t)
+		test.That(t, filepath.Ext(f.GetPath()), test.ShouldEqual, InProgressCaptureFileExt)
+		test.That(t, f.Close(), test.ShouldBeNil)
+		test.That(t, filepath.Ext(f.GetPath()), test.ShouldEqual, CompletedCaptureFileExt)
+		_, err := os.Stat(f.GetPath())
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("Delete after Close removes the renamed file", func(t *testing.T) {
+		f := newFileWithReading(t)
+		test.That(t, f.Close(), test.ShouldBeNil)
+		test.That(t, f.Delete(), test.ShouldBeNil)
+		_, err := os.Stat(f.GetPath())
+		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+	})
+
+	t.Run("Close after Delete is a no-op", func(t *testing.T) {
+		f := newFileWithReading(t)
+		test.That(t, f.Delete(), test.ShouldBeNil)
+		test.That(t, f.Close(), test.ShouldBeNil)
+	})
+
+	t.Run("reads and writes after Close return ErrFileClosed", func(t *testing.T) {
+		f := newFileWithReading(t)
+		test.That(t, f.Close(), test.ShouldBeNil)
+
+		err := f.WriteNext(&v1.SensorData{Data: &v1.SensorData_Struct{Struct: &structpb.Struct{}}})
+		test.That(t, errors.Is(err, ErrFileClosed), test.ShouldBeTrue)
+		test.That(t, errors.Is(err, os.ErrClosed), test.ShouldBeTrue)
+
+		_, err = f.ReadNext()
+		test.That(t, errors.Is(err, ErrFileClosed), test.ShouldBeTrue)
+
+		_, _, _, err = f.BinaryPayloadReader()
+		test.That(t, errors.Is(err, ErrFileClosed), test.ShouldBeTrue)
+
+		// Flushing a closed file is trivially satisfied.
+		test.That(t, f.Flush(), test.ShouldBeNil)
+	})
 }
 
 // TestCloseIsIdempotent ensures repeated Close calls return nil rather than

--- a/data/capture_file_test.go
+++ b/data/capture_file_test.go
@@ -335,6 +335,8 @@ func TestCloseIsIdempotent(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		// Rename the .prog file externally so Close's os.Rename fails with ENOENT.
+		// That the destination matches Close's own target name is incidental; all
+		// that matters is that the .prog source path no longer exists.
 		src := f.GetPath()
 		dst := src[:len(src)-len(InProgressCaptureFileExt)] + CompletedCaptureFileExt
 		test.That(t, os.Rename(src, dst), test.ShouldBeNil)

--- a/data/capture_file_test.go
+++ b/data/capture_file_test.go
@@ -317,6 +317,16 @@ func TestReadCorruptedFile(t *testing.T) {
 	test.That(t, len(sd), test.ShouldEqual, numReadings)
 }
 
+// TestNewCaptureFileSetsMetadata ensures writer-created capture files expose the
+// metadata they were created with, matching reader-created files (ReadCaptureFile).
+func TestNewCaptureFileSetsMetadata(t *testing.T) {
+	md := &v1.DataCaptureMetadata{ComponentName: "sensor1", Type: CaptureTypeTabular.ToProto()}
+	f, err := NewCaptureFile(t.TempDir(), md)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, f.ReadMetadata(), test.ShouldEqual, md)
+	test.That(t, f.Close(), test.ShouldBeNil)
+}
+
 // TestCloseIsIdempotent ensures repeated Close calls return nil rather than
 // "file already closed" errors, so callers retrying after a transient failure
 // can recover (RSDK-14184).

--- a/services/datamanager/builtin/sync/sync.go
+++ b/services/datamanager/builtin/sync/sync.go
@@ -448,8 +448,13 @@ func (s *Sync) syncFile(config Config, filePath string) {
 	if data.IsDataCaptureFile(f) {
 		s.syncDataCaptureFile(f, config.CaptureDir, s.logger)
 	} else {
-		//nolint:errcheck
-		s.syncArbitraryFile(s.configCtx, f, config.Tags, []string{}, config.FileLastModifiedMillis, s.logger)
+		if _, err = s.syncArbitraryFile(s.configCtx, f, config.Tags, []string{}, config.FileLastModifiedMillis, s.logger); err != nil {
+			if errors.Is(err, context.Canceled) {
+				s.logger.Infow("context cancelled while syncing arbitrary file", "filename", filePath)
+			} else {
+				s.logger.Errorw("failed to sync arbitrary file", "filename", filePath, "err", err)
+			}
+		}
 	}
 }
 
@@ -609,7 +614,16 @@ func (s *Sync) UploadBinaryDataToDatasets(ctx context.Context, binaryData []byte
 		}
 		// Since we wrote to the file, the file last modified time should be 0, indicating we should wait no time
 		// before deciding this file is ready for upload and is not still being written to.
-		s.syncArbitraryFile(ctx, f, tags, datasetIDs, 0, s.logger) //nolint:errcheck
+		// TODO: syncArbitraryFile's returned ID/error are not consumed by any caller (leftover
+		// from the #6102 refactor). Decide whether to propagate the error to our caller
+		// (errChan is buffered and closed on exit, so sending here is safe) or drop the returns.
+		if _, err = s.syncArbitraryFile(ctx, f, tags, datasetIDs, 0, s.logger); err != nil {
+			if errors.Is(err, context.Canceled) {
+				s.logger.Infow("context cancelled while syncing arbitrary file", "filename", filename)
+			} else {
+				s.logger.Errorw("failed to sync arbitrary file", "filename", filename, "err", err)
+			}
+		}
 	}()
 
 	return <-errChan

--- a/services/datamanager/builtin/sync/sync.go
+++ b/services/datamanager/builtin/sync/sync.go
@@ -614,8 +614,8 @@ func (s *Sync) UploadBinaryDataToDatasets(ctx context.Context, binaryData []byte
 		}
 		// Since we wrote to the file, the file last modified time should be 0, indicating we should wait no time
 		// before deciding this file is ready for upload and is not still being written to.
-		// TODO: syncArbitraryFile's returned ID/error are not consumed by any caller (leftover
-		// from the #6102 refactor). Decide whether to propagate the error to our caller
+		// TODO(APP-17394): syncArbitraryFile's returned ID/error are not consumed by any caller
+		// (leftover from the #6102 refactor). Decide whether to propagate the error to our caller
 		// (errChan is buffered and closed on exit, so sending here is safe) or drop the returns.
 		if _, err = s.syncArbitraryFile(ctx, f, tags, datasetIDs, 0, s.logger); err != nil {
 			if errors.Is(err, context.Canceled) {


### PR DESCRIPTION
Fixes [RSDK-14184](https://viam.atlassian.net/browse/RSDK-14184): once a collector&#39;s `file.Close` failed, data capture never recovered — `CaptureBuffer.nextFile` kept pointing at the broken file, so every subsequent capture attempt failed the same way, escalating a single transient close failure into permanent capture loss. This is an action item from the [Data capture broken on Reconfigure](https://docs.google.com/document/d/1lOTCO67AePbLKrQDyl5xIcLJNubKokLRbd77bDjeYhw/edit?tab=t.0#heading=h.36fu6u14y8j6) post-mortem.

Recovery comes from two complementary changes:

- **`CaptureBuffer.Flush()` clears `nextFile` even when `Close()` fails.** The error still propagates to the caller, but the next write starts a fresh file instead of retrying a broken one forever. Any data left behind in a `.prog` file is picked up by sync on the next restart.
- **`CaptureFile` now has explicit close semantics** instead of incidental file-descriptor behavior:
  - `Close()` and `Delete()` are idempotent with respect to the file descriptor and valid in either order. Previously, once `os.Rename` failed after the fd was already closed, every retry hit &#34;file already closed&#34; — the failure mode that made the stuck state permanent (e.g. on the `WriteTabular` size-rotation path, which retries `Close()` on the next write).
  - A successful `Close()` updates the tracked path, so `GetPath()` reflects the `.prog` → `.capture` rename and `Delete()` removes the file wherever it currently lives on disk.
  - Reads and writes on a closed file fail with a defined `ErrFileClosed` sentinel (matches `errors.Is(err, os.ErrClosed)`); `Flush()` on a closed file is a no-op, since nothing can be buffered.
  - `NewCaptureFile` sets the `metadata` field, so `ReadMetadata()` works on writer-created files just like reader-created ones (it silently returned nil since 2022).

Additionally, both `syncArbitraryFile` call sites now log the previously-discarded error — Info for `context.Canceled` (routine during shutdown, previously fully silent), Error otherwise. A TODO notes the function&#39;s return values are unconsumed leftovers from #6102, to be propagated or removed in a follow-up.

## Testing

- Extended the APP-16267 regression test (now `TestFlushRecoversAfterProgRenamedExternally`) to assert that after a failed flush, subsequent writes and flushes succeed with a fresh file.
- Added `TestWriteTabularRecoversAfterRotationCloseFails` for the size-rotation close-failure path.
- Added `TestCloseIsIdempotent` covering double-close after success and close-retry after a failed rename.
- Added `TestCaptureFileLifecycle` (rename/path tracking, Delete-after-Close, Close-after-Delete, post-close I/O errors) and `TestNewCaptureFileSetsMetadata`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSDK-14184]: https://viam.atlassian.net/browse/RSDK-14184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ