### PR TITLE
fix R3ToR4 zero-vector check

### DIFF
--- a/spatialmath/axisAngle.go
+++ b/spatialmath/axisAngle.go
@@ -111,7 +111,7 @@ func (r4 *R4AA) fixOrientation() {
 
 // R3ToR4 converts an R3 angle axis to R4.
 func R3ToR4(aa r3.Vector) *R4AA {
-	if aa == (r3.Vector{1, 0, 0}) { // zero
+	if aa == (r3.Vector{}) { // zero
 		return NewR4AA()
 	}
 	theta := aa.Norm()

--- a/spatialmath/axisAngle.go
+++ b/spatialmath/axisAngle.go
@@ -111,7 +111,7 @@ func (r4 *R4AA) fixOrientation() {
 
 // R3ToR4 converts an R3 angle axis to R4.
 func R3ToR4(aa r3.Vector) *R4AA {
-	if aa == (r3.Vector{}) { // zero
+	if aa.Norm() == 0 {
 		return NewR4AA()
 	}
 	theta := aa.Norm()

--- a/spatialmath/axisAngle_test.go
+++ b/spatialmath/axisAngle_test.go
@@ -1,6 +1,7 @@
 package spatialmath
 
 import (
+	"math"
 	"testing"
 
 	"github.com/golang/geo/r3"
@@ -18,4 +19,22 @@ func TestAAConversion(t *testing.T) {
 	test.That(t, r3_2.X, test.ShouldAlmostEqual, 1.5)
 	test.That(t, r3_2.Y, test.ShouldAlmostEqual, 1.5)
 	test.That(t, r3_2.Z, test.ShouldAlmostEqual, 1.5)
+}
+
+func TestR3ToR4EdgeCases(t *testing.T) {
+	t.Run("zero vector returns identity", func(t *testing.T) {
+		r4 := R3ToR4(r3.Vector{})
+		test.That(t, r4.Theta, test.ShouldEqual, 0.0)
+		test.That(t, math.IsNaN(r4.RX), test.ShouldBeFalse)
+		test.That(t, math.IsNaN(r4.RY), test.ShouldBeFalse)
+		test.That(t, math.IsNaN(r4.RZ), test.ShouldBeFalse)
+	})
+
+	t.Run("unit X rotation is preserved", func(t *testing.T) {
+		r4 := R3ToR4(r3.Vector{1, 0, 0})
+		test.That(t, r4.Theta, test.ShouldAlmostEqual, 1.0)
+		test.That(t, r4.RX, test.ShouldAlmostEqual, 1.0)
+		test.That(t, r4.RY, test.ShouldAlmostEqual, 0.0)
+		test.That(t, r4.RZ, test.ShouldAlmostEqual, 0.0)
+	})
 }


### PR DESCRIPTION
spatialmath.R3ToR4 special cased (1, 0, 0) with a `// zero` comment that is just wrong - should be the zero vector

There are no internal rdk users

I'll patch downstream consumers (viam-modules/frame-calibration, luddite/apriltag and my own camera-calibration module) myself before bumping their RDK versions