### PR TITLE
[APP-17425] Remove artificial log count limits from the CLI

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -2726,7 +2726,7 @@ Note: There is no progress meter while copying is in progress.
 						&cli.StringFlag{
 							Name:        generalFlagStart,
 							Usage:       "ISO-8601 timestamp in RFC3339 format indicating the start of the interval filter (e.g., 2025-01-15T14:00:00Z)",
-							DefaultText: "12 hours ago",
+							DefaultText: "24 hours ago",
 						},
 						&cli.StringFlag{
 							Name:  generalFlagEnd,
@@ -2734,8 +2734,8 @@ Note: There is no progress meter while copying is in progress.
 						},
 						&cli.IntFlag{
 							Name:        generalFlagCount,
-							Usage:       fmt.Sprintf("number of logs to fetch (max %v)", maxNumLogs),
-							DefaultText: fmt.Sprintf("%v", defaultNumLogs),
+							Usage:       "maximum number of logs to fetch",
+							DefaultText: "all logs in the time range",
 						},
 					},
 					Action: createActionCommandWithT[robotsLogsArgs](RobotsLogsAction),
@@ -2908,7 +2908,7 @@ Note: There is no progress meter while copying is in progress.
 								&cli.StringFlag{
 									Name:        generalFlagStart,
 									Usage:       "ISO-8601 timestamp in RFC3339 format indicating the start of the interval filter (e.g., 2025-01-15T14:00:00Z)",
-									DefaultText: "12 hours ago",
+									DefaultText: "24 hours ago",
 								},
 								&cli.StringFlag{
 									Name:  generalFlagEnd,
@@ -2916,8 +2916,8 @@ Note: There is no progress meter while copying is in progress.
 								},
 								&cli.IntFlag{
 									Name:        generalFlagCount,
-									Usage:       fmt.Sprintf("number of logs to fetch (max %v)", maxNumLogs),
-									DefaultText: fmt.Sprintf("%v", defaultNumLogs),
+									Usage:       "maximum number of logs to fetch",
+									DefaultText: "all logs in the time range",
 								},
 							},
 							Action: createActionCommandWithT[robotsPartLogsArgs](RobotsPartLogsAction),

--- a/cli/client.go
+++ b/cli/client.go
@@ -70,21 +70,10 @@ import (
 const (
 	rdkReleaseURL = "https://api.github.com/repos/viamrobotics/rdk/releases/latest"
 	osWindows     = "windows"
-	// defaultNumLogs is the same as the number of logs currently returned by app
-	// in a single GetRobotPartLogsResponse.
-	defaultNumLogs = 100
-	// maxNumLogs is an arbitrary limit used to stop CLI users from overwhelming
-	// our logs DB with heavy reads.
-	maxNumLogs = 10000
 	// logoMaxSize is the maximum size of a logo in bytes.
 	logoMaxSize = 1024 * 200 // 200 KB
-	// defaultLogStartTime is set to the last 12 hours,
-	// logs older than 24 hours are stored in the online archive.
-	//
-	// 12 hours is a temporary decrease from the matching 24 hour window to
-	// avoid an edge case where network latency always triggers an online
-	// archive query and causes a "resource usage limit exceeded" error.
-	defaultLogStartTime = -12 * time.Hour
+	// defaultLogStartTime is set to the last 24 hours.
+	defaultLogStartTime = -24 * time.Hour
 	// yellow is the format string used to output warnings in yellow color.
 	yellow = "\033[1;33m%s\033[0m"
 )
@@ -1044,20 +1033,6 @@ func RobotsStatusAction(ctx context.Context, cmd *cli.Command, args robotsStatus
 	return nil
 }
 
-func getNumLogs(cmd *cli.Command, numLogs int) (int, error) {
-	if numLogs < 0 {
-		warningf(cmd.Root().ErrWriter, "Provided negative %q value. Defaulting to %d", generalFlagCount, defaultNumLogs)
-		return defaultNumLogs, nil
-	}
-	if numLogs == 0 {
-		return defaultNumLogs, nil
-	}
-	if numLogs > maxNumLogs {
-		return 0, errors.Errorf("provided too high of a %q value. Maximum is %d", generalFlagCount, maxNumLogs)
-	}
-	return numLogs, nil
-}
-
 type robotsLogsArgs struct {
 	Organization string
 	Location     string
@@ -1078,6 +1053,14 @@ func RobotsLogsAction(ctx context.Context, cmd *cli.Command, args robotsLogsArgs
 		return err
 	}
 
+	return client.robotsLogsAction(ctx, cmd, args)
+}
+
+func (c *viamClient) robotsLogsAction(ctx context.Context, cmd *cli.Command, args robotsLogsArgs) error {
+	if args.Count < 0 {
+		return errors.Errorf("%q cannot be negative", generalFlagCount)
+	}
+
 	// Check if both start time and count are provided
 	// TODO: [APP-7415] Enhance LogsForPart API to Support Sorting Options for Log Display Order
 	// TODO: [APP-7450] Implement "Start Time with Count without End Time" Functionality in LogsForPart
@@ -1093,7 +1076,7 @@ func RobotsLogsAction(ctx context.Context, cmd *cli.Command, args robotsLogsArgs
 	orgStr := args.Organization
 	locStr := args.Location
 	robotStr := args.Machine
-	robot, err := client.robot(ctx, orgStr, locStr, robotStr)
+	robot, err := c.robot(ctx, orgStr, locStr, robotStr)
 	if err != nil {
 		return errors.Wrap(err, "could not get machine")
 	}
@@ -1101,7 +1084,7 @@ func RobotsLogsAction(ctx context.Context, cmd *cli.Command, args robotsLogsArgs
 	// TODO(RSDK-9727) - this is a little inefficient insofar as a `robot` is created immediately
 	// above and then also again within this `robotParts` call. Might be nice to have a helper
 	// API for getting parts when we already have a `Robot`
-	parts, err := client.robotParts(ctx, orgStr, locStr, robotStr)
+	parts, err := c.robotParts(ctx, orgStr, locStr, robotStr)
 	if err != nil {
 		return errors.Wrap(err, "could not get machine parts")
 	}
@@ -1121,7 +1104,7 @@ func RobotsLogsAction(ctx context.Context, cmd *cli.Command, args robotsLogsArgs
 		writer = cmd.Root().Writer
 	}
 
-	return client.fetchAndSaveLogs(ctx, robot, parts, args, writer)
+	return c.fetchAndSaveLogs(ctx, robot, parts, args, writer)
 }
 
 // fetchLogs fetches logs for all parts and writes them to the provided writer.
@@ -1155,11 +1138,6 @@ func (c *viamClient) fetchAndSaveLogs(
 
 // streamLogsForPart streams logs for a specific part directly to a file.
 func (c *viamClient) streamLogsForPart(ctx context.Context, part *apppb.RobotPart, args robotsLogsArgs, writer io.Writer) error {
-	maxLogsToFetch, err := getNumLogs(c.c, args.Count)
-	if err != nil {
-		return err
-	}
-
 	if args.Start == "" {
 		args.Start = time.Now().Add(defaultLogStartTime).UTC().Format(time.RFC3339)
 	}
@@ -1179,12 +1157,9 @@ func (c *viamClient) streamLogsForPart(ctx context.Context, part *apppb.RobotPar
 	var pageToken string
 
 	// Fetch logs in batches and write them to the output.
-	for fetchedLogCount := 0; fetchedLogCount < maxLogsToFetch; {
-		// We do not request the exact limit specified by the user in the `count` argument because the API enforces a maximum
-		// limit of 100 logs per batch fetch. To keep the RDK independent of specific limits imposed by the app API,
-		// we always request the next full batch of logs as allowed by the API (currently 100). This approach
-		// ensures that if the API limit changes in the future, only the app API logic needs to be updated without requiring
-		// changes in the RDK.
+	for fetchedLogCount := 0; ; {
+		// We never request a specific limit: app caps a single response at its own batch size, so
+		// asking for the full batch each time keeps the RDK independent of whatever that cap is.
 		resp, err := c.client.GetRobotPartLogs(ctx, &apppb.GetRobotPartLogsRequest{
 			Id:        part.Id,
 			Filter:    keyword,
@@ -1202,17 +1177,12 @@ func (c *viamClient) streamLogsForPart(ctx context.Context, part *apppb.RobotPar
 			break
 		}
 
-		// The API may return more logs than the user requested via the `count` argument.
-		// This is because the API uses pagination internally and fetches logs in batches.
-		// To ensure we do not append more logs than the user requested, we calculate the
-		// `remainingLogsNeeded` by subtracting the logs we have already fetched (`logsFetched`)
-		// from the total number of logs the user asked for (`numLogs`).
-		// If the current batch contains more logs than the remaining needed, we truncate the
-		// batch to include only the necessary number of logs.
-		// This ensures the output strictly adheres to the `count` limit specified by the user.
-		remainingLogsNeeded := maxLogsToFetch - fetchedLogCount
-		if remainingLogsNeeded < len(resp.Logs) {
-			resp.Logs = resp.Logs[:remainingLogsNeeded]
+		// A batch can overshoot the user's `--count`, since batch size is app's choice, not ours.
+		// Truncate the logs for the final response if this happens.
+		if args.Count > 0 {
+			if remainingLogsNeeded := args.Count - fetchedLogCount; remainingLogsNeeded < len(resp.Logs) {
+				resp.Logs = resp.Logs[:remainingLogsNeeded]
+			}
 		}
 
 		for _, log := range resp.Logs {
@@ -1227,6 +1197,10 @@ func (c *viamClient) streamLogsForPart(ctx context.Context, part *apppb.RobotPar
 		}
 
 		fetchedLogCount += len(resp.Logs)
+
+		if args.Count > 0 && fetchedLogCount >= args.Count {
+			break
+		}
 
 		// End of pagination if there is no next page token.
 		if pageToken = resp.NextPageToken; pageToken == "" {
@@ -3404,6 +3378,10 @@ func RobotsPartLogsAction(ctx context.Context, cmd *cli.Command, args robotsPart
 }
 
 func (c *viamClient) robotsPartLogsAction(ctx context.Context, cmd *cli.Command, args robotsPartLogsArgs) error {
+	if args.Count < 0 {
+		return errors.Errorf("%q cannot be negative", generalFlagCount)
+	}
+
 	// Check if both start time and count are provided
 	// TODO: [APP-7415] Enhance LogsForPart API to Support Sorting Options for Log Display Order
 	// TODO: [APP-7450] Implement "Start Time with Count without End Time" Functionality in LogsForPart
@@ -3458,16 +3436,12 @@ func (c *viamClient) robotsPartLogsAction(ctx context.Context, cmd *cli.Command,
 			header,
 		)
 	}
-	numLogs, err := getNumLogs(cmd, args.Count)
-	if err != nil {
-		return err
-	}
 	return c.printRobotPartLogs(
 		ctx, orgStr, locStr, robotStr, partStr,
 		args.Errors,
 		"",
 		header,
-		numLogs,
+		args.Count,
 		startTime, endTime,
 	)
 }
@@ -5218,11 +5192,11 @@ func (c *viamClient) robotPartLogs(ctx context.Context, orgStr, locStr, robotStr
 		return nil, err
 	}
 
-	// Use page tokens to get batches of 100 up to numLogs and throw away any
-	// extra logs in last batch.
-	logs := make([]*commonpb.LogEntry, 0, numLogs)
+	// Page through logs until exhausted, or until numLogs is reached when the user capped it.
+	// `numLogs` is unvalidated user input, so let append grow rather than preallocating from it.
+	var logs []*commonpb.LogEntry
 	var pageToken string
-	for i := 0; i < numLogs; {
+	for {
 		resp, err := c.client.GetRobotPartLogs(ctx, &apppb.GetRobotPartLogsRequest{
 			Id:         part.Id,
 			ErrorsOnly: errorsOnly,
@@ -5234,22 +5208,27 @@ func (c *viamClient) robotPartLogs(ctx context.Context, orgStr, locStr, robotStr
 			return nil, err
 		}
 
-		pageToken = resp.NextPageToken
-		// Break in the event of no logs in GetRobotPartLogsResponse or when
-		// page token is empty (no more pages).
-		if resp.Logs == nil || pageToken == "" {
+		if len(resp.Logs) == 0 {
 			break
 		}
 
 		// Truncate this intermediate slice of resp.Logs based on how many logs
 		// are still required by numLogs.
-		remainingLogsNeeded := numLogs - i
-		if remainingLogsNeeded < len(resp.Logs) {
-			resp.Logs = resp.Logs[:remainingLogsNeeded]
+		if numLogs > 0 {
+			if remainingLogsNeeded := numLogs - len(logs); remainingLogsNeeded < len(resp.Logs) {
+				resp.Logs = resp.Logs[:remainingLogsNeeded]
+			}
 		}
 		logs = append(logs, resp.Logs...)
 
-		i += len(resp.Logs)
+		if numLogs > 0 && len(logs) >= numLogs {
+			break
+		}
+
+		// End of pagination if there is no next page token.
+		if pageToken = resp.NextPageToken; pageToken == "" {
+			break
+		}
 	}
 
 	return logs, nil

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -728,9 +729,11 @@ func TestLogEntryFieldsToString(t *testing.T) {
 }
 
 func TestGetRobotPartLogs(t *testing.T) {
+	const testTotalLogs = 10000
+
 	// Create fake logs of "0"->"9999".
-	logs := make([]*commonpb.LogEntry, 0, maxNumLogs)
-	for i := 0; i < maxNumLogs; i++ {
+	logs := make([]*commonpb.LogEntry, 0, testTotalLogs)
+	for i := 0; i < testTotalLogs; i++ {
 		logs = append(logs, &commonpb.LogEntry{Message: fmt.Sprintf("%d", i)})
 	}
 
@@ -745,9 +748,16 @@ func TestGetRobotPartLogs(t *testing.T) {
 			pt, err = strconv.Atoi(*receivedPt)
 			test.That(t, err, test.ShouldBeNil)
 		}
-		resp := &apppb.GetRobotPartLogsResponse{
-			Logs:          logs[(pt-1)*100 : pt*100],
-			NextPageToken: fmt.Sprintf("%d", pt+1),
+		batchStart := (pt - 1) * 100
+		if batchStart >= testTotalLogs {
+			return &apppb.GetRobotPartLogsResponse{}, nil
+		}
+		batchEnd := min(pt*100, testTotalLogs)
+
+		resp := &apppb.GetRobotPartLogsResponse{Logs: logs[batchStart:batchEnd]}
+		// An empty next page token marks the last page, as app does when logs are exhausted.
+		if batchEnd < testTotalLogs {
+			resp.NextPageToken = fmt.Sprintf("%d", pt+1)
 		}
 		return resp, nil
 	}
@@ -801,7 +811,7 @@ func TestGetRobotPartLogs(t *testing.T) {
 		GetOrganizationsWithAccessToLocationFunc: getOrganizationsWithAccessToLocationFunc,
 	}
 
-	t.Run("no count", func(t *testing.T) {
+	t.Run("no count fetches every log", func(t *testing.T) {
 		cCtx, ac, out, errOut := setup(asc, nil, nil, nil, "")
 
 		test.That(t, ac.robotsPartLogsAction(context.Background(), cCtx, parseStructFromCtx[robotsPartLogsArgs](cCtx)), test.ShouldBeNil)
@@ -810,12 +820,12 @@ func TestGetRobotPartLogs(t *testing.T) {
 		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
 
 		// There should be a message for "organization -> location -> robot"
-		// followed by maxNumLogs messages.
-		test.That(t, len(out.messages), test.ShouldEqual, defaultNumLogs+1)
+		// followed by every log, since omitting count no longer caps the fetch.
+		test.That(t, len(out.messages), test.ShouldEqual, testTotalLogs+1)
 		test.That(t, out.messages[0], test.ShouldEqual, "jedi -> naboo -> r2d2\n")
-		// Logs should be printed in order oldest->newest ("99"->"0").
-		expectedLogNum := defaultNumLogs - 1
-		for i := 1; i <= defaultNumLogs; i++ {
+		// Logs should be printed in order oldest->newest ("9999"->"0").
+		expectedLogNum := testTotalLogs - 1
+		for i := 1; i <= testTotalLogs; i++ {
 			test.That(t, out.messages[i], test.ShouldContainSubstring,
 				fmt.Sprintf("%d", expectedLogNum))
 			expectedLogNum--
@@ -842,8 +852,8 @@ func TestGetRobotPartLogs(t *testing.T) {
 			expectedLogNum--
 		}
 	})
-	t.Run("max count", func(t *testing.T) {
-		flags := map[string]any{generalFlagCount: maxNumLogs}
+	t.Run("large count", func(t *testing.T) {
+		flags := map[string]any{generalFlagCount: testTotalLogs}
 		cCtx, ac, out, errOut := setup(asc, nil, nil, flags, "")
 
 		test.That(t, ac.robotsPartLogsAction(context.Background(), cCtx, parseStructFromCtx[robotsPartLogsArgs](cCtx)), test.ShouldBeNil)
@@ -852,48 +862,121 @@ func TestGetRobotPartLogs(t *testing.T) {
 		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
 
 		// There should be a message for "organization -> location -> robot"
-		// followed by maxNumLogs messages.
-		test.That(t, len(out.messages), test.ShouldEqual, maxNumLogs+1)
+		// followed by testTotalLogs messages.
+		test.That(t, len(out.messages), test.ShouldEqual, testTotalLogs+1)
 		test.That(t, out.messages[0], test.ShouldEqual, "jedi -> naboo -> r2d2\n")
 
 		// Logs should be printed in order oldest->newest ("9999"->"0").
-		expectedLogNum := maxNumLogs - 1
-		for i := 1; i <= maxNumLogs; i++ {
+		expectedLogNum := testTotalLogs - 1
+		for i := 1; i <= testTotalLogs; i++ {
 			test.That(t, out.messages[i], test.ShouldContainSubstring,
 				fmt.Sprintf("%d", expectedLogNum))
 			expectedLogNum--
 		}
 	})
-	t.Run("negative count", func(t *testing.T) {
+	t.Run("negative count errors before fetching", func(t *testing.T) {
 		flags := map[string]any{"count": -1}
+		cCtx, ac, out, errOut := setup(asc, nil, nil, flags, "")
+
+		err := ac.robotsPartLogsAction(context.Background(), cCtx, parseStructFromCtx[robotsPartLogsArgs](cCtx))
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, `"count" cannot be negative`)
+
+		// Validation runs before the header lookup, so nothing is emitted on either stream.
+		test.That(t, len(out.messages), test.ShouldEqual, 0)
+		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+	})
+	t.Run("count stopping mid-batch does not over-fetch", func(t *testing.T) {
+		// 250 lands mid-batch on the third page, exercising the truncation path.
+		flags := map[string]any{generalFlagCount: 250}
 		cCtx, ac, out, errOut := setup(asc, nil, nil, flags, "")
 
 		test.That(t, ac.robotsPartLogsAction(context.Background(), cCtx, parseStructFromCtx[robotsPartLogsArgs](cCtx)), test.ShouldBeNil)
 
-		// Warning should read: `Warning:\nProvided negative "count" value. Defaulting to 100`.
-		test.That(t, len(errOut.messages), test.ShouldEqual, 2)
-		test.That(t, errOut.messages[0], test.ShouldEqual, "Warning: ")
-		test.That(t, errOut.messages[1], test.ShouldContainSubstring, `Provided negative "count" value. Defaulting to 100`)
-
-		// There should be a message for "organization -> location -> robot"
-		// followed by maxNumLogs messages.
-		test.That(t, len(out.messages), test.ShouldEqual, defaultNumLogs+1)
+		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+		test.That(t, len(out.messages), test.ShouldEqual, 251)
 		test.That(t, out.messages[0], test.ShouldEqual, "jedi -> naboo -> r2d2\n")
-		// Logs should be printed in order oldest->oldest ("99"->"0").
-		expectedLogNum := defaultNumLogs - 1
-		for i := 1; i <= defaultNumLogs; i++ {
-			test.That(t, out.messages[i], test.ShouldContainSubstring,
-				fmt.Sprintf("%d", expectedLogNum))
-			expectedLogNum--
-		}
+		test.That(t, out.messages[1], test.ShouldContainSubstring, "249")
+		test.That(t, out.messages[250], test.ShouldContainSubstring, "0")
 	})
-	t.Run("count too high", func(t *testing.T) {
-		flags := map[string]any{"count": 1000000}
-		cCtx, ac, _, _ := setup(asc, nil, nil, flags, "")
+}
 
-		err := ac.robotsPartLogsAction(context.Background(), cCtx, parseStructFromCtx[robotsPartLogsArgs](cCtx))
+// TestStreamLogsForPart covers the `machines logs` fetch loop, which pages independently of the
+// `machines part logs` path exercised by TestGetRobotPartLogs.
+func TestStreamLogsForPart(t *testing.T) {
+	const testTotalLogs = 450
+
+	logs := make([]*commonpb.LogEntry, 0, testTotalLogs)
+	for i := 0; i < testTotalLogs; i++ {
+		logs = append(logs, &commonpb.LogEntry{Message: fmt.Sprintf("%d", i)})
+	}
+
+	var requests int
+	getRobotPartLogsFunc := func(ctx context.Context, in *apppb.GetRobotPartLogsRequest,
+		opts ...grpc.CallOption,
+	) (*apppb.GetRobotPartLogsResponse, error) {
+		requests++
+		pt := 1
+		if receivedPt := in.PageToken; receivedPt != nil && *receivedPt != "" {
+			var err error
+			pt, err = strconv.Atoi(*receivedPt)
+			test.That(t, err, test.ShouldBeNil)
+		}
+		batchStart := (pt - 1) * 100
+		if batchStart >= testTotalLogs {
+			return &apppb.GetRobotPartLogsResponse{}, nil
+		}
+		batchEnd := min(pt*100, testTotalLogs)
+
+		resp := &apppb.GetRobotPartLogsResponse{Logs: logs[batchStart:batchEnd]}
+		if batchEnd < testTotalLogs {
+			resp.NextPageToken = fmt.Sprintf("%d", pt+1)
+		}
+		return resp, nil
+	}
+
+	asc := &inject.AppServiceClient{GetRobotPartLogsFunc: getRobotPartLogsFunc}
+	part := &apppb.RobotPart{Id: "part-id", Name: "main"}
+
+	countLines := func(s string) int {
+		return len(strings.Split(strings.TrimSuffix(s, "\n"), "\n"))
+	}
+
+	t.Run("no count drains every page", func(t *testing.T) {
+		cCtx, ac, _, _ := setup(asc, nil, nil, nil, "")
+		requests = 0
+
+		var buf bytes.Buffer
+		args := parseStructFromCtx[robotsLogsArgs](cCtx)
+		test.That(t, ac.streamLogsForPart(context.Background(), part, args, &buf), test.ShouldBeNil)
+
+		// All logs, including the final short page, which the old page-token handling dropped.
+		test.That(t, countLines(buf.String()), test.ShouldEqual, testTotalLogs)
+		test.That(t, buf.String(), test.ShouldContainSubstring, "449")
+		test.That(t, requests, test.ShouldEqual, 5)
+	})
+	t.Run("count caps the fetch and stops paging early", func(t *testing.T) {
+		flags := map[string]any{generalFlagCount: 150}
+		cCtx, ac, _, _ := setup(asc, nil, nil, flags, "")
+		requests = 0
+
+		var buf bytes.Buffer
+		args := parseStructFromCtx[robotsLogsArgs](cCtx)
+		test.That(t, ac.streamLogsForPart(context.Background(), part, args, &buf), test.ShouldBeNil)
+
+		test.That(t, countLines(buf.String()), test.ShouldEqual, 150)
+		// Two pages are enough for 150 logs; a third request would be wasted work.
+		test.That(t, requests, test.ShouldEqual, 2)
+	})
+	t.Run("negative count errors before fetching", func(t *testing.T) {
+		flags := map[string]any{generalFlagCount: -1}
+		cCtx, ac, _, _ := setup(asc, nil, nil, flags, "")
+		requests = 0
+
+		err := ac.robotsLogsAction(context.Background(), cCtx, parseStructFromCtx[robotsLogsArgs](cCtx))
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err, test.ShouldBeError, errors.New(`provided too high of a "count" value. Maximum is 10000`))
+		test.That(t, err.Error(), test.ShouldContainSubstring, `"count" cannot be negative`)
+		test.That(t, requests, test.ShouldEqual, 0)
 	})
 }
 


### PR DESCRIPTION
https://viam.atlassian.net/browse/APP-17425

## Where this sits in the sequence

Part of the logs CLI modernization. Six changes total, bringing the CLI to parity with the redesigned logs page now that reads are moving to ClickHouse. **This PR is 1b.**

| # | Repo | Change | Ticket | PR |
|---|---|---|---|---|
| 1a | app | Page size 100 → 1000; default window 12h → 24h | APP-17245 | https://github.com/viamrobotics/app/pull/13004 |
| **1b** | **rdk** | **Remove CLI log count caps; `--count` becomes an opt-in cap** | **APP-17245** | **◀ this PR** |
| 2 | app | Logs-page export command always emits `--start`/`--end` | APP-17426 | TBD |
| 3 | api + app | Add `order` + `range` to both `GetRobotPartLogsRequest` protos | APP-17427 | TBD |
| 4 | app | ClickHouse query support for `order` + `range` | APP-17427 | TBD |
| 5 | rdk | `--order` / `--range` flags on `machines logs` | APP-17428 | TBD |
| 6 | app | Export command emits `--order=ascending` + `--range` for relative filters | APP-17429 | TBD |

Ordering: 1a, 1b, and 2 are independent and can land in any order. 3 gates everything after it — both app and rdk consume `go.viam.com/api` as a versioned module, so the proto change must land *and* be released before 4 and 5 compile. Then 4 → 5 → 6 in sequence.

**1a is the companion to this PR.** This one needs no page-size awareness: the CLI never sends `limit` and pages purely on `NextPageToken`, so the larger server pages just mean ~10× fewer round trips.

## What

Removes the artificial log count limits from `viam machines logs` and `viam machines part logs`, and moves the default lookback window to 24 hours. ClickHouse removes the query constraints these caps were built around, and the redesigned logs page expects the CLI to be able to export a whole time range.

- **Deleted `maxNumLogs = 10000`** — the hard ceiling that rejected `--count` above 10k outright.
- **Deleted `defaultNumLogs = 100`** — the silent cap applied whenever `--count` was omitted. Both commands now page until the server stops returning a `NextPageToken`. `--count` remains as an opt-in cap.
- **`defaultLogStartTime` −12h → −24h**, with `--start` help text updated on both subcommands. The 12-hour value was a workaround for a Data Federation edge case that no longer applies.
- **`--count` help** now reads "maximum number of logs to fetch", defaulting to "all logs in the time range".
- **`--count=-1`** previously warned and silently fell back to 100. It is now an error, raised at the top of each action.

## Bug fixed along the way

`robotPartLogs` assigned `pageToken = resp.NextPageToken` and broke on an empty token **before** appending that page's logs. Bounded by a count you would rarely notice; unbounded it drops the final page of every query — for a 10k-log fixture, 100 logs silently missing. It now appends first, then checks the token.

The test mock hid this: it returned a non-empty `NextPageToken` unconditionally while slicing a fixed-size fixture, so unbounded pagination would have run off the end and panicked at page 101. It now serves a real terminating page, which is also what makes the bug observable.