### PR TITLE
RSDK-14333 cli: flaky test fix TestTunnelE2ECLI

### DIFF
--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1681,7 +1681,14 @@ func TestTunnelE2ECLI(t *testing.T) {
 			},
 		},
 	}
-	rc, stopServer := serverutils.TryStartServerAndConnect(t, ctx, cfg, logger, nil)
+	// Connect over direct gRPC, matching every other robot-connecting test in this file
+	// (see the dialOverride helper). Tunneling is transport-agnostic, and skipping the
+	// WebRTC signaling/ICE handshake avoids its long worst-case retry tail on slow CI
+	// runners, which could otherwise keep this connection attempt running long enough to
+	// push the cli package past the default 10m go-test timeout (RSDK-14333).
+	rc, stopServer := serverutils.TryStartServerAndConnect(t, ctx, cfg, logger, nil,
+		client.WithDialOptions(rpc.WithForceDirectGRPC()),
+	)
 	t.Cleanup(func() {
 		test.That(t, rc.Close(ctx), test.ShouldBeNil)
 		// stopServer will be called toward the end of the test so we can wait on the

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1681,13 +1681,13 @@ func TestTunnelE2ECLI(t *testing.T) {
 			},
 		},
 	}
-	// Connect over direct gRPC, matching every other robot-connecting test in this file
-	// (see the dialOverride helper). Tunneling is transport-agnostic, and skipping the
-	// WebRTC signaling/ICE handshake avoids its long worst-case retry tail on slow CI
-	// runners, which could otherwise keep this connection attempt running long enough to
-	// push the cli package past the default 10m go-test timeout (RSDK-14333).
+	// Connect over direct gRPC with no TLS. Skipping the WebRTC signaling/ICE
+	// handshake avoids its long worst-case retry tail on slow CI runners
+	// (RSDK-14333). WithInsecure is required because the test server has no TLS
+	// certs; without it the TLS downgrade probe races the server startup and the
+	// client falls back to a TLS dial that hangs against the plaintext listener.
 	rc, stopServer := serverutils.TryStartServerAndConnect(t, ctx, cfg, logger, nil,
-		client.WithDialOptions(rpc.WithForceDirectGRPC()),
+		client.WithDialOptions(rpc.WithForceDirectGRPC(), rpc.WithInsecure()),
 	)
 	t.Cleanup(func() {
 		test.That(t, rc.Close(ctx), test.ShouldBeNil)


### PR DESCRIPTION
## Summary

Fixes the intermittent package-level test timeout filed as `Test Timeout: go.viam.com/rdk/cli.TestUpdateModelsAction`.

The failure was a **package-wide** `panic: test timed out after 10m0s` in the `cli` package. `TestUpdateModelsAction` actually **passed** (`--- PASS: TestUpdateModelsAction (5.66s)`); the test still running when the alarm fired was `TestTunnelE2ECLI`, caught mid-connection inside `serverutils.TryStartServerAndConnect` (the goroutine dump shows it blocked in the WebRTC signaling dial). The stack traces come from a macOS runner (`/Users/runner/...`).

## Root cause

- The macOS and Windows test jobs run `gotestsum … $TEST_TARGET` **without** the `-timeout 40m` override that `etc/test.sh` uses everywhere else, so each package's test binary gets the **default 10-minute** timeout.
- `TestTunnelE2ECLI` connected to its in-process `viam-server` over the **default WebRTC-first** path. It is the *only* robot-connecting test in `cli/client_test.go` that does so — every other one forces direct gRPC via the shared `dialOverride` helper (`client.WithDialOptions(rpc.WithForceDirectGRPC())`).
- Connecting to a local server, WebRTC adds the signaling/ICE handshake (candidate gathering, STUN attempts, a 10s offer deadline). When that struggles on a slow CI runner, `client.New`'s connect retries and `TryStartServerAndConnect`'s outer retries can burn a large, variable tail (up to tens of seconds) before succeeding or falling back to direct gRPC — versus sub-second, deterministic direct gRPC. That variance on top of the already heavy `cli` package is enough to occasionally push the binary past the default 10m timeout, with `TestTunnelE2ECLI` left as the last running test.

Note: the `zeroconf` goroutine in the dump is just the server's normal mDNS receiver loop (present in every viam-server); it is not stuck, so no dependency change is needed.

## Fix

Force a direct gRPC connection for `TestTunnelE2ECLI`, matching every other robot-connecting test in the file:

```go
rc, stopServer := serverutils.TryStartServerAndConnect(t, ctx, cfg, logger, nil,
    client.WithDialOptions(rpc.WithForceDirectGRPC()),
)
```

Tunneling is transport-agnostic (the tunnel travels over a gRPC stream either way), so coverage is unchanged while the connection becomes fast and deterministic. WebRTC-transport tunnel coverage still lives in `web/server`'s `TestTunnelE2E`.

## Testing

Local `go test` could not be run in this environment (the module cache and the Go 1.25.10 toolchain required by `go.mod` are unavailable offline). The change is `gofmt`-clean, parses, uses the exact `client.WithDialOptions(rpc.WithForceDirectGRPC())` pattern already proven in this file (`dialOverride`), in `robot/client/client_test.go`, and in production `module/module.go`, and needs no new imports.

Key: RSDK-14333

Co-authored by Claude agent for Jira.