### PR TITLE
deb: pin /usr/bin/viam mode to 0755

### DIFF
--- a/etc/apt-e2e.sh
+++ b/etc/apt-e2e.sh
@@ -31,7 +31,12 @@ if [ -n "${EXPECTED_VERSION:-}" ]; then
 fi
 
 # `viam update` must go through apt and leave dpkg-owned files untouched
+# (dpkg -V exits 0 even when it reports differences, so assert on its output)
 viam update
-dpkg -V viam-cli
+if [ -n "$(dpkg -V viam-cli)" ]; then
+	echo "viam update modified dpkg-owned files:" >&2
+	dpkg -V viam-cli >&2
+	exit 1
+fi
 
 echo "apt e2e OK: $(viam version)"

--- a/etc/packaging/nfpm/viam-cli.yaml
+++ b/etc/packaging/nfpm/viam-cli.yaml
@@ -15,6 +15,8 @@ description: |
 contents:
   - src: bin/linux-${DEB_ARCH}/viam-cli
     dst: /usr/bin/viam
+    file_info:
+      mode: 0755
   - src: /usr/bin/viam
     dst: /usr/bin/viam-cli
     type: symlink


### PR DESCRIPTION
nfpm copies the source file's mode into the package. CI never hits this (`go build` outputs 0755), but a deb built from a downloaded binary — as in the v1.0.0 backfill — ships a non-executable `/usr/bin/viam`. Pinning `file_info.mode` makes the package independent of the source file's mode.

Follow-up to #6293, caught during the v1.0.0 backfill: install produced `bash: /usr/bin/viam: Permission denied`; with the pin, the same staged binary installs and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)