### PR TITLE
RSDK-14334 movementsensor/replay: flaky test fix TestReplayMovementSensorTimestampsMetadata

### DIFF
--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/golang/geo/r3"
 	geo "github.com/kellydunn/golang-geo"
@@ -117,8 +116,7 @@ var (
 func TestNewReplayMovementSensor(t *testing.T) {
 	ctx := context.Background()
 
-	initializePropertiesTimeout = 2 * time.Second
-	tabularDataByFilterTimeout = 1 * time.Second
+	useShortInitTimeouts(t)
 
 	cases := []struct {
 		description          string
@@ -280,8 +278,7 @@ func TestNewReplayMovementSensor(t *testing.T) {
 func TestReplayMovementSensorFunctions(t *testing.T) {
 	ctx := context.Background()
 
-	initializePropertiesTimeout = 2 * time.Second
-	tabularDataByFilterTimeout = 1 * time.Second
+	useShortInitTimeouts(t)
 
 	cases := []struct {
 		description        string

--- a/components/movementsensor/replay/replay_utils_test.go
+++ b/components/movementsensor/replay/replay_utils_test.go
@@ -35,6 +35,23 @@ const (
 
 var errTestCloudConnection = errors.New("cloud connection error")
 
+// useShortInitTimeouts lowers the property-initialization timeouts so tests exercising
+// failure-to-initialize paths fail quickly. The original values are restored via t.Cleanup so
+// that subsequent tests in the package run with the production timeouts. Otherwise the shortened
+// deadlines leak across tests (package-level vars are shared) and make later tests flaky under
+// load, since a single slow TabularDataByFilter call exceeds the 1s deadline (RSDK-14334).
+func useShortInitTimeouts(t *testing.T) {
+	t.Helper()
+	origInitializePropertiesTimeout := initializePropertiesTimeout
+	origTabularDataByFilterTimeout := tabularDataByFilterTimeout
+	t.Cleanup(func() {
+		initializePropertiesTimeout = origInitializePropertiesTimeout
+		tabularDataByFilterTimeout = origTabularDataByFilterTimeout
+	})
+	initializePropertiesTimeout = 2 * time.Second
+	tabularDataByFilterTimeout = 1 * time.Second
+}
+
 // mockDataServiceServer is a struct that includes unimplemented versions of all the Data Service endpoints. These
 // can be overwritten to allow developers to trigger desired behaviors during testing.
 type mockDataServiceServer struct {


### PR DESCRIPTION
## Summary

Fixes the intermittent failure of `TestReplayMovementSensorTimestampsMetadata` (and other later tests in the package) reported in RSDK-14334:

```
replay_test.go:852: Expected: nil
    Actual:   'Properties failed to initialize: could not update the cache: rpc error: code = DeadlineExceeded desc = context deadline exceeded'
```

## Root cause

`TestNewReplayMovementSensor` and `TestReplayMovementSensorFunctions` reassign the **package-level** vars `initializePropertiesTimeout` (→ `2s`) and `tabularDataByFilterTimeout` (→ `1s`) so their failure-to-initialize cases fail fast, but they never restore the originals.

Go runs a package's tests sequentially in source order, and those vars are shared, so every test declared **after** those two — including `TestReplayMovementSensorTimestampsMetadata` — runs with a **1‑second per‑call deadline** and a **2‑second init budget** instead of the production `20s` / `180s` values.

`initializeProperties` polls the cloud via `TabularDataByFilter` during construction. Under CI load a single call can easily stall for more than 1 second, exceeding the leaked 1s deadline and returning `DeadlineExceeded`, which aborts construction. This exactly matches the failure logs, where the server-side `grpc.request.deadline` is only ~1 second after `grpc.start_time` (not the 20s the code nominally sets) and a call is observed taking ~31s to complete after a process stall.

## Fix

Introduce a `useShortInitTimeouts(t)` test helper that:
- captures the current timeout values,
- lowers them to `2s` / `1s` for the tests that need fast failure paths, and
- restores the originals via `t.Cleanup`.

This keeps the fast-fail behavior within the two tests that need it while ensuring the shortened deadlines no longer leak into subsequent tests. Later tests now run with the production `20s` / `180s` timeouts and are robust to transient CI slowness. The change is order-independent: no test can leak the shortened deadlines to another.

## Testing notes

This environment could not download the required Go toolchain (`go 1.25.10`), so the suite could not be executed here; changes were verified with `gofmt` and manual review. The change is confined to test files and does not alter production behavior.

Key: RSDK-14334

Co-authored by Claude agent for Jira.