### PR TITLE
RSDK-14357 Use viam home prefix for ftdc when it's available

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -3217,7 +3217,10 @@ Note: There is no progress meter while copying is in progress.
 								[]string{generalFlagPart},
 								true, false,
 								"[target]"),
-							Flags:  commonPartFlags,
+							Flags: lo.Flatten([][]cli.Flag{
+								commonPartFlags,
+								commonPathFlags,
+							}),
 							Action: createActionCommandWithT(MachinesPartGetFTDCAction),
 						},
 						{

--- a/cli/client.go
+++ b/cli/client.go
@@ -90,10 +90,34 @@ const (
 	yellow = "\033[1;33m%s\033[0m"
 )
 
+// ftdc data is stored at VIAM_HOME/diagnostics.data/[part-id]
+const ftdcRelativePath = "diagnostics.data"
+
+// legacyViamHomeDir is where the CLI assumed viam-server kept its data before it
+// learned to let the machine resolve its own VIAM_HOME.
+const legacyViamHomeDir = "~/.viam"
+
 var (
 	errNoShellService = errors.New("shell service is not enabled on this machine part")
-	ftdcPath          = path.Join("~", ".viam", "diagnostics.data")
+	ftdcPath          = path.Join(shell.ViamHomePrefix, ftdcRelativePath)
 )
+
+// legacyViamHomePath rewrites a shell.ViamHomePrefix path to the directory the CLI used
+// to hardcode, reporting whether src was rooted at the prefix at all.
+//
+// A viam-server predating the prefix does not know how to expand it. A machine that old
+// either has VIAM_HOME unset — in which case ~/.viam is the right answer — or was
+// already failing this command before the prefix existed.
+func legacyViamHomePath(src string) (string, bool) {
+	rest, found := strings.CutPrefix(src, shell.ViamHomePrefix)
+	if !found {
+		return "", false
+	}
+	// Intentional use of path instead of filepath: Windows understands both / and
+	// \ as path separators, and we don't want a cli running on Windows to send
+	// a path using \ to a *NIX machine.
+	return path.Join(legacyViamHomeDir, rest), true
+}
 
 // viamClient wraps a cli.Context and provides all the CLI command functionality
 // needed to talk to the app and data services but not directly to robot parts.
@@ -3742,6 +3766,7 @@ type machinesPartGetFTDCArgs struct {
 	Location     string
 	Machine      string
 	Part         string
+	ViamHomeDir  string
 }
 
 // MachinesPartGetFTDCAction is the corresponding Action for 'machines part get-ftdc'.
@@ -3941,6 +3966,10 @@ func (c *viamClient) machinesPartGetFTDCAction(
 	// \ as path separators, and we don't want a cli running on Windows to send
 	// a path using \ to a *NIX machine.
 	src := path.Join(ftdcPath, part.Id)
+	// if target part has a non-default VIAM_HOME, the caller can specify it.
+	if flagArgs.ViamHomeDir != "" {
+		src = path.Join(flagArgs.ViamHomeDir, ftdcRelativePath, part.Id)
+	}
 	gArgs, err := getGlobalArgs(cmd)
 	quiet := err == nil && gArgs != nil && gArgs.Quiet
 	var startTime time.Time
@@ -6112,14 +6141,46 @@ func (c *viamClient) copyFilesFromMachine(
 		utils.UncheckedError(closeClient(ctx))
 	}()
 
-	// prepare a factory that understands how to work with our local filesystem.
+	// prepare a factory that understands how to work with our local filesystem. It is
+	// stateless across attempts, and a failed copy errors on the machine before any
+	// metadata comes back, so no copier is ever made for one.
 	factory, err := shell.NewLocalFileCopyFactory(destination, preserve, false)
 	if err != nil {
 		return err
 	}
 
+	// A machine whose viam-server predates shell.ViamHomePrefix cannot expand it, so try
+	// the path the CLI used to hardcode too. Retried on this connection rather than by
+	// the caller, since dialing the machine again would cost far more than the copy.
+	attempts := [][]string{paths}
+	if len(paths) == 1 {
+		if legacy, ok := legacyViamHomePath(paths[0]); ok {
+			attempts = append(attempts, []string{legacy})
+		}
+	}
+
 	// let the shell service figure out how to grab the files for and pass them to our copier.
-	return shellSvc.CopyFilesFromMachine(ctx, paths, allowRecursion, preserve, factory, nil)
+	// The first attempt's error is the one worth reporting, since that is the path we
+	// expect to work.
+	var firstErr error
+	for i, attempt := range attempts {
+		err := shellSvc.CopyFilesFromMachine(ctx, attempt, allowRecursion, preserve, factory, nil)
+		if err == nil {
+			if i > 0 {
+				// Never hand back files from a path the caller did not ask for without
+				// saying so: on a machine mid-migration to viam-agent this directory can
+				// still hold stale data from before the move.
+				warningf(c.c.Root().Writer,
+					"%s could not be resolved by this machine, copied from %s instead",
+					shell.ViamHomePrefix, strings.Join(attempt, " "))
+			}
+			return nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 func logEntryFieldsToString(fields []*structpb.Struct) (string, error) {

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1452,6 +1452,47 @@ func TestShellGetFTDC(t *testing.T) {
 			testDownload(t, t.TempDir())
 		})
 	})
+
+	// The CLI cannot know where the machine keeps VIAM_HOME, so by default it asks the
+	// machine to resolve it. Restoring the real default and pointing this process's
+	// VIAM_HOME at the test filesystem stands in for a machine whose VIAM_HOME is not
+	// under any user's home directory (an agent install).
+	t.Run("ftdc data lives outside the home directory", func(t *testing.T) {
+		partFtdcPath := filepath.Join(tfs.Root, ftdcRelativePath, partID)
+		test.That(t, os.MkdirAll(partFtdcPath, 0o750), test.ShouldBeNil)
+		t.Cleanup(func() {
+			test.That(t, os.RemoveAll(filepath.Join(tfs.Root, ftdcRelativePath)), test.ShouldBeNil)
+		})
+		test.That(t, os.WriteFile(filepath.Join(partFtdcPath, "foo"), nil, 0o640), test.ShouldBeNil)
+
+		origViamDotDir := utils.ViamDotDir
+		utils.ViamDotDir = tfs.Root
+		t.Cleanup(func() { utils.ViamDotDir = origViamDotDir })
+
+		targetPath := t.TempDir()
+		cCtx, viamClient, _, _ := setupWithRunningPart(
+			t, asc, nil, nil, partFlags, "token", partFqdn, targetPath)
+		test.That(t,
+			viamClient.machinesPartGetFTDCAction(context.Background(), cCtx, parseStructFromCtx[machinesPartGetFTDCArgs](cCtx), true, logger),
+			test.ShouldBeNil)
+
+		entries, err := os.ReadDir(filepath.Join(targetPath, partID))
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, entries, test.ShouldHaveLength, 1)
+		test.That(t, entries[0].Name(), test.ShouldEqual, "foo")
+	})
+}
+
+func TestLegacyViamHomePath(t *testing.T) {
+	// paths rooted at the prefix get a legacy candidate for machines whose
+	// viam-server is too old to expand it
+	legacy, ok := legacyViamHomePath("$VIAM_HOME/diagnostics.data/abc123")
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, legacy, test.ShouldEqual, "~/.viam/diagnostics.data/abc123")
+
+	// an explicit --viam-home-dir, or a path a test has redirected, has no legacy form
+	_, ok = legacyViamHomePath("/opt/viam/trace/abc123")
+	test.That(t, ok, test.ShouldBeFalse)
 }
 
 func TestCreateOAuthAppAction(t *testing.T) {

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1454,19 +1454,23 @@ func TestShellGetFTDC(t *testing.T) {
 	})
 
 	// The CLI cannot know where the machine keeps VIAM_HOME, so by default it asks the
-	// machine to resolve it. Restoring the real default and pointing this process's
-	// VIAM_HOME at the test filesystem stands in for a machine whose VIAM_HOME is not
-	// under any user's home directory (an agent install).
+	// machine to resolve it. Leaving ftdcPath at its real default and pointing this
+	// process's VIAM_HOME at a directory outside any user's home stands in for an agent
+	// install, where the two diverge.
 	t.Run("ftdc data lives outside the home directory", func(t *testing.T) {
-		partFtdcPath := filepath.Join(tfs.Root, ftdcRelativePath, partID)
+		// Use a short temp dir (not t.TempDir, whose Windows path is long) because
+		// redirecting ViamDotDir also relocates the module socket dir on Windows, and the
+		// unix socket path has a 103-char OS limit (see module.CreateSocketAddress).
+		viamHome, err := os.MkdirTemp("", "vds")
+		test.That(t, err, test.ShouldBeNil)
+		t.Cleanup(func() { goutils.UncheckedError(os.RemoveAll(viamHome)) })
+
+		partFtdcPath := filepath.Join(viamHome, ftdcRelativePath, partID)
 		test.That(t, os.MkdirAll(partFtdcPath, 0o750), test.ShouldBeNil)
-		t.Cleanup(func() {
-			test.That(t, os.RemoveAll(filepath.Join(tfs.Root, ftdcRelativePath)), test.ShouldBeNil)
-		})
 		test.That(t, os.WriteFile(filepath.Join(partFtdcPath, "foo"), nil, 0o640), test.ShouldBeNil)
 
 		origViamDotDir := utils.ViamDotDir
-		utils.ViamDotDir = tfs.Root
+		utils.ViamDotDir = viamHome
 		t.Cleanup(func() { utils.ViamDotDir = origViamDotDir })
 
 		targetPath := t.TempDir()

--- a/cli/traces.go
+++ b/cli/traces.go
@@ -26,7 +26,7 @@ import (
 const tracesRelativePath = "trace"
 
 var (
-	tracesRootDir     = path.Join("~", ".viam")
+	tracesRootDir     = shell.ViamHomePrefix
 	defaultTracesPath = path.Join(tracesRootDir, tracesRelativePath)
 )
 

--- a/services/shell/copy_local.go
+++ b/services/shell/copy_local.go
@@ -17,6 +17,8 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	rutils "go.viam.com/rdk/utils"
 )
 
 // copy_local supports local filesystem copy operations and is agnostic to which
@@ -442,10 +444,23 @@ func (reader *localFileReadCopier) Close(ctx context.Context) error {
 
 var errUnexpectedEmptyPath = errors.New("unexpected empty path")
 
-// fixPeerPath works with the usage of ~ or empty paths and turns
+// ViamHomePrefix leads a path that expands to the VIAM_HOME directory of whichever
+// machine ends up interpreting it, the same way ~ expands to that machine's home
+// directory.
+//
+// A peer cannot compute the other side's VIAM_HOME for it: viam-agent may point
+// viam-server at a directory that has nothing to do with any user's home (/opt/viam),
+// and the answer depends on the remote OS and the environment viam-server was started
+// with. Callers wanting a file that viam-server wrote under its own home directory —
+// FTDC and traces, for example — should send this prefix and let the remote expand it.
+const ViamHomePrefix = "$VIAM_HOME"
+
+// fixPeerPath works with the usage of ~, $VIAM_HOME or empty paths and turns
 // them into the proper HOME pathings.
 // Security Note: this is the only time we end up interpreting a user's path
-// string before it's passed to a file related syscall.
+// string before it's passed to a file related syscall. Both ~ and $VIAM_HOME are
+// fixed tokens that expand to values this process already controls; no general
+// environment variable expansion happens here.
 func fixPeerPath(path string, allowEmpty, relativeToHome bool) (string, error) {
 	if !filepath.IsAbs(path) {
 		homeDir, err := os.UserHomeDir()
@@ -454,6 +469,8 @@ func fixPeerPath(path string, allowEmpty, relativeToHome bool) (string, error) {
 		}
 
 		switch {
+		case path == ViamHomePrefix || strings.HasPrefix(path, ViamHomePrefix+"/"):
+			path = filepath.Join(rutils.ViamDotDir, strings.TrimPrefix(path, ViamHomePrefix))
 		case strings.HasPrefix(path, "~/"):
 			path = strings.Replace(path, "~", homeDir, 1)
 		case path == "":

--- a/services/shell/copy_local_test.go
+++ b/services/shell/copy_local_test.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	shelltestutils "go.viam.com/rdk/services/shell/testutils"
+	rutils "go.viam.com/rdk/utils"
 )
 
 func TestFixPeerPath(t *testing.T) {
@@ -62,6 +63,31 @@ func TestFixPeerPath(t *testing.T) {
 	fixed, err = fixPeerPath("", true, false)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, fixed, test.ShouldEqual, realTempDir)
+
+	// $VIAM_HOME resolves against this process's VIAM_HOME, which is what makes it
+	// safe for a peer to send: only this side knows where viam-server keeps its data.
+	origViamDotDir := rutils.ViamDotDir
+	rutils.ViamDotDir = filepath.Join(realTempDir, "viamhome")
+	t.Cleanup(func() { rutils.ViamDotDir = origViamDotDir })
+
+	for _, relativeToHome := range []bool{true, false} {
+		fixed, err = fixPeerPath("$VIAM_HOME/one/two/three", false, relativeToHome)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, fixed, test.ShouldEqual, filepath.Join(rutils.ViamDotDir, "one/two/three"))
+	}
+
+	fixed, err = fixPeerPath("$VIAM_HOME", false, true)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fixed, test.ShouldEqual, rutils.ViamDotDir)
+
+	// only a whole leading path element counts as the prefix
+	fixed, err = fixPeerPath("$VIAM_HOMEDIR/one", false, true)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fixed, test.ShouldEqual, filepath.Join(homeDir, "$VIAM_HOMEDIR/one"))
+
+	fixed, err = fixPeerPath("one/$VIAM_HOME/two", false, true)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fixed, test.ShouldEqual, filepath.Join(homeDir, "one/$VIAM_HOME/two"))
 }
 
 // TestLocalFileCopy contains tests are very similar to cli.TestShellFileCopy but


### PR DESCRIPTION
Addresses RSDK-14357

FTDC fetch from Windows host via `viam` cli has been broken since https://github.com/viamrobotics/agent/pull/215

Fix on this branch includes changes to the cli and rdk:

### cli
- cli used to pass a path starting with `~/.viam` which effectively hardcodes `$VIAM_HOME` - removed this
- added a `--viam-home-dir` argument to the ftdc command to match toher commands 
### rdk
- use `$VIAM_HOME` for the FTDC path if it's set, otherwise fall back to `~/.viam`

This fix requires both new rdk and cli versions - if a setup has only one or the other, it still won't work, but that's not any worse than how it is without this.