### PR TITLE
RSDK-14335 robot/impl: flaky test fix TestCrashedModuleDependentRecovery

### DIFF
--- a/robot/impl/module_lifecycle_test.go
+++ b/robot/impl/module_lifecycle_test.go
@@ -471,10 +471,14 @@ func TestCrashedModuleDependentRecovery(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	// Assert that restoring the testmodule binary makes 'h' start working again
-	// after the auto-restart code succeeds.
+	// after the auto-restart code succeeds. The background restart loop only
+	// retries every oueRestartInterval and a single restart (process start plus
+	// the WebRTC ready handshake) can itself take several seconds, so wait
+	// generously for the module to recover before asserting its resources are
+	// re-added.
 	err = os.Rename(testPath+".disabled", testPath)
 	test.That(t, err, test.ShouldBeNil)
-	testutils.WaitForAssertionWithSleep(t, time.Second, 20, func(tb testing.TB) {
+	testutils.WaitForAssertionWithSleep(t, time.Second, 60, func(tb testing.TB) {
 		tb.Helper()
 		test.That(tb, logs.FilterMessage("Module resources to be re-added after module restart").Len(),
 			test.ShouldEqual, 1)
@@ -553,9 +557,12 @@ func TestCrashedModuleDependentRecoveryAfterFailedFirstConstruction(t *testing.T
 	test.That(t, countActivityEvents(activityLogs, "resource_construct", "complete"), test.ShouldEqual, 3)
 
 	// Assert that restoring the testmodule binary restores the module but not 'h'.
+	// The background restart loop only retries every oueRestartInterval and a
+	// single restart (process start plus the WebRTC ready handshake) can itself
+	// take several seconds, so wait generously for the module to recover.
 	err = os.Rename(testPath+".disabled", testPath)
 	test.That(t, err, test.ShouldBeNil)
-	testutils.WaitForAssertionWithSleep(t, time.Second, 20, func(tb testing.TB) {
+	testutils.WaitForAssertionWithSleep(t, time.Second, 60, func(tb testing.TB) {
 		tb.Helper()
 		test.That(tb, logs.FilterMessage("Module resources to be re-added after module restart").Len(),
 			test.ShouldEqual, 1)


### PR DESCRIPTION
## Summary

Fixes the intermittent failure of `TestCrashedModuleDependentRecovery` (and the analogous `TestCrashedModuleDependentRecoveryAfterFailedFirstConstruction`) in `robot/impl`:

```
module_lifecycle_test.go:477: Expected: '1' Actual: '0' (Should be equal)
```

## Root cause

Both tests disable a module's binary, kill the module, then restore the binary and wait for the module manager to auto-restart the crashed module and re-add its resources, asserting on the log line `"Module resources to be re-added after module restart"`.

The restart is driven by the background loop in `newOnUnexpectedExitHandler` (`module/modmanager/manager.go`), which:

- retries `attemptRestart` only every `oueRestartInterval` (**5s**), and
- performs a restart that includes launching the module process, dialing it, and completing the WebRTC/gRPC `Ready` handshake — a step that can itself take several seconds on a loaded CI machine.

In the failing CI run the `SlowLogger` shows a single `attemptRestart` running continuously to `time_elapsed=15s`. Combined with the up-to-5s backoff, this exceeded the test's budget of `WaitForAssertionWithSleep(t, time.Second, 20, ...)` (20 × 1s = ~20s), so the message count was still `0` when the assertion gave up. Teardown then cancelled the restart context (`context canceled` in the logs), confirming the operation was simply slower than the budget rather than genuinely stuck.

## Fix

Increase the wait budget from 20 to 60 iterations (60s) for the two `"Module resources to be re-added after module restart"` assertions.

`WaitForAssertionWithSleep` returns as soon as the assertion passes, so this only extends the slow/failure path and does not slow the happy path. The restart loop retries indefinitely once the binary is restored and each attempt is bounded by the module startup timeout, so a genuine regression would still fail (after the larger budget) rather than being masked.

## Testing

- `gofmt` clean on the changed file.
- Building/running the full suite locally isn't possible in this sandbox (the module requires Go 1.25.10, which the sandbox cannot fetch). The change is limited to a numeric literal and comments in an already-compiling test, so it does not affect compilation.

Key: RSDK-14335

Co-authored by Claude agent for Jira.