### PR TITLE
Add static tagging for error motion plan JSON

### DIFF
--- a/services/motion/builtin/builtin.go
+++ b/services/motion/builtin/builtin.go
@@ -814,12 +814,14 @@ func (ms *builtIn) writePlanRequest(
 	fn := fmt.Sprintf("plan-%s-ms-%d-%s.json",
 		time.Now().Format(time.RFC3339), int(time.Since(start).Milliseconds()), planExtra)
 
-	// Full plans (request + response) get tag=motion-plan so data manager can infer a
-	// stable type tag on arbitrary-file upload.
+	// Type tags so data manager can infer a stable filter on arbitrary-file upload.
 	const motionPlanTypeTag = "motion-plan"
+	const motionPlanErrTypeTag = "motion-plan-err"
 	tags := []string{}
 	if plan != nil {
 		tags = append(tags, "tag="+motionPlanTypeTag)
+	} else {
+		tags = append(tags, "tag="+motionPlanErrTypeTag)
 	}
 	if ms.conf.PlanDirectoryIncludeTraceID && traceID != "" {
 		tags = append(tags, "tag="+traceID)

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -770,7 +770,7 @@ func TestWritePlanRequest(t *testing.T) {
 
 	test.That(t, os.RemoveAll(typeTagDir), test.ShouldBeNil)
 
-	// Fourth case: request-only error dump (plan == nil) must NOT get tag=motion-plan.
+	// Fourth case: request-only error dump (plan == nil) → tag=motion-plan-err/tag=<traceID>/.
 	err = msBuiltin.writePlanRequest(
 		&armplanning.PlanRequest{},
 		nil,
@@ -785,10 +785,45 @@ func TestWritePlanRequest(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, planDirEntries, test.ShouldHaveLength, 1)
 	test.That(t, planDirEntries[0].IsDir(), test.ShouldBeTrue)
-	test.That(t, planDirEntries[0].Name(), test.ShouldEqual, "tag=1234-abc-56-no-78")
+	test.That(t, planDirEntries[0].Name(), test.ShouldEqual, "tag=motion-plan-err")
 
-	traceIDDir = filepath.Join(planDir, planDirEntries[0].Name())
+	typeTagDir = filepath.Join(planDir, planDirEntries[0].Name())
+	planDirEntries, err = os.ReadDir(typeTagDir)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, planDirEntries, test.ShouldHaveLength, 1)
+	traceIDDirEntry = planDirEntries[0]
+	test.That(t, traceIDDirEntry.IsDir(), test.ShouldBeTrue)
+	test.That(t, traceIDDirEntry.Name(), test.ShouldEqual, "tag=1234-abc-56-no-78")
+
+	traceIDDir = filepath.Join(typeTagDir, traceIDDirEntry.Name())
 	planDirEntries, err = os.ReadDir(traceIDDir)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, planDirEntries, test.ShouldHaveLength, 1)
+	planFile = planDirEntries[0]
+	test.That(t, planFile.IsDir(), test.ShouldBeFalse)
+	test.That(t, planFile.Name(), test.ShouldContainSubstring, "-err")
+
+	test.That(t, os.RemoveAll(typeTagDir), test.ShouldBeNil)
+
+	// Fifth case: error dump with no TraceID → under tag=motion-plan-err only.
+	err = msBuiltin.writePlanRequest(
+		&armplanning.PlanRequest{},
+		nil,
+		&armplanning.PlanMeta{},
+		time.Now(),
+		"",
+		"",
+		errors.New("planning failed"))
+	test.That(t, err, test.ShouldBeNil)
+
+	planDirEntries, err = os.ReadDir(planDir)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, planDirEntries, test.ShouldHaveLength, 1)
+	test.That(t, planDirEntries[0].IsDir(), test.ShouldBeTrue)
+	test.That(t, planDirEntries[0].Name(), test.ShouldEqual, "tag=motion-plan-err")
+
+	typeTagDir = filepath.Join(planDir, planDirEntries[0].Name())
+	planDirEntries, err = os.ReadDir(typeTagDir)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, planDirEntries, test.ShouldHaveLength, 1)
 	planFile = planDirEntries[0]


### PR DESCRIPTION
## Issue
Failed plan dumps only got an optional trace-ID directory, so data manager could not filter them as planning errors. writePlanRequest now nests request-only error dumps under tag=motion-plan-err/, matching how full plans use tag=motion-plan/. This allows for the motion plan replayer to filter for error files for our upcoming inspect-ik debugging feature. 

## Changes
- Tags plan == nil dumps with motion-plan-err
- Tests: Asserts error path layout with and without a trace ID

## Testing 
Run a local viam-server with motion plan_file_path, log_planner_errors, and plan_directory_include_trace_id set Trigger a successful move → file under /…/tag=motion-plan/tag=<traceID>/ Trigger an unreachable move → file under /…/tag=motion-plan-err/tag=<traceID>/…-err.json