### PR TITLE
Enforce machine-wide resource name uniqueness

### DIFF
--- a/etc/configs/fake.json
+++ b/etc/configs/fake.json
@@ -237,7 +237,7 @@
             "model": "builtin"
         },
         {
-            "name": "generic1",
+            "name": "generic1svc",
             "type": "generic",
             "model": "fake"
         }

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -416,27 +416,61 @@ func seq2First[K, V any](seq iter.Seq2[K, V]) (K, V, bool) {
 func (g *Graph) SimpleNamesWhere(filter func(Name, *GraphNode) bool) []Name {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
+
+	type candidate struct {
+		name Name
+		node *GraphNode
+	}
 	var result []Name
+	emit := func(c candidate) {
+		if filter(c.name, c.node) {
+			result = append(result, c.name)
+		}
+	}
+
+	// Group candidates by bare name to enforce name uniqueness across APIs.
+	byName := make(map[string][]candidate)
 	for k, v := range g.nodes.simpleNameCache {
 		if v.local == nil && len(v.remote) != 1 {
 			continue
 		}
-		name := Name{
-			API:  k.api,
-			Name: k.name,
-		}
+		c := candidate{name: Name{API: k.api, Name: k.name}}
 		if v.local != nil {
-			if !filter(name, v.local) {
-				continue
-			}
+			c.node = v.local
 		} else {
 			remName, remNode, _ := seq2First(maps.All(v.remote))
-			name.Remote = remName
-			if !filter(name, remNode) {
+			c.name.Remote = remName
+			c.node = remNode
+		}
+
+		// Only components and services participate in machine-wide name uniqueness. The
+		// reserved default-service name and rdk-internal resources are exempt and emitted per-API.
+		if k.name == DefaultServiceName ||
+			k.api.Type.Namespace == APINamespaceRDKInternal ||
+			!(k.api.IsComponent() || k.api.IsService()) {
+			emit(c)
+			continue
+		}
+		byName[k.name] = append(byName[k.name], c)
+	}
+
+	for _, cands := range byName {
+		chosen := cands[0]
+		if len(cands) > 1 {
+			// A local resource wins over remotes claiming the same name. If there is not
+			// exactly one local claimant (e.g. remote resources collide), the name is hidden.
+			var localCands []candidate
+			for _, c := range cands {
+				if c.name.Remote == "" {
+					localCands = append(localCands, c)
+				}
+			}
+			if len(localCands) != 1 {
 				continue
 			}
+			chosen = localCands[0]
 		}
-		result = append(result, name)
+		emit(chosen)
 	}
 	return result
 }

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -1254,6 +1254,62 @@ func TestFindBySimpleNameAndAPI(t *testing.T) {
 	test.That(t, err, test.ShouldResemble, fooPrefixedNotFoundError)
 }
 
+func TestSimpleNamesWhereNameUniqueness(t *testing.T) {
+	// Verifies machine-wide name uniqueness in SimpleNamesWhere: a bare name claimed by more
+	// than one resource across different APIs is hidden (a local resource wins over remotes),
+	// while the reserved "builtin" default-service name and rdk-internal resources are exempt
+	// and remain per-API.
+	logger := logging.NewTestLogger(t)
+
+	compA := APINamespace("namespace").WithComponentType("aapi")
+	svcB := APINamespace("namespace").WithServiceType("bapi")
+	internalA := APINamespaceRDKInternal.WithServiceType("iapi")
+	internalB := APINamespaceRDKInternal.WithServiceType("japi")
+
+	newNode := func() *GraphNode { return NewUnconfiguredGraphNode(Config{}, nil) }
+	all := func(Name, *GraphNode) bool { return true }
+
+	g := NewGraph(logger)
+
+	// Single local resource: advertised.
+	g.AddNode(Name{API: compA, Name: "solo"}, newNode())
+	// A local component and a local service sharing a name: both hidden.
+	g.AddNode(Name{API: compA, Name: "dupLocal"}, newNode())
+	g.AddNode(Name{API: svcB, Name: "dupLocal"}, newNode())
+	// Local + remote sharing a name across APIs: local wins, remote hidden.
+	g.AddNode(Name{API: compA, Name: "localWins"}, newNode())
+	g.AddNode(Name{API: svcB, Name: "localWins", Remote: "r1"}, newNode())
+	// Two remotes sharing a name across APIs, no local: both hidden.
+	g.AddNode(Name{API: compA, Name: "dupRemote", Remote: "r1"}, newNode())
+	g.AddNode(Name{API: svcB, Name: "dupRemote", Remote: "r2"}, newNode())
+	// Two "builtin" default services across APIs: both advertised (exempt).
+	g.AddNode(Name{API: compA, Name: DefaultServiceName}, newNode())
+	g.AddNode(Name{API: svcB, Name: DefaultServiceName}, newNode())
+	// Two rdk-internal resources sharing a name across APIs: both advertised (exempt).
+	g.AddNode(Name{API: internalA, Name: "shared"}, newNode())
+	g.AddNode(Name{API: internalB, Name: "shared"}, newNode())
+
+	got := g.SimpleNamesWhere(all)
+
+	expected := []Name{
+		{API: compA, Name: "solo"},
+		{API: compA, Name: "localWins"},
+		{API: compA, Name: DefaultServiceName},
+		{API: svcB, Name: DefaultServiceName},
+		{API: internalA, Name: "shared"},
+		{API: internalB, Name: "shared"},
+	}
+	test.That(t, len(got), test.ShouldEqual, len(expected))
+	for _, e := range expected {
+		test.That(t, got, test.ShouldContain, e)
+	}
+	// The hidden names must not appear under any API.
+	for _, n := range got {
+		test.That(t, n.Name, test.ShouldNotEqual, "dupLocal")
+		test.That(t, n.Name, test.ShouldNotEqual, "dupRemote")
+	}
+}
+
 func shouldMatchMultipleNodesErr(actual interface{}, expected ...interface{}) string {
 	if len(expected) != 1 {
 		panic("takes exactly one argument")

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -1968,13 +1968,15 @@ func TestCheckMaxInstanceInvalid(t *testing.T) {
 		},
 		Components: []resource.Config{
 			{
-				Name:                "fake2",
+				// Distinct from the data_manager service names above: resource names must be
+				// unique across the machine regardless of type.
+				Name:                "fakeArm1",
 				Model:               fake.Model,
 				API:                 arm.API,
 				ConvertedAttributes: &fake.Config{},
 			},
 			{
-				Name:                "fake3",
+				Name:                "fakeArm2",
 				Model:               fake.Model,
 				API:                 arm.API,
 				ConvertedAttributes: &fake.Config{},

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -1243,18 +1243,30 @@ func (manager *resourceManager) addToBeConstructedResource(
 		return fmt.Errorf("cannot add duplicate local resource %s", name)
 	}
 
-	// Check for a full resource name collision and log an error if there is one.
-	_, err := manager.resources.FindBySimpleNameAndAPI(name.Name, name.API)
-	switch {
-	case err == nil, resource.IsMultipleMatchingRemoteNodesError(err):
-		// A collision could be indicated by a non-nil graph node (a single pre-existing
-		// resource with the same name), or a MultipleMatchingRemoteNodesError (multiple
-		// pre-existing remote resources with the same name).
-		manager.logger.Errorw("Found resource name collision, please check your configuration", "name", name.Name, "api", name.API)
-	case resource.IsNodeNotFoundError(err):
-		// No resources with the given simple name + API exists yet. All good.
-	default:
-		manager.logger.Warnw("Unexpected error while checking for resource name collision", "err", err)
+	// Detection-only rollout for machine-wide name uniqueness: a component or service whose
+	// simple name is already used by another local resource of a different API will be refused
+	// in a future viam-server release. For now we only log so operators can fix configs before
+	// enforcement lands; the resource is still built. The reserved default-service name is
+	// exempt (every service API registers its own "builtin"), and nodes already marked for
+	// removal (e.g. a resource being reconfigured to a new API under the same name) are not
+	// collisions.
+	if (name.API.IsComponent() || name.API.IsService()) && name.Name != resource.DefaultServiceName {
+		var collidingLocalNames []resource.Name
+		for _, existing := range manager.resources.FindBySimpleName(name.Name) {
+			if existing.Remote != "" {
+				continue
+			}
+			if node, ok := manager.resources.Node(existing); ok && node.MarkedForRemoval() {
+				continue
+			}
+			collidingLocalNames = append(collidingLocalNames, existing)
+		}
+		if len(collidingLocalNames) > 0 {
+			manager.logger.Errorw("Resource name collision: this name is already used by another resource of a "+
+				"different type. Resource names must be unique across the machine regardless of type; a future "+
+				"viam-server release will refuse to build colliding resources. Please rename one of them",
+				"name", name.Name, "api", name.API, "colliding", resource.NamesToStrings(collidingLocalNames))
+		}
 	}
 
 	gNode := resource.NewUnconfiguredGraphNode(conf, deps)

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -336,6 +336,18 @@ func (manager *resourceManager) updateRemoteResourceNames(
 				manager.logger.Warnw("Unexpected error while checking for resource name collision", "err", err)
 			}
 
+			// The check above catches same-API collisions. Also flag cross-API name
+			// collisions: this remote resource is hidden from the machine's resource list
+			// but still added to the resource graph.
+			for _, other := range manager.resources.FindBySimpleName(prefixedSimpleName) {
+				if other.API != resName.API {
+					manager.logger.Errorw("Remote resource name collision with a different-type resource; the remote "+
+						"resource will be hidden until the collision is fixed",
+						"name", prefixedSimpleName, "remote_api", resName.API, "conflicts_with", other.String(), "remote", remoteName.Name)
+					break
+				}
+			}
+
 			// Configure a new graph node with the gRPC client to this remote resource.
 			gNode = resource.NewConfiguredGraphNodeWithPrefix(resource.Config{}, res, unknownModel, prefix)
 			if err := manager.resources.AddNode(resName, gNode); err != nil {
@@ -1241,25 +1253,33 @@ func (manager *resourceManager) addToBeConstructedResource(
 	deps []string,
 	revision string,
 ) error {
-	if _, hasNode := manager.resources.Node(name); hasNode {
-		manager.markResourcesRemoved([]resource.Name{name}, nil, true /* remove dependents */)
-		manager.logger.Errorw("Cannot add duplicate local resource. Rename the resource. Neither resource will be reachable through "+
-			"this machine until collision is fixed", "colliding name", name)
-		return fmt.Errorf("cannot add duplicate local resource %s", name)
+	// Machine-wide name uniqueness. Components and services may not share a simple name with any
+	// other local resource, even under a different API; other resource types conflict only on an
+	// exact name. On a collision neither the new nor the pre-existing resource(s) are reachable
+	// until the config is fixed.
+	var collidingNames []resource.Name
+	if (name.API.IsComponent() || name.API.IsService()) && name.Name != resource.DefaultServiceName {
+		for _, existing := range manager.resources.FindBySimpleName(name.Name) {
+			if existing.Remote != "" {
+				continue
+			}
+			// A node already marked for removal is on its way out and is not a real collision.
+			if node, ok := manager.resources.Node(existing); ok && node.MarkedForRemoval() {
+				continue
+			}
+			collidingNames = append(collidingNames, existing)
+		}
+	} else if _, hasNode := manager.resources.Node(name); hasNode {
+		// Non-component/service resources (remotes, builtin) conflict only on an exact name.
+		collidingNames = append(collidingNames, name)
 	}
-
-	// Check for a full resource name collision and log an error if there is one.
-	_, err := manager.resources.FindBySimpleNameAndAPI(name.Name, name.API)
-	switch {
-	case err == nil, resource.IsMultipleMatchingRemoteNodesError(err):
-		// A collision could be indicated by a non-nil graph node (a single pre-existing
-		// resource with the same name), or a MultipleMatchingRemoteNodesError (multiple
-		// pre-existing remote resources with the same name).
-		manager.logger.Errorw("Found resource name collision, please check your configuration", "name", name.Name, "api", name.API)
-	case resource.IsNodeNotFoundError(err):
-		// No resources with the given simple name + API exists yet. All good.
-	default:
-		manager.logger.Warnw("Unexpected error while checking for resource name collision", "err", err)
+	if len(collidingNames) > 0 {
+		manager.markResourcesRemoved(collidingNames, nil, true /* remove dependents */)
+		manager.logger.Errorw("Cannot add resource with a duplicate name; resource names must be unique across the "+
+			"machine regardless of type. Neither the new resource nor the existing resource(s) with this name will be "+
+			"reachable until the collision is fixed",
+			"name", name.Name, "api", name.API, "colliding", resource.NamesToStrings(collidingNames))
+		return fmt.Errorf("cannot add duplicate resource %q: name %q is already in use", name, name.Name)
 	}
 
 	gNode := resource.NewUnconfiguredGraphNode(conf, deps)

--- a/robot/impl/robot_reconfigure_remote_test.go
+++ b/robot/impl/robot_reconfigure_remote_test.go
@@ -866,6 +866,67 @@ func TestFullResourceNameCollision(t *testing.T) {
 	}
 }
 
+func TestCrossAPINameCollision(t *testing.T) {
+	// Detection-only rollout: two local resources sharing a simple name under different APIs
+	// log an error-level collision, but both are still built and reachable (enforcement lands
+	// in a later release).
+	ctx := context.Background()
+
+	armModel := resource.DefaultModelFamily.WithModel(goutils.RandomAlphaString(8))
+	resource.RegisterComponent(arm.API, armModel, resource.Registration[arm.Arm, resource.NoNativeConfig]{
+		Constructor: func(context.Context, resource.Dependencies, resource.Config, logging.Logger) (arm.Arm, error) {
+			return &inject.Arm{}, nil
+		},
+	})
+	defer resource.Deregister(arm.API, armModel)
+
+	sensorModel := resource.DefaultModelFamily.WithModel(goutils.RandomAlphaString(8))
+	resource.RegisterComponent(sensor.API, sensorModel, resource.Registration[sensor.Sensor, resource.NoNativeConfig]{
+		Constructor: func(context.Context, resource.Dependencies, resource.Config, logging.Logger) (sensor.Sensor, error) {
+			return &inject.Sensor{}, nil
+		},
+	})
+	defer resource.Deregister(sensor.API, sensorModel)
+
+	logger, logs := logging.NewObservedTestLogger(t)
+
+	// Start with an arm and a sensor that share the name "dup" across different APIs.
+	cfg := &config.Config{
+		Components: []resource.Config{
+			{Name: "dup", Model: armModel, API: arm.API},
+			{Name: "dup", Model: sensorModel, API: sensor.API},
+		},
+	}
+	r := setupLocalRobot(t, ctx, cfg, logger)
+
+	// A collision was logged, but both resources are still built and reachable.
+	test.That(t, logs.FilterMessageSnippet("collision").Len(), test.ShouldBeGreaterThan, 0)
+	rdktestutils.VerifySameResourceNames(t, r.ResourceNames(),
+		[]resource.Name{arm.Named("dup"), sensor.Named("dup")})
+	_, err := r.ResourceByName(arm.Named("dup"))
+	test.That(t, err, test.ShouldBeNil)
+	_, err = r.ResourceByName(sensor.Named("dup"))
+	test.That(t, err, test.ShouldBeNil)
+
+	// Renaming clears the collision: no new collision is logged.
+	before := logs.FilterMessageSnippet("collision").Len()
+	cfg = &config.Config{
+		Components: []resource.Config{
+			{Name: "armDup", Model: armModel, API: arm.API},
+			{Name: "sensorDup", Model: sensorModel, API: sensor.API},
+		},
+	}
+	r.Reconfigure(ctx, cfg)
+
+	test.That(t, logs.FilterMessageSnippet("collision").Len(), test.ShouldEqual, before)
+	rdktestutils.VerifySameResourceNames(t, r.ResourceNames(),
+		[]resource.Name{arm.Named("armDup"), sensor.Named("sensorDup")})
+	_, err = r.ResourceByName(arm.Named("armDup"))
+	test.That(t, err, test.ShouldBeNil)
+	_, err = r.ResourceByName(sensor.Named("sensorDup"))
+	test.That(t, err, test.ShouldBeNil)
+}
+
 func TestRemoteCaptureMethodsName(t *testing.T) {
 	// Primarily a regression test for RSDK-13349.
 	//

--- a/robot/impl/robot_reconfigure_remote_test.go
+++ b/robot/impl/robot_reconfigure_remote_test.go
@@ -866,6 +866,121 @@ func TestFullResourceNameCollision(t *testing.T) {
 	}
 }
 
+func TestCrossAPINameCollision(t *testing.T) {
+	// Asserts machine-wide name uniqueness: two local resources may not share a simple name
+	// even under different APIs. On collision neither resource is built, and both become
+	// reachable again once the collision is resolved by renaming.
+	ctx := context.Background()
+
+	armModel := resource.DefaultModelFamily.WithModel(goutils.RandomAlphaString(8))
+	resource.RegisterComponent(arm.API, armModel, resource.Registration[arm.Arm, resource.NoNativeConfig]{
+		Constructor: func(context.Context, resource.Dependencies, resource.Config, logging.Logger) (arm.Arm, error) {
+			return &inject.Arm{}, nil
+		},
+	})
+	defer resource.Deregister(arm.API, armModel)
+
+	sensorModel := resource.DefaultModelFamily.WithModel(goutils.RandomAlphaString(8))
+	resource.RegisterComponent(sensor.API, sensorModel, resource.Registration[sensor.Sensor, resource.NoNativeConfig]{
+		Constructor: func(context.Context, resource.Dependencies, resource.Config, logging.Logger) (sensor.Sensor, error) {
+			return &inject.Sensor{}, nil
+		},
+	})
+	defer resource.Deregister(sensor.API, sensorModel)
+
+	logger, logs := logging.NewObservedTestLogger(t)
+
+	// Start with an arm and a sensor that share the name "dup" across different APIs.
+	cfg := &config.Config{
+		Components: []resource.Config{
+			{Name: "dup", Model: armModel, API: arm.API},
+			{Name: "dup", Model: sensorModel, API: sensor.API},
+		},
+	}
+	r := setupLocalRobot(t, ctx, cfg, logger)
+
+	// A collision was logged, and neither resource is reachable.
+	test.That(t, logs.FilterMessageSnippet("collision").Len(), test.ShouldBeGreaterThan, 0)
+	rdktestutils.VerifySameResourceNames(t, r.ResourceNames(), []resource.Name{})
+	_, err := r.ResourceByName(arm.Named("dup"))
+	test.That(t, resource.IsNotFoundError(err), test.ShouldBeTrue)
+	_, err = r.ResourceByName(sensor.Named("dup"))
+	test.That(t, resource.IsNotFoundError(err), test.ShouldBeTrue)
+
+	// Resolve the collision by renaming: both resources should now be reachable.
+	cfg = &config.Config{
+		Components: []resource.Config{
+			{Name: "armDup", Model: armModel, API: arm.API},
+			{Name: "sensorDup", Model: sensorModel, API: sensor.API},
+		},
+	}
+	r.Reconfigure(ctx, cfg)
+
+	rdktestutils.VerifySameResourceNames(t, r.ResourceNames(),
+		[]resource.Name{arm.Named("armDup"), sensor.Named("sensorDup")})
+	_, err = r.ResourceByName(arm.Named("armDup"))
+	test.That(t, err, test.ShouldBeNil)
+	_, err = r.ResourceByName(sensor.Named("sensorDup"))
+	test.That(t, err, test.ShouldBeNil)
+}
+
+func TestCrossAPIRemoteNameCollision(t *testing.T) {
+	// A remote resource whose name collides with a local resource of a different API is hidden
+	// from the machine's resource list (local wins) and logged, but is still directly resolvable
+	// by its exact name+API (advertise-hide-only: the lookup path is unchanged).
+	ctx := context.Background()
+
+	armModel := resource.DefaultModelFamily.WithModel(goutils.RandomAlphaString(8))
+	resource.RegisterComponent(arm.API, armModel, resource.Registration[arm.Arm, resource.NoNativeConfig]{
+		Constructor: func(context.Context, resource.Dependencies, resource.Config, logging.Logger) (arm.Arm, error) {
+			return &inject.Arm{}, nil
+		},
+	})
+	defer resource.Deregister(arm.API, armModel)
+
+	sensorModel := resource.DefaultModelFamily.WithModel(goutils.RandomAlphaString(8))
+	resource.RegisterComponent(sensor.API, sensorModel, resource.Registration[sensor.Sensor, resource.NoNativeConfig]{
+		Constructor: func(context.Context, resource.Dependencies, resource.Config, logging.Logger) (sensor.Sensor, error) {
+			return &inject.Sensor{}, nil
+		},
+	})
+	defer resource.Deregister(sensor.API, sensorModel)
+
+	logger, logs := logging.NewObservedTestLogger(t)
+
+	// Remote exposes a sensor named "shared".
+	remote := setupLocalRobot(t, ctx, &config.Config{
+		Components: []resource.Config{{Name: "shared", Model: sensorModel, API: sensor.API}},
+	}, logger.Sublogger("remote"))
+	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
+	test.That(t, remote.StartWeb(ctx, options), test.ShouldBeNil)
+
+	// Main has a local arm named "shared" and connects to the remote with no prefix.
+	main := setupLocalRobot(t, ctx, &config.Config{
+		Components: []resource.Config{{Name: "shared", Model: armModel, API: arm.API}},
+		Remotes:    []config.Remote{{Name: "r", Address: addr}},
+	}, logger.Sublogger("main"))
+
+	// Local arm "shared" wins; the remote sensor "shared" is hidden from the resource list, and
+	// the cross-API collision is logged.
+	testutils.WaitForAssertionWithSleep(t, time.Millisecond*100, 300, func(tb testing.TB) {
+		names := main.ResourceNames()
+		test.That(tb, names, test.ShouldContain, arm.Named("shared"))
+		test.That(tb, names, test.ShouldNotContain, sensor.Named("shared"))
+		test.That(tb, logs.FilterMessageSnippet("Remote resource name collision").Len(), test.ShouldBeGreaterThan, 0)
+	})
+
+	// The local arm "shared" is reachable.
+	_, err := main.ResourceByName(arm.Named("shared"))
+	test.That(t, err, test.ShouldBeNil)
+
+	// The hidden remote sensor "shared" is still directly resolvable by exact name+API.
+	res, err := main.ResourceByName(sensor.Named("shared"))
+	test.That(t, err, test.ShouldBeNil)
+	_, ok := res.(sensor.Sensor)
+	test.That(t, ok, test.ShouldBeTrue)
+}
+
 func TestRemoteCaptureMethodsName(t *testing.T) {
 	// Primarily a regression test for RSDK-13349.
 	//


### PR DESCRIPTION
## Description

Makes resource-name uniqueness machine-wide instead of per-API. Previously a name only had to be unique within a single API (the `(name, API)` key), so two components of different subtypes could share a name. Now a simple name identifies at most one resource across the whole machine.

Follow up to RSDK-11267 / #5221. This is a breaking change (it rejects configs accepted today);  impact was measured below.

## Behavior

| Situation | Result |
|---|---|
| Two local resources share a name | Neither is built; both (and their required dependents) are unreachable until the config is fixed. |
| Local + remote resource share a name | Local wins; the remote duplicate is hidden from the resource list (but remains in the graph). |
| Two remotes resources share a name | Both hidden. |
| Two resources share a name and API | Unchanged (already rejected today). |
| `builtin` / rdk-internal resources | Unchanged (exempt from check) |

## Implementation

- `addToBeConstructedResource` — a resource whose simple name is already used by another live local resource of any API is refused, and the pre-existing one is marked for removal until the collision is resolved. Skips `builtin` and nodes already marked for removal.
- `SimpleNamesWhere` — `ResourceNames` advertises unique names. Resources are grouped by bare name and cross-API duplicates are hidden (if a single local resource that name exist, it will be shown)
- `updateRemoteResourceNames` — logs cross-API remote collisions (the remote resource is hidden)

## Fleet impact

Scanned every machine's fragment-merged config for a name used by ≥2 different APIs (`builtin` excluded):

- 8 machine parts across 6 orgs — all internal test/demo machines, no customer production machines. Authored configs are essentially clean; every collision appears only after a fragment is merged in. Plan: hand-fix these 8 before merge.

  | Machine | Org | Duplicated name | Conflicting APIs |
  |---|---|---|---|
  | asdf3-main | Operator Org | `asdf` | arm + base_remote_control |
  | asdf-main | Michael Org 2 | `asdf` | base + slam |
  | asdf-main | Michael Org 2 | `asdf` | arm + sensors |
  | robert-main | Micheal's org | `hi` | board + navigation |
  | frag-test-main | Natalia's Org | `detCam` | base + camera |
  | frag-overwrites-main | viam-dev-beta | `asdf` | camera + sensor |
  | dawn-frog-main | Natalia's Org | `asdf` | vision + data_manager + mlmodel |
  | test-june-29-main | Fleet Team | `billing` | camera + sensor |

- Remotes: not a concern. 42 machines have an unprefixed, connecting remote (the collision ceiling), but every one resolves to an internal target (localhost, a LAN IP, a staging machine, or a lab rig), so the real collision count is ~0. A remote collision only hides a remote resource anyway — the machine keeps running.

## Tests

- `TestCrossAPINameCollision` — two local resources sharing a name across APIs: neither reachable on collision, both reachable after rename.
- `TestCrossAPIRemoteNameCollision` — a remote resource whose name collides with a local one is hidden from `ResourceNames` and logged, but still directly resolvable by exact name+API (advertise-hide-only).
- `TestSimpleNamesWhereNameUniqueness` — unit test for the cross-API collapse (local-wins / hide-all / `builtin` + rdk-internal exempt).
- Updated fixtures/tests that had pre-existing cross-API name collisions: `TestCheckMaxInstanceInvalid`, `TestResourceStartsOnReconfigure`, and `etc/configs/fake.json` (split the duplicated `generic1` into distinct component/service names).
- [x] Manual E2E (built server binary + `grpcurl`): two local resources sharing a name → both refused, absent from `ResourceNames`, collision logged, machine stays up. A remote resource colliding with a local one → local wins in `ResourceNames`, remote hidden + logged, machine stays up, and the hidden remote resource is still directly resolvable by exact name+API.
