### PR TITLE
RSDK-14177 state.TestStreamState: flaky test fix for rtp_passthrough/gostream upgrade/downgrade race

### DIFF
--- a/robot/web/stream/state/state_test.go
+++ b/robot/web/stream/state/state_test.go
@@ -548,7 +548,10 @@ func TestStreamState(t *testing.T) {
 					"timed out waiting for gostream start to be called on stream which terminated unexpectedly",
 					test.ShouldBeFalse)
 			}
-			if subscribeRTPCount.Load() == 2 {
+			// Wait for Start() (the terminal event) rather than the SubscribeRTP counter. The
+			// counter is bumped via a defer inside SubscribeRTP, so it reaches 2 before tick()
+			// falls back and calls Start(). Waiting on startCount avoids racing that window.
+			if startCount.Load() == 1 {
 				break
 			}
 			time.Sleep(time.Millisecond * 50)


### PR DESCRIPTION
## Summary

Fixes the flaky test `TestStreamState/when_rtppassthrough.Source_is_provided_and_sometimes_returns_an_errors_(test_rtp_passthrough/gostream_upgrade/downgrade_path)` which intermittently failed at `robot/web/stream/state/state_test.go:559` with `Expected: '1' / Actual: '0'`.

## Root cause

The subtest simulates a passthrough subscription terminating while `SubscribeRTP` is configured to return an error, expecting the state machine to fall back to gostream (`Stream.Start()`).

After the subscription is cancelled, the 1s ticker fires `tick()`, which for a terminated passthrough source runs:

```go
err := state.streamH264Passthrough() // calls SubscribeRTP internally
if err != nil {
    state.Stream.Start()              // bumps startCount
    state.streamSource = streamSourceGoStream
}
```

The mock's `subscribeRTPFunc` increments `subscribeRTPCount` via a `defer`, so the counter reaches `2` the moment `SubscribeRTP` returns the error — **before** control returns to `tick()` and `Stream.Start()` is invoked (which bumps `startCount` to `1`).

The manual polling loop broke as soon as `subscribeRTPCount.Load() == 2` and then immediately asserted `startCount.Load() == 1`. When the poll happened to observe that in-between window, `startCount` was still `0`, producing the spurious failure.

Notably, the loop's own timeout message already states it is *"waiting for gostream start to be called"* — the intent was to wait for `Start()`, but the condition erroneously checked the subscribe counter.

## Fix

Wait on `startCount.Load() == 1` (the terminal event) instead of `subscribeRTPCount.Load() == 2`. Because `startCount` is incremented strictly after `subscribeRTPCount` within the same `sourceEventHandler` goroutine, observing `startCount == 1` guarantees the subsequent assertions (`subscribeRTPCount == 2`, `startCount == 1`, etc.) all hold. This also makes the loop consistent with the sibling polling loop later in the same subtest, which correctly waits on `startCount.Load() == 4`.

No production code changed — this is a test-synchronization fix only.

## Testing

The change is a one-line synchronization fix that mirrors an existing correct pattern in the same file; the file is `gofmt`-clean and parses correctly. Full local test execution was not possible in this environment: the module requires a Go 1.25.9+ toolchain that cannot be downloaded here (`storage.googleapis.com` egress is blocked), and a transitive dependency zip (`google.golang.org/api`) is unavailable for the same reason. CI should exercise the test on the correct toolchain.

Key: RSDK-14177

Co-authored by Claude agent for Jira.