### PR TITLE
Fix four critical defects in spatial math, camera projection, and control blocks

### DIFF
--- a/control/encoder_speed.go
+++ b/control/encoder_speed.go
@@ -2,6 +2,7 @@ package control
 
 import (
 	"context"
+	"math"
 	"sync"
 	"time"
 
@@ -43,7 +44,24 @@ func (b *encoderToRPM) reset() error {
 	if len(b.cfg.DependsOn) != 1 {
 		return errors.Errorf("invalid number of inputs for encoderToRPM block %s expected 1 got %d", b.cfg.Name, len(b.cfg.DependsOn))
 	}
-	b.ticksPerRevolution = b.cfg.Attribute["ticks_per_revolution"].(int) // default 0
+	// Block configs are decoded from JSON, so every number arrives as a float64 and a plain .(int)
+	// assertion would panic on any real config.
+	switch ticks := b.cfg.Attribute["ticks_per_revolution"].(type) {
+	case int:
+		b.ticksPerRevolution = ticks
+	case float64:
+		if ticks != math.Trunc(ticks) {
+			return errors.Errorf("encoderToRPM block %s ticks_per_revolution must be a whole number, got %v", b.cfg.Name, ticks)
+		}
+		b.ticksPerRevolution = int(ticks)
+	default:
+		return errors.Errorf("encoderToRPM block %s ticks_per_revolution must be a number, got %T",
+			b.cfg.Name, b.cfg.Attribute["ticks_per_revolution"])
+	}
+	// Guarding here rather than in Next keeps the divide-by-zero out of the control loop entirely.
+	if b.ticksPerRevolution == 0 {
+		return errors.Errorf("encoderToRPM block %s ticks_per_revolution must be nonzero", b.cfg.Name)
+	}
 	b.prevEncCount = 0
 	b.y = make([]*Signal, 1)
 	b.y[0] = makeSignal(b.cfg.Name, b.cfg.Type)

--- a/control/encoder_speed_test.go
+++ b/control/encoder_speed_test.go
@@ -1,0 +1,45 @@
+package control
+
+import (
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/utils"
+)
+
+func TestEncoderSpeedConfig(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	for _, tc := range []struct {
+		name  string
+		ticks interface{}
+		err   string
+	}{
+		// Block configs are decoded from JSON, so numbers arrive as float64 rather than int.
+		{"json float64", float64(1000), ""},
+		{"native int", 1000, ""},
+		{"non-integral", 10.5, "must be a whole number"},
+		{"wrong type", "1000", "must be a number"},
+		{"zero", float64(0), "must be nonzero"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := BlockConfig{
+				Name:      "E1",
+				Type:      "encoderToRpm",
+				Attribute: utils.AttributeMap{"ticks_per_revolution": tc.ticks},
+				DependsOn: []string{"A"},
+			}
+			var blk Block
+			var err error
+			test.That(t, func() { blk, err = newEncoderSpeed(cfg, logger) }, test.ShouldNotPanic)
+			if tc.err == "" {
+				test.That(t, err, test.ShouldBeNil)
+				test.That(t, blk.(*encoderToRPM).ticksPerRevolution, test.ShouldEqual, 1000)
+			} else {
+				test.That(t, err, test.ShouldNotBeNil)
+				test.That(t, err.Error(), test.ShouldContainSubstring, tc.err)
+			}
+		})
+	}
+}

--- a/control/pid.go
+++ b/control/pid.go
@@ -68,8 +68,10 @@ func (p *basicPID) Next(ctx context.Context, x []*Signal, dt time.Duration) ([]*
 
 		// For each PID Set and its respective Tuner Object, Step through an iteration of tuning until done.
 		for i := 0; i < len(p.PIDSets); i++ {
-			// if we do not need to tune this signal, skip to the next signal
-			if !p.tuners[i].tuning {
+			// if we do not need to tune this signal, skip to the next signal.
+			// tuners[i] is nil for any PID set that was fully configured (see NeedsAutoTuning), and getTuning()
+			// is true as soon as *any* set is tuning, so the nil check has to come first.
+			if p.tuners[i] == nil || !p.tuners[i].tuning {
 				continue
 			}
 			out, done := p.tuners[i].pidTunerStep(math.Abs(x[0].GetSignalValueAt(i)), p.logger)

--- a/control/pid_test.go
+++ b/control/pid_test.go
@@ -213,3 +213,35 @@ func TestPIDMultiTuner(t *testing.T) {
 		pid.tuners[signalIndex].tuning = false
 	}
 }
+
+// A MIMO PID where only some sets need auto-tuning leaves the remaining tuners nil. getTuning()
+// reports true as soon as any one set is tuning, so Next() walks every index and used to
+// dereference the nil tuners belonging to the fully-configured sets.
+func TestPIDMixedAutoTuningDoesNotPanic(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+	cfg := BlockConfig{
+		Name: "PID1",
+		Attribute: utils.AttributeMap{
+			// first set is fully configured (tuner stays nil), second needs tuning
+			"PIDSets": []*PIDConfig{{P: .12, I: .22, D: .11}, {P: 0, I: 0, D: 0}},
+		},
+		Type:      "PID",
+		DependsOn: []string{"A", "B"},
+	}
+	pid, err := loop.newPID(cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	b, ok := pid.(*basicPID)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, b.tuners[0], test.ShouldBeNil)
+	test.That(t, b.tuners[1], test.ShouldNotBeNil)
+	test.That(t, b.GetTuning(), test.ShouldBeTrue)
+
+	s := makeSignals("A", "endpoint", 2)
+	s.SetSignalValueAt(0, 10.0)
+	s.SetSignalValueAt(1, 10.0)
+	test.That(t, func() {
+		pid.Next(ctx, []*Signal{s}, time.Millisecond*10)
+	}, test.ShouldNotPanic)
+}

--- a/rimage/transform/pinhole_camera_parameters.go
+++ b/rimage/transform/pinhole_camera_parameters.go
@@ -187,12 +187,15 @@ func (params *PinholeCameraIntrinsics) PixelToPoint(x, y, z float64) (float64, f
 // The intrinsics parameters should be the ones of the sensor we want to project to.
 func (params *PinholeCameraIntrinsics) PointToPixel(x, y, z float64) (float64, float64) {
 	// TODO(louise): add unit test
-	if z != 0. {
+	// z must be strictly positive: the camera looks down +Z, so z <= 0 is at or behind the pinhole and has no
+	// image-plane projection. Dividing by a negative z flips both signs and yields an in-bounds pixel for a point
+	// that is behind the camera, so the sign test cannot be relaxed to z != 0.
+	if z > 0. {
 		xPx := math.Round((x/z)*params.Fx + params.Ppx)
 		yPx := math.Round((y/z)*params.Fy + params.Ppy)
 		return xPx, yPx
 	}
-	// if depth is zero at this pixel, return negative coordinates so that the cropping to RGB bounds will filter it out
+	// if depth is non-positive at this pixel, return negative coordinates so that the cropping to RGB bounds will filter it out
 	return -1.0, -1.0
 }
 
@@ -297,12 +300,22 @@ func intrinsics3DTo2D(cloud pointcloud.PointCloud, pci *PinholeCameraIntrinsics)
 	cloud.Iterate(0, 0, func(pt r3.Vector, d pointcloud.Data) bool {
 		j, i := pci.PointToPixel(pt.X, pt.Y, pt.Z)
 		x, y := int(math.Round(j)), int(math.Round(i))
-		z := int(pt.Z)
+		// PointToPixel already rejects z <= 0, so pt.Z is positive whenever the pixel is in bounds.
+		// Depth is a uint16, so anything past its range has to be dropped rather than silently wrapped.
+		if pt.Z > float64(math.MaxUint16) {
+			return true
+		}
+		z := rimage.Depth(pt.Z)
 		// if point has color and is inside the image bounds, add it to the images
 		if x >= 0 && x < width && y >= 0 && y < height && d != nil && d.HasColor() {
+			// Several cloud points can land on one pixel; keep the nearest so foreground is not
+			// overwritten by background depending on iteration order. Zero means "no point yet".
+			if existing := depth.GetDepth(x, y); existing != 0 && existing <= z {
+				return true
+			}
 			r, g, b := d.RGB255()
 			color.Set(image.Point{x, y}, rimage.NewColor(r, g, b))
-			depth.Set(x, y, rimage.Depth(z))
+			depth.Set(x, y, z)
 		}
 		return true
 	})

--- a/rimage/transform/pinhole_camera_parameters_test.go
+++ b/rimage/transform/pinhole_camera_parameters_test.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"context"
 	"image"
+	"image/color"
 	"math"
 	"testing"
 
@@ -268,4 +269,51 @@ func TestNilIntrinsics(t *testing.T) {
 	test.That(t, func() { nilIntrinsics.ImagePointTo3DPoint(image.Point{}, rimage.Depth(0)) }, test.ShouldNotPanic)
 	test.That(t, func() { nilIntrinsics.RGBDToPointCloud(&rimage.Image{}, &rimage.DepthMap{}) }, test.ShouldNotPanic)
 	test.That(t, func() { nilIntrinsics.PointCloudToRGBD(pointcloud.PointCloud(nil)) }, test.ShouldNotPanic)
+}
+
+func TestPointToPixelRejectsNonPositiveDepth(t *testing.T) {
+	params := &PinholeCameraIntrinsics{Width: 640, Height: 480, Fx: 500, Fy: 500, Ppx: 320, Ppy: 240}
+
+	// In front of the camera: projects normally.
+	u, v := params.PointToPixel(10, 10, 1000)
+	test.That(t, u, test.ShouldEqual, 325.)
+	test.That(t, v, test.ShouldEqual, 245.)
+
+	// At or behind the pinhole there is no projection. Dividing by a negative z would otherwise
+	// flip both signs and hand back a perfectly in-bounds pixel for a point behind the camera.
+	for _, z := range []float64{0, -1, -1000} {
+		u, v := params.PointToPixel(10, 10, z)
+		test.That(t, u, test.ShouldEqual, -1.)
+		test.That(t, v, test.ShouldEqual, -1.)
+	}
+}
+
+func TestPointCloudToRGBDDepthOrdering(t *testing.T) {
+	params := &PinholeCameraIntrinsics{Width: 640, Height: 480, Fx: 500, Fy: 500, Ppx: 320, Ppy: 240}
+
+	// (10,10,1000) and (-10,-10,-1000) both land on pixel (325,245); the second is behind the camera.
+	cloud := pointcloud.NewBasicEmpty()
+	test.That(t, cloud.Set(r3.Vector{10, 10, 1000}, pointcloud.NewColoredData(color.NRGBA{255, 0, 0, 255})), test.ShouldBeNil)
+	test.That(t, cloud.Set(r3.Vector{-10, -10, -1000}, pointcloud.NewColoredData(color.NRGBA{0, 255, 0, 255})), test.ShouldBeNil)
+
+	_, dm, err := params.PointCloudToRGBD(cloud)
+	test.That(t, err, test.ShouldBeNil)
+	// The behind-camera point must not appear anywhere, and must not have clobbered the real one.
+	test.That(t, dm.GetDepth(325, 245), test.ShouldEqual, rimage.Depth(1000))
+	test.That(t, dm.GetDepth(315, 235), test.ShouldEqual, rimage.Depth(0))
+}
+
+func TestPointCloudToRGBDKeepsNearest(t *testing.T) {
+	params := &PinholeCameraIntrinsics{Width: 640, Height: 480, Fx: 500, Fy: 500, Ppx: 320, Ppy: 240}
+
+	// Two points on the same ray -> same pixel. The nearer one must win regardless of iteration order.
+	cloud := pointcloud.NewBasicEmpty()
+	test.That(t, cloud.Set(r3.Vector{20, 20, 2000}, pointcloud.NewColoredData(color.NRGBA{0, 255, 0, 255})), test.ShouldBeNil)
+	test.That(t, cloud.Set(r3.Vector{10, 10, 1000}, pointcloud.NewColoredData(color.NRGBA{255, 0, 0, 255})), test.ShouldBeNil)
+
+	img, dm, err := params.PointCloudToRGBD(cloud)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, dm.GetDepth(325, 245), test.ShouldEqual, rimage.Depth(1000))
+	r, g, b := img.GetXY(325, 245).RGB255()
+	test.That(t, []uint8{r, g, b}, test.ShouldResemble, []uint8{255, 0, 0})
 }

--- a/services/motion/localizer_test.go
+++ b/services/motion/localizer_test.go
@@ -100,53 +100,53 @@ func TestCorrectStartPose(t *testing.T) {
 	origin := geo.NewPoint(0, 0)
 	t.Run("Test angle from +Y to +X, +Y quadrant", func(t *testing.T) {
 		t.Parallel()
-		// -45
-		askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: 1, OZ: 1}
-		movementSensor := createInjectedOrientationMovementSensor(askewOrient)
-		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
-		corrected, err := localizer.CurrentPosition(ctx)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, -45.)
-	})
-	t.Run("Test angle from +Y to -X, +Y quadrant", func(t *testing.T) {
-		t.Parallel()
 		// 45
-		askewOrient := &spatialmath.OrientationVectorDegrees{OX: -1, OY: 1, OZ: 1}
+		askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: 1, OZ: 1}
 		movementSensor := createInjectedOrientationMovementSensor(askewOrient)
 		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
 		corrected, err := localizer.CurrentPosition(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, 45.)
 	})
-	t.Run("Test angle from +Y to +X, -Y quadrant", func(t *testing.T) {
-		t.Parallel()
-		// -135
-		askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: -1, OZ: 1}
-		movementSensor := createInjectedOrientationMovementSensor(askewOrient)
-		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
-		corrected, err := localizer.CurrentPosition(ctx)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, -135.)
-	})
-	t.Run("Test angle from +Y to -X, -Y quadrant", func(t *testing.T) {
+	t.Run("Test angle from +Y to -X, +Y quadrant", func(t *testing.T) {
 		t.Parallel()
 		// 135
-		askewOrient := &spatialmath.OrientationVectorDegrees{OX: -1, OY: -1, OZ: 1}
+		askewOrient := &spatialmath.OrientationVectorDegrees{OX: -1, OY: 1, OZ: 1}
 		movementSensor := createInjectedOrientationMovementSensor(askewOrient)
 		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
 		corrected, err := localizer.CurrentPosition(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, 135.)
 	})
+	t.Run("Test angle from +Y to +X, -Y quadrant", func(t *testing.T) {
+		t.Parallel()
+		// -45
+		askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: -1, OZ: 1}
+		movementSensor := createInjectedOrientationMovementSensor(askewOrient)
+		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
+		corrected, err := localizer.CurrentPosition(ctx)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, -45.)
+	})
+	t.Run("Test angle from +Y to -X, -Y quadrant", func(t *testing.T) {
+		t.Parallel()
+		// -135
+		askewOrient := &spatialmath.OrientationVectorDegrees{OX: -1, OY: -1, OZ: 1}
+		movementSensor := createInjectedOrientationMovementSensor(askewOrient)
+		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
+		corrected, err := localizer.CurrentPosition(ctx)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, -135.)
+	})
 	t.Run("Test non-multiple-of-45 angle from +Y to +X, +Y quadrant", func(t *testing.T) {
 		t.Parallel()
-		// -30
+		// 60
 		askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: math.Sqrt(3), OZ: 1}
 		movementSensor := createInjectedOrientationMovementSensor(askewOrient)
 		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
 		corrected, err := localizer.CurrentPosition(ctx)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, -30.)
+		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, 60.)
 	})
 	t.Run("Test orientation already at OZ=1", func(t *testing.T) {
 		t.Parallel()

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -481,8 +481,10 @@ func (svc *builtIn) Location(ctx context.Context, extra map[string]interface{}) 
 	if err != nil {
 		return nil, err
 	}
-	// When rotation about the +Z axis, an OV theta is right handed but compass heading is left handed. Account for this.
-	compassHeading -= movementSensor2dOrientation.Orientation().OrientationVectorDegrees().Theta
+	// theta is the sensor's mounting yaw within the base, right handed about +Z; compass heading is left handed,
+	// so the base heading is the sensor's reported heading minus that yaw expressed left handed, i.e. plus theta.
+	compassHeading += movementSensor2dOrientation.Orientation().OrientationVectorDegrees().Theta
+	compassHeading = math.Mod(compassHeading, 360)
 	if compassHeading < 0 {
 		compassHeading += 360
 	}

--- a/spatialmath/pose.go
+++ b/spatialmath/pose.go
@@ -244,7 +244,10 @@ func ProjectOrientationTo2dRotation(pose Pose) (Pose, error) {
 		return nil, errors.New("orientation appears to be pointing straight down, cannot project to 2d")
 	}
 	// This is the vector across the ground of the above hypothetical vector, projected onto the X-Y plane.
-	theta := -math.Atan2(newAdjPt.Y, -newAdjPt.X)
+	// adjPt starts at +Y, so a pure Z rotation of psi sends it to (-sin(psi), cos(psi), 0); atan2(-X, Y) recovers psi.
+	// Argument order matters here: swapping it collapses to psi-90deg and makes this discontinuous with the
+	// in-plane early return above.
+	theta := math.Atan2(-newAdjPt.X, newAdjPt.Y)
 	return NewPose(pose.Point(), &OrientationVector{OZ: 1, Theta: theta}), nil
 }
 

--- a/spatialmath/pose_test.go
+++ b/spatialmath/pose_test.go
@@ -9,6 +9,8 @@ import (
 	"go.viam.com/test"
 	"gonum.org/v1/gonum/num/dualquat"
 	"gonum.org/v1/gonum/num/quat"
+
+	"go.viam.com/rdk/utils"
 )
 
 func TestBasicPoseConstruction(t *testing.T) {
@@ -219,4 +221,38 @@ func TestInterpolateSand1(t *testing.T) {
 	y := Interpolate(a, b, .75)
 
 	test.That(t, x.Point().Distance(y.Point()), test.ShouldAlmostEqual, y.Point().Distance(b.Point()), .00001)
+}
+
+func TestProjectOrientationTo2dRotation(t *testing.T) {
+	// A pure yaw must survive the projection unchanged, and must not depend on whether the
+	// component happens to be perfectly level: an infinitesimal tilt takes the general code path
+	// while a perfectly level pose takes the in-plane early return, and the two must agree.
+	for _, yawDeg := range []float64{0, 30, 90, 180, -45, -170} {
+		yaw := utils.DegToRad(yawDeg)
+		for _, pitch := range []float64{0, 1e-12, 1e-6, 0.02, 0.3} {
+			pose := NewPose(r3.Vector{1, 2, 3}, &EulerAngles{Yaw: yaw, Pitch: pitch})
+			projected, err := ProjectOrientationTo2dRotation(pose)
+			test.That(t, err, test.ShouldBeNil)
+
+			// position is carried through untouched
+			test.That(t, projected.Point().Distance(pose.Point()), test.ShouldAlmostEqual, 0, 1e-9)
+
+			ov := projected.Orientation().OrientationVectorDegrees()
+			// the result is a pure rotation about +Z
+			test.That(t, ov.OX, test.ShouldAlmostEqual, 0, 1e-8)
+			test.That(t, ov.OY, test.ShouldAlmostEqual, 0, 1e-8)
+			test.That(t, ov.OZ, test.ShouldAlmostEqual, 1, 1e-8)
+			// and it preserves the heading
+			test.That(t, utils.DegToRad(ov.Theta), test.ShouldAlmostEqual, yaw, 1e-6)
+		}
+	}
+}
+
+func TestProjectOrientationTo2dRotationPoles(t *testing.T) {
+	// Pointing the "forward" axis straight up or down has no ground projection.
+	for _, roll := range []float64{math.Pi / 2, -math.Pi / 2} {
+		_, err := ProjectOrientationTo2dRotation(NewPoseFromOrientation(&EulerAngles{Roll: roll}))
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "cannot project to 2d")
+	}
 }


### PR DESCRIPTION
## Summary

Fixes four defects found during a math-focused audit of the repo. Each one produces a plausible-looking wrong number or a hard crash rather than an error, and none were covered by existing tests. Every fix ships with a regression test that was confirmed to fail without the corresponding source change.

**Contains one behavior change to a user-facing API:** `navigation.Location()` compass heading is corrected for machines whose movement sensor is mounted at a non-identity orientation relative to the base. Identity-mounted sensors (the common case, and what `nav_cfg.json` uses) are unaffected.

## Changes

- **spatialmath**: `ProjectOrientationTo2dRotation` computed `-atan2(Y, -X)`, which returns the true heading minus 90°. The in-plane early return (`OX == 0 && OY == 0`) returns the pose untouched, so the same physical orientation produced answers 90° apart depending on an infinitesimal tilt. Now `atan2(-X, Y)`, which agrees with the early return and preserves a pure yaw through any pitch.
- **services/navigation/builtin**: `Location()` compensated for the old sign with `compassHeading -= theta`. Since an `OrientationVector` theta is right-handed and compass heading is left-handed, composing the sensor's mounting yaw into the base heading is `+= theta`. Also added a `math.Mod` so the result normalises into `[0, 360)` — the old expression could return values above 360.
- **rimage/transform**: `PointToPixel` only rejected `z == 0`. A negative `z` flips both signs and yields a perfectly in-bounds pixel, so points *behind* the camera were projected into the image. Now rejects `z <= 0`.
- **rimage/transform**: `intrinsics3DTo2D` (`PointCloudToRGBD`) had no depth test, so whichever point the cloud iterator visited last won the pixel — background silently overwrote foreground. It also did `rimage.Depth(int(pt.Z))` into a `uint16`, so a point at `z = -1000` was recorded as depth `64536`. Now keeps the nearest point per pixel and drops anything outside `Depth` range.
- **control**: `basicPID.Next` dereferenced `p.tuners[i]` for every PID set, but tuners are only allocated for sets that need auto-tuning (`NeedsAutoTuning` — all of P, I, D zero). `getTuning()` returns true as soon as *any* set is tuning, so a MIMO PID mixing tuned and untuned sets panicked on its first tick. Added the nil check.
- **control**: `encoderToRPM.reset` did `Attribute["ticks_per_revolution"].(int)`. `BlockConfig.Attribute` is decoded from JSON, where every number is a `float64`, so this panicked for any real config — the block was unusable. Now accepts either type, rejects non-integral and non-numeric values with an error, and rejects zero up front instead of dividing by it inside the control loop.

## Testing

`go test` passes across `spatialmath`, `control`, `rimage`, `services`, `vision`, `components/camera`, `pointcloud`, `motionplan`, and `referenceframe`. `golangci-lint` clean on all touched packages.

Each new test was verified to fail against the unpatched source, with these symptoms:

| Test | Failure before fix |
| --- | --- |
| `spatialmath.TestProjectOrientationTo2dRotation` | `-1.5707963267948963` (−90°) instead of `0` |
| `transform.TestPointCloudToRGBDDepthOrdering` | depth `64536` instead of `1000` |
| `control.TestPIDMixedAutoTuningDoesNotPanic` | `runtime error: invalid memory address or nil pointer dereference` |
| `control.TestEncoderSpeedConfig` | `interface conversion: interface {} is float64, not int` |

Added:
- `spatialmath/pose_test.go` — a pure yaw survives projection unchanged across tilts from `0` to `0.3` rad (this is the invariant the old code violated), plus the pole error cases.
- `rimage/transform/pinhole_camera_parameters_test.go` — non-positive depth rejection, behind-camera points excluded from the depth map, nearest-point-wins on a shared pixel.
- `control/pid_test.go` — MIMO PID with one configured and one auto-tuning set.
- `control/encoder_speed_test.go` — table over JSON `float64`, native `int`, non-integral, wrong type, and zero.

Updated `services/motion/localizer_test.go`: `TestCorrectStartPose` encoded the buggy convention. Its expectations are now the right-handed headings, which for these inputs equal `atan2(OY, OX)`. Note that the `OZ=1` subtest in the same function already asserted the right-handed value (`127 → 127`) — the two paths of one function were asserting opposite conventions, which is the bug.

### Reviewer attention

The navigation sign flip is the riskiest hunk. The derivation, anchored on `TestLocalizerOrientation` (which pins `OV theta == -compassHeading`):

> `yaw_sensor = yaw_base + theta_mount` (right-handed) → `-H_S = -H_B + theta` → `H_B = H_S + theta`

Old behavior was wrong for any non-identity mounting and correct only when `theta == 0`, which is why `TestNavSetup` passes both before and after. There is no navigation-level test covering a rotated sensor mount; adding one needs frame-system scaffolding and is worth a follow-up.

## Not included

- Finding #8 (`R3ToR4` zero-vector guard) is already fixed by #6310.
- The remaining high/medium findings from the audit — `OrientationAlmostEqualEps` comparing a squared norm against a linear epsilon, the PID auto-tuner's `avgSpeedSS` and Ziegler-Nichols amplitude errors, the homography estimator math, and the unnamed-collision-geometry naming collision — are deliberately left out to keep this PR reviewable. The `OrientationAlmostEqualEps` change in particular tightens a tolerance 100× and deserves its own branch.

## Tickets

None

## Claude Code Prompts Used

- "Hi Claude, I would like you to take a hard look at this repo. I want you to search for bugs, mistakes, and strange choices. Please pay particular attention to the math and see if something was done wrong. Please review all the packages and outline your findings by order of severity and provide recommendations of what we should do about what you found."
- "can you create a worktree and prepare a draft PR for the critical issues, except for # 8 for which you should read https://github.com/viamrobotics/rdk/pull/6310 and let me know if it is an appropriate fix?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
