### PR TITLE
angela/App 16013: File upload lacks progress feedback for large files

### DIFF
--- a/services/datamanager/builtin/sync/upload_arbitrary_file.go
+++ b/services/datamanager/builtin/sync/upload_arbitrary_file.go
@@ -126,7 +126,10 @@ func uploadArbitraryFile(
 		return 0, "", errors.Wrap(err, "FileUpload failed sending metadata")
 	}
 
-	if err := sendFileUploadRequests(ctx, stream, f, path, logger, bytesUploadingCounter); err != nil {
+	// Log throttled progress of the upload at Info level.
+	progress := newUploadProgressLogger(logger, clock, path, info.Size())
+
+	if err := sendFileUploadRequests(ctx, stream, f, path, logger, bytesUploadingCounter, progress); err != nil {
 		return 0, "", errors.Wrap(err, "FileUpload failed to sync")
 	}
 
@@ -135,6 +138,7 @@ func uploadArbitraryFile(
 	if err != nil {
 		return 0, "", errors.Wrap(err, "FileUpload  CloseAndRecv failed")
 	}
+	progress.complete()
 	return uint64(info.Size()), resp.GetBinaryDataId(), nil
 }
 
@@ -145,6 +149,7 @@ func sendFileUploadRequests(
 	path string,
 	logger logging.Logger,
 	bytesUploadingCounter *atomic.Uint64,
+	progress *uploadProgressLogger,
 ) error {
 	// Loop until there is no more content to be read from file.
 	i := 0
@@ -169,12 +174,13 @@ func sendFileUploadRequests(
 			return err
 		}
 
-		// Update byte counter after successful chunk upload.
-		if bytesUploadingCounter != nil {
-			if fileContents := uploadReq.GetFileContents(); fileContents != nil {
-				chunkSize := uint64(len(fileContents.Data))
-				bytesUploadingCounter.Add(chunkSize)
+		// Update byte counter and progress logging after successful chunk upload.
+		if fileContents := uploadReq.GetFileContents(); fileContents != nil {
+			chunkSize := len(fileContents.Data)
+			if bytesUploadingCounter != nil {
+				bytesUploadingCounter.Add(uint64(chunkSize))
 			}
+			progress.addBytes(chunkSize)
 		}
 
 		i++

--- a/services/datamanager/builtin/sync/upload_progress.go
+++ b/services/datamanager/builtin/sync/upload_progress.go
@@ -44,9 +44,6 @@ func newUploadProgressLogger(logger logging.Logger, clk clock.Clock, path string
 // Info level if at least UploadProgressLogInterval has passed since the last progress
 // log (or since the upload started).
 func (p *uploadProgressLogger) addBytes(n int) {
-	if p == nil {
-		return
-	}
 	p.sentBytes += uint64(n)
 	now := p.clock.Now()
 	if now.Sub(p.lastLog) < UploadProgressLogInterval {
@@ -67,9 +64,6 @@ func (p *uploadProgressLogger) addBytes(n int) {
 // progress line was already emitted; otherwise it logs at Debug so small, fast
 // uploads stay quiet at the default level.
 func (p *uploadProgressLogger) complete() {
-	if p == nil {
-		return
-	}
 	now := p.clock.Now()
 	msg := fmt.Sprintf("uploaded %s: %s in %s (avg rate: %s/s)",
 		p.path,

--- a/services/datamanager/builtin/sync/upload_progress.go
+++ b/services/datamanager/builtin/sync/upload_progress.go
@@ -18,14 +18,13 @@ var UploadProgressLogInterval = 30 * time.Second
 // upload stream is in flight. Each instance tracks a single upload attempt and is
 // used by a single goroutine; it is not safe for concurrent use.
 type uploadProgressLogger struct {
-	logger         logging.Logger
-	clock          clock.Clock
-	path           string
-	totalBytes     uint64
-	sentBytes      uint64
-	startTime      time.Time
-	lastLog        time.Time
-	loggedProgress bool
+	logger     logging.Logger
+	clock      clock.Clock
+	path       string
+	totalBytes uint64
+	sentBytes  uint64
+	startTime  time.Time
+	lastLog    time.Time
 }
 
 func newUploadProgressLogger(logger logging.Logger, clk clock.Clock, path string, totalBytes int64) *uploadProgressLogger {
@@ -50,7 +49,6 @@ func (p *uploadProgressLogger) addBytes(n int) {
 		return
 	}
 	p.lastLog = now
-	p.loggedProgress = true
 	p.logger.Infof("uploading %s: %s / %s (%s), rate: %s/s",
 		p.path,
 		utils.FormatBytes(p.sentBytes),
@@ -60,22 +58,15 @@ func (p *uploadProgressLogger) addBytes(n int) {
 	)
 }
 
-// complete logs a summary of the finished upload. The summary logs at Info only if a
-// progress line was already emitted; otherwise it logs at Debug so small, fast
-// uploads stay quiet at the default level.
+// complete logs a summary of the finished upload at Info level.
 func (p *uploadProgressLogger) complete() {
 	now := p.clock.Now()
-	msg := fmt.Sprintf("uploaded %s: %s in %s (avg rate: %s/s)",
+	p.logger.Infof("uploaded %s: %s in %s (avg rate: %s/s)",
 		p.path,
 		utils.FormatBytes(p.sentBytes),
 		now.Sub(p.startTime).Round(time.Millisecond),
 		utils.FormatBytes(p.rate(now)),
 	)
-	if p.loggedProgress {
-		p.logger.Info(msg)
-	} else {
-		p.logger.Debug(msg)
-	}
 }
 
 // percent renders sentBytes/totalBytes as a percentage string.

--- a/services/datamanager/builtin/sync/upload_progress.go
+++ b/services/datamanager/builtin/sync/upload_progress.go
@@ -1,0 +1,102 @@
+package sync
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/benbjohnson/clock"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/utils"
+)
+
+// UploadProgressLogInterval is the minimum duration between Info-level progress logs
+// emitted while a file is uploading.
+var UploadProgressLogInterval = 30 * time.Second
+
+// uploadProgressLogger emits human-readable progress logs while a file
+// upload stream is in flight. Each instance tracks a single upload attempt and is
+// used by a single goroutine; it is not safe for concurrent use.
+type uploadProgressLogger struct {
+	logger         logging.Logger
+	clock          clock.Clock
+	path           string
+	totalBytes     uint64
+	sentBytes      uint64
+	startTime      time.Time
+	lastLog        time.Time
+	loggedProgress bool
+}
+
+func newUploadProgressLogger(logger logging.Logger, clk clock.Clock, path string, totalBytes int64) *uploadProgressLogger {
+	now := clk.Now()
+	return &uploadProgressLogger{
+		logger:     logger,
+		clock:      clk,
+		path:       path,
+		totalBytes: uint64(max(totalBytes, 0)),
+		startTime:  now,
+		lastLog:    now,
+	}
+}
+
+// addBytes records that n more bytes were sent on the stream, and logs progress at
+// Info level if at least UploadProgressLogInterval has passed since the last progress
+// log (or since the upload started).
+func (p *uploadProgressLogger) addBytes(n int) {
+	if p == nil {
+		return
+	}
+	p.sentBytes += uint64(n)
+	now := p.clock.Now()
+	if now.Sub(p.lastLog) < UploadProgressLogInterval {
+		return
+	}
+	p.lastLog = now
+	p.loggedProgress = true
+	p.logger.Infof("uploading %s: %s / %s (%s), rate: %s/s",
+		p.path,
+		utils.FormatBytes(p.sentBytes),
+		utils.FormatBytes(p.totalBytes),
+		p.percent(),
+		utils.FormatBytes(p.rate(now)),
+	)
+}
+
+// complete logs a summary of the finished upload. The summary logs at Info only if a
+// progress line was already emitted; otherwise it logs at Debug so small, fast
+// uploads stay quiet at the default level.
+func (p *uploadProgressLogger) complete() {
+	if p == nil {
+		return
+	}
+	now := p.clock.Now()
+	msg := fmt.Sprintf("uploaded %s: %s in %s (avg rate: %s/s)",
+		p.path,
+		utils.FormatBytes(p.sentBytes),
+		now.Sub(p.startTime).Round(time.Millisecond),
+		utils.FormatBytes(p.rate(now)),
+	)
+	if p.loggedProgress {
+		p.logger.Info(msg)
+	} else {
+		p.logger.Debug(msg)
+	}
+}
+
+// percent renders sentBytes/totalBytes as a percentage string.
+func (p *uploadProgressLogger) percent() string {
+	if p.totalBytes == 0 {
+		return "?%"
+	}
+	return fmt.Sprintf("%d%%", p.sentBytes*100/p.totalBytes)
+}
+
+// rate returns the average upload rate in bytes/sec since the upload started.
+func (p *uploadProgressLogger) rate(now time.Time) uint64 {
+	elapsed := now.Sub(p.startTime).Seconds()
+	if elapsed <= 0 {
+		return 0
+	}
+	return uint64(float64(p.sentBytes) / elapsed)
+}

--- a/services/datamanager/builtin/sync/upload_progress_test.go
+++ b/services/datamanager/builtin/sync/upload_progress_test.go
@@ -58,23 +58,4 @@ func TestUploadProgressLogger(t *testing.T) {
 		test.That(t, len(debugs), test.ShouldEqual, 1)
 		test.That(t, debugs[0].Message, test.ShouldContainSubstring, "uploaded /tmp/small.bin")
 	})
-
-	t.Run("unknown total size renders an unknown percentage rather than dividing by zero", func(t *testing.T) {
-		logger, observed := logging.NewObservedTestLogger(t)
-		clk := clock.NewMock()
-		p := newUploadProgressLogger(logger, clk, "/tmp/unknown.bin", 0)
-
-		clk.Add(UploadProgressLogInterval)
-		p.addBytes(10)
-
-		infos := observed.FilterLevelExact(zapcore.InfoLevel).All()
-		test.That(t, len(infos), test.ShouldEqual, 1)
-		test.That(t, infos[0].Message, test.ShouldContainSubstring, "(?%)")
-	})
-
-	t.Run("nil progress logger is a no-op", func(t *testing.T) {
-		var p *uploadProgressLogger
-		p.addBytes(10)
-		p.complete()
-	})
 }

--- a/services/datamanager/builtin/sync/upload_progress_test.go
+++ b/services/datamanager/builtin/sync/upload_progress_test.go
@@ -35,7 +35,7 @@ func TestUploadProgressLogger(t *testing.T) {
 		p.addBytes(25)
 		test.That(t, observed.FilterLevelExact(zapcore.InfoLevel).Len(), test.ShouldEqual, 1)
 
-		// Completion logs at Info because a progress line was emitted.
+		// Completion logs at Info summary.
 		clk.Add(time.Second)
 		p.addBytes(25)
 		p.complete()
@@ -46,7 +46,7 @@ func TestUploadProgressLogger(t *testing.T) {
 		test.That(t, infos[1].Message, test.ShouldContainSubstring, "(avg rate: 3 Bytes/s)")
 	})
 
-	t.Run("uploads that finish within one interval stay quiet at Info", func(t *testing.T) {
+	t.Run("uploads that finish within one interval log only an Info summary", func(t *testing.T) {
 		logger, observed := logging.NewObservedTestLogger(t)
 		clk := clock.NewMock()
 		p := newUploadProgressLogger(logger, clk, "/tmp/small.bin", 100)
@@ -54,10 +54,8 @@ func TestUploadProgressLogger(t *testing.T) {
 		p.addBytes(100)
 		p.complete()
 
-		test.That(t, observed.FilterLevelExact(zapcore.InfoLevel).Len(), test.ShouldEqual, 0)
-		// The completion summary still exists at Debug for debugging.
-		debugs := observed.FilterLevelExact(zapcore.DebugLevel).All()
-		test.That(t, len(debugs), test.ShouldEqual, 1)
-		test.That(t, debugs[0].Message, test.ShouldContainSubstring, "uploaded /tmp/small.bin")
+		infos := observed.FilterLevelExact(zapcore.InfoLevel).All()
+		test.That(t, len(infos), test.ShouldEqual, 1)
+		test.That(t, infos[0].Message, test.ShouldContainSubstring, "uploaded /tmp/small.bin")
 	})
 }

--- a/services/datamanager/builtin/sync/upload_progress_test.go
+++ b/services/datamanager/builtin/sync/upload_progress_test.go
@@ -1,0 +1,80 @@
+package sync
+
+import (
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"go.uber.org/zap/zapcore"
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/logging"
+)
+
+func TestUploadProgressLogger(t *testing.T) {
+	t.Run("logs progress at Info once per interval and an Info summary on completion", func(t *testing.T) {
+		logger, observed := logging.NewObservedTestLogger(t)
+		clk := clock.NewMock()
+		p := newUploadProgressLogger(logger, clk, "/tmp/big.bin", 100)
+
+		// Before the interval elapses, chunks do not produce progress logs.
+		p.addBytes(10)
+		test.That(t, observed.FilterLevelExact(zapcore.InfoLevel).Len(), test.ShouldEqual, 0)
+
+		// Once the interval has passed, the next chunk triggers a progress log.
+		clk.Add(UploadProgressLogInterval)
+		p.addBytes(40)
+		infos := observed.FilterLevelExact(zapcore.InfoLevel).All()
+		test.That(t, len(infos), test.ShouldEqual, 1)
+		test.That(t, infos[0].Message, test.ShouldContainSubstring, "uploading /tmp/big.bin")
+		test.That(t, infos[0].Message, test.ShouldContainSubstring, "50 Bytes / 100 Bytes")
+		test.That(t, infos[0].Message, test.ShouldContainSubstring, "(50%)")
+
+		// Within the same interval, further chunks do not log again.
+		p.addBytes(25)
+		test.That(t, observed.FilterLevelExact(zapcore.InfoLevel).Len(), test.ShouldEqual, 1)
+
+		// Completion logs at Info because a progress line was emitted.
+		clk.Add(time.Second)
+		p.addBytes(25)
+		p.complete()
+		infos = observed.FilterLevelExact(zapcore.InfoLevel).All()
+		test.That(t, len(infos), test.ShouldEqual, 2)
+		test.That(t, infos[1].Message, test.ShouldContainSubstring, "uploaded /tmp/big.bin")
+		test.That(t, infos[1].Message, test.ShouldContainSubstring, "100 Bytes")
+	})
+
+	t.Run("uploads that finish within one interval stay quiet at Info", func(t *testing.T) {
+		logger, observed := logging.NewObservedTestLogger(t)
+		clk := clock.NewMock()
+		p := newUploadProgressLogger(logger, clk, "/tmp/small.bin", 100)
+
+		p.addBytes(100)
+		p.complete()
+
+		test.That(t, observed.FilterLevelExact(zapcore.InfoLevel).Len(), test.ShouldEqual, 0)
+		// The completion summary still exists at Debug for debugging.
+		debugs := observed.FilterLevelExact(zapcore.DebugLevel).All()
+		test.That(t, len(debugs), test.ShouldEqual, 1)
+		test.That(t, debugs[0].Message, test.ShouldContainSubstring, "uploaded /tmp/small.bin")
+	})
+
+	t.Run("unknown total size renders an unknown percentage rather than dividing by zero", func(t *testing.T) {
+		logger, observed := logging.NewObservedTestLogger(t)
+		clk := clock.NewMock()
+		p := newUploadProgressLogger(logger, clk, "/tmp/unknown.bin", 0)
+
+		clk.Add(UploadProgressLogInterval)
+		p.addBytes(10)
+
+		infos := observed.FilterLevelExact(zapcore.InfoLevel).All()
+		test.That(t, len(infos), test.ShouldEqual, 1)
+		test.That(t, infos[0].Message, test.ShouldContainSubstring, "(?%)")
+	})
+
+	t.Run("nil progress logger is a no-op", func(t *testing.T) {
+		var p *uploadProgressLogger
+		p.addBytes(10)
+		p.complete()
+	})
+}

--- a/services/datamanager/builtin/sync/upload_progress_test.go
+++ b/services/datamanager/builtin/sync/upload_progress_test.go
@@ -29,6 +29,7 @@ func TestUploadProgressLogger(t *testing.T) {
 		test.That(t, infos[0].Message, test.ShouldContainSubstring, "uploading /tmp/big.bin")
 		test.That(t, infos[0].Message, test.ShouldContainSubstring, "50 Bytes / 100 Bytes")
 		test.That(t, infos[0].Message, test.ShouldContainSubstring, "(50%)")
+		test.That(t, infos[0].Message, test.ShouldContainSubstring, "rate: 1 Bytes/s")
 
 		// Within the same interval, further chunks do not log again.
 		p.addBytes(25)
@@ -42,6 +43,7 @@ func TestUploadProgressLogger(t *testing.T) {
 		test.That(t, len(infos), test.ShouldEqual, 2)
 		test.That(t, infos[1].Message, test.ShouldContainSubstring, "uploaded /tmp/big.bin")
 		test.That(t, infos[1].Message, test.ShouldContainSubstring, "100 Bytes")
+		test.That(t, infos[1].Message, test.ShouldContainSubstring, "(avg rate: 3 Bytes/s)")
 	})
 
 	t.Run("uploads that finish within one interval stay quiet at Info", func(t *testing.T) {


### PR DESCRIPTION
**Summary**
Added an upload progress logger to emit throttled, human-readable progress logs (bytes sent, total, percent, rate) while a file upload stream is in flight. Progress logs at Info level at most once every 30 seconds; a completion summary logs at Info only if the upload outlived one interval (otherwise Debug), so small/fast uploads add no log noise at the default level. The tracking is wired into uploadArbitraryFile, so it covers all uploads of arbitrary (non-data-capture) files through the shared code path: scheduled/manual sync from the capture directory and additional sync paths, UploadDataFromPath, and UploadBinaryDataToDatasets.

**Testing**

Unit Testing: Added unit tests in upload_progress_test.go to test that logs progress at Info once per interval and an Info summary on completion and uploads that finish within one interval stay quiet at Info.

Manual Testing: uploaded a 4 GB file via an additional sync path and another via UploadDataFromPath — both produced progress lines every ~30s (sample below) and a completion summary; a 5 MB file synced with no Info-level output.
<img width="1635" height="257" alt="Screenshot 2026-07-30 at 11 45 37 AM" src="https://github.com/user-attachments/assets/63449d20-24d9-4276-8ab5-e469f0a39c28" />
