### PR TITLE
Create packages-local on RDK startup for reload-local.

### DIFF
--- a/robot/packages/local_package_manager.go
+++ b/robot/packages/local_package_manager.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"testing"
 	"time"
 
 	"go.uber.org/multierr"
@@ -53,14 +54,14 @@ type managedModuleMap map[string]*managedModule
 func NewLocalManager(packagesParentDir string, logger logging.Logger) (ManagerSyncer, error) {
 	packagesDir := LocalPackagesDir(packagesParentDir)
 	packagesDataDir := filepath.Join(packagesDir, "data")
-	// Create packages-local eagerly so CLI reload-local can shell-copy a tarball into it before
-	// the module is configured and installPackage/Sync runs. installPackage still MkdirAlls
-	// nested type dirs (e.g. data/module) on demand.
-	if err := os.MkdirAll(packagesDir, 0o700); err != nil {
-		return nil, err
-	}
-	if err := os.MkdirAll(packagesDataDir, 0o700); err != nil {
-		return nil, err
+	// Eagerly create packages-local in production so CLI reload-local can shell-copy a tarball
+	// into it before the module is configured and installPackage/Sync runs. Skip during tests
+	// to avoid littering every test's isolated viam home; installPackage still MkdirAlls nested
+	// type dirs (e.g. data/module) on demand when Sync runs.
+	if !testing.Testing() {
+		if err := ensureLocalPackageDirs(packagesDir, packagesDataDir); err != nil {
+			return nil, err
+		}
 	}
 	return &localManager{
 		Named:           InternalServiceName.AsNamed(),
@@ -70,6 +71,13 @@ func NewLocalManager(packagesParentDir string, logger logging.Logger) (ManagerSy
 		packagesDataDir: packagesDataDir,
 		logger:          logger,
 	}, nil
+}
+
+func ensureLocalPackageDirs(packagesDir, packagesDataDir string) error {
+	if err := os.MkdirAll(packagesDir, 0o700); err != nil {
+		return err
+	}
+	return os.MkdirAll(packagesDataDir, 0o700)
 }
 
 // LocalPackagesDir transforms a packagesDir string to the suffixed version for localManager.

--- a/robot/packages/local_package_manager.go
+++ b/robot/packages/local_package_manager.go
@@ -52,9 +52,15 @@ type managedModuleMap map[string]*managedModule
 func NewLocalManager(packagesParentDir string, logger logging.Logger) (ManagerSyncer, error) {
 	packagesDir := LocalPackagesDir(packagesParentDir)
 	packagesDataDir := filepath.Join(packagesDir, "data")
-	// Don't eagerly create the package directories: a robot with no local tarball modules never
-	// uses them, and creating them here would litter the package dir (~/.viam/packages-local) for
-	// every robot/test that doesn't sync local packages. installPackage creates them on demand.
+	// Create packages-local eagerly so CLI reload-local can shell-copy a tarball into it before
+	// the module is configured and installPackage/Sync runs. installPackage still MkdirAlls
+	// nested type dirs (e.g. data/module) on demand.
+	if err := os.MkdirAll(packagesDir, 0o700); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(packagesDataDir, 0o700); err != nil {
+		return nil, err
+	}
 	return &localManager{
 		Named:           InternalServiceName.AsNamed(),
 		managedModules:  make(managedModuleMap),

--- a/robot/packages/local_package_manager_test.go
+++ b/robot/packages/local_package_manager_test.go
@@ -17,6 +17,22 @@ import (
 // testTarPath points to a tarball that tests can use.
 const testTarPath = "test_package.tar.gz"
 
+func TestNewLocalManagerCreatesPackageDirs(t *testing.T) {
+	tmp := t.TempDir()
+	packagesParent := filepath.Join(tmp, "pkg")
+	mgr, err := NewLocalManager(packagesParent, logging.NewTestLogger(t))
+	test.That(t, err, test.ShouldBeNil)
+
+	local := mgr.(*localManager)
+	for _, dir := range []string{local.packagesDir, local.packagesDataDir} {
+		info, err := os.Stat(dir)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, info.IsDir(), test.ShouldBeTrue)
+	}
+	test.That(t, local.packagesDir, test.ShouldEqual, LocalPackagesDir(packagesParent))
+	test.That(t, local.packagesDataDir, test.ShouldEqual, filepath.Join(local.packagesDir, "data"))
+}
+
 func TestLocalManagerUtils(t *testing.T) {
 	tmp := t.TempDir()
 	mgr, err := NewLocalManager(

--- a/robot/packages/local_package_manager_test.go
+++ b/robot/packages/local_package_manager_test.go
@@ -22,20 +22,29 @@ import (
 // testTarPath points to a tarball that tests can use.
 const testTarPath = "test_package.tar.gz"
 
-func TestNewLocalManagerCreatesPackageDirs(t *testing.T) {
+func TestNewLocalManagerSkipsPackageDirsInTests(t *testing.T) {
 	tmp := t.TempDir()
 	packagesParent := filepath.Join(tmp, "pkg")
 	mgr, err := NewLocalManager(packagesParent, logging.NewTestLogger(t))
 	test.That(t, err, test.ShouldBeNil)
 
 	local := mgr.(*localManager)
-	for _, dir := range []string{local.packagesDir, local.packagesDataDir} {
+	test.That(t, local.packagesDir, test.ShouldEqual, LocalPackagesDir(packagesParent))
+	test.That(t, local.packagesDataDir, test.ShouldEqual, filepath.Join(local.packagesDir, "data"))
+	_, err = os.Stat(local.packagesDir)
+	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+}
+
+func TestEnsureLocalPackageDirs(t *testing.T) {
+	tmp := t.TempDir()
+	packagesDir := filepath.Join(tmp, "packages-local")
+	packagesDataDir := filepath.Join(packagesDir, "data")
+	test.That(t, ensureLocalPackageDirs(packagesDir, packagesDataDir), test.ShouldBeNil)
+	for _, dir := range []string{packagesDir, packagesDataDir} {
 		info, err := os.Stat(dir)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, info.IsDir(), test.ShouldBeTrue)
 	}
-	test.That(t, local.packagesDir, test.ShouldEqual, LocalPackagesDir(packagesParent))
-	test.That(t, local.packagesDataDir, test.ShouldEqual, filepath.Join(local.packagesDir, "data"))
 }
 
 // writeSingleFileTarGz writes a .tar.gz holding one regular file of the given size into a temp


### PR DESCRIPTION
I found a regression where using local hot reloading was not working because the RDK previously made the directory on startup. I think its still best to create the directory on startup than having the CLI create the directory through the shell service.

Example of the bug
```
(base) michaellee@ROBOT-MYHLX2FTJN python-reload-example % viam module reload-local --no-build --part-id f7805b66-39ef-45b4-9494-74200ea879e9
Info: Using "https://app.viam.dev/" as base URL value
 …  Reloading to part...
 ✓     → Shell service already exists (0s)                                                                                                                                                           
 ⠏     → Uploading package... (12s)
 ✗       → Attempt 1/6...: rpc error: code = NotFound desc = destination "/root/.viam/packages-local/michaellee1019_python-reload-example-dist-archive.tar.gz": stat /root/.viam/packages-local: no such file or directory
 ✗       → Attempt 2/6...: rpc error: code = NotFound desc = destination "/root/.viam/packages-local/michaellee1019_python-reload-example-dist-archive.tar.gz": stat /root/.viam/packages-local: no such file or directory
 ⠼       → Attempt 3/6... (3s)^C
```