### PR TITLE
RSDK-14336 robot/impl: flaky test fix TestCrashedModuleModelReregisteredAfterRecovery

### DIFF
--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -2462,10 +2462,13 @@ func TestCrashedModuleModelReregisteredAfterRecovery(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 
 	// Assert that restoring the testmodule binary makes h start working again
-	// after the auto-restart code succeeds.
+	// after the auto-restart code succeeds. This can take a while: the restart
+	// loop only retries every oueRestartInterval (5s), and a freshly-forked
+	// module process can be slow to start listening on its socket when the CI
+	// machine is under load, so allow a generous window here to avoid flakiness.
 	err = os.Rename(testPath+".disabled", testPath)
 	test.That(t, err, test.ShouldBeNil)
-	testutils.WaitForAssertionWithSleep(t, time.Second, 20, func(tb testing.TB) {
+	testutils.WaitForAssertionWithSleep(t, time.Second, 100, func(tb testing.TB) {
 		tb.Helper()
 		test.That(tb, logs.FilterMessage("Module resources to be re-added after module restart").Len(),
 			test.ShouldEqual, 1)


### PR DESCRIPTION
## Summary

`TestCrashedModuleModelReregisteredAfterRecovery` is intermittently failing in CI:

```
File:     go.viam.com/rdk/robot/impl/local_robot_test.go:2468
Expected: '1'
Actual:   '0'
```

## Root cause

The test removes a module's binary, kills the module, waits for the first restart attempt to fail (`"Error while restarting crashed module"`), then restores the binary and waits for the module to auto-restart and re-add its resources (the `"Module resources to be re-added after module restart"` log).

Two factors make this restart slow:

1. The crash-restart loop only retries every `oueRestartInterval` (**5s**), so the first *successful* attempt doesn't begin until ~5s after the crash.
2. Starting a module blocks in the parent's `startProcess` until the freshly-forked module process is listening on its socket. Under CI load this fork can be badly starved of CPU — in the failing run the module took **~39s** to go from fork to `"server listening"`, even though the same binary started in ~40ms the first time.

The combined restart time (~44s) exceeded the test's **20s** wait window, so the re-registration log had not yet appeared when the assertion ran (`Expected: 1, Actual: 0`). This is an environmental/timing flake — the restart machinery worked correctly and would have completed had the test not torn down first.

## Fix

Increase the wait window for the re-registration assertion from 20s to 100s so it comfortably tolerates the 5s restart backoff plus a slow module startup under CI load. 100s matches the existing wait already used for a similar module-restart assertion in this file. The assertion still checks for exactly `1` occurrence, and only one successful restart happens in this window, so the larger timeout cannot cause a spurious count of `2`.

Key: RSDK-14336

Co-authored by Claude agent for Jira.