### PR TITLE
Publish viam-cli as an apt package on stable releases

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -113,17 +113,11 @@ jobs:
       id-token: "write" # WIF auth for the stable upload
     steps:
     - name: Check out code
-      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'pull_request'
       # actions/checkout@v7.0.1
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       with:
-        fetch-depth: 0
-    - name: Check out PR branch code
-      if: github.event_name == 'pull_request_target'
-      # actions/checkout@v7.0.1
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        # empty ref checks out the triggering commit
+        ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
         fetch-depth: 0
         # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pullrequest-trusted.yml).
         allow-unsafe-pr-checkout: true

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -107,7 +107,7 @@ jobs:
         rm meta.json meta2.json
 
   viam-cli-deb:
-    runs-on: ubuntu-large
+    runs-on: ubuntu-latest
     permissions:
       contents: "read"
       id-token: "write" # WIF auth for the stable upload
@@ -178,7 +178,7 @@ jobs:
   viam-cli-apt-e2e:
     if: inputs.release_type == 'stable'
     needs: viam-cli-deb
-    runs-on: ubuntu-large
+    runs-on: ubuntu-latest
     permissions:
       contents: "read"
     steps:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -105,3 +105,91 @@ jobs:
         pip install -r cli/test-requirements.txt
         check-jsonschema --schemafile ./cli/module.schema.json meta2.json
         rm meta.json meta2.json
+
+  viam-cli-deb:
+    runs-on: ubuntu-large
+    permissions:
+      contents: "read"
+      id-token: "write" # WIF auth for the stable upload
+    steps:
+    - name: Check out code
+      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'pull_request'
+      # actions/checkout@v7.0.1
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      with:
+        fetch-depth: 0
+    - name: Check out PR branch code
+      if: github.event_name == 'pull_request_target'
+      # actions/checkout@v7.0.1
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+        # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pullrequest-trusted.yml).
+        allow-unsafe-pr-checkout: true
+
+    # actions/setup-go@v7.0.0
+    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+      with:
+        go-version-file: go.mod
+
+    - name: build debs
+      shell: bash
+      env:
+        RELEASE_TYPE: ${{ inputs.release_type }}
+      run: |
+        # only stable tags carry a real version
+        if [ "$RELEASE_TYPE" != stable ]; then
+          export TAG_VERSION='0.0.0~ci'
+        fi
+        GOOS=linux GOARCH=amd64 make deb-cli
+        GOOS=linux GOARCH=arm64 make deb-cli
+
+    - name: install test amd64
+      run: |
+        for img in debian:bookworm ubuntu:24.04; do
+          docker run --rm -v "$PWD/bin/deb:/deb:ro" "$img" \
+            bash -ec 'apt-get update -qq && apt-get install -yqq /deb/viam-cli_*_amd64.deb >/dev/null && viam version'
+        done
+
+    - name: install test arm64 (qemu)
+      continue-on-error: true # emulation is best-effort
+      run: |
+        docker run --privileged --rm tonistiigi/binfmt --install arm64
+        docker run --platform linux/arm64 --rm -v "$PWD/bin/deb:/deb:ro" debian:bookworm \
+          bash -ec 'apt-get update -qq && apt-get install -yqq /deb/viam-cli_*_arm64.deb >/dev/null && viam version'
+
+    - name: Authorize GAR upload
+      if: inputs.release_type == 'stable'
+      # google-github-actions/auth@v3
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
+      with:
+        workload_identity_provider: projects/785265540/locations/global/workloadIdentityPools/github-rdk-id/providers/github-provider-rdk
+        service_account: rdk-apt-publisher@static-file-server-310021.iam.gserviceaccount.com
+    - name: Set up gcloud
+      if: inputs.release_type == 'stable'
+      # google-github-actions/setup-gcloud@v3.0.1
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
+    - name: upload to apt repo
+      if: inputs.release_type == 'stable'
+      run: make deb-cli-upload
+
+  # installs from the published repo exactly as the docs describe
+  viam-cli-apt-e2e:
+    if: inputs.release_type == 'stable'
+    needs: viam-cli-deb
+    runs-on: ubuntu-large
+    permissions:
+      contents: "read"
+    steps:
+    - name: Check out code
+      # actions/checkout@v7.0.1
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+    - name: apt install e2e
+      env:
+        EXPECTED_VERSION: ${{ github.ref_name }}
+      run: |
+        for img in debian:bookworm ubuntu:24.04; do
+          docker run --rm -v "$PWD/etc/apt-e2e.sh:/apt-e2e.sh:ro" \
+            -e EXPECTED_VERSION="${EXPECTED_VERSION#v}" "$img" bash /apt-e2e.sh
+        done

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,28 @@ cli-ci: bin/$(GOOS)-$(GOARCH)/viam-cli
 		cp $< bin/deploy-ci/viam-cli-$(CI_RELEASE)-$(GOOS)-$(GOARCH)$(EXE_SUFFIX); \
 	fi
 
