### PR TITLE
[RSDK-14158] Update trajex in RDK for streaming support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/u2takey/ffmpeg-go v0.4.1
 	github.com/urfave/cli/v3 v3.7.0
 	github.com/viam-labs/motion-tools v1.35.1
-	github.com/viam-modules/trajex/go v0.100.2-rc1
+	github.com/viam-modules/trajex/go v0.100.2-rc2
 	github.com/viamrobotics/evdev v0.1.3
 	github.com/viamrobotics/webrtc/v3 v3.99.16
 	github.com/xfmoulet/qoi v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1084,8 +1084,6 @@ github.com/viam-labs/go-getter v0.0.0-20251022162721-98d73b852c8a h1:qk5MX36oytF
 github.com/viam-labs/go-getter v0.0.0-20251022162721-98d73b852c8a/go.mod h1:MwPm+Hpd8PZRx+jkOVLGxqHl/bN+Hcsw0dD7ntSpLy0=
 github.com/viam-labs/motion-tools v1.35.1 h1:j6Cix6kowcZjrX3Hcoi24/B9ZkIyR9te5kYJVcMN/Tg=
 github.com/viam-labs/motion-tools v1.35.1/go.mod h1:ZCYe0bRfVwWeYmYmuZUqXtTooNQL5M/jQ9LKhmK/2lo=
-github.com/viam-modules/trajex/go v0.100.2-rc1 h1:O6q18o7NhWYa5mm8iHNpHotL1Vm+pF55nuXFU6izGD8=
-github.com/viam-modules/trajex/go v0.100.2-rc1/go.mod h1:6heejC0j41y9ZXYMmWppOYSVSn8h/56iDO+IawZBRFI=
 github.com/viam-modules/trajex/go v0.100.2-rc2 h1:aNlc/dh1XEDc0pHTJDAUSWhOpD9wss007bY/BmgpfCw=
 github.com/viam-modules/trajex/go v0.100.2-rc2/go.mod h1:6heejC0j41y9ZXYMmWppOYSVSn8h/56iDO+IawZBRFI=
 github.com/viamrobotics/evdev v0.1.3 h1:mR4HFafvbc5Wx4Vp1AUJp6/aITfVx9AKyXWx+rWjpfc=

--- a/go.sum
+++ b/go.sum
@@ -1086,6 +1086,8 @@ github.com/viam-labs/motion-tools v1.35.1 h1:j6Cix6kowcZjrX3Hcoi24/B9ZkIyR9te5kY
 github.com/viam-labs/motion-tools v1.35.1/go.mod h1:ZCYe0bRfVwWeYmYmuZUqXtTooNQL5M/jQ9LKhmK/2lo=
 github.com/viam-modules/trajex/go v0.100.2-rc1 h1:O6q18o7NhWYa5mm8iHNpHotL1Vm+pF55nuXFU6izGD8=
 github.com/viam-modules/trajex/go v0.100.2-rc1/go.mod h1:6heejC0j41y9ZXYMmWppOYSVSn8h/56iDO+IawZBRFI=
+github.com/viam-modules/trajex/go v0.100.2-rc2 h1:aNlc/dh1XEDc0pHTJDAUSWhOpD9wss007bY/BmgpfCw=
+github.com/viam-modules/trajex/go v0.100.2-rc2/go.mod h1:6heejC0j41y9ZXYMmWppOYSVSn8h/56iDO+IawZBRFI=
 github.com/viamrobotics/evdev v0.1.3 h1:mR4HFafvbc5Wx4Vp1AUJp6/aITfVx9AKyXWx+rWjpfc=
 github.com/viamrobotics/evdev v0.1.3/go.mod h1:N6nuZmPz7HEIpM7esNWwLxbYzqWqLSZkfI/1Sccckqk=
 github.com/viamrobotics/ice/v2 v2.3.40 h1:H9r4ztsKkxWSn42R4fLvYlaPtpBys1Yj7/MERBtZY0k=


### PR DESCRIPTION
I've tagged trajex v0.100.2-rc2 which has the streaming support that @EshaMaharishi needs; this PR pulls it into RDK.