### PR TITLE
Quiet noisy restart-check log when offline

### DIFF
--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -592,7 +592,7 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 
 				mustRestart, newRestartInterval, err := restartCheck.needsRestart(ctx)
 				if err != nil {
-					s.networkingLogger.Infow("failed to check restart", "error", err)
+					s.networkingLogger.Debugw("failed to check restart", "error", err)
 					continue
 				}
 


### PR DESCRIPTION
### What
Downgrade the cloud restart checker's `failed to check restart` log from Info to Debug.

### Why
The restart checker fires every 5s. When viam-server is offline, the `NeedsRestart` RPC fails (DNS lookup for `app.viam.com`) and every failure was logged at Info — ~12 lines/minute of transport dial errors flooding the logs.

A failed restart check is transient and self-healing, so Debug is the right level. This matches the config watcher's transient-vs-real philosophy in `config/watcher.go`, where transient cloud-unreachable errors already log at Debug and only genuinely malformed configs log loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)