### PR TITLE
RSDK-14362: shell copy: surface the real server status instead of "context canceled"

### DIFF
--- a/services/shell/copy_rpc.go
+++ b/services/shell/copy_rpc.go
@@ -357,6 +357,16 @@ type shellRPCCopyWriterTo struct {
 	rpcClient pb.ShellService_CopyFilesToMachineClient
 	ctx       context.Context
 	acks      chan struct{}
+
+	// recvDone is closed once the background receiver has exited. recvErr, guarded by
+	// recvMu, holds the terminal error that receiver observed (the authoritative gRPC
+	// status from the server). We capture it explicitly rather than relying solely on
+	// context.Cause: the underlying webrtc stream cancels its own context with a bare
+	// context.Canceled cause, which can race ahead of our cancel(err) and mask the real
+	// status (surfacing "context canceled" instead of e.g. NotFound). See terminalErr.
+	recvDone chan struct{}
+	recvMu   sync.Mutex
+	recvErr  error
 }
 
 func newShellRPCCopyWriterTo(rpcClient pb.ShellService_CopyFilesToMachineClient) *shellRPCCopyWriterTo {
@@ -365,11 +375,16 @@ func newShellRPCCopyWriterTo(rpcClient pb.ShellService_CopyFilesToMachineClient)
 		rpcClient: rpcClient,
 		ctx:       ctx,
 		// files are sent one at a time, so at most one un-awaited ACK is in flight
-		acks: make(chan struct{}, 1),
+		acks:     make(chan struct{}, 1),
+		recvDone: make(chan struct{}),
 	}
 	utils.PanicCapturingGo(func() {
+		defer close(client.recvDone)
 		for {
 			if _, err := rpcClient.Recv(); err != nil {
+				client.recvMu.Lock()
+				client.recvErr = err
+				client.recvMu.Unlock()
 				cancel(err)
 				return
 			}
@@ -383,11 +398,27 @@ func newShellRPCCopyWriterTo(rpcClient pb.ShellService_CopyFilesToMachineClient)
 	return client
 }
 
+// terminalErr returns the error that ended the copy. It waits for the background receiver
+// to observe the terminal gRPC status (the authoritative source) and prefers it, only
+// falling back to context.Cause when the stream context was canceled without a status
+// (e.g. the peer connection dropped). This avoids surfacing a bare "context canceled" when
+// the server actually reported a specific error such as NotFound. terminalErr is only
+// called once the stream is known to be ending, so the wait on recvDone is bounded.
+func (client *shellRPCCopyWriterTo) terminalErr() error {
+	<-client.recvDone
+	client.recvMu.Lock()
+	defer client.recvMu.Unlock()
+	if client.recvErr != nil {
+		return client.recvErr
+	}
+	return context.Cause(client.ctx)
+}
+
 func (client *shellRPCCopyWriterTo) SendFile(fileDataProto *pb.FileData) error {
-	if err := client.ctx.Err(); err != nil {
+	if client.ctx.Err() != nil {
 		// the server already terminated the copy; fail fast instead of
 		// streaming the rest of the file data.
-		return context.Cause(client.ctx)
+		return client.terminalErr()
 	}
 	if err := client.rpcClient.Send(&pb.CopyFilesToMachineRequest{
 		Request: &pb.CopyFilesToMachineRequest_FileData{
@@ -395,9 +426,8 @@ func (client *shellRPCCopyWriterTo) SendFile(fileDataProto *pb.FileData) error {
 		},
 	}); err != nil {
 		// a send error means the stream is dead (gRPC reports the reason via
-		// Recv); wait for the receiver to surface the actual error.
-		<-client.ctx.Done()
-		return context.Cause(client.ctx)
+		// Recv); surface the actual error the receiver observed.
+		return client.terminalErr()
 	}
 	return nil
 }
@@ -413,7 +443,7 @@ func (client *shellRPCCopyWriterTo) WaitLastACK() error {
 			return nil
 		default:
 		}
-		return context.Cause(client.ctx)
+		return client.terminalErr()
 	}
 }
 

--- a/services/shell/copy_rpc_test.go
+++ b/services/shell/copy_rpc_test.go
@@ -458,6 +458,30 @@ func TestShellRPCCopyWriterTo(t *testing.T) {
 		test.That(t, status.Convert(err).Code(), test.ShouldEqual, codes.NotFound)
 	})
 
+	t.Run("terminal server status wins over a bare stream-context cancellation", func(t *testing.T) {
+		// mimic the real webrtc client stream, whose context is canceled with a bare
+		// context.Canceled cause. If that cancellation races ahead of the server status,
+		// we must still surface the status (NotFound), not "context canceled".
+		streamCtx, cancelStream := context.WithCancel(context.Background())
+		fake := newFakeCopyFilesToMachineClient()
+		fake.ctx = streamCtx
+		writer := newShellRPCCopyWriterTo(fake)
+
+		terminalErr := status.Error(codes.NotFound, `"/some/dir" does not exist or is not a directory`)
+		// cancel the stream context first (bare cause), then deliver the real status.
+		cancelStream()
+		fake.recvCh <- copyToMachineRecv{err: terminalErr}
+		<-writer.ctx.Done()
+
+		err := writer.SendFile(&pb.FileData{Name: "foo", Data: []byte("data")})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, status.Convert(err).Code(), test.ShouldEqual, codes.NotFound)
+
+		err = writer.WaitLastACK()
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, status.Convert(err).Code(), test.ShouldEqual, codes.NotFound)
+	})
+
 	t.Run("WaitLastACK returns nil per ACK and prefers a buffered ACK over EOF", func(t *testing.T) {
 		fake := newFakeCopyFilesToMachineClient()
 		writer := newShellRPCCopyWriterTo(fake)


### PR DESCRIPTION
Jira: https://viam.atlassian.net/browse/RSDK-14362

## Problem

When a `CopyFilesToMachine` terminates early on the server — e.g. the destination parent directory doesn't exist, so the server returns `NotFound` — the client could surface a bare **`context canceled`** instead of the real gRPC status.

Root cause: the underlying webrtc client stream cancels its own context with a plain `context.Canceled` cause. That cancellation can race ahead of the background receiver's `cancel(err)`, so `context.Cause(client.ctx)` returned the bare cancellation and masked the actual status.

Two user-visible consequences:
- The CLI's `NotFound` / `PermissionDenied` special-casing in `retryableCopy` never triggered (the code saw `context canceled`, not the status), so an unrecoverable copy burned all 6 retries instead of aborting with a helpful message.
- Users saw a confusing "connection instability" symptom for what was actually a clean, deterministic server-side error.

This surfaced in practice via `module reload-local` uploading into a not-yet-created `~/.viam/packages-local/…`: every attempt failed with `context canceled` + 6 retries.

## Fix

`shellRPCCopyWriterTo` now captures the terminal error observed by its background receiver explicitly (`recvErr` guarded by `recvMu`, with `recvDone` signaling receiver exit). `terminalErr()` waits for the receiver and prefers that captured status, only falling back to `context.Cause` when the stream was canceled without a status (e.g. the peer connection genuinely dropped).

Client-side only — `shellRPCCopyWriterTo` is constructed solely by the shell **client**'s `CopyFilesToMachine` (the sender). No server change required; the server was already returning the correct status.

## Test

Added `terminal server status wins over a bare stream-context cancellation` to `TestShellRPCCopyWriterTo`, which reproduces the race — cancel the stream context first (bare cause), then deliver `NotFound` via `Recv`. It fails on the old code (`NotFound` → `Unknown`/`Canceled`) and passes now. Full `go test -race ./services/shell/...` is green.

## Note

This is a follow-up to #6244 (RSDK-14247), which introduced the background-receiver approach; that version relied on `cancel(err)` winning the race, which isn't guaranteed over real webrtc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)