### PR TITLE
RSDK-14351 web/server.TestCloudModulesRespondToDebugAndLogChanges: flaky test fix module rebuild timing

### DIFF
--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -732,13 +732,22 @@ func TestCloudModulesRespondToDebugAndLogChanges(t *testing.T) {
 		test.That(t, stopServer(), test.ShouldBeNil)
 	})
 
-	// helper function that waits longer than the specified refreshInterval
-	// to make sure we always wait long enough for a reconfigure to happen
+	// helper function that polls an assertion for well longer than the cloud
+	// RefreshInterval so we always wait long enough for a reconfigure to happen.
+	//
+	// After a config change is stored in the fake cloud the server must (1) re-fetch
+	// the config on its next poll (up to one refreshInterval away) and then (2) tear
+	// down and rebuild the module process. Replacing the module reconfigure with a
+	// full rebuild made shutdown slower, and on loaded Windows CI that rebuild can
+	// take several seconds. While the module is restarting the "helper" resource is
+	// briefly absent and DoCommand fails with "resource ... not found" (RSDK-14351).
+	// The previous 3*refreshInterval (~3s) budget was occasionally too short, so give
+	// ample headroom. The poll returns as soon as the assertion passes, so this does
+	// not slow down the common case.
 	waitForAssertionLongerThanRefreshInterval := func(t *testing.T, assertion func(tb testing.TB)) {
 		t.Helper()
-		// flake on Windows with original 50ms x 50 attempts after replacing reconfigure with rebuild (slower shutdown, unclear why)
 		retryInterval := 200 * time.Millisecond
-		nRuns := int(refreshInterval * 3 / retryInterval)
+		nRuns := int(refreshInterval * 15 / retryInterval)
 		gtestutils.WaitForAssertionWithSleep(t, retryInterval, nRuns, assertion)
 	}
 


### PR DESCRIPTION
## Summary

Fixes the intermittent failure of `go.viam.com/rdk/web/server.TestCloudModulesRespondToDebugAndLogChanges` (observed on Windows CI):

```
entrypoint_test.go:804
Expected: nil
Actual:   'rpc error: code = Unknown desc = resource rdk:component:generic/helper not found'
```

## Root cause

The test drives a series of `debug`/`log` config transitions through a fake cloud server and, after each one, polls the `helper` component with `DoCommand` until it reports the expected log level.

Each debug/log change forces the module process to be **rebuilt** (the module log level is passed as a `--log-level` process argument, so it can only change on a full restart). After a config change is stored in the fake cloud, the server must:

1. re-fetch the config on its next poll (up to one `refreshInterval` away), then
2. tear down and rebuild the module process.

While the module is restarting, the `helper` resource is briefly removed from the server's resource collection, so `DoCommand` returns `resource ... not found` (from `apiResourceCollection.Resource`). The poll helper retries the whole assertion and returns as soon as it passes, but its budget was only `3 * refreshInterval` (≈3s). On loaded Windows CI — where the module rebuild (a full process restart) is slow and this test runs in parallel with many others — the poll delay plus the rebuild can exceed 3s, exhausting every retry while the resource is still absent.

## Fix

Increase the poll budget in `waitForAssertionLongerThanRefreshInterval` from `3 * refreshInterval` to `15 * refreshInterval` and document why. Because the poll returns immediately once the assertion passes, the larger cap only adds wall-clock time on the slow/failing path and does not slow down the common case. A genuine regression in debug/log propagation would still fail (just later), so this does not mask real bugs.

## Testing

This is a comment + numeric-constant change to test timing logic; `gofmt` is clean. The repository pins Go 1.25.10 in `go.mod` and the toolchain download is blocked in this environment, so a full `go test` could not be run here; the flake is also Windows-specific and would not reproduce on Linux.

Key: RSDK-14351

Co-authored by Claude agent for Jira.