### PR TITLE
skip WebRTC stream for cameras reporting frame_rate below streaming threshold

### DIFF
--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -31,6 +31,8 @@ const (
 	backoffCooldown           = 30 * time.Second
 	defaultDebugLogInterval   = time.Minute
 	defaultWarnRepeatInterval = 5 * time.Minute
+	// Hz. Positive rates below this are on-demand cameras; 0 stays "unknown, use default".
+	minStreamableFrameRate = 5
 )
 
 // streamErrorState tracks per-camera error logging timestamps for throttling.
@@ -502,14 +504,17 @@ func (server *Server) AddNewStreams(ctx context.Context) error {
 			server.logger.Warn("video streaming not supported on Windows yet")
 			break
 		}
-		// Attempt to look up the framerate for the camera. If the framerate is not available, we'll
-		// end up with a framerate of 0. This is fine as gostream will default to 30fps in this case.
 		framerate, err := server.getFramerateFromCamera(name)
 		if err != nil {
 			server.logger.Debugf("error getting framerate from camera %q: %v", name, err)
 		}
-		// We walk the updated set of `videoSources` and ensure all of the sources are "created" and
-		// "started".
+		if !shouldOfferStream(framerate) {
+			server.logger.Infof(
+				"camera %q reports frame_rate=%d Hz (below streaming threshold of %d Hz); skipping WebRTC stream",
+				name, framerate, minStreamableFrameRate,
+			)
+			continue
+		}
 		config := gostream.StreamConfig{
 			Name:                name,
 			VideoEncoderFactory: server.streamConfig.VideoEncoderFactory,
@@ -755,6 +760,12 @@ func (server *Server) getFramerateFromCamera(name string) (int, error) {
 		return 0, fmt.Errorf("failed to get camera properties: %w", err)
 	}
 	return int(props.FrameRate), nil
+}
+
+// shouldOfferStream reports whether the camera qualifies for a WebRTC video track.
+// framerate == 0 is the "unknown" sentinel and passes through unchanged.
+func shouldOfferStream(framerate int) bool {
+	return framerate == 0 || framerate >= minStreamableFrameRate
 }
 
 // GenerateResolutions takes the original width and height of an image and returns

--- a/robot/web/stream/server.go
+++ b/robot/web/stream/server.go
@@ -31,8 +31,9 @@ const (
 	backoffCooldown           = 30 * time.Second
 	defaultDebugLogInterval   = time.Minute
 	defaultWarnRepeatInterval = 5 * time.Minute
-	// Hz. Positive rates below this are on-demand cameras; 0 stays "unknown, use default".
-	minStreamableFrameRate = 5
+	// Below this a camera is treated as on-demand rather than a video source.
+	// 0 means the module didn't report a rate — gostream will apply its default.
+	minStreamableFrameRateHz = 5
 )
 
 // streamErrorState tracks per-camera error logging timestamps for throttling.
@@ -511,7 +512,7 @@ func (server *Server) AddNewStreams(ctx context.Context) error {
 		if !shouldOfferStream(framerate) {
 			server.logger.Infof(
 				"camera %q reports frame_rate=%d Hz (below streaming threshold of %d Hz); skipping WebRTC stream",
-				name, framerate, minStreamableFrameRate,
+				name, framerate, minStreamableFrameRateHz,
 			)
 			continue
 		}
@@ -763,9 +764,9 @@ func (server *Server) getFramerateFromCamera(name string) (int, error) {
 }
 
 // shouldOfferStream reports whether the camera qualifies for a WebRTC video track.
-// framerate == 0 is the "unknown" sentinel and passes through unchanged.
+// framerate == 0 means the module didn't report a rate; gostream will apply its default.
 func shouldOfferStream(framerate int) bool {
-	return framerate == 0 || framerate >= minStreamableFrameRate
+	return framerate == 0 || framerate >= minStreamableFrameRateHz
 }
 
 // GenerateResolutions takes the original width and height of an image and returns

--- a/robot/web/stream/server_internal_test.go
+++ b/robot/web/stream/server_internal_test.go
@@ -85,6 +85,27 @@ func filterLogsByLevelAndMessage(logs []observer.LoggedEntry, level zapcore.Leve
 	return result
 }
 
+func TestShouldOfferStream(t *testing.T) {
+	cases := []struct {
+		name      string
+		framerate int
+		expected  bool
+	}{
+		{"zero passes through as unknown", 0, true},
+		{"negative refused as invalid", -1, false},
+		{"on-demand 1 Hz refused", 1, false},
+		{"on-demand 4 Hz refused", 4, false},
+		{"threshold 5 Hz allowed", 5, true},
+		{"video-rate 30 Hz allowed", 30, true},
+		{"video-rate 60 Hz allowed", 60, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			test.That(t, shouldOfferStream(tc.framerate), test.ShouldEqual, tc.expected)
+		})
+	}
+}
+
 func TestRemoveMissingStreams_LogThrottling(t *testing.T) {
 	logger, observedLogs := logging.NewObservedTestLogger(t)
 


### PR DESCRIPTION
## The Problem
- On demand cameras (like zivid, ensenso, etc) capture at ~1 Hz
- When they honestly report frame_rate: 1, AddNewStreams still opens a WebRTC stream and the frontend's Live button silently hangs on a stream that produces no video rate frames

## The Fix
Add a guard in AddNewStreams - when framerate > 0 && framerate < minStreamableFrameRate (5 Hz), log the reason and skip stream creation

## Why this is a safe change
- Cameras reporting 0 continue to work exactly as before - the "0 = unknown, default to 30fps" fallback is preserved to avoid breaking any streaming camera that doesn't currently set the field
- Behavior is invisible in production until modules start reporting positive-low values

## Alternatives considered
Adding a new field to `camera.proto` but I chose not to since frame_rate already carries the signal

## Related PRs
Gonna wait for this PR to land first but will do these as followups: 
- Zivid/Ensenso module reports frame_rate = 1.0f explicitly
- test-widgets frontend uses getProperties to hide unsupported poll intervals