### PR TITLE
RSDK-13565 Fix module directory helper functions on Windows

### DIFF
--- a/config/module.go
+++ b/config/module.go
@@ -183,13 +183,16 @@ func (m Module) SyntheticPackage() (PackageConfig, error) {
 // ExeDir returns the parent directory for the unpacked module.
 func (m Module) ExeDir(packagesDir string) (string, error) {
 	if !m.NeedsSyntheticPackage() {
-		return filepath.Dir(m.ExePath), nil
+		// Resolve to an absolute path. Otherwise a relative or bare ExePath yields
+		// ".", which downstream produces a nonsensical first-run marker path such as
+		// "..first_run_succeeded" (see FirstRun).
+		return filepath.Abs(filepath.Dir(m.ExePath))
 	}
 	pkg, err := m.SyntheticPackage()
 	if err != nil {
 		return "", err
 	}
-	return pkg.LocalDataDirectory(packagesDir), nil
+	return filepath.Abs(pkg.LocalDataDirectory(packagesDir))
 }
 
 // parseJSONFile returns a *T by parsing the json file at `path`.

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -96,6 +96,21 @@ func TestSyntheticModule(t *testing.T) {
 		test.That(t, dir, test.ShouldEqual, filepath.Join(tmp, "data/module/synthetic--"))
 	})
 
+	// ExeDir must always return an absolute directory. A relative or bare ExePath
+	// (e.g. from a misconfigured local module) previously resolved to ".", which
+	// downstream produced a nonsensical first-run marker path like "..first_run_succeeded".
+	t.Run("exeDirIsAbsolute", func(t *testing.T) {
+		wd, err := os.Getwd()
+		test.That(t, err, test.ShouldBeNil)
+
+		bareExe := Module{Type: ModuleTypeLocal, ExePath: "whatever.sh"}
+		dir, err := bareExe.ExeDir(tmp)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, dir, test.ShouldNotEqual, ".")
+		test.That(t, filepath.IsAbs(dir), test.ShouldBeTrue)
+		test.That(t, dir, test.ShouldEqual, wd)
+	})
+
 	t.Run("EvaluateExePath", func(t *testing.T) {
 		meta := JSONManifest{
 			Entrypoint: "entry",

--- a/utils/file.go
+++ b/utils/file.go
@@ -40,11 +40,18 @@ func RemoveFileNoError(path string) {
 }
 
 // SafeJoinDir performs a filepath.Join of 'parent' and 'subdir' but returns an error
-// if the resulting path points outside of 'parent'.
+// if the resulting path points outside of 'parent'. It handles relative parents
+// (including ".") and is cross-platform (Windows and POSIX).
 // See also https://github.com/cyphar/filepath-securejoin.
 func SafeJoinDir(parent, subdir string) (string, error) {
 	res := filepath.Join(parent, subdir)
-	if !strings.HasPrefix(filepath.Clean(res), filepath.Clean(parent)+string(os.PathSeparator)) {
+	// Compute the location of the result relative to parent. If that path climbs
+	// above parent (i.e. it is ".." or starts with "../"), the join escaped parent
+	// and is unsafe. Using filepath.Rel here (instead of a string prefix check)
+	// correctly handles relative parents such as ".", which previously produced a
+	// spurious error.
+	rel, err := filepath.Rel(filepath.Clean(parent), res)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 		return res, fmt.Errorf("unsafe path join: '%s' with '%s'", parent, subdir)
 	}
 	return res, nil

--- a/utils/file_test.go
+++ b/utils/file_test.go
@@ -22,12 +22,10 @@ func TestResolveFile(t *testing.T) {
 }
 
 func TestSafeJoinDir(t *testing.T) {
-	parentDir := "/some/parent"
-
-	validate := func(in, expectedOut string, expectedErr error) {
+	validate := func(parent, in, expectedOut string, expectedErr error) {
 		t.Helper()
 
-		out, err := SafeJoinDir(parentDir, in)
+		out, err := SafeJoinDir(parent, in)
 		if expectedErr == nil {
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, out, test.ShouldEqual, expectedOut)
@@ -37,9 +35,21 @@ func TestSafeJoinDir(t *testing.T) {
 		}
 	}
 
-	validate("sub/dir", "/some/parent/sub/dir", nil)
-	validate("/other/parent", "/some/parent/other/parent", nil)
-	validate("../../../root", "", errors.New("unsafe path join"))
+	parentDir := "/some/parent"
+	validate(parentDir, "sub/dir", filepath.Join(parentDir, "sub/dir"), nil)
+	validate(parentDir, "/other/parent", filepath.Join(parentDir, "other/parent"), nil)
+	validate(parentDir, "meta.json", filepath.Join(parentDir, "meta.json"), nil)
+	validate(parentDir, "../../../root", "", errors.New("unsafe path join"))
+	validate(parentDir, "..", "", errors.New("unsafe path join"))
+
+	// Relative parents (including ".") must be handled. Previously SafeJoinDir(".", "meta.json")
+	// returned a spurious error, which broke module meta.json discovery (notably on Windows).
+	validate(".", "meta.json", "meta.json", nil)
+	validate(".", "sub/dir", filepath.Join("sub", "dir"), nil)
+	validate(".", "..", "", errors.New("unsafe path join"))
+	validate(".", "../escape", "", errors.New("unsafe path join"))
+	validate("relative/parent", "child", filepath.Join("relative/parent", "child"), nil)
+	validate("relative/parent", "../../escape", "", errors.New("unsafe path join"))
 }
 
 func TestExpandHomeDir(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes two related bugs in the module directory helper functions that surface on Windows (per RSDK-13565).

### 1. `utils.SafeJoinDir` fails for relative parents (e.g. `"."`)

`SafeJoinDir(".", "meta.json")` returned a spurious `unsafe path join` error. The old safety check required the cleaned result to be prefixed with `filepath.Clean(parent) + os.PathSeparator`:

```go
if !strings.HasPrefix(filepath.Clean(res), filepath.Clean(parent)+string(os.PathSeparator)) { ... }
```

When `parent` cleans to `"."`, the required prefix becomes `"./"` (or `".\"` on Windows), which the joined result (`"meta.json"`) never has — so a legitimate, in-bounds join was rejected. This broke module `meta.json` discovery (`findMetaJSONFile`) whenever a module's exe dir resolved to `"."`, which is what was observed on Windows.

The check is rewritten to compute the result's path **relative** to the parent via `filepath.Rel` and reject only when it climbs above the parent (`".."` or `"../…"`). This correctly handles relative parents (including `"."`) while still blocking directory-traversal escapes, on both Windows and POSIX.

### 2. `config.Module.ExeDir` could return a bare `"."`

For a relative or bare `ExePath`, `filepath.Dir(m.ExePath)` returns `"."`. In `FirstRun`, the marker path is built by string concatenation (`unpackedModDir + FirstRunSuccessSuffix`), so `"."` produced the nonsensical `"..first_run_succeeded"`. `ExeDir` now resolves its result with `filepath.Abs`, so callers always receive a concrete absolute directory. In the common case (`ExePath`/`packagesDir` already absolute) this is a no-op.

## Testing

- Extended `TestSafeJoinDir` to cover relative parents (`"."`, `relative/parent`) — including the previously-broken `SafeJoinDir(".", "meta.json")` case — alongside the existing traversal-escape cases. Expected values use `filepath.Join` so assertions hold cross-platform.
- Added `TestSyntheticModule/exeDirIsAbsolute` asserting `ExeDir` returns an absolute directory (never `"."`) for a bare `ExePath`.

Note: the repo's `go.mod` pins Go `1.25.10`, which was not installable in this environment (network-restricted) and no local toolchain ≥ 1.25.9 was available, so `go test ./...` could not be run here. The changed logic and test assertions were validated by executing the exact `SafeJoinDir` implementation and its updated test table in a standalone module with Go 1.25.1 (all cases pass), and the `ExeDir` behavior was verified with equivalent standalone checks. Full CI will exercise the suite with the pinned toolchain.

Key: RSDK-13565

Co-authored by Claude agent for Jira.