### PR TITLE
spatialmath: fix ProjectOrientationTo2dRotation heading by 90 degrees

### DIFF
--- a/services/motion/localizer_test.go
+++ b/services/motion/localizer_test.go
@@ -100,53 +100,53 @@ func TestCorrectStartPose(t *testing.T) {
 	origin := geo.NewPoint(0, 0)
 	t.Run("Test angle from +Y to +X, +Y quadrant", func(t *testing.T) {
 		t.Parallel()
-		// -45
-		askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: 1, OZ: 1}
-		movementSensor := createInjectedOrientationMovementSensor(askewOrient)
-		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
-		corrected, err := localizer.CurrentPosition(ctx)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, -45.)
-	})
-	t.Run("Test angle from +Y to -X, +Y quadrant", func(t *testing.T) {
-		t.Parallel()
 		// 45
-		askewOrient := &spatialmath.OrientationVectorDegrees{OX: -1, OY: 1, OZ: 1}
+		askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: 1, OZ: 1}
 		movementSensor := createInjectedOrientationMovementSensor(askewOrient)
 		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
 		corrected, err := localizer.CurrentPosition(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, 45.)
 	})
-	t.Run("Test angle from +Y to +X, -Y quadrant", func(t *testing.T) {
-		t.Parallel()
-		// -135
-		askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: -1, OZ: 1}
-		movementSensor := createInjectedOrientationMovementSensor(askewOrient)
-		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
-		corrected, err := localizer.CurrentPosition(ctx)
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, -135.)
-	})
-	t.Run("Test angle from +Y to -X, -Y quadrant", func(t *testing.T) {
+	t.Run("Test angle from +Y to -X, +Y quadrant", func(t *testing.T) {
 		t.Parallel()
 		// 135
-		askewOrient := &spatialmath.OrientationVectorDegrees{OX: -1, OY: -1, OZ: 1}
+		askewOrient := &spatialmath.OrientationVectorDegrees{OX: -1, OY: 1, OZ: 1}
 		movementSensor := createInjectedOrientationMovementSensor(askewOrient)
 		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
 		corrected, err := localizer.CurrentPosition(ctx)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, 135.)
 	})
+	t.Run("Test angle from +Y to +X, -Y quadrant", func(t *testing.T) {
+		t.Parallel()
+		// -45
+		askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: -1, OZ: 1}
+		movementSensor := createInjectedOrientationMovementSensor(askewOrient)
+		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
+		corrected, err := localizer.CurrentPosition(ctx)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, -45.)
+	})
+	t.Run("Test angle from +Y to -X, -Y quadrant", func(t *testing.T) {
+		t.Parallel()
+		// -135
+		askewOrient := &spatialmath.OrientationVectorDegrees{OX: -1, OY: -1, OZ: 1}
+		movementSensor := createInjectedOrientationMovementSensor(askewOrient)
+		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
+		corrected, err := localizer.CurrentPosition(ctx)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, -135.)
+	})
 	t.Run("Test non-multiple-of-45 angle from +Y to +X, +Y quadrant", func(t *testing.T) {
 		t.Parallel()
-		// -30
+		// 60
 		askewOrient := &spatialmath.OrientationVectorDegrees{OX: 1, OY: math.Sqrt(3), OZ: 1}
 		movementSensor := createInjectedOrientationMovementSensor(askewOrient)
 		localizer := motion.TwoDLocalizer(motion.NewMovementSensorLocalizer(movementSensor, origin, spatialmath.NewZeroPose()))
 		corrected, err := localizer.CurrentPosition(ctx)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, -30.)
+		test.That(t, corrected.Pose().Orientation().OrientationVectorDegrees().Theta, test.ShouldAlmostEqual, 60.)
 	})
 	t.Run("Test orientation already at OZ=1", func(t *testing.T) {
 		t.Parallel()

--- a/services/navigation/builtin/builtin.go
+++ b/services/navigation/builtin/builtin.go
@@ -481,8 +481,10 @@ func (svc *builtIn) Location(ctx context.Context, extra map[string]interface{}) 
 	if err != nil {
 		return nil, err
 	}
-	// When rotation about the +Z axis, an OV theta is right handed but compass heading is left handed. Account for this.
-	compassHeading -= movementSensor2dOrientation.Orientation().OrientationVectorDegrees().Theta
+	// theta is the sensor's mounting yaw within the base, right handed about +Z; compass heading is left handed,
+	// so the base heading is the sensor's reported heading minus that yaw expressed left handed, i.e. plus theta.
+	compassHeading += movementSensor2dOrientation.Orientation().OrientationVectorDegrees().Theta
+	compassHeading = math.Mod(compassHeading, 360)
 	if compassHeading < 0 {
 		compassHeading += 360
 	}

--- a/spatialmath/pose.go
+++ b/spatialmath/pose.go
@@ -244,7 +244,10 @@ func ProjectOrientationTo2dRotation(pose Pose) (Pose, error) {
 		return nil, errors.New("orientation appears to be pointing straight down, cannot project to 2d")
 	}
 	// This is the vector across the ground of the above hypothetical vector, projected onto the X-Y plane.
-	theta := -math.Atan2(newAdjPt.Y, -newAdjPt.X)
+	// adjPt starts at +Y, so a pure Z rotation of psi sends it to (-sin(psi), cos(psi), 0); atan2(-X, Y) recovers psi.
+	// Argument order matters here: swapping it collapses to psi-90deg and makes this discontinuous with the
+	// in-plane early return above.
+	theta := math.Atan2(-newAdjPt.X, newAdjPt.Y)
 	return NewPose(pose.Point(), &OrientationVector{OZ: 1, Theta: theta}), nil
 }
 

--- a/spatialmath/pose_test.go
+++ b/spatialmath/pose_test.go
@@ -9,6 +9,8 @@ import (
 	"go.viam.com/test"
 	"gonum.org/v1/gonum/num/dualquat"
 	"gonum.org/v1/gonum/num/quat"
+
+	"go.viam.com/rdk/utils"
 )
 
 func TestBasicPoseConstruction(t *testing.T) {
@@ -219,4 +221,38 @@ func TestInterpolateSand1(t *testing.T) {
 	y := Interpolate(a, b, .75)
 
 	test.That(t, x.Point().Distance(y.Point()), test.ShouldAlmostEqual, y.Point().Distance(b.Point()), .00001)
+}
+
+func TestProjectOrientationTo2dRotation(t *testing.T) {
+	// A pure yaw must survive the projection unchanged, and must not depend on whether the
+	// component happens to be perfectly level: an infinitesimal tilt takes the general code path
+	// while a perfectly level pose takes the in-plane early return, and the two must agree.
+	for _, yawDeg := range []float64{0, 30, 90, 180, -45, -170} {
+		yaw := utils.DegToRad(yawDeg)
+		for _, pitch := range []float64{0, 1e-12, 1e-6, 0.02, 0.3} {
+			pose := NewPose(r3.Vector{1, 2, 3}, &EulerAngles{Yaw: yaw, Pitch: pitch})
+			projected, err := ProjectOrientationTo2dRotation(pose)
+			test.That(t, err, test.ShouldBeNil)
+
+			// position is carried through untouched
+			test.That(t, projected.Point().Distance(pose.Point()), test.ShouldAlmostEqual, 0, 1e-9)
+
+			ov := projected.Orientation().OrientationVectorDegrees()
+			// the result is a pure rotation about +Z
+			test.That(t, ov.OX, test.ShouldAlmostEqual, 0, 1e-8)
+			test.That(t, ov.OY, test.ShouldAlmostEqual, 0, 1e-8)
+			test.That(t, ov.OZ, test.ShouldAlmostEqual, 1, 1e-8)
+			// and it preserves the heading
+			test.That(t, utils.DegToRad(ov.Theta), test.ShouldAlmostEqual, yaw, 1e-6)
+		}
+	}
+}
+
+func TestProjectOrientationTo2dRotationPoles(t *testing.T) {
+	// Pointing the "forward" axis straight up or down has no ground projection.
+	for _, roll := range []float64{math.Pi / 2, -math.Pi / 2} {
+		_, err := ProjectOrientationTo2dRotation(NewPoseFromOrientation(&EulerAngles{Roll: roll}))
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "cannot project to 2d")
+	}
 }


### PR DESCRIPTION
## Summary

`spatialmath.ProjectOrientationTo2dRotation` returns a heading 90° off, and disagrees with its own in-plane early return. This corrects it and updates `navigation.Location()`, which was compensating for the old sign.

**Contains a user-facing behavior change.** `navigation.Location()` compass heading is corrected for machines whose movement sensor is mounted at a non-identity orientation relative to the base. Identity-mounted sensors — the common case, and what `nav_cfg.json` uses — are unaffected.

## Changes

- **spatialmath**: the projected heading was `-atan2(Y, -X)`, which evaluates to the true heading minus 90°. Now `atan2(-X, Y)`. `adjPt` starts at `+Y`, so a pure Z rotation of ψ sends it to `(-sin ψ, cos ψ, 0)`, and `atan2(-X, Y)` recovers ψ.
- **services/navigation/builtin**: `Location()` used `compassHeading -= theta`. An `OrientationVector` theta is right-handed and compass heading is left-handed, so composing the sensor's mounting yaw into the base heading is `+= theta`. Also added a `math.Mod` so the result normalises into `[0, 360)` — the old expression could return values above 360.

## Why the fix direction is right

The function was applying two different conventions on its two paths, which the existing tests already showed:

- `TestCorrectStartPose/Test orientation already at OZ=1` asserts `127 → 127`. That path is the early return, which hands the pose back untouched, so it is right-handed by construction and not arguable.
- The tilted subtests in the same function asserted left-handed values.

The early return pins the convention, so the general path is what's wrong. The invariant is now tested directly: a pure yaw survives projection unchanged at any pitch, which the old code violated.

For the navigation sign, anchored on `TestLocalizerOrientation` (which pins `OV theta == -compassHeading`):

> `yaw_sensor = yaw_base + theta_mount` (right-handed) → `-H_S = -H_B + theta` → `H_B = H_S + theta`

The old behavior was wrong for any non-identity mounting and correct only when `theta == 0`. That is why `TestNavSetup` passes both before and after — its sensor is identity-mounted and takes the early return.

## Testing

`go test ./spatialmath/... ./services/motion/... ./services/navigation/...` passes. `golangci-lint` clean on all touched packages.

Added `spatialmath/pose_test.go`:
- `TestProjectOrientationTo2dRotation` — a pure yaw survives projection unchanged across tilts from `0` to `0.3` rad, and the result is a pure `+Z` rotation with the position carried through. Verified to fail against the unpatched source with `-1.5707963267948963` (−90°) instead of `0`.
- `TestProjectOrientationTo2dRotationPoles` — straight-up and straight-down both error.

Updated `services/motion/localizer_test.go`: `TestCorrectStartPose` encoded the buggy convention on its tilted subtests. Expectations are now the right-handed headings, which for these inputs equal `atan2(OY, OX)`.

### Reviewer attention

The navigation sign flip is the hunk to scrutinise. There is no navigation-level test covering a rotated sensor mount — adding one needs frame-system scaffolding, and is worth a follow-up.

## Claude Code Prompts Used

- "Hi Claude, I would like you to take a hard look at this repo. I want you to search for bugs, mistakes, and strange choices. Please pay particular attention to the math and see if something was done wrong. Please review all the packages and outline your findings by order of severity and provide recommendations of what we should do about what you found."
- "can you create a worktree and prepare a draft PR for the critical issues, except for # 8 for which you should read https://github.com/viamrobotics/rdk/pull/6310 and let me know if it is an appropriate fix?"
- "https://github.com/viamrobotics/rdk/pull/6313 is pretty complex. Can we split it in multiple cohesive PRs?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
