### PR TITLE
RSDK-14337 robot/impl: flaky test fix TestOrphanedResources/automatic_reconfiguration

### DIFF
--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -2383,17 +2383,25 @@ func TestOrphanedResources(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "rpc error")
 
-		// Wait for restart attempt in logs.
+		// Wait for the new restart attempt in logs. This is the second such log:
+		// the first came from the successful testmodule restart above, so we must
+		// wait for the count to reach 2 to know the disguised-simplemodule restart
+		// has actually happened.
 		testutils.WaitForAssertionWithSleep(t, time.Second, 20, func(tb testing.TB) {
 			tb.Helper()
 			test.That(tb, logs.FilterMessage("Module resources to be re-added after module restart").Len(),
-				test.ShouldBeGreaterThanOrEqualTo, 1)
+				test.ShouldBeGreaterThanOrEqualTo, 2)
 		})
-		time.Sleep(2 * time.Second)
 
-		_, err = r.ResourceByName(generic.Named("h"))
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, `resource rdk:component:generic/h not available`)
+		// simplemodule cannot manage helper 'h', so the reconfigure triggered by
+		// the restart should orphan it and make it unavailable. Poll until this
+		// happens rather than relying on a fixed sleep.
+		testutils.WaitForAssertionWithSleep(t, time.Second, 20, func(tb testing.TB) {
+			tb.Helper()
+			_, err := r.ResourceByName(generic.Named("h"))
+			test.That(tb, err, test.ShouldNotBeNil)
+			test.That(tb, err.Error(), test.ShouldContainSubstring, `resource rdk:component:generic/h not available`)
+		})
 
 		// Also assert that testmodule's resources were deregistered.
 		_, ok := resource.LookupRegistration(generic.API, helperModel)


### PR DESCRIPTION
## Summary

Fixes flaky `TestOrphanedResources/automatic_reconfiguration` in `robot/impl/local_robot_test.go`.

The observed failure was:

```
local_robot_test.go:2395: Expected '<nil>' to NOT be nil (but it was)!
--- FAIL: TestOrphanedResources/automatic_reconfiguration
```

## Root cause

The subtest exercises several module restarts against a shared robot:

1. Restore the `testmodule` binary and wait for the log `"Module resources to be re-added after module restart"` to equal **1** (successful restart re-adds helper `h`).
2. Replace the `testmodule` binary with a disguised `simplemodule`, kill the module, and assert that `h` becomes orphaned/unavailable because `simplemodule` cannot manage it.

For step 2 the test waited for that same log message to be `>= 1`. Since it was **already** emitted once by the step‑1 restart, the wait returned immediately and never actually gated on the *new* restart. The only remaining buffer was a fixed `time.Sleep(2 * time.Second)`.

Under load, the restart + restart‑triggered reconfigure (which rebuilds `h`, fails because the model is no longer registered, and marks `h` unavailable) can take longer than 2 seconds. When it did, `r.ResourceByName(generic.Named("h"))` still returned a nil error and the assertion at line 2395 failed intermittently.

## Fix

- Wait for the "re-added" log count to reach **2**, so we actually wait for the disguised‑`simplemodule` restart to happen (the first log came from the step‑1 restart).
- Replace the fixed `time.Sleep` + one‑shot assertion with a `WaitForAssertionWithSleep` that polls `r.ResourceByName(generic.Named("h"))` until it returns the expected `resource ... not available` error. This waits on the actual condition of interest instead of a fixed duration, following the existing pattern used elsewhere in the file.

`h` only transitions available → unavailable once (and stays unavailable), so polling cannot produce a false positive.

## Testing

Built the exact toolchain and ran the affected tests locally:

- `go test ./robot/impl/ -run 'TestOrphanedResources/automatic_reconfiguration' -count=5` — all pass.
- `go test ./robot/impl/ -run 'TestOrphanedResources$'` — all subtests pass.
- `gofmt` reports no changes needed.

Key: RSDK-14337

Co-authored by Claude agent for Jira.