### PR TITLE
APP-17471 Gate /debug endpoints behind web profile flag

### DIFF
--- a/robot/web/debug_test.go
+++ b/robot/web/debug_test.go
@@ -1,0 +1,82 @@
+package web
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	weboptions "go.viam.com/rdk/robot/web/options"
+	"go.viam.com/rdk/testutils/inject"
+	"go.viam.com/rdk/testutils/robottestutils"
+)
+
+// TestDebugEndpointsGatedByWebProfile verifies that the /debug endpoints (pprof and the
+// resource graph visualization) are only exposed when the web profile option is enabled.
+func TestDebugEndpointsGatedByWebProfile(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	ctx, robot := setupRobotCtx(t)
+
+	const dot = "digraph rdk {}"
+	robot.(*inject.Robot).ExportResourcesAsDotFunc = func(index int) (resource.GetSnapshotInfo, error) {
+		return resource.GetSnapshotInfo{
+			Snapshot: resource.Snapshot{Dot: dot, CreatedAt: time.Now()},
+			Index:    0,
+			Count:    1,
+		}, nil
+	}
+
+	get := func(t *testing.T, url string) (int, string) {
+		t.Helper()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		test.That(t, err, test.ShouldBeNil)
+		resp, err := http.DefaultClient.Do(req)
+		test.That(t, err, test.ShouldBeNil)
+		defer func() { test.That(t, resp.Body.Close(), test.ShouldBeNil) }()
+		body, err := io.ReadAll(resp.Body)
+		test.That(t, err, test.ShouldBeNil)
+		return resp.StatusCode, string(body)
+	}
+
+	startWeb := func(t *testing.T, enableWebProfile bool) string {
+		t.Helper()
+		svc := New(robot, logger)
+		options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
+		options.Pprof = enableWebProfile
+		test.That(t, svc.Start(ctx, options), test.ShouldBeNil)
+		t.Cleanup(func() { test.That(t, svc.Close(context.Background()), test.ShouldBeNil) })
+		return "http://" + addr
+	}
+
+	// Sanity check: the web profile option defaults to disabled.
+	test.That(t, weboptions.New().Pprof, test.ShouldBeFalse)
+
+	t.Run("disabled by default", func(t *testing.T) {
+		base := startWeb(t, false)
+
+		code, body := get(t, base+"/debug/pprof/")
+		test.That(t, code, test.ShouldNotEqual, http.StatusOK)
+		test.That(t, body, test.ShouldNotContainSubstring, "Types of profiles available")
+
+		code, body = get(t, base+"/debug/graph?layout=text")
+		test.That(t, code, test.ShouldNotEqual, http.StatusOK)
+		test.That(t, body, test.ShouldNotContainSubstring, dot)
+	})
+
+	t.Run("enabled with web profile", func(t *testing.T) {
+		base := startWeb(t, true)
+
+		code, body := get(t, base+"/debug/pprof/")
+		test.That(t, code, test.ShouldEqual, http.StatusOK)
+		test.That(t, body, test.ShouldContainSubstring, "Types of profiles available")
+
+		code, body = get(t, base+"/debug/graph?layout=text")
+		test.That(t, code, test.ShouldEqual, http.StatusOK)
+		test.That(t, body, test.ShouldContainSubstring, dot)
+	})
+}

--- a/robot/web/options/options.go
+++ b/robot/web/options/options.go
@@ -14,7 +14,9 @@ import (
 
 // Options are used for configuring the web server.
 type Options struct {
-	// Pprof turns on the pprof profiler accessible at /debug
+	// Pprof exposes the debug HTTP endpoints (the pprof profiler and the resource
+	// graph visualization) under /debug. These are disabled by default since they
+	// can leak internal details about the robot.
 	Pprof bool
 
 	// StaticHost is a url to use for static assets, like app.viam.com

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -812,18 +812,20 @@ func (svc *webService) initMux(options weboptions.Options) *goji.Mux {
 		}
 	})
 
+	// The /debug endpoints can leak internal details about the robot, so they are only
+	// registered when the web profile option is enabled (via the `enable_web_profile`
+	// config field or the `--webprofile` command line flag).
 	if options.Pprof {
 		mux.HandleFunc(pat.New("/debug/pprof/"), pprof.Index)
 		mux.HandleFunc(pat.New("/debug/pprof/cmdline"), pprof.Cmdline)
 		mux.HandleFunc(pat.New("/debug/pprof/profile"), pprof.Profile)
 		mux.HandleFunc(pat.New("/debug/pprof/symbol"), pprof.Symbol)
 		mux.HandleFunc(pat.New("/debug/pprof/trace"), pprof.Trace)
-	}
 
-	// serve resource graph visualization
-	// TODO: hide behind option
-	// TODO: accept params to display different formats
-	mux.HandleFunc(pat.New("/debug/graph"), svc.handleVisualizeResourceGraph)
+		// serve resource graph visualization
+		// TODO: accept params to display different formats
+		mux.HandleFunc(pat.New("/debug/graph"), svc.handleVisualizeResourceGraph)
+	}
 
 	// serve restart status
 	mux.HandleFunc(pat.New("/restart_status"), svc.handleRestartStatus)

--- a/testutils/inject/robot.go
+++ b/testutils/inject/robot.go
@@ -53,14 +53,15 @@ type Robot struct {
 		dst string,
 		additionalTransforms []*referenceframe.LinkInFrame,
 	) (*referenceframe.PoseInFrame, error)
-	TransformPointCloudFunc func(ctx context.Context, srcpc pointcloud.PointCloud, srcName, dstName string) (pointcloud.PointCloud, error)
-	CurrentInputsFunc       func(ctx context.Context) (referenceframe.FrameSystemInputs, error)
-	ModuleAddressesFunc     func() (config.ParentSockAddrs, error)
-	CloudMetadataFunc       func(ctx context.Context) (cloud.Metadata, error)
-	MachineStatusFunc       func(ctx context.Context) (robot.MachineStatus, error)
-	ShutdownFunc            func(ctx context.Context) error
-	ListTunnelsFunc         func(ctx context.Context) ([]config.TrafficTunnelEndpoint, error)
-	UploadDataFromPathFunc  func(
+	TransformPointCloudFunc  func(ctx context.Context, srcpc pointcloud.PointCloud, srcName, dstName string) (pointcloud.PointCloud, error)
+	CurrentInputsFunc        func(ctx context.Context) (referenceframe.FrameSystemInputs, error)
+	ModuleAddressesFunc      func() (config.ParentSockAddrs, error)
+	CloudMetadataFunc        func(ctx context.Context) (cloud.Metadata, error)
+	MachineStatusFunc        func(ctx context.Context) (robot.MachineStatus, error)
+	ExportResourcesAsDotFunc func(index int) (resource.GetSnapshotInfo, error)
+	ShutdownFunc             func(ctx context.Context) error
+	ListTunnelsFunc          func(ctx context.Context) ([]config.TrafficTunnelEndpoint, error)
+	UploadDataFromPathFunc   func(
 		ctx context.Context,
 		path string,
 		uploadMetadata *datasyncpb.UploadMetadata, extra map[string]interface{},
@@ -357,6 +358,16 @@ func (r *Robot) MachineStatus(ctx context.Context) (robot.MachineStatus, error) 
 		return r.LocalRobot.MachineStatus(ctx)
 	}
 	return r.MachineStatusFunc(ctx)
+}
+
+// ExportResourcesAsDot calls the injected ExportResourcesAsDot or the real one.
+func (r *Robot) ExportResourcesAsDot(index int) (resource.GetSnapshotInfo, error) {
+	r.Mu.RLock()
+	defer r.Mu.RUnlock()
+	if r.ExportResourcesAsDotFunc == nil {
+		return r.LocalRobot.ExportResourcesAsDot(index)
+	}
+	return r.ExportResourcesAsDotFunc(index)
 }
 
 // Shutdown calls the injected Shutdown or the real one.


### PR DESCRIPTION
## Summary

The `/debug/graph` resource-graph visualization endpoint was registered unconditionally on the web server mux (see the pre-existing `// TODO: hide behind option` comment), exposing internal details about the robot to anyone who could reach the server on its bind address. Only the `/debug/pprof/*` endpoints were gated behind the web profile option.

This PR moves the `/debug/graph` registration inside the existing `options.Pprof` gate so that **all** `/debug` endpoints require the web profile to be explicitly enabled. This matches the two remediation options in the work item ("bind to localhost or be protected by a flag") by choosing the flag approach, consistent with how the pprof endpoints already behave.

The web profile is enabled via either:
- the `enable_web_profile` config field, or
- the `--webprofile` command line flag.

Both remain **disabled by default**, so `/debug/pprof/*` and `/debug/graph` now return the default (non-debug) response unless the operator opts in.

## Changes

- `robot/web/web.go` — register `/debug/graph` inside the `if options.Pprof` block; removed the stale `TODO: hide behind option`.
- `robot/web/options/options.go` — clarified the `Pprof` option doc comment to note it also gates the resource graph endpoint.
- `testutils/inject/robot.go` — added `ExportResourcesAsDotFunc` to the injected robot so the graph handler can be exercised in tests.
- `robot/web/debug_test.go` — new test `TestDebugEndpointsGatedByWebProfile` asserting `/debug/pprof/` and `/debug/graph` are only served when the web profile option is enabled.

## Testing

- `go test ./robot/web -run 'TestWebStart|TestDebugEndpointsGatedByWebProfile|TestForeignResource|TestWebStartOptions'` — pass
- `golangci-lint run` (pinned v1.62.2) on `./robot/web` and `./testutils/inject` — clean
- `go vet` on both packages — clean

Key: APP-17471

Co-authored by Claude agent for Jira.