### PR TITLE
reconnect on appropriate error type

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -4131,13 +4131,6 @@ func (c *viamClient) robotPartTunnel(ctx context.Context, cmd *cli.Command, args
 		return err
 	}
 
-	// Reconnect using global context, because the client may have reconnected
-	// using a shorter context when updating the network config
-	err = robotClient.Connect(ctx)
-	if err != nil {
-		return err
-	}
-
 	return tunnelTraffic(ctx, cmd, robotClient, args.LocalPort, args.DestinationPort)
 }
 
@@ -4156,22 +4149,7 @@ type tunnelLister interface {
 func tunnelPortAllowed(ctx context.Context, lister tunnelLister, dest int) (allowed, known bool) {
 	tunnels, err := lister.ListTunnels(ctx)
 	if err != nil {
-		if strings.Contains(err.Error(), client.ErrNotConnectedPrefix) {
-			// If the error is specifically a not connected error,
-			// that likely means the machine is updating after
-			// the network config change. So, try to reconnect
-			// and list tunnels ONCE more from this attempt.
-			err = lister.Connect(ctx)
-			if err != nil {
-				return false, false
-			}
-			tunnels, err = lister.ListTunnels(ctx)
-			if err != nil {
-				return false, false
-			}
-		} else {
-			return false, false
-		}
+		return false, false
 	}
 	for _, t := range tunnels {
 		if t.Port == dest {
@@ -4254,8 +4232,14 @@ func (c *viamClient) ensureTunnelPortAllowed(
 	timeoutCtx, cancel := context.WithTimeout(ctx, tunnelConfigTimeout)
 	defer cancel()
 	for {
-		if allowed, _ := tunnelPortAllowed(timeoutCtx, lister, dest); allowed {
+		allowed, known := tunnelPortAllowed(timeoutCtx, lister, dest)
+		if allowed {
 			return nil
+		}
+		if !known {
+			// If we couldn't read the tunnel list, viam-server may have restarted due
+			// the network config change and we may need to reconnect before retrying.
+			lister.Connect(ctx) //nolint: errcheck
 		}
 		select {
 		case <-timeoutCtx.Done():

--- a/cli/client.go
+++ b/cli/client.go
@@ -4131,6 +4131,13 @@ func (c *viamClient) robotPartTunnel(ctx context.Context, cmd *cli.Command, args
 		return err
 	}
 
+	// Reconnect using global context, because the client may have reconnected
+	// using a shorter context when updating the network config
+	err = robotClient.Connect(ctx)
+	if err != nil {
+		return err
+	}
+
 	return tunnelTraffic(ctx, cmd, robotClient, args.LocalPort, args.DestinationPort)
 }
 
@@ -4139,6 +4146,7 @@ func (c *viamClient) robotPartTunnel(ctx context.Context, cmd *cli.Command, args
 // flow can be tested without a live machine.
 type tunnelLister interface {
 	ListTunnels(ctx context.Context) ([]rconfig.TrafficTunnelEndpoint, error)
+	Connect(ctx context.Context) error
 }
 
 // tunnelPortAllowed reports whether the given destination port is present in the
@@ -4148,7 +4156,22 @@ type tunnelLister interface {
 func tunnelPortAllowed(ctx context.Context, lister tunnelLister, dest int) (allowed, known bool) {
 	tunnels, err := lister.ListTunnels(ctx)
 	if err != nil {
-		return false, false
+		if strings.Contains(err.Error(), client.ErrNotConnectedPrefix) {
+			// If the error is specifically a not connected error,
+			// that likely means the machine is updating after
+			// the network config change. So, try to reconnect
+			// and list tunnels ONCE more from this attempt.
+			err = lister.Connect(ctx)
+			if err != nil {
+				return false, false
+			}
+			tunnels, err = lister.ListTunnels(ctx)
+			if err != nil {
+				return false, false
+			}
+		} else {
+			return false, false
+		}
 	}
 	for _, t := range tunnels {
 		if t.Port == dest {

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1754,6 +1754,11 @@ func (f *fakeTunnelLister) ListTunnels(ctx context.Context) ([]robotconfig.Traff
 	return out, nil
 }
 
+func (f *fakeTunnelLister) Connect(ctx context.Context) error {
+	// This is a no-op
+	return nil
+}
+
 func TestEnsureTunnelPortAllowed(t *testing.T) {
 	const (
 		partID       = "part-id"

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -202,13 +202,8 @@ func isDisconnectedError(err error) bool {
 		strings.Contains(err.Error(), io.ErrClosedPipe.Error())
 }
 
-// ErrNotConnectedPrefix is the string prefix for the error arising from not being
-// connected to the robot. The full error will include this prefix,
-// along with the remote address appended.
-const ErrNotConnectedPrefix = "not connected to remote robot at"
-
 func (rc *RobotClient) notConnectedToRemoteError() error {
-	return fmt.Errorf("%s %s", ErrNotConnectedPrefix, rc.address)
+	return fmt.Errorf("not connected to remote robot at %s", rc.address)
 }
 
 func isResourceExhaustedError(err error) bool {

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -202,8 +202,13 @@ func isDisconnectedError(err error) bool {
 		strings.Contains(err.Error(), io.ErrClosedPipe.Error())
 }
 
+// ErrNotConnectedPrefix is the string prefix for the error arising from not being
+// connected to the robot. The full error will include this prefix,
+// along with the remote address appended.
+const ErrNotConnectedPrefix = "not connected to remote robot at"
+
 func (rc *RobotClient) notConnectedToRemoteError() error {
-	return fmt.Errorf("not connected to remote robot at %s", rc.address)
+	return fmt.Errorf("%s %s", ErrNotConnectedPrefix, rc.address)
 }
 
 func isResourceExhaustedError(err error) bool {


### PR DESCRIPTION
Right now, if you try to tunnel and the port is not in your config, the cli will try to add it if you have the appropriate credentials.

however, after adding the tunnel port, the client may lose connection to the machine as it applies the new config. 

So this PR will attempt to reconnect on those instances where a disconnect is detected. Disconnect is detected by comparing the error string `rpc error: code = Unavailable desc = not connected to remote robot at <REMOTE_HOST>`, which has been extracted to a constant.