### PR TITLE
Add --file to module reload-local to upload a tarball without build.path in meta.json

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -106,6 +106,7 @@ const (
 	moduleFlagAppType         = "app-type"
 	moduleFlagUpload          = "upload"
 	moduleFlagAnnotation      = "annotation"
+	moduleFlagFile            = "file"
 
 	moduleBuildFlagRef         = "ref"
 	moduleBuildFlagWait        = "wait"
@@ -4075,7 +4076,10 @@ This won't work unless you have an existing installation of our GitHub app on yo
 	viam module reload-local --model-name acme:module-name:mybase --name my-resource
 
 	# Build and configure a module running on your local machine without shipping a tarball.
-	viam module reload-local --local`,
+	viam module reload-local --local
+
+	# Upload an already-built tarball without requiring build.path in meta.json.
+	viam module reload-local --file module.tar.gz --part-id UUID`,
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:        generalFlagPartID,
@@ -4098,6 +4102,11 @@ This won't work unless you have an existing installation of our GitHub app on yo
 						&cli.BoolFlag{
 							Name:  moduleBuildFlagNoBuild,
 							Usage: "don't do build step",
+						},
+						&cli.StringFlag{
+							Name:      moduleFlagFile,
+							Usage:     "path to a module tarball to upload. skips the build step and does not require build.path in meta.json",
+							TakesFile: true,
 						},
 						&cli.BoolFlag{
 							Name:  moduleFlagLocal,

--- a/cli/app.go
+++ b/cli/app.go
@@ -4105,7 +4105,7 @@ This won't work unless you have an existing installation of our GitHub app on yo
 						},
 						&cli.StringFlag{
 							Name:      moduleFlagFile,
-							Usage:     "path to a module tarball to upload. skips the build step and does not require build.path in meta.json",
+							Usage:     "path to a module tarball to upload. implies --no-build and does not require build.path in meta.json",
 							TakesFile: true,
 						},
 						&cli.BoolFlag{

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -1821,6 +1821,7 @@ func reloadingDestination(cmd *cli.Command, manifest *ModuleManifest) string {
 // It also logs warnings for likely problems, such as a missing meta.json or a first_run script
 // declared in the manifest but absent from the archive.
 func validateReloadableArchive(cmd *cli.Command, archivePath, firstRun string) error {
+	//nolint:gosec // archivePath is a user-provided path from meta.json build.path or --file
 	reader, err := os.Open(archivePath)
 	if err != nil {
 		return errors.Wrap(err, "error opening module archive")

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -753,7 +753,7 @@ type reloadModuleArgs struct {
 	Annotation   string
 	Builder      string
 	// File is an optional path to a module tarball to upload (reload-local only).
-	// When set, skips the build step and does not require build.path in meta.json.
+	// When set, implies NoBuild and does not require build.path in meta.json.
 	File string
 }
 
@@ -1592,6 +1592,10 @@ func reloadModuleActionInner(
 		printf(cmd.Root().ErrWriter, "Reloading to the machine configured at %s", args.CloudConfig)
 	}
 
+	if args.File != "" {
+		args.NoBuild = true
+	}
+
 	var needsRestart bool
 	var buildPath string
 	var buildInfo *moduleCloudBuildInfo
@@ -1605,7 +1609,7 @@ func reloadModuleActionInner(
 			return errors.New("--file cannot be used with --local (nothing to upload)")
 		}
 		if manifest == nil {
-			return fmt.Errorf(`manifest not found at "%s". manifest required for reload`, moduleFlagPath)
+			return fmt.Errorf(`manifest not found at "%s". manifest required for reload`, args.Module)
 		}
 		buildPath = args.File
 		if manifest.Build == nil {
@@ -1616,7 +1620,7 @@ func reloadModuleActionInner(
 		manifest.Build.Path = filepath.Base(args.File)
 	case !args.NoBuild:
 		if manifest == nil {
-			return fmt.Errorf(`manifest not found at "%s". manifest required for build`, moduleFlagPath)
+			return fmt.Errorf(`manifest not found at "%s". manifest required for build`, args.Module)
 		}
 		if manifest.Build == nil || manifest.Build.Build == "" {
 			return errors.New("your meta.json cannot have an empty build step. It is required for 'reload' and 'reload-local' commands")
@@ -1649,7 +1653,7 @@ func reloadModuleActionInner(
 	default:
 		// --no-build flag is set, look for existing artifact (only for reload-local)
 		if manifest == nil || manifest.Build == nil {
-			return fmt.Errorf(`manifest not found at "%s". manifest required for reload`, moduleFlagPath)
+			return fmt.Errorf(`manifest not found at "%s". manifest required for reload`, args.Module)
 		}
 		buildPath = manifest.Build.Path
 	}

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -1824,16 +1824,26 @@ func reloadingDestination(cmd *cli.Command, manifest *ModuleManifest) string {
 // validateReloadableArchive returns an error if there is a fatal issue (for now just file not found).
 // It also logs warnings for likely problems, such as a missing meta.json or a first_run script
 // declared in the manifest but absent from the archive.
-func validateReloadableArchive(cmd *cli.Command, archivePath, firstRun string) error {
+func validateReloadableArchive(cmd *cli.Command, archivePath, firstRun string) (err error) {
 	//nolint:gosec // archivePath is a user-provided path from meta.json build.path or --file
 	reader, err := os.Open(archivePath)
 	if err != nil {
 		return errors.Wrap(err, "error opening module archive")
 	}
+	defer func() {
+		if closeErr := reader.Close(); closeErr != nil {
+			err = multierr.Append(err, errors.Wrap(closeErr, "failed to close module archive"))
+		}
+	}()
 	decompressed, err := gzip.NewReader(reader)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if closeErr := decompressed.Close(); closeErr != nil {
+			err = multierr.Append(err, errors.Wrap(closeErr, "failed to close gzip reader"))
+		}
+	}()
 	archive := tar.NewReader(decompressed)
 	metaFound := false
 	firstRunFound := false

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -752,6 +752,9 @@ type reloadModuleArgs struct {
 	Path         string
 	Annotation   string
 	Builder      string
+	// File is an optional path to a module tarball to upload (reload-local only).
+	// When set, skips the build step and does not require build.path in meta.json.
+	File string
 }
 
 func (c *viamClient) createGitArchive(repoPath string) (string, error) {
@@ -1592,7 +1595,26 @@ func reloadModuleActionInner(
 	var needsRestart bool
 	var buildPath string
 	var buildInfo *moduleCloudBuildInfo
-	if !args.NoBuild {
+	switch {
+	case args.File != "":
+		// --file provides the tarball to upload; skip building and do not require build.path.
+		if cloudBuild {
+			return errors.New("--file is only supported with 'reload-local'")
+		}
+		if args.Local {
+			return errors.New("--file cannot be used with --local (nothing to upload)")
+		}
+		if manifest == nil {
+			return fmt.Errorf(`manifest not found at "%s". manifest required for reload`, moduleFlagPath)
+		}
+		buildPath = args.File
+		if manifest.Build == nil {
+			manifest.Build = &manifestBuildInfo{}
+		}
+		// Destination and reload_path on the robot use this basename; the upload
+		// source remains the full path in buildPath.
+		manifest.Build.Path = filepath.Base(args.File)
+	case !args.NoBuild:
 		if manifest == nil {
 			return fmt.Errorf(`manifest not found at "%s". manifest required for build`, moduleFlagPath)
 		}
@@ -1624,7 +1646,7 @@ func reloadModuleActionInner(
 		if err != nil {
 			return err
 		}
-	} else {
+	default:
 		// --no-build flag is set, look for existing artifact (only for reload-local)
 		if manifest == nil || manifest.Build == nil {
 			return fmt.Errorf(`manifest not found at "%s". manifest required for reload`, moduleFlagPath)
@@ -1642,10 +1664,10 @@ func reloadModuleActionInner(
 		if manifest == nil || manifest.Build == nil || buildPath == "" {
 			return errors.New(
 				"remote reloading requires a meta.json with the 'build.path' field set. " +
-					"try --local if you are testing on the same machine.",
+					"try --local if you are testing on the same machine, or pass --file with a tarball.",
 			)
 		}
-		if err := validateReloadableArchive(cmd, manifest.Build, manifest.FirstRun); err != nil {
+		if err := validateReloadableArchive(cmd, buildPath, manifest.FirstRun); err != nil {
 			return err
 		}
 
@@ -1798,10 +1820,10 @@ func reloadingDestination(cmd *cli.Command, manifest *ModuleManifest) string {
 // validateReloadableArchive returns an error if there is a fatal issue (for now just file not found).
 // It also logs warnings for likely problems, such as a missing meta.json or a first_run script
 // declared in the manifest but absent from the archive.
-func validateReloadableArchive(cmd *cli.Command, build *manifestBuildInfo, firstRun string) error {
-	reader, err := os.Open(build.Path)
+func validateReloadableArchive(cmd *cli.Command, archivePath, firstRun string) error {
+	reader, err := os.Open(archivePath)
 	if err != nil {
-		return errors.Wrap(err, "error opening the build.path field in your meta.json")
+		return errors.Wrap(err, "error opening module archive")
 	}
 	decompressed, err := gzip.NewReader(reader)
 	if err != nil {
@@ -1816,7 +1838,7 @@ func validateReloadableArchive(cmd *cli.Command, build *manifestBuildInfo, first
 			break
 		}
 		if err != nil {
-			return errors.Wrapf(err, "reading tar at %s", build.Path)
+			return errors.Wrapf(err, "reading tar at %s", archivePath)
 		}
 		name := filepath.Base(header.Name)
 		if name == "meta.json" {
@@ -1830,13 +1852,13 @@ func validateReloadableArchive(cmd *cli.Command, build *manifestBuildInfo, first
 		}
 	}
 	if !metaFound {
-		warningf(cmd.Root().ErrWriter, "archive at %s doesn't contain a meta.json, your module will probably fail to start", build.Path)
+		warningf(cmd.Root().ErrWriter, "archive at %s doesn't contain a meta.json, your module will probably fail to start", archivePath)
 	}
 	if firstRun != "" && !firstRunFound {
 		warningf(cmd.Root().ErrWriter,
 			"archive at %s doesn't contain the first_run script %q declared in meta.json; "+
 				"the script will not run on the target machine. Include it in your build artifact",
-			build.Path, firstRun)
+			archivePath, firstRun)
 	}
 	return nil
 }

--- a/cli/module_reload_test.go
+++ b/cli/module_reload_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -709,6 +711,114 @@ func TestReloadWithMissingBuildSection(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "manifest required for reload")
 	})
+
+	t.Run("reload-local with --file bypasses missing build section", func(t *testing.T) {
+		manifestPath := createTestManifest(t, "", map[string]any{
+			"build": nil,
+		})
+
+		// Point at a missing archive so we fail at open (after build.path checks), not on shell upload.
+		archivePath := filepath.Join(t.TempDir(), "custom-module.tar.gz")
+
+		confStruct, err := structpb.NewStruct(map[string]any{
+			"modules": []any{},
+		})
+		test.That(t, err, test.ShouldBeNil)
+
+		userInfo, err := structpb.NewStruct(map[string]any{
+			"version":  "0.90.0",
+			"platform": "linux/amd64",
+		})
+		test.That(t, err, test.ShouldBeNil)
+
+		cCtx, vc, _, _ := setup(
+			mockFullAppServiceClient(confStruct, userInfo, nil),
+			nil,
+			&inject.BuildServiceClient{},
+			map[string]any{
+				moduleFlagPath:        manifestPath,
+				generalFlagPartID:     "part-123",
+				moduleFlagFile:        archivePath,
+				generalFlagNoProgress: true,
+			},
+			"token",
+		)
+
+		err = reloadModuleActionInner(context.Background(), cCtx, vc, parseStructFromCtx[reloadModuleArgs](cCtx), logger, false)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "error opening module archive")
+		test.That(t, err.Error(), test.ShouldNotContainSubstring, "empty build step")
+		test.That(t, err.Error(), test.ShouldNotContainSubstring, "build.path")
+		test.That(t, err.Error(), test.ShouldNotContainSubstring, "manifest required for reload")
+	})
+
+	t.Run("reload-local with --file and --local errors", func(t *testing.T) {
+		manifestPath := createTestManifest(t, "", map[string]any{
+			"build": nil,
+		})
+
+		confStruct, err := structpb.NewStruct(map[string]any{
+			"modules": []any{},
+		})
+		test.That(t, err, test.ShouldBeNil)
+
+		userInfo, err := structpb.NewStruct(map[string]any{
+			"version":  "0.90.0",
+			"platform": "linux/amd64",
+		})
+		test.That(t, err, test.ShouldBeNil)
+
+		cCtx, vc, _, _ := setup(
+			mockFullAppServiceClient(confStruct, userInfo, nil),
+			nil,
+			&inject.BuildServiceClient{},
+			map[string]any{
+				moduleFlagPath:        manifestPath,
+				generalFlagPartID:     "part-123",
+				moduleFlagFile:        "module.tar.gz",
+				moduleFlagLocal:       true,
+				generalFlagNoProgress: true,
+			},
+			"token",
+		)
+
+		err = reloadModuleActionInner(context.Background(), cCtx, vc, parseStructFromCtx[reloadModuleArgs](cCtx), logger, false)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "--file cannot be used with --local")
+	})
+}
+
+func TestValidateReloadableArchiveWithFile(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "custom-module.tar.gz")
+	createTestModuleArchive(t, archivePath)
+
+	cCtx := newTestContext(t, map[string]any{})
+	err := validateReloadableArchive(cCtx, archivePath, "")
+	test.That(t, err, test.ShouldBeNil)
+}
+
+// createTestModuleArchive writes a minimal valid module.tar.gz containing a meta.json.
+func createTestModuleArchive(t *testing.T, path string) {
+	t.Helper()
+	f, err := os.Create(path)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() { test.That(t, f.Close(), test.ShouldBeNil) }()
+
+	gz := gzip.NewWriter(f)
+	defer func() { test.That(t, gz.Close(), test.ShouldBeNil) }()
+
+	tw := tar.NewWriter(gz)
+	defer func() { test.That(t, tw.Close(), test.ShouldBeNil) }()
+
+	content := []byte(`{"module_id":"test:test","entrypoint":"bin/module"}`)
+	err = tw.WriteHeader(&tar.Header{
+		Name: "meta.json",
+		Mode: 0o644,
+		Size: int64(len(content)),
+	})
+	test.That(t, err, test.ShouldBeNil)
+	_, err = tw.Write(content)
+	test.That(t, err, test.ShouldBeNil)
 }
 
 func TestUpdateRobotPartPassesLastKnownUpdate(t *testing.T) {


### PR DESCRIPTION
This functionality is useful for custom build scripts in modules to specify the exact location of a module archive, since some repositories make the meta.json during a build.

Tested with a local build of the CLI:

```
(base) michaellee@ROBOT-MYHLX2FTJN python-reload-example % viam module reload-local --no-build --part-id f7805b66-39ef-45b4-9494-74200ea879e9 --file dist/archive.tar.gz 
Info: Using "https://app.viam.dev/" as base URL value
 …  Reloading to part...
 ✓     → Shell service already exists (0s)                                                                                                                                                           
 ✓     → Package uploaded (9s)                                                                                                                                                                       
 ✓     → Module added to part (0s)                                                                                                                                                                   
 ✓  Reloaded to part (9s)
```