### PR TITLE
Verify published manifests match the binaries they point at

### DIFF
--- a/.github/workflows/staticbuild-deploy.yml
+++ b/.github/workflows/staticbuild-deploy.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
     - name: Authorize GCP
       uses: google-github-actions/auth@v2
       with:
@@ -40,9 +43,36 @@ jobs:
         gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ inputs.date }}/${{ github.sha }}/viam-server-v*" "gs://packages.viam.com/apps/viam-server/prerelease/"
         gsutil mv "gs://packages.viam.com/apps/viam-server/testing/static/${{ inputs.date }}/${{ github.sha }}/viam-server-latest*" "gs://packages.viam.com/apps/viam-server/"
 
+    # Captured before the move, because the move is what empties this prefix.
+    - name: List Manifests To Publish
+      id: staged_manifests
+      run: |
+        names=$(gsutil ls "gs://packages.viam.com/apps/viam-subsystems/testing/viam-server/${{ inputs.date }}/${{ github.sha }}/*" | sed 's|.*/||' | tr '\n' ' ')
+        echo "names=$names" >> $GITHUB_OUTPUT
+
     - name: Publish Subsystem Metadata
+      id: publish_manifests
       run: |
         gsutil mv "gs://packages.viam.com/apps/viam-subsystems/testing/viam-server/${{ inputs.date }}/${{ github.sha }}/*" "gs://packages.viam.com/apps/viam-subsystems/"
+
+    # Gated on the publish step's outcome rather than on a copy of the upload
+    # steps' `if` conditions. Restating `release_type == 'latest'` would tie the
+    # check to the same predicate that routes the binaries, so a regression in
+    # that predicate would skip the check in exactly the run that mispublished.
+    # Keying off what actually ran means any run that publishes also re-reads
+    # what it published, so the last writer in a race inspects the state it left.
+    - name: Verify Published Manifests
+      if: steps.publish_manifests.outcome == 'success'
+      run: |
+        names="${{ steps.staged_manifests.outputs.names }}"
+        # Unquoted below so the names word-split into separate arguments. Empty
+        # would make the script fall back to sweeping recent history, which is
+        # not what this step is for -- fail instead.
+        if [ -z "${names// /}" ]; then
+          echo "no manifests were staged for this run" >&2
+          exit 1
+        fi
+        ./etc/verify-manifests.sh $names
 
     - name: Output Summary
       run: |

--- a/.github/workflows/verify-manifests.yml
+++ b/.github/workflows/verify-manifests.yml
@@ -1,0 +1,49 @@
+name: Verify Published Manifests
+
+# On-demand sweep of manifests already in the bucket. The post-publish check in
+# staticbuild-deploy.yml only sees what its own run published; this covers
+# history, prereleases, and anything written outside CI.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Single version to check, e.g. v1.1.0. Overrides count."
+        required: false
+        type: string
+      count:
+        description: "Check the N most recently written manifests. 0 checks every one."
+        required: false
+        default: '20'
+        type: string
+      include_prerelease:
+        description: "Include -dev./-rc manifests in a count sweep."
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    # A full sweep downloads every binary it checks; the default count of 20 is
+    # a few minutes, count=0 is considerably more.
+    timeout-minutes: 120
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    # Reads published objects anonymously, so this job needs no GCP credentials.
+    - name: Verify
+      run: |
+        args=()
+        if [ -n "${{ inputs.version }}" ]; then
+          args+=(--version "${{ inputs.version }}")
+        else
+          args+=(--count "${{ inputs.count }}")
+          if [ "${{ inputs.include_prerelease }}" = "true" ]; then
+            args+=(--include-prerelease)
+          fi
+        fi
+        ./etc/verify-manifests.sh "${args[@]}"

--- a/etc/verify-manifests.sh
+++ b/etc/verify-manifests.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+
+# Verify that published viam-server manifests advertise the sha256 of the object
+# their upload-path actually points at.
+#
+# A manifest and the binary it describes are published by two separate gsutil mv
+# calls (staticbuild-deploy.yml), and whether a build is a prerelease is decided
+# twice over: packaging.make keys the manifest's upload-path on "-dev" appearing
+# in BUILD_CHANNEL, while the deploy workflow keys the binary's destination on
+# release_type == 'latest'. Nothing enforces that those two agree, and nothing
+# re-reads the result. When they disagree -- or when concurrent runs interleave
+# the two moves -- the bucket is left with a manifest describing a binary nobody
+# can download, and every agent targeting that version rejects its download and
+# retries forever (see viam-agent v1.0.1 windows, viamrobotics/agent#280).
+#
+# This never consults a local build. It answers "is the bucket self-consistent?"
+# rather than "does the bucket match me?", which is what makes it meaningful
+# regardless of which of two racing runs published last.
+#
+# Reads are anonymous; no credentials needed.
+
+set -euo pipefail
+
+BUCKET="packages.viam.com"
+MANIFEST_DIR="apps/viam-subsystems"
+PREFIX="$MANIFEST_DIR/viam-server-"
+BASE_URL="https://storage.googleapis.com"
+PLATFORMS="x86_64|aarch64|windows-x86_64|darwin-aarch64"
+
+usage() {
+	cat <<'EOF'
+Usage:
+  verify-manifests.sh NAME.json [NAME.json ...]  check exactly these manifests
+  verify-manifests.sh --version v1.2.3           every platform for one version
+  verify-manifests.sh --count 20                 the 20 most recently written
+  verify-manifests.sh --count 0                  every release manifest
+  verify-manifests.sh --count 0 --include-prerelease   ... plus -dev./-rc
+
+Names are basenames within gs://packages.viam.com/apps/viam-subsystems/. The
+publishing workflow passes the manifests it just moved, so every run that
+publishes re-reads what it published.
+
+On a mismatch this prints the corrected manifest and the gsutil command that
+would apply it, but never writes. Rewriting the sha256 is only the right repair
+when the published binary is the artifact you meant to ship; if the binary is
+what is wrong, rebuild instead. See the summary this prints on failure.
+EOF
+}
+
+count=""
+include_prerelease=false
+version_filter=""
+explicit_names=()
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--count)
+		count="${2:?--count needs a value}"
+		shift
+		;;
+	--include-prerelease)
+		include_prerelease=true
+		;;
+	--version)
+		version_filter="${2:?--version needs a value}"
+		shift
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	-*)
+		echo "unknown argument: $1" >&2
+		usage >&2
+		exit 2
+		;;
+	*)
+		explicit_names+=("$1")
+		;;
+	esac
+	shift
+done
+
+selectors=0
+[ -n "$version_filter" ] && selectors=$((selectors + 1))
+[ -n "$count" ] && selectors=$((selectors + 1))
+[ ${#explicit_names[@]} -gt 0 ] && selectors=$((selectors + 1))
+if [ "$selectors" -gt 1 ]; then
+	echo "explicit names, --version and --count select different things; pass only one" >&2
+	exit 2
+fi
+
+sha256() {
+	if command -v sha256sum >/dev/null; then
+		sha256sum
+	else
+		shasum -a 256
+	fi
+}
+
+# Emit "<updated>\t<object name>" for every object under a prefix. Anonymous
+# reads are enough; no gcloud auth required.
+list_objects() {
+	local prefix="$1" token="" url page
+	while :; do
+		url="$BASE_URL/storage/v1/b/$BUCKET/o?prefix=$prefix&fields=items(name,updated),nextPageToken&maxResults=1000"
+		if [ -n "$token" ]; then
+			url="$url&pageToken=$token"
+		fi
+		page=$(curl -fsS --retry 3 -H "Cache-Control: no-cache" "$url")
+		jq -r '.items[]? | "\(.updated)\t\(.name)"' <<<"$page"
+		token=$(jq -r '.nextPageToken // empty' <<<"$page")
+		if [ -z "$token" ]; then
+			break
+		fi
+	done
+}
+
+names=()
+if [ ${#explicit_names[@]} -gt 0 ]; then
+	for n in "${explicit_names[@]}"; do
+		names+=("${n##*/}")
+	done
+else
+	if [ -n "$version_filter" ]; then
+		# Listed under the version's own prefix, so this is one small API call
+		# rather than a full bucket listing. The platform-suffix anchor still
+		# matters: the prefix v1.2.3- also matches v1.2.3-dev.N and v1.2.3-rcN,
+		# which are different sets of artifacts.
+		escaped=$(printf '%s' "$version_filter" | sed 's/\./\\./g')
+		candidates=$(list_objects "$PREFIX$version_filter-" | cut -f2 |
+			grep -E "/viam-server-${escaped}-($PLATFORMS)\.json$" | sort || true)
+	else
+		# Newest first by mtime rather than by version: a clobbered manifest gets
+		# a fresh mtime, so the recently-written window is where a race shows up.
+		# (Name order would not do: the bucket still holds pre-semver
+		# viam-server-<timestamp>-* manifests that sort ahead of every v*.)
+		candidates=$(list_objects "$PREFIX" | sort -r | cut -f2)
+		if [ "$include_prerelease" != true ]; then
+			candidates=$(printf '%s\n' "$candidates" | grep -v -e '-dev\.' -e '-rc' || true)
+		fi
+		if [ "${count:-20}" -gt 0 ]; then
+			candidates=$(printf '%s\n' "$candidates" | sed -n "1,${count:-20}p")
+		fi
+	fi
+
+	if [ -z "$candidates" ]; then
+		echo "no manifests matched gs://$BUCKET/$PREFIX${version_filter}*" >&2
+		exit 1
+	fi
+
+	while IFS= read -r object; do
+		names+=("${object##*/}")
+	done <<<"$candidates"
+fi
+
+echo "Checking ${#names[@]} manifest(s) in gs://$BUCKET/$MANIFEST_DIR/"
+echo
+
+sha=""
+reason_lines=()
+
+# Compare one manifest against the object its upload-path names. Sets `sha` on
+# success, `reason_lines` on failure.
+check_manifest() {
+	local name="$1" manifest_url manifest want upload_path binary_url got fix_json
+	sha=""
+	reason_lines=()
+
+	manifest_url="$BASE_URL/$BUCKET/$MANIFEST_DIR/$name"
+	if ! manifest=$(curl -fsS --retry 3 -H "Cache-Control: no-cache" "$manifest_url"); then
+		reason_lines=("manifest not readable at $manifest_url")
+		return 1
+	fi
+
+	want=$(jq -r '.sha256 // empty' <<<"$manifest")
+	upload_path=$(jq -r '."upload-path" // empty' <<<"$manifest")
+	if [ -z "$want" ] || [ -z "$upload_path" ]; then
+		reason_lines=("manifest is missing sha256 or upload-path")
+		return 1
+	fi
+
+	binary_url="$BASE_URL/$upload_path"
+	if ! got=$(curl -fsSL --retry 3 -H "Cache-Control: no-cache" "$binary_url" | sha256 | cut -d' ' -f1); then
+		reason_lines=("cannot download upload-path $binary_url")
+		return 1
+	fi
+
+	if [ "$want" != "$got" ]; then
+		reason_lines=("manifest sha256 $want" "binary   sha256 $got  ($binary_url)")
+		# Printed only. A mismatch looks the same whether the manifest's sha is
+		# wrong or the wrong binary landed at upload-path, and this script cannot
+		# tell which; applying it in the second case blesses the wrong artifact
+		# for every agent on that version. An operator decides.
+		fix_json=$(jq --tab --arg s "$got" '.sha256 = $s' <<<"$manifest")
+		reason_lines+=("" "if the object above is the artifact you meant to publish," "correct the manifest with:" "")
+		while IFS= read -r line; do
+			reason_lines+=("  $line")
+		done <<<"$fix_json"
+		reason_lines+=("" "  gsutil -h \"Cache-Control:no-cache\" cp $name gs://$BUCKET/$MANIFEST_DIR/" "")
+		reason_lines+=("otherwise the binary itself is wrong; see the summary below.")
+		return 1
+	fi
+
+	sha="$want"
+	return 0
+}
+
+failures=0
+for name in "${names[@]}"; do
+	if check_manifest "$name"; then
+		echo "ok    $name  $sha"
+		continue
+	fi
+
+	# A publish writes the binary before the manifest, so a version being
+	# published right now looks like a mismatch until its manifest lands.
+	# Re-check once before failing; a real mismatch persists.
+	sleep 10
+	if check_manifest "$name"; then
+		echo "ok    $name  $sha  (cleared on re-check, publish was in flight)"
+		continue
+	fi
+
+	echo "FAIL  $name"
+	printf '        %s\n' "${reason_lines[@]}"
+	failures=$((failures + 1))
+done
+
+echo
+if [ "$failures" -gt 0 ]; then
+	echo "$failures of ${#names[@]} manifest(s) do not match the object they point at."
+	echo
+	echo "Repair by hand, choosing what matches what the object at upload-path is:"
+	echo
+	echo "  The published binary is the artifact you meant to ship and only the"
+	echo "  sha256 is wrong -- apply the corrected manifest printed above."
+	echo "  Binaries are untouched. This is the repair for a concurrent-run"
+	echo "  clobber or a prerelease-path disagreement."
+	echo
+	echo "  The binary itself is wrong -- rebuild the channel and republish"
+	echo "  binary and manifest together. Windows binaries are not reproducible"
+	echo "  (Authenticode timestamps), so that publishes new bytes rather than"
+	echo "  restoring the old ones."
+	echo
+	echo "Either way, agents cache the bad sha and skip re-reading it for an"
+	echo "unchanged version string, so expect a version bump or a cache clear to"
+	echo "unstick machines that already pulled it."
+	exit 1
+fi
+echo "All ${#names[@]} manifest(s) match."


### PR DESCRIPTION
Ports the manifest check from viamrobotics/agent#282 to viam-server. Nothing is broken in production today — this is the detection that repo added after v1.0.1, applied to the artifact that ships on every device.

## Problem

viam-server manifests land in `gs://packages.viam.com/apps/viam-subsystems/` — the same directory as viam-agent's, same `upload-path` + `sha256` schema — and the agent uses them to verify every viam-server download. A manifest that disagrees with its binary bricks updates for every device on that version.

Two things can produce that, and neither is checked:

- **The prerelease decision is made twice, on different inputs.** `packaging.make:5` keys the manifest's `upload-path` on `-dev` in `BUILD_CHANNEL`; `staticbuild-deploy.yml` keys the binary's destination on `release_type == 'latest'`. They agree only because `dev-version.sh` normally emits `-dev.` for main — but its `DIRECT_TAG` branch returns the bare tag, so dispatching `main.yml` on a tagged HEAD gives `BUILD_CHANNEL=v1.2.3` with `release_type=latest`: manifest claims the release root, binary goes to `prerelease/`. Same shape as the viam-agent v1.0.1 bug that #280 fixed one route to.
- **Binary and manifest move in two separate gsutil steps**, and `main.yml`/`stable.yml` have per-workflow concurrency groups, so concurrent runs can interleave them and leave binary B with manifest A.

## What this adds

**`etc/verify-manifests.sh`** reads a published manifest's `sha256`, downloads whatever object its own `upload-path` names, and compares. It never consults a local build — it answers "is the bucket self-consistent?" rather than "does the bucket match me?", which is what makes it meaningful regardless of which of two racing runs published last. Reads are anonymous; it needs no credentials and never writes.

```
./etc/verify-manifests.sh NAME.json [...]   # exactly these
./etc/verify-manifests.sh --version v1.1.0  # every platform for one version
./etc/verify-manifests.sh --count 20        # 20 most recently written (0 = all)
```

**`staticbuild-deploy.yml`** captures the staged manifest names before the move and verifies exactly those after. It's gated on `steps.publish_manifests.outcome == 'success'` rather than a copy of the upload steps' conditions: restating `release_type == 'latest'` would tie the check to the same predicate that routes the binaries, so a regression there would skip the check in exactly the run that mispublished.

**`verify-manifests.yml`** (dispatch) sweeps history, prereleases, and writes made outside CI.

## Why it only reports

On a mismatch the script prints the corrected manifest and the `gsutil` command that would apply it, but never writes. A mismatch looks identical whichever side is at fault: rewriting the sha256 when the *binary* is wrong permanently blesses the wrong artifact, since the checksum then validates. agent's `--fix` and Fix Manifest workflow are deliberately not ported — the rebuild half needs rdk-focal, upx, and Authenticode signing reproduced in a dispatch workflow.

## Test

Against the live production bucket: `--count 8` and `--version v1.1.0` all match; 8 recent `-dev.` manifests match via explicit names; across the 200 most recent manifests every `upload-path` resolves, with dev→`prerelease/`, rc→root, release→root and no exceptions.

The failure path is exercised against a real broken manifest, not a synthetic one — pointed at `viam-agent-v1.0.1-windows-x86_64.json` (still wrong in production, same bucket directory) it fails, reports both checksums, and derives `8e0c004af9f1...`, matching what agent#282 independently documented.

`shellcheck` clean, all three workflows parse, both branches of the new deploy step run locally.

## Not covered

- The dispatch workflow isn't exercised end-to-end.
- The post-publish check only sees manifests its own run staged; writes outside CI need the sweep.
- Both repos now carry near-identical copies of this script against the same bucket directory. One sweeper with a `--subsystem` flag would avoid the drift, but that's cross-repo coordination.
- Unrelated, noticed in passing: `etc/subsystem_manifest/main.go` maps `x86_64` to `linux/amd64` unconditionally, so Windows manifests read `platform: linux/amd64`. Didn't chase whether anything consumes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
