### PR TITLE
crop input to 16-aligned dims to avoid pion stride bug

### DIFF
--- a/gostream/codec/x264/encoder.go
+++ b/gostream/codec/x264/encoder.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"image"
+	"image/draw"
 
 	"github.com/pion/mediadevices/pkg/codec"
 	"github.com/pion/mediadevices/pkg/codec/x264"
@@ -14,10 +15,19 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
+// H.264 encodes in 16x16 macroblocks. Pion's x264 wrapper doesn't set
+// pic_in.img.i_stride[] on each frame, so unaligned widths cause x264 to
+// read rows at wrong offsets — visible as stripes.
+// Upstream issue: https://github.com/pion/mediadevices/issues/707
+const macroblockAlign = 16
+
 type encoder struct {
-	codec  codec.ReadCloser
-	img    image.Image
-	logger logging.Logger
+	codec       codec.ReadCloser
+	img         image.Image
+	logger      logging.Logger
+	needsCrop   bool
+	dstBounds   image.Rectangle
+	scratchRGBA *image.RGBA
 }
 
 // NewEncoder returns an x264 encoder that can encode images of the given width and height. It will
@@ -29,7 +39,19 @@ func NewEncoder(width, height, keyFrameInterval int, logger logging.Logger) (our
 			"Please provide frames with even dimensions for width and height")
 	}
 
-	enc := &encoder{logger: logger}
+	alignedW := width &^ (macroblockAlign - 1)
+	alignedH := height &^ (macroblockAlign - 1)
+	enc := &encoder{
+		logger:    logger,
+		needsCrop: alignedW != width || alignedH != height,
+	}
+	if enc.needsCrop {
+		enc.dstBounds = image.Rect(0, 0, alignedW, alignedH)
+		enc.scratchRGBA = image.NewRGBA(enc.dstBounds)
+		logger.Infow("x264: input dims not macroblock-aligned; cropping per frame",
+			"from", []int{width, height},
+			"to", []int{alignedW, alignedH})
+	}
 
 	var builder codec.VideoEncoderBuilder
 	params, err := x264.NewParams()
@@ -38,13 +60,13 @@ func NewEncoder(width, height, keyFrameInterval int, logger logging.Logger) (our
 	}
 	builder = &params
 	params.KeyFrameInterval = keyFrameInterval
-	params.BitRate = calcBitrateFromResolution(width, height, float32(params.KeyFrameInterval))
+	params.BitRate = calcBitrateFromResolution(alignedW, alignedH, float32(params.KeyFrameInterval))
 	params.LogLevel = x264.LogWarning
 
 	codec, err := builder.BuildVideoEncoder(enc, prop.Media{
 		Video: prop.Video{
-			Width:  width,
-			Height: height,
+			Width:  alignedW,
+			Height: alignedH,
 		},
 	})
 	if err != nil {
@@ -62,6 +84,11 @@ func (v *encoder) Read() (img image.Image, release func(), err error) {
 
 // Encode asks the codec to process the given image.
 func (v *encoder) Encode(_ context.Context, img image.Image) ([]byte, error) {
+	if v.needsCrop {
+		src := img.Bounds()
+		draw.Draw(v.scratchRGBA, v.dstBounds, img, src.Min, draw.Src)
+		img = v.scratchRGBA
+	}
 	v.img = img
 	data, release, err := v.codec.Read()
 	dataCopy := make([]byte, len(data))

--- a/gostream/codec/x264/encoder.go
+++ b/gostream/codec/x264/encoder.go
@@ -15,16 +15,33 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
-// H.264 encodes in 16x16 macroblocks. Pion's x264 wrapper doesn't set
-// pic_in.img.i_stride[] on each frame, so unaligned widths cause x264 to
-// read rows at wrong offsets — visible as stripes.
-// Upstream issue: https://github.com/pion/mediadevices/issues/707
+// Macroblock alignment workaround.
+//
+// H.264 encodes in 16x16 macroblocks. Pion's x264 wrapper (bridge.h
+// enc_encode) swaps pic_in.img.plane[] to point at Go pixel data on every
+// frame but never updates pic_in.img.i_stride[]. When the input width or
+// height isn't a multiple of 16, x264's stride assumption diverges from
+// Go's image.YCbCr layout, so x264 reads rows at the wrong memory offset.
+// Symptom is horizontal stripes when width is off, unassemblable frames
+// when height is off.
+//
+// Workaround: crop input to the nearest 16-multiple before handing to
+// pion so the stride mismatch can't happen. Aligned inputs pass through
+// unchanged.
+//
+// Remove this entire mechanism (the macroblockAlign constant, the
+// needsCrop/dstBounds/scratchRGBA fields, the alignment logic in
+// NewEncoder, and the crop in Encode) once
+// https://github.com/pion/mediadevices/issues/707 ships upstream.
 const macroblockAlign = 16
 
 type encoder struct {
-	codec       codec.ReadCloser
-	img         image.Image
-	logger      logging.Logger
+	codec  codec.ReadCloser
+	img    image.Image
+	logger logging.Logger
+
+	// Fields below implement the macroblock alignment workaround; delete
+	// with the rest of the workaround.
 	needsCrop   bool
 	dstBounds   image.Rectangle
 	scratchRGBA *image.RGBA
@@ -39,6 +56,8 @@ func NewEncoder(width, height, keyFrameInterval int, logger logging.Logger) (our
 			"Please provide frames with even dimensions for width and height")
 	}
 
+	// Round dims DOWN to the nearest 16-multiple. If input is already
+	// aligned, alignedW == width and needsCrop stays false (no-op path).
 	alignedW := width &^ (macroblockAlign - 1)
 	alignedH := height &^ (macroblockAlign - 1)
 	enc := &encoder{
@@ -46,6 +65,8 @@ func NewEncoder(width, height, keyFrameInterval int, logger logging.Logger) (our
 		needsCrop: alignedW != width || alignedH != height,
 	}
 	if enc.needsCrop {
+		// Pre-allocate one scratch buffer for the whole encoder lifetime;
+		// reused per frame in Encode() to avoid churning allocations.
 		enc.dstBounds = image.Rect(0, 0, alignedW, alignedH)
 		enc.scratchRGBA = image.NewRGBA(enc.dstBounds)
 		logger.Infow("x264: input dims not macroblock-aligned; cropping per frame",
@@ -85,6 +106,8 @@ func (v *encoder) Read() (img image.Image, release func(), err error) {
 // Encode asks the codec to process the given image.
 func (v *encoder) Encode(_ context.Context, img image.Image) ([]byte, error) {
 	if v.needsCrop {
+		// Copy pixels into the aligned scratch buffer. draw.Draw handles
+		// stride correctly across YCbCr / RGBA / Gray inputs.
 		src := img.Bounds()
 		draw.Draw(v.scratchRGBA, v.dstBounds, img, src.Min, draw.Src)
 		img = v.scratchRGBA

--- a/gostream/codec/x264/encoder.go
+++ b/gostream/codec/x264/encoder.go
@@ -15,33 +15,16 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
-// Macroblock alignment workaround.
-//
-// H.264 encodes in 16x16 macroblocks. Pion's x264 wrapper (bridge.h
-// enc_encode) swaps pic_in.img.plane[] to point at Go pixel data on every
-// frame but never updates pic_in.img.i_stride[]. When the input width or
-// height isn't a multiple of 16, x264's stride assumption diverges from
-// Go's image.YCbCr layout, so x264 reads rows at the wrong memory offset.
-// Symptom is horizontal stripes when width is off, unassemblable frames
-// when height is off.
-//
-// Workaround: crop input to the nearest 16-multiple before handing to
-// pion so the stride mismatch can't happen. Aligned inputs pass through
-// unchanged.
-//
-// Remove this entire mechanism (the macroblockAlign constant, the
-// needsCrop/dstBounds/scratchRGBA fields, the alignment logic in
-// NewEncoder, and the crop in Encode) once
-// https://github.com/pion/mediadevices/issues/707 ships upstream.
+// Workaround for pion/mediadevices#707: pion's x264 wrapper doesn't update
+// pic_in.img.i_stride[] when the input width isn't macroblock-aligned,
+// causing corrupt frames. Crop input width to the nearest 16-multiple
+// before handing to pion. Remove once pion/mediadevices#707 ships upstream.
 const macroblockAlign = 16
 
 type encoder struct {
-	codec  codec.ReadCloser
-	img    image.Image
-	logger logging.Logger
-
-	// Fields below implement the macroblock alignment workaround; delete
-	// with the rest of the workaround.
+	codec       codec.ReadCloser
+	img         image.Image
+	logger      logging.Logger
 	needsCrop   bool
 	dstBounds   image.Rectangle
 	scratchRGBA *image.RGBA
@@ -50,28 +33,21 @@ type encoder struct {
 // NewEncoder returns an x264 encoder that can encode images of the given width and height. It will
 // also ensure that it produces key frames at the given interval.
 func NewEncoder(width, height, keyFrameInterval int, logger logging.Logger) (ourcodec.VideoEncoder, error) {
-	// Check to make sure dimensions are even.
 	if width%2 != 0 || height%2 != 0 {
 		return nil, errors.New("x264 encoder does not support odd dimensions. " +
 			"Please provide frames with even dimensions for width and height")
 	}
 
-	// Round dims DOWN to the nearest 16-multiple. If input is already
-	// aligned, alignedW == width and needsCrop stays false (no-op path).
 	alignedW := width &^ (macroblockAlign - 1)
-	alignedH := height &^ (macroblockAlign - 1)
 	enc := &encoder{
 		logger:    logger,
-		needsCrop: alignedW != width || alignedH != height,
+		needsCrop: alignedW != width,
 	}
 	if enc.needsCrop {
-		// Pre-allocate one scratch buffer for the whole encoder lifetime;
-		// reused per frame in Encode() to avoid churning allocations.
-		enc.dstBounds = image.Rect(0, 0, alignedW, alignedH)
+		enc.dstBounds = image.Rect(0, 0, alignedW, height)
 		enc.scratchRGBA = image.NewRGBA(enc.dstBounds)
-		logger.Infow("x264: input dims not macroblock-aligned; cropping per frame",
-			"from", []int{width, height},
-			"to", []int{alignedW, alignedH})
+		logger.Infow("x264: input width not macroblock-aligned; cropping per frame",
+			"from_width", width, "to_width", alignedW, "height", height)
 	}
 
 	var builder codec.VideoEncoderBuilder
@@ -81,13 +57,13 @@ func NewEncoder(width, height, keyFrameInterval int, logger logging.Logger) (our
 	}
 	builder = &params
 	params.KeyFrameInterval = keyFrameInterval
-	params.BitRate = calcBitrateFromResolution(alignedW, alignedH, float32(params.KeyFrameInterval))
+	params.BitRate = calcBitrateFromResolution(alignedW, height, float32(params.KeyFrameInterval))
 	params.LogLevel = x264.LogWarning
 
 	codec, err := builder.BuildVideoEncoder(enc, prop.Media{
 		Video: prop.Video{
 			Width:  alignedW,
-			Height: alignedH,
+			Height: height,
 		},
 	})
 	if err != nil {
@@ -106,10 +82,7 @@ func (v *encoder) Read() (img image.Image, release func(), err error) {
 // Encode asks the codec to process the given image.
 func (v *encoder) Encode(_ context.Context, img image.Image) ([]byte, error) {
 	if v.needsCrop {
-		// Copy pixels into the aligned scratch buffer. draw.Draw handles
-		// stride correctly across YCbCr / RGBA / Gray inputs.
-		src := img.Bounds()
-		draw.Draw(v.scratchRGBA, v.dstBounds, img, src.Min, draw.Src)
+		draw.Draw(v.scratchRGBA, v.dstBounds, img, img.Bounds().Min, draw.Src)
 		img = v.scratchRGBA
 	}
 	v.img = img

--- a/gostream/codec/x264/encoder_test.go
+++ b/gostream/codec/x264/encoder_test.go
@@ -105,6 +105,49 @@ func BenchmarkEncodeYCbCr(b *testing.B) {
 	}
 }
 
+func TestNewEncoderCropsUnalignedDims(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	// Ensenso native: 2472 is 8 pixels past the nearest 16-multiple.
+	enc, err := NewEncoder(2472, 2064, DefaultKeyFrameInterval, logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, enc.Close(), test.ShouldBeNil)
+	}()
+
+	e := enc.(*encoder)
+	test.That(t, e.needsCrop, test.ShouldBeTrue)
+	test.That(t, e.dstBounds.Dx(), test.ShouldEqual, 2464)
+	test.That(t, e.dstBounds.Dy(), test.ShouldEqual, 2064)
+	test.That(t, e.scratchRGBA, test.ShouldNotBeNil)
+}
+
+func TestNewEncoderAlignedDimsNoOp(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	// 1280x720 — both dims already 16-aligned (720p, common on webcams).
+	enc, err := NewEncoder(1280, 720, DefaultKeyFrameInterval, logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, enc.Close(), test.ShouldBeNil)
+	}()
+
+	e := enc.(*encoder)
+	test.That(t, e.needsCrop, test.ShouldBeFalse)
+	test.That(t, e.scratchRGBA, test.ShouldBeNil)
+}
+
+func TestEncodeUnalignedInputDoesNotPanic(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	enc, err := NewEncoder(2472, 2064, DefaultKeyFrameInterval, logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, enc.Close(), test.ShouldBeNil)
+	}()
+
+	img := image.NewYCbCr(image.Rect(0, 0, 2472, 2064), image.YCbCrSubsampleRatio420)
+	_, err = enc.Encode(context.Background(), img)
+	test.That(t, err, test.ShouldBeNil)
+}
+
 func TestCalcBitrateFromResolution(t *testing.T) {
 	bitrateTests := []struct {
 		width, height int

--- a/gostream/codec/x264/encoder_test.go
+++ b/gostream/codec/x264/encoder_test.go
@@ -105,34 +105,40 @@ func BenchmarkEncodeYCbCr(b *testing.B) {
 	}
 }
 
-func TestNewEncoderCropsUnalignedDims(t *testing.T) {
-	logger := logging.NewTestLogger(t)
-	// Ensenso native: 2472 is 8 pixels past the nearest 16-multiple.
-	enc, err := NewEncoder(2472, 2064, DefaultKeyFrameInterval, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, enc.Close(), test.ShouldBeNil)
-	}()
+func TestNewEncoderCropDecision(t *testing.T) {
+	tests := []struct {
+		name         string
+		width        int
+		height       int
+		wantCrop     bool
+		wantAlignedW int
+	}{
+		{"aligned width and height (no-op)", 1280, 720, false, 1280},
+		{"aligned width, unaligned height (no-op)", 1280, 730, false, 1280},
+		{"unaligned width, aligned height (crop)", 2472, 2064, true, 2464},
+		{"unaligned width and height (crop, height preserved)", 1000, 730, true, 992},
+	}
 
-	e := enc.(*encoder)
-	test.That(t, e.needsCrop, test.ShouldBeTrue)
-	test.That(t, e.dstBounds.Dx(), test.ShouldEqual, 2464)
-	test.That(t, e.dstBounds.Dy(), test.ShouldEqual, 2064)
-	test.That(t, e.scratchRGBA, test.ShouldNotBeNil)
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := logging.NewTestLogger(t)
+			enc, err := NewEncoder(tt.width, tt.height, DefaultKeyFrameInterval, logger)
+			test.That(t, err, test.ShouldBeNil)
+			defer func() {
+				test.That(t, enc.Close(), test.ShouldBeNil)
+			}()
 
-func TestNewEncoderAlignedDimsNoOp(t *testing.T) {
-	logger := logging.NewTestLogger(t)
-	// 1280x720 — both dims already 16-aligned (720p, common on webcams).
-	enc, err := NewEncoder(1280, 720, DefaultKeyFrameInterval, logger)
-	test.That(t, err, test.ShouldBeNil)
-	defer func() {
-		test.That(t, enc.Close(), test.ShouldBeNil)
-	}()
-
-	e := enc.(*encoder)
-	test.That(t, e.needsCrop, test.ShouldBeFalse)
-	test.That(t, e.scratchRGBA, test.ShouldBeNil)
+			e := enc.(*encoder)
+			test.That(t, e.needsCrop, test.ShouldEqual, tt.wantCrop)
+			if tt.wantCrop {
+				test.That(t, e.dstBounds.Dx(), test.ShouldEqual, tt.wantAlignedW)
+				test.That(t, e.dstBounds.Dy(), test.ShouldEqual, tt.height)
+				test.That(t, e.scratchRGBA, test.ShouldNotBeNil)
+			} else {
+				test.That(t, e.scratchRGBA, test.ShouldBeNil)
+			}
+		})
+	}
 }
 
 func TestEncodeUnalignedInputDoesNotPanic(t *testing.T) {


### PR DESCRIPTION
## The issue
Stripes / corrupted output when streaming cameras with non 16 aligned dimensions. Ensenso example:

<img width="1282" height="1440" alt="Screenshot 2026-07-23 at 11 20 39 AM" src="https://github.com/user-attachments/assets/f54fc33b-8bf0-4769-ad72-d1d2cb1d0ac0" />

## Root cause
In pion/mediadevices' x264 wrapper - upstream issue: https://github.com/pion/mediadevices/issues/707

(Verified against the proposed fix in that issue)

  tl;dr: enc_encode in pion swaps `pic_in.img.plane[0..2]` to point at Go pixel data every frame but never updates `pic_in.img.i_stride[0..2]`. Those stride values were computed once at init by `x264_picture_alloc()` and can differ from Go's `image.YCbCr` layout when the dimensions aren't 16 aligned. x264 then reads rows at wrong offsets - visible as stripes when the width is off, unassemblable frames when the height is off.

## Fix in the interim 
Temporary workaround until the issue in pion/mediadevices is addressed or I get the green light to put up a PR (unsure how long that will take): **crop input to the nearest 16 multiple before handing to pion**. 

Aligned inputs pass through unchanged with zero overhead

## Validation
### Ensenso
<img width="985" height="937" alt="Screenshot 2026-07-23 at 1 59 59 PM" src="https://github.com/user-attachments/assets/f9dfe5bd-352c-427c-9125-ca45ac56273c" />