+NFPM_VERSION = v2.47.0
+GAR_PROJECT ?= static-file-server-310021
+GAR_REPO ?= viam
+GAR_LOCATION ?= us
+
+# GOOS=linux GOARCH=amd64|arm64 make deb-cli; set TAG_VERSION on a dirty tree (nfpm rejects empty)
+.PHONY: deb-cli
+deb-cli: bin/linux-$(GOARCH)/viam-cli
+	mkdir -p bin/deb
+	sed -e 's/$${DEB_ARCH}/$(GOARCH)/g' -e 's/$${DEB_VERSION}/$(TAG_VERSION)/g' \
+		etc/packaging/nfpm/viam-cli.yaml > bin/deb/.nfpm-$(GOARCH).yaml
+	GOOS= GOARCH= go run github.com/goreleaser/nfpm/v2/cmd/nfpm@$(NFPM_VERSION) package \
+		--config bin/deb/.nfpm-$(GOARCH).yaml --packager deb --target bin/deb/
+
+# needs gcloud auth with artifactregistry.writer; re-runs skip versions already in the repo
+.PHONY: deb-cli-upload
+deb-cli-upload:
+	for deb in bin/deb/*.deb; do \
+		out=$$(gcloud artifacts apt upload $(GAR_REPO) --project=$(GAR_PROJECT) --location=$(GAR_LOCATION) --source=$$deb 2>&1) \
+			|| { echo "$$out" | grep -qi "already exists" && echo "skipping $$deb: already in repo" || { echo "$$out"; exit 1; }; }; \
+	done
+
 tool-install:
 	GOBIN=`pwd`/$(TOOL_BIN) go install \
 		github.com/AlekSi/gocov-xml \

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,8 @@ deb-cli: bin/linux-$(GOARCH)/viam-cli
 	mkdir -p bin/deb
 	sed -e 's/$${DEB_ARCH}/$(GOARCH)/g' -e 's/$${DEB_VERSION}/$(TAG_VERSION)/g' \
 		etc/packaging/nfpm/viam-cli.yaml > bin/deb/.nfpm-$(GOARCH).yaml
-	GOOS= GOARCH= go run github.com/goreleaser/nfpm/v2/cmd/nfpm@$(NFPM_VERSION) package \
+	# GOTOOLCHAIN=auto: nfpm needs a newer Go than go.mod; CI's setup-go pins GOTOOLCHAIN=local
+	GOOS= GOARCH= GOTOOLCHAIN=auto go run github.com/goreleaser/nfpm/v2/cmd/nfpm@$(NFPM_VERSION) package \
 		--config bin/deb/.nfpm-$(GOARCH).yaml --packager deb --target bin/deb/
 
 # needs gcloud auth with artifactregistry.writer; re-runs skip versions already in the repo

--- a/cli/client.go
+++ b/cli/client.go
@@ -70,6 +70,7 @@ import (
 const (
 	rdkReleaseURL = "https://api.github.com/repos/viamrobotics/rdk/releases/latest"
 	osWindows     = "windows"
+	osLinux       = "linux"
 	// defaultNumLogs is the same as the number of logs currently returned by app
 	// in a single GetRobotPartLogsResponse.
 	defaultNumLogs = 100
@@ -4402,6 +4403,7 @@ func UpdateCLIAction(ctx context.Context, cmd *cli.Command, args updateArgs) err
 		{ID: "check", Message: "Checking for updates", IndentLevel: 0},
 		{ID: "update", Message: "Updating...", IndentLevel: 0},
 		{ID: "brew-upgrade", Message: "Updating via Homebrew", IndentLevel: 1},
+		{ID: "apt-upgrade", Message: "Updating via apt", IndentLevel: 1},
 		{ID: "download", Message: "Downloading latest CLI", IndentLevel: 1},
 		{ID: "install", Message: "Installing update", IndentLevel: 1},
 	}, WithProgressOutput(!args.NoProgress))
@@ -4508,7 +4510,47 @@ func UpdateCLIAction(ctx context.Context, cmd *cli.Command, args updateArgs) err
 		return nil
 	}
 
-	// 4. get the local version binary path (use full path if no symlinks)
+	// 4. if the binary is dpkg-managed, upgrade through apt instead of self-replacing.
+	isApt, aptCheckErr := isRunningAptBinary()
+	if aptCheckErr != nil {
+		if failErr := pm.Fail("update", aptCheckErr); failErr != nil {
+			return failErr
+		}
+		return errors.Errorf("CLI update failed: %v", aptCheckErr)
+	}
+	if isApt {
+		if err := pm.Start("apt-upgrade"); err != nil {
+			return err
+		}
+		pm.UpdateText("  → Updating via apt — you may be prompted for your sudo password")
+		if aptErr := tryAptUpgrade(); aptErr != nil {
+			if failErr := pm.Fail("apt-upgrade", aptErr); failErr != nil {
+				return failErr
+			}
+			return errors.Errorf("CLI update via apt failed: %v\n"+
+				"To update manually: sudo apt update && sudo apt install --only-upgrade viam-cli", aptErr)
+		}
+		installed, installedErr := installedDebVersion()
+		if installedErr != nil {
+			debugf(cmd.Root().Writer, globalArgs.Debug, "CLI Update: failed to read installed deb version: %v", installedErr)
+		}
+		aptMsg := "Updated via apt"
+		if installedErr == nil {
+			aptMsg = fmt.Sprintf("Updated via apt (version %s)", installed.Original())
+		}
+		if err := pm.Complete("apt-upgrade"); err != nil {
+			return err
+		}
+		if err := pm.CompleteWithMessage("update", aptMsg); err != nil {
+			return err
+		}
+		if args.NoProgress {
+			infof(cmd.Root().Writer, aptMsg)
+		}
+		return nil
+	}
+
+	// 5. get the local version binary path (use full path if no symlinks)
 	execPath, err := os.Executable()
 	if err != nil {
 		return errors.Errorf("CLI update failed: failed to get executable path: %v", err)
@@ -4519,7 +4561,7 @@ func UpdateCLIAction(ctx context.Context, cmd *cli.Command, args updateArgs) err
 	}
 	directoryPath := filepath.Dir(localBinaryPath)
 
-	// 5. get the latest binary (from storage.googleapis.com) and write it into a temp file
+	// 6. get the latest binary (from storage.googleapis.com) and write it into a temp file
 	if err := pm.Start("download"); err != nil {
 		return err
 	}
@@ -4536,7 +4578,7 @@ func UpdateCLIAction(ctx context.Context, cmd *cli.Command, args updateArgs) err
 		return err
 	}
 
-	// 6. replace the old binary with the new one
+	// 7. replace the old binary with the new one
 	if err := pm.Start("install"); err != nil {
 		return err
 	}
@@ -4550,7 +4592,7 @@ func UpdateCLIAction(ctx context.Context, cmd *cli.Command, args updateArgs) err
 		return err
 	}
 
-	// 7. on Windows, ensure the CLI directory is in the user's PATH
+	// 8. on Windows, ensure the CLI directory is in the user's PATH
 	if runtime.GOOS == osWindows {
 		if err := addToWindowsUserPATH(cmd, directoryPath); err != nil {
 			warningf(cmd.Root().ErrWriter, "Failed to add CLI to user PATH. "+
@@ -4659,6 +4701,77 @@ func tryBrewUpgrade() (bool, error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+// tryAptUpgrade upgrades viam-cli through apt, with sudo when not root.
+// Call only after isRunningAptBinary confirms the binary is dpkg-managed.
+func tryAptUpgrade() error {
+	var prefix []string
+	if os.Geteuid() != 0 {
+		if _, err := exec.LookPath("sudo"); err != nil {
+			return errors.New("not running as root and sudo is not available")
+		}
+		prefix = []string{"sudo"}
+	}
+	for _, args := range [][]string{
+		{"apt-get", "update"},
+		{"apt-get", "install", "--only-upgrade", "-y", "viam-cli"},
+	} {
+		full := append(append([]string{}, prefix...), args...)
+		// fixed args, not user input
+		aptCmd := exec.Command(full[0], full[1:]...) //nolint:gosec
+		// keep stdin attached so sudo can prompt for a password
+		aptCmd.Stdin = os.Stdin
+		if out, err := aptCmd.CombinedOutput(); err != nil {
+			return errors.Errorf("failed to run %q: %v\n%s", strings.Join(full, " "), err, strings.TrimSpace(string(out)))
+		}
+	}
+	return nil
+}
+
+// installedDebVersion returns the version of the viam-cli deb currently installed.
+func installedDebVersion() (*semver.Version, error) {
+	out, err := exec.Command("dpkg-query", "-W", "-f=${Version}", "viam-cli").Output()
+	if err != nil {
+		return nil, errors.Errorf("failed to get installed deb version: %v", err)
+	}
+	version, err := semver.NewVersion(strings.TrimSpace(string(out)))
+	if err != nil {
+		return nil, errors.Errorf("failed to parse installed deb version %q: %v", strings.TrimSpace(string(out)), err)
+	}
+	return version, nil
+}
+
+// dpkgQueryOwnerFunc runs `dpkg -S <path>`; overridable in tests.
+var dpkgQueryOwnerFunc = func(path string) (string, error) {
+	out, err := exec.Command("dpkg", "-S", path).Output()
+	return string(out), err
+}
+
+// isRunningAptBinary reports whether the running binary is owned by the viam-cli
+// deb. Returns (false, nil) when dpkg is absent or does not own the path.
+func isRunningAptBinary() (bool, error) {
+	if runtime.GOOS != osLinux {
+		return false, nil
+	}
+	execPath, err := os.Executable()
+	if err != nil {
+		return false, errors.Errorf("failed to get executable path: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(execPath)
+	if err != nil {
+		resolved = execPath
+	}
+	out, err := dpkgQueryOwnerFunc(resolved)
+	if err != nil {
+		// dpkg absent or path unowned: not an apt install
+		var exitErr *exec.ExitError
+		if errors.Is(err, exec.ErrNotFound) || errors.As(err, &exitErr) {
+			return false, nil
+		}
+		return false, errors.Errorf("failed to query dpkg for %q: %v", resolved, err)
+	}
+	return strings.HasPrefix(strings.TrimSpace(out), "viam-cli:"), nil
 }
 
 func binaryURL() string {

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -2095,6 +2096,56 @@ func TestCLIUpdateAction(t *testing.T) {
 	_, err = os.ReadFile(newBinaryPath)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+}
+
+func TestIsRunningAptBinary(t *testing.T) {
+	originalDpkgQueryOwner := dpkgQueryOwnerFunc
+	defer func() {
+		dpkgQueryOwnerFunc = originalDpkgQueryOwner
+	}()
+
+	if runtime.GOOS != "linux" {
+		// dpkg query must never run off linux
+		dpkgQueryOwnerFunc = func(string) (string, error) {
+			panic("dpkg query must not run off linux")
+		}
+		isApt, err := isRunningAptBinary()
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, isApt, test.ShouldBeFalse)
+		return
+	}
+
+	// real ExitError, like dpkg returns for an unowned path
+	exitErr := exec.Command("sh", "-c", "exit 1").Run()
+	var asExitErr *exec.ExitError
+	test.That(t, errors.As(exitErr, &asExitErr), test.ShouldBeTrue)
+
+	for _, tc := range []struct {
+		name      string
+		out       string
+		err       error
+		wantIsApt bool
+		wantErr   bool
+	}{
+		{name: "owned by viam-cli", out: "viam-cli: /usr/bin/viam\n", wantIsApt: true},
+		{name: "owned by another package", out: "coreutils: /usr/bin/viam\n"},
+		{name: "dpkg not installed", err: exec.ErrNotFound},
+		{name: "path not owned by any package", err: exitErr},
+		{name: "unexpected dpkg failure", err: errors.New("boom"), wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dpkgQueryOwnerFunc = func(string) (string, error) {
+				return tc.out, tc.err
+			}
+			isApt, err := isRunningAptBinary()
+			if tc.wantErr {
+				test.That(t, err, test.ShouldNotBeNil)
+			} else {
+				test.That(t, err, test.ShouldBeNil)
+			}
+			test.That(t, isApt, test.ShouldEqual, tc.wantIsApt)
+		})
+	}
 }
 
 func TestRetryableCopy(t *testing.T) {

--- a/etc/apt-e2e.sh
+++ b/etc/apt-e2e.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Installs viam-cli from the public Viam apt repo, exactly as the docs describe.
+# Run in a clean Debian/Ubuntu container as root. Set EXPECTED_VERSION (no
+# leading v) to assert the installed version, retrying while the repo index
+# catches up after an upload.
+set -euo pipefail
+
+apt-get update -qq
+apt-get install -yqq curl gpg ca-certificates >/dev/null
+
+curl -fsSL https://us-apt.pkg.dev/doc/repo-signing-key.gpg | gpg --dearmor -o /usr/share/keyrings/viam.gpg
+echo "deb [signed-by=/usr/share/keyrings/viam.gpg] https://us-apt.pkg.dev/projects/static-file-server-310021 viam main" \
+	> /etc/apt/sources.list.d/viam.list
+
+for attempt in $(seq 1 10); do
+	apt-get update -qq
+	if [ -z "${EXPECTED_VERSION:-}" ] || apt-cache policy viam-cli | grep -qF "$EXPECTED_VERSION"; then
+		break
+	fi
+	if [ "$attempt" = 10 ]; then
+		echo "version $EXPECTED_VERSION never appeared in the repo" >&2
+		exit 1
+	fi
+	sleep 30
+done
+
+apt-get install -yqq viam-cli >/dev/null
+viam version
+if [ -n "${EXPECTED_VERSION:-}" ]; then
+	viam version | grep -qF "$EXPECTED_VERSION"
+fi
+
+# `viam update` must go through apt and leave dpkg-owned files untouched
+viam update
+dpkg -V viam-cli
+
+echo "apt e2e OK: $(viam version)"

--- a/etc/packaging/nfpm/postinstall.sh
+++ b/etc/packaging/nfpm/postinstall.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "viam-cli installed the 'viam' command. Get started: viam --help"

--- a/etc/packaging/nfpm/postinstall.sh
+++ b/etc/packaging/nfpm/postinstall.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-echo "viam-cli installed the 'viam' command. Get started: viam --help"
+echo "viam-cli installed the 'viam' command. Run 'viam' to get started."

--- a/etc/packaging/nfpm/viam-cli.yaml
+++ b/etc/packaging/nfpm/viam-cli.yaml
@@ -1,0 +1,16 @@
+# viam-cli deb template; `make deb-cli` substitutes DEB_ARCH and DEB_VERSION
+name: viam-cli
+arch: ${DEB_ARCH} # amd64 | arm64
+platform: linux
+version: ${DEB_VERSION} # e.g. 0.108.0, no leading v
+section: utils
+priority: optional
+maintainer: Viam Inc. <support@viam.com>
+vendor: Viam Inc.
+homepage: https://www.viam.com
+license: AGPL-3.0-only
+description: |
+  Viam CLI for managing machines, modules, and data on the Viam platform.
+contents:
+  - src: bin/linux-${DEB_ARCH}/viam-cli
+    dst: /usr/bin/viam

--- a/etc/packaging/nfpm/viam-cli.yaml
+++ b/etc/packaging/nfpm/viam-cli.yaml
@@ -11,6 +11,12 @@ homepage: https://www.viam.com
 license: AGPL-3.0-only
 description: |
   Viam CLI for managing machines, modules, and data on the Viam platform.
+  Installs the command as 'viam' (with a 'viam-cli' symlink).
 contents:
   - src: bin/linux-${DEB_ARCH}/viam-cli
     dst: /usr/bin/viam
+  - src: /usr/bin/viam
+    dst: /usr/bin/viam-cli
+    type: symlink
+scripts:
+  postinstall: etc/packaging/nfpm/postinstall.sh


### PR DESCRIPTION
## What

Users can now install the CLI with `sudo apt install viam-cli` (the command stays `viam`, matching brew). Debs build for linux amd64 and arm64 and publish to the public GAR apt repo `viam` in `static-file-server-310021` on `vX.Y.Z` tags.

- `make deb-cli` builds `bin/deb/viam-cli_<ver>_<arch>.deb` via nfpm (pinned v2.47.0), installing `/usr/bin/viam`; `make deb-cli-upload` pushes to Artifact Registry and skips versions already present, so re-dispatched workflows don't fail
- `cli.yml` gains two jobs: `viam-cli-deb` builds the debs on every run and install-tests them in `debian:bookworm` and `ubuntu:24.04` containers (amd64 native, arm64 via qemu best-effort), then uploads via WIF on stable only; `viam-cli-apt-e2e` (stable only) installs from the published repo through `etc/apt-e2e.sh` — the same commands the docs will show — asserts the released version, and checks that `viam update` leaves dpkg-owned files untouched
- `viam update` now detects a dpkg-owned binary and upgrades through apt (directly as root, via sudo otherwise) instead of overwriting `/usr/bin/viam` in place; on failure it prints the manual apt commands

New actions are pinned to commit SHAs; both new jobs carry minimal `permissions` blocks (`id-token: write` only on the upload job, mirroring `cli-windows-installer.yml`).

## Depends on

viamrobotics/declarative-infra#330 must apply before the first stable tag after merge; until then the upload and e2e jobs are dormant (stable-only) and everything else works.

## Testing

- Debs built locally for both arches; installed in `debian:bookworm` and `ubuntu:24.04` containers on arm64 (native) and amd64 (emulated); `viam version` runs, `dpkg -V viam-cli` clean
- `viam update` inside an apt install took the apt path, exited 0, and reported "Updated via apt" without modifying the binary
- No `viam`/`viam-cli` package or `/usr/bin/viam` exists in Debian/Ubuntu archives
- `go test ./cli` passes on darwin and linux (dpkg stub cases run on linux); golangci-lint clean; actionlint reports only the pre-existing `allow-unsafe-pr-checkout` finding that exists on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)