### PR TITLE
Make fake gantry component's length configurable

### DIFF
--- a/components/gantry/fake/gantry.go
+++ b/components/gantry/fake/gantry.go
@@ -39,17 +39,10 @@ func (conf *Config) Validate(path string) ([]string, []string, error) {
 		err = errAttrCfgPopulation
 	case conf.ModelFilePath != "":
 		_, err = referenceframe.KinematicModelFromFile(conf.ModelFilePath, "")
-	case conf.LengthMm != 0:
-		err = conf.validateLengthMm()
+	case conf.LengthMm < 0:
+		err = errors.Errorf("length_mm must be positive, got %v", conf.LengthMm)
 	}
 	return nil, nil, err
-}
-
-func (conf *Config) validateLengthMm() error {
-	if conf.LengthMm <= 0 {
-		return errors.Errorf("length_mm must be positive, got %v", conf.LengthMm)
-	}
-	return nil
 }
 
 func init() {
@@ -202,5 +195,10 @@ func modelFromLength(name string, lengthMm float64) (referenceframe.Model, error
 		return nil, errors.Errorf("embedded gantry model must have exactly one joint, got %d", len(mcfg.Joints))
 	}
 	mcfg.Joints[0].Max = lengthMm
+	patched, err := json.Marshal(mcfg)
+	if err != nil {
+		return nil, err
+	}
+	mcfg.OriginalFile = &referenceframe.ModelFile{Bytes: patched, Extension: "json"}
 	return mcfg.ParseConfig(name)
 }

--- a/components/gantry/fake/gantry.go
+++ b/components/gantry/fake/gantry.go
@@ -4,34 +4,86 @@ package fake
 import (
 	"context"
 	_ "embed"
-	"fmt"
+	"encoding/json"
+
+	"github.com/pkg/errors"
 
 	"go.viam.com/rdk/components/gantry"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/spatialmath"
-	"go.viam.com/rdk/testutils"
 )
+
+// errAttrCfgPopulation is the returned error if the Config's fields are fully populated.
+var errAttrCfgPopulation = errors.New("can only populate either model_path or length_mm - not both")
+
+// Model is the name used to refer to the fake gantry model.
+var Model = resource.DefaultModelFamily.WithModel("fake")
+
+// Config is used for converting config attributes.
+// Fake gantry is single-axis only; use model_path for a custom prismatic direction.
+type Config struct {
+	ModelFilePath string  `json:"model_path,omitempty"`
+	LengthMm      float64 `json:"length_mm,omitempty"`
+}
 
 //go:embed test_gantry_model.json
 var gantryModelJSON []byte
 
-// Config is used for converting config attributes.
-type Config struct {
-	ModelFilePath string `json:"model_path,omitempty"`
-}
-
 // Validate ensures all parts of the config are valid.
 func (conf *Config) Validate(path string) ([]string, []string, error) {
 	var err error
-	if conf.ModelFilePath != "" {
+	switch {
+	case conf.ModelFilePath != "" && conf.LengthMm != 0:
+		err = errAttrCfgPopulation
+	case conf.ModelFilePath != "":
 		_, err = referenceframe.KinematicModelFromFile(conf.ModelFilePath, "")
+	case conf.LengthMm != 0:
+		err = conf.validateLengthMm()
 	}
 	return nil, nil, err
 }
 
-func makeGantryModel(cfg resource.Config, newConf *Config) (referenceframe.Model, error) {
+func (conf *Config) validateLengthMm() error {
+	if conf.LengthMm <= 0 {
+		return errors.Errorf("length_mm must be positive, got %v", conf.LengthMm)
+	}
+	return nil
+}
+
+func init() {
+	resource.RegisterComponent(gantry.API, Model, resource.Registration[gantry.Gantry, *Config]{
+		Constructor: NewGantry,
+	})
+}
+
+// NewGantry returns a new fake gantry.
+func NewGantry(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger) (gantry.Gantry, error) {
+	newConf, err := resource.NativeConfig[*Config](conf)
+	if err != nil {
+		return nil, err
+	}
+
+	model, err := buildModel(conf, newConf)
+	if err != nil {
+		return nil, err
+	}
+	if len(model.DoF()) != 1 {
+		return nil, errors.Errorf("gantry model must have exactly one degree of freedom, got %d", len(model.DoF()))
+	}
+
+	return &Gantry{
+		Named:          conf.ResourceName().AsNamed(),
+		positionsMm:    []float64{model.DoF()[0].Max / 2},
+		speedsMmPerSec: []float64{50},
+		lengthsMm:      []float64{model.DoF()[0].Max},
+		model:          model,
+		logger:         logger,
+	}, nil
+}
+
+func buildModel(cfg resource.Config, newConf *Config) (referenceframe.Model, error) {
 	var (
 		model referenceframe.Model
 		err   error
@@ -39,57 +91,18 @@ func makeGantryModel(cfg resource.Config, newConf *Config) (referenceframe.Model
 	modelPath := newConf.ModelFilePath
 
 	switch {
+	case modelPath != "" && newConf.LengthMm != 0:
+		err = errAttrCfgPopulation
 	case modelPath != "":
 		model, err = referenceframe.KinematicModelFromFile(modelPath, cfg.Name)
+	case newConf.LengthMm != 0:
+		model, err = modelFromLength(cfg.Name, newConf.LengthMm)
 	default:
-		// if no gantry model is specified, we return a default one.
+		// if no model_path or length_mm are specified, use the embedded single-axis model
 		model, err = referenceframe.UnmarshalModelJSON(gantryModelJSON, cfg.Name)
 	}
 
-	if len(model.DoF()) != 1 {
-		return nil, fmt.Errorf("gantry model must have exactly one degree of freedom, got %d", len(model.DoF()))
-	}
-
 	return model, err
-}
-
-func init() {
-	resource.RegisterComponent(
-		gantry.API,
-		resource.DefaultModelFamily.WithModel("fake"),
-		resource.Registration[gantry.Gantry, *Config]{
-			Constructor: func(
-				ctx context.Context,
-				_ resource.Dependencies,
-				conf resource.Config,
-				logger logging.Logger,
-			) (gantry.Gantry, error) {
-				return NewGantry(conf, logger)
-			},
-		})
-}
-
-// NewGantry returns a new fake gantry.
-func NewGantry(conf resource.Config, logger logging.Logger) (gantry.Gantry, error) {
-	newConf, err := resource.NativeConfig[*Config](conf)
-	if err != nil {
-		return nil, err
-	}
-
-	m, err := makeGantryModel(conf, newConf)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Gantry{
-		testutils.NewUnimplementedResource(conf.ResourceName()),
-		resource.TriviallyCloseable{},
-		[]float64{m.DoF()[0].Max / 2},
-		[]float64{50},
-		[]float64{m.DoF()[0].Max},
-		m,
-		logger,
-	}, nil
 }
 
 // Gantry is a fake gantry that can simply read and set properties.
@@ -103,12 +116,12 @@ type Gantry struct {
 	logger         logging.Logger
 }
 
-// Position returns the position in meters.
+// Position returns the position in mm.
 func (g *Gantry) Position(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
 	return g.positionsMm, nil
 }
 
-// Lengths returns the position in meters.
+// Lengths returns the lengths of the axes of the gantry in mm.
 func (g *Gantry) Lengths(ctx context.Context, extra map[string]interface{}) ([]float64, error) {
 	return g.lengthsMm, nil
 }
@@ -119,11 +132,11 @@ func (g *Gantry) Home(ctx context.Context, extra map[string]interface{}) (bool, 
 	return true, nil
 }
 
-// MoveToPosition is in meters.
+// MoveToPosition sets the position in mm.
 func (g *Gantry) MoveToPosition(ctx context.Context, positionsMm, speedsMmPerSec []float64, extra map[string]interface{}) error {
 	for i, position := range positionsMm {
 		if position < 0 || position > g.lengthsMm[i] {
-			return fmt.Errorf("position %v out of range [0, %v]", position, g.lengthsMm[i])
+			return errors.Errorf("position %v out of range [0, %v]", position, g.lengthsMm[i])
 		}
 	}
 
@@ -160,7 +173,7 @@ func (g *Gantry) Kinematics(ctx context.Context) (referenceframe.Model, error) {
 	return g.model, nil
 }
 
-// CurrentInputs returns positions in the Gantry frame model..
+// CurrentInputs returns the current inputs of the fake gantry.
 func (g *Gantry) CurrentInputs(ctx context.Context) ([]referenceframe.Input, error) {
 	res, err := g.Position(ctx, nil)
 	if err != nil {
@@ -169,7 +182,7 @@ func (g *Gantry) CurrentInputs(ctx context.Context) ([]referenceframe.Input, err
 	return res, nil
 }
 
-// GoToInputs moves using the Gantry frames..
+// GoToInputs moves the fake gantry to the given inputs.
 func (g *Gantry) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.Input) error {
 	for _, goal := range inputSteps {
 		err := g.MoveToPosition(ctx, goal, g.speedsMmPerSec, nil)
@@ -178,4 +191,16 @@ func (g *Gantry) GoToInputs(ctx context.Context, inputSteps ...[]referenceframe.
 		}
 	}
 	return nil
+}
+
+func modelFromLength(name string, lengthMm float64) (referenceframe.Model, error) {
+	mcfg := &referenceframe.ModelConfigJSON{}
+	if err := json.Unmarshal(gantryModelJSON, mcfg); err != nil {
+		return nil, err
+	}
+	if len(mcfg.Joints) != 1 {
+		return nil, errors.Errorf("embedded gantry model must have exactly one joint, got %d", len(mcfg.Joints))
+	}
+	mcfg.Joints[0].Max = lengthMm
+	return mcfg.ParseConfig(name)
 }

--- a/components/gantry/fake/gantry_test.go
+++ b/components/gantry/fake/gantry_test.go
@@ -1,0 +1,85 @@
+package fake
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/golang/geo/r3"
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/spatialmath"
+)
+
+func TestDefaultModel(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+	g, err := NewGantry(ctx, nil, resource.Config{
+		Name:                "gantry-1",
+		ConvertedAttributes: &Config{},
+	}, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	lengths, err := g.Lengths(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, lengths, test.ShouldResemble, []float64{100})
+
+	model, err := g.Kinematics(ctx)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, model.DoF()[0].Max, test.ShouldEqual, 100)
+
+	pose, err := model.Transform([]referenceframe.Input{10})
+	test.That(t, err, test.ShouldBeNil)
+	// embedded model offsets base by -50mm on X
+	test.That(t, spatialmath.R3VectorAlmostEqual(pose.Point(), r3.Vector{X: -40, Y: 0, Z: 0}, 1e-6), test.ShouldBeTrue)
+}
+
+func TestLengthMmOverride(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+	g, err := NewGantry(ctx, nil, resource.Config{
+		Name: "gantry-1",
+		ConvertedAttributes: &Config{
+			LengthMm: 1000,
+		},
+	}, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	lengths, err := g.Lengths(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, lengths, test.ShouldResemble, []float64{1000})
+
+	model, err := g.Kinematics(ctx)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, model.DoF()[0].Max, test.ShouldEqual, 1000)
+}
+
+func TestModelPathConflictsWithLength(t *testing.T) {
+	conf := &Config{
+		ModelFilePath: filepath.Join("..", "..", "..", "referenceframe", "testfiles", "example_gantry.json"),
+		LengthMm:      1000,
+	}
+	_, _, err := conf.Validate("")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "model_path")
+
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+	_, err = NewGantry(ctx, nil, resource.Config{
+		Name:                "gantry-1",
+		ConvertedAttributes: conf,
+	}, logger)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "model_path")
+}
+
+func TestValidateLengthMm(t *testing.T) {
+	_, _, err := (&Config{LengthMm: -1}).Validate("")
+	test.That(t, err, test.ShouldNotBeNil)
+
+	_, _, err = (&Config{LengthMm: 500}).Validate("")
+	test.That(t, err, test.ShouldBeNil)
+}

--- a/components/gantry/fake/gantry_test.go
+++ b/components/gantry/fake/gantry_test.go
@@ -55,6 +55,12 @@ func TestLengthMmOverride(t *testing.T) {
 	model, err := g.Kinematics(ctx)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, model.DoF()[0].Max, test.ShouldEqual, 1000)
+
+	cfg := model.ModelConfig()
+	test.That(t, cfg, test.ShouldNotBeNil)
+	test.That(t, cfg.OriginalFile, test.ShouldNotBeNil)
+	test.That(t, cfg.OriginalFile.Extension, test.ShouldEqual, "json")
+	test.That(t, string(cfg.OriginalFile.Bytes), test.ShouldContainSubstring, `"max":1000`)
 }
 
 func TestModelPathConflictsWithLength(t *testing.T) {


### PR DESCRIPTION
## Issue
Fake gantry ignored travel limits from config and always used the embedded/default 100 mm model. This makes the single-axis travel limit configurable via length_mm, with model_path kept as a mutually exclusive full-model override.

## Changes
- Extends fake gantry Config with optional length_mm, patches the embedded SVA joint max when set, and rejects model_path + length_mm together 
- Tests: Adds coverage for default length, length_mm override, validation failures, and model_path conflict

## Links
- https://viam.atlassian.net/browse/APP-17446

## Testing
Testing Build and run local viam-server from this RDK branch against a machine with a fake gantry Set attributes to { "length_mm": 1000 }, restart, call get_lengths → expect [1000] Move the gantry within that length via the motion service or TEST panel → expect success Set both length_mm and model_path → expect config validation / construct failure Omit attributes → expect default length 100