### PR TITLE
RSDK-14312 - lower maxBitrate to 3Mbps for WebRTC delivery

### DIFF
--- a/gostream/codec/x264/encoder_test.go
+++ b/gostream/codec/x264/encoder_test.go
@@ -112,7 +112,7 @@ func TestCalcBitrateFromResolution(t *testing.T) {
 		expected      int
 	}{
 		{640, 480, 30, 1382400},
-		{1920, 1080, 30, 9331200},
+		{1920, 1080, 30, maxBitrate},
 		{3840, 2160, 30, maxBitrate},
 		{240, 180, 30, minBitrate},
 	}

--- a/gostream/codec/x264/utils.go
+++ b/gostream/codec/x264/utils.go
@@ -14,9 +14,9 @@ const (
 	// handle frame bursts. This is the minimum bitrate that we can use without causing the encoder
 	// to spew out warnings about the buffer size being too small.
 	minBitrate = 300_000 // 300kbps
-	// This encoder is used exclusively for WebRTC delivery, which typically routes
-	// through TURN relays or over Wi-Fi where sustained bitrates above ~3Mbps cause
-	// packet loss that fragments H.264 keyframes and cascades into unrecoverable
+	// RSDK-14312: This encoder is used exclusively for WebRTC delivery, which typically
+	// routes through TURN relays or over Wi-Fi where sustained bitrates above ~3Mbps
+	// cause packet loss that fragments H.264 keyframes and cascades into unrecoverable
 	// decode failures.
 	maxBitrate = 3_000_000 // 3Mbps
 )

--- a/gostream/codec/x264/utils.go
+++ b/gostream/codec/x264/utils.go
@@ -14,9 +14,11 @@ const (
 	// handle frame bursts. This is the minimum bitrate that we can use without causing the encoder
 	// to spew out warnings about the buffer size being too small.
 	minBitrate = 300_000 // 300kbps
-	// Setting a reasonable max bitrate to prevent the encoder from using too much bandwidth.
-	// 4K resolution at 20fps is around 24.8Mbps.
-	maxBitrate = 25_000_000 // 25Mbps
+	// This encoder is used exclusively for WebRTC delivery, which typically routes
+	// through TURN relays or over Wi-Fi where sustained bitrates above ~3Mbps cause
+	// packet loss that fragments H.264 keyframes and cascades into unrecoverable
+	// decode failures.
+	maxBitrate = 3_000_000 // 3Mbps
 )
 
 // DefaultStreamConfig configures x264 as the encoder for a stream.


### PR DESCRIPTION
> Follow up to 

## The issue I've been observing
1080p webcam over app.viam.com (Emeet C950). This is a specific example I captured:
- 0 frames decoded over 39s
- 3000 packets lost
- 214 keyframe requests

**I've observed it taking 6+ minutes to render on my setup**

Browser stuck repeatedly asking the server for keyframes because none of the received ones successfully decode

## What I think is going on
 calcBitrateFromResolution sets the encoder target to 
```
w × h × fps × 0.15
```
For 1920×1080@30fps that's 9.3Mbps

In our test path, that produced ~5% packet loss

Because H.264 keyframes fragment into ~100 RTP packets each, ~5% loss gives each keyframe a ~99% probability of losing at least one packet which is enough to prevent the keyframe from reconstructing

All subsequent P-frames reference the broken keyframe, cascade fails, and the browser sees 0 decodable frames despite receiving 62MB of data

It's interesting that the Ensenso escapes this at 0.25fps because keyframes are rare enough that occasional loss doesn't cascade.
  
## Proposed fix
Lower maxBitrate from 25Mbps to 3Mbps

### Why I think this is ok
We empirically verified 2Mbps eliminates the packet loss on our test setup, and 3Mbps offers modest quality headroom while staying inside the capacity of typical WebRTC paths
  
There's also a compounding effect at lower bitrates: 
- smaller keyframes mean fewer packets per keyframe
- AND we stop saturating the network so per packet loss rate drops

## Some alternative approaches we can explore:
- Config attribute for per-camera bitrate override
- A more dynamic bitrate leveraging congestion control 

## Manual testing
I normally can repro the hang on main by refreshing a few times. Running against this branch I've refreshed 30+ times and not one hung

___

[RSDK-14325](https://viam.atlassian.net/browse/RSDK-14325) Follow-up ticket to investigate future improvements to the video streaming bitrate stack.

[RSDK-14325]: https://viam.atlassian.net/browse/RSDK-14325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