### PR TITLE
rimage/transform: reject points behind the camera 

### DIFF
--- a/rimage/transform/pinhole_camera_parameters.go
+++ b/rimage/transform/pinhole_camera_parameters.go
@@ -187,12 +187,15 @@ func (params *PinholeCameraIntrinsics) PixelToPoint(x, y, z float64) (float64, f
 // The intrinsics parameters should be the ones of the sensor we want to project to.
 func (params *PinholeCameraIntrinsics) PointToPixel(x, y, z float64) (float64, float64) {
 	// TODO(louise): add unit test
-	if z != 0. {
+	// z must be strictly positive: the camera looks down +Z, so z <= 0 is at or behind the pinhole and has no
+	// image-plane projection. Dividing by a negative z flips both signs and yields an in-bounds pixel for a point
+	// that is behind the camera, so the sign test cannot be relaxed to z != 0.
+	if z > 0. {
 		xPx := math.Round((x/z)*params.Fx + params.Ppx)
 		yPx := math.Round((y/z)*params.Fy + params.Ppy)
 		return xPx, yPx
 	}
-	// if depth is zero at this pixel, return negative coordinates so that the cropping to RGB bounds will filter it out
+	// if depth is non-positive at this pixel, return negative coordinates so that the cropping to RGB bounds will filter it out
 	return -1.0, -1.0
 }
 
@@ -297,12 +300,22 @@ func intrinsics3DTo2D(cloud pointcloud.PointCloud, pci *PinholeCameraIntrinsics)
 	cloud.Iterate(0, 0, func(pt r3.Vector, d pointcloud.Data) bool {
 		j, i := pci.PointToPixel(pt.X, pt.Y, pt.Z)
 		x, y := int(math.Round(j)), int(math.Round(i))
-		z := int(pt.Z)
+		// PointToPixel already rejects z <= 0, so pt.Z is positive whenever the pixel is in bounds.
+		// Depth is a uint16, so anything past its range has to be dropped rather than silently wrapped.
+		if pt.Z > float64(math.MaxUint16) {
+			return true
+		}
+		z := rimage.Depth(pt.Z)
 		// if point has color and is inside the image bounds, add it to the images
 		if x >= 0 && x < width && y >= 0 && y < height && d != nil && d.HasColor() {
+			// Several cloud points can land on one pixel; keep the nearest so foreground is not
+			// overwritten by background depending on iteration order. Zero means "no point yet".
+			if existing := depth.GetDepth(x, y); existing != 0 && existing <= z {
+				return true
+			}
 			r, g, b := d.RGB255()
 			color.Set(image.Point{x, y}, rimage.NewColor(r, g, b))
-			depth.Set(x, y, rimage.Depth(z))
+			depth.Set(x, y, z)
 		}
 		return true
 	})

--- a/rimage/transform/pinhole_camera_parameters.go
+++ b/rimage/transform/pinhole_camera_parameters.go
@@ -187,9 +187,9 @@ func (params *PinholeCameraIntrinsics) PixelToPoint(x, y, z float64) (float64, f
 // The intrinsics parameters should be the ones of the sensor we want to project to.
 func (params *PinholeCameraIntrinsics) PointToPixel(x, y, z float64) (float64, float64) {
 	// TODO(louise): add unit test
-	// z must be strictly positive: the camera looks down +Z, so z <= 0 is at or behind the pinhole and has no
-	// image-plane projection. Dividing by a negative z flips both signs and yields an in-bounds pixel for a point
-	// that is behind the camera, so the sign test cannot be relaxed to z != 0.
+	// The camera looks down +Z, so z <= 0 is at or behind the pinhole and has no image-plane
+	// projection. The test has to be z > 0 rather than z != 0: a negative z flips both signs and
+	// lands a point that is behind the camera on a perfectly in-bounds pixel.
 	if z > 0. {
 		xPx := math.Round((x/z)*params.Fx + params.Ppx)
 		yPx := math.Round((y/z)*params.Fy + params.Ppy)
@@ -308,8 +308,8 @@ func intrinsics3DTo2D(cloud pointcloud.PointCloud, pci *PinholeCameraIntrinsics)
 		z := rimage.Depth(pt.Z)
 		// if point has color and is inside the image bounds, add it to the images
 		if x >= 0 && x < width && y >= 0 && y < height && d != nil && d.HasColor() {
-			// Several cloud points can land on one pixel; keep the nearest so foreground is not
-			// overwritten by background depending on iteration order. Zero means "no point yet".
+			// Several cloud points can land on one pixel; keep the nearest so the result does not
+			// depend on iteration order. Zero means "no point yet".
 			if existing := depth.GetDepth(x, y); existing != 0 && existing <= z {
 				return true
 			}

--- a/rimage/transform/pinhole_camera_parameters_test.go
+++ b/rimage/transform/pinhole_camera_parameters_test.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"context"
 	"image"
+	"image/color"
 	"math"
 	"testing"
 
@@ -268,4 +269,51 @@ func TestNilIntrinsics(t *testing.T) {
 	test.That(t, func() { nilIntrinsics.ImagePointTo3DPoint(image.Point{}, rimage.Depth(0)) }, test.ShouldNotPanic)
 	test.That(t, func() { nilIntrinsics.RGBDToPointCloud(&rimage.Image{}, &rimage.DepthMap{}) }, test.ShouldNotPanic)
 	test.That(t, func() { nilIntrinsics.PointCloudToRGBD(pointcloud.PointCloud(nil)) }, test.ShouldNotPanic)
+}
+
+func TestPointToPixelRejectsNonPositiveDepth(t *testing.T) {
+	params := &PinholeCameraIntrinsics{Width: 640, Height: 480, Fx: 500, Fy: 500, Ppx: 320, Ppy: 240}
+
+	// In front of the camera: projects normally.
+	u, v := params.PointToPixel(10, 10, 1000)
+	test.That(t, u, test.ShouldEqual, 325.)
+	test.That(t, v, test.ShouldEqual, 245.)
+
+	// At or behind the pinhole there is no projection. Dividing by a negative z would otherwise
+	// flip both signs and hand back a perfectly in-bounds pixel for a point behind the camera.
+	for _, z := range []float64{0, -1, -1000} {
+		u, v := params.PointToPixel(10, 10, z)
+		test.That(t, u, test.ShouldEqual, -1.)
+		test.That(t, v, test.ShouldEqual, -1.)
+	}
+}
+
+func TestPointCloudToRGBDDepthOrdering(t *testing.T) {
+	params := &PinholeCameraIntrinsics{Width: 640, Height: 480, Fx: 500, Fy: 500, Ppx: 320, Ppy: 240}
+
+	// (10,10,1000) and (-10,-10,-1000) both land on pixel (325,245); the second is behind the camera.
+	cloud := pointcloud.NewBasicEmpty()
+	test.That(t, cloud.Set(r3.Vector{10, 10, 1000}, pointcloud.NewColoredData(color.NRGBA{255, 0, 0, 255})), test.ShouldBeNil)
+	test.That(t, cloud.Set(r3.Vector{-10, -10, -1000}, pointcloud.NewColoredData(color.NRGBA{0, 255, 0, 255})), test.ShouldBeNil)
+
+	_, dm, err := params.PointCloudToRGBD(cloud)
+	test.That(t, err, test.ShouldBeNil)
+	// The behind-camera point must not appear anywhere, and must not have clobbered the real one.
+	test.That(t, dm.GetDepth(325, 245), test.ShouldEqual, rimage.Depth(1000))
+	test.That(t, dm.GetDepth(315, 235), test.ShouldEqual, rimage.Depth(0))
+}
+
+func TestPointCloudToRGBDKeepsNearest(t *testing.T) {
+	params := &PinholeCameraIntrinsics{Width: 640, Height: 480, Fx: 500, Fy: 500, Ppx: 320, Ppy: 240}
+
+	// Two points on the same ray -> same pixel. The nearer one must win regardless of iteration order.
+	cloud := pointcloud.NewBasicEmpty()
+	test.That(t, cloud.Set(r3.Vector{20, 20, 2000}, pointcloud.NewColoredData(color.NRGBA{0, 255, 0, 255})), test.ShouldBeNil)
+	test.That(t, cloud.Set(r3.Vector{10, 10, 1000}, pointcloud.NewColoredData(color.NRGBA{255, 0, 0, 255})), test.ShouldBeNil)
+
+	img, dm, err := params.PointCloudToRGBD(cloud)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, dm.GetDepth(325, 245), test.ShouldEqual, rimage.Depth(1000))
+	r, g, b := img.GetXY(325, 245).RGB255()
+	test.That(t, []uint8{r, g, b}, test.ShouldResemble, []uint8{255, 0, 0})
 }


### PR DESCRIPTION
## Summary

`PinholeCameraIntrinsics` projected points that are behind the camera into valid in-frame pixels, and `PointCloudToRGBD` had no depth test, so a background point could silently overwrite a foreground one. Combined, a point 1000mm *behind* the camera was recorded as depth `64536` on top of a legitimate point 1000mm in front of it.

## Changes

- **`PointToPixel`**: only rejected `z == 0`. The camera looks down `+Z`, so `z <= 0` is at or behind the pinhole and has no image-plane projection — but dividing by a negative `z` flips both signs and produces a perfectly in-bounds pixel. Now rejects `z <= 0`, returning the same `(-1, -1)` sentinel the callers' bounds checks already filter.
- **`intrinsics3DTo2D`** (`PointCloudToRGBD`): added a depth test so the nearest point wins a contested pixel instead of whichever the iterator visited last, and dropped the `int` → `rimage.Depth` (`uint16`) cast that wrapped out-of-range values.

## Reproduction

With `Fx=Fy=500, Ppx=320, Ppy=240`, these two points land on the same pixel `(325, 245)`:

| point | in front? | before |
| --- | --- | --- |
| `(10, 10, 1000)` | yes | overwritten |
| `(-10, -10, -1000)` | no, behind the camera | wins the pixel, recorded as depth `64536` |

## Testing

`go test ./rimage/... ./components/camera/... ./vision/... ./services/vision/...` passes. `golangci-lint` clean on all touched packages.

Added to `rimage/transform/pinhole_camera_parameters_test.go`:
- `TestPointToPixelRejectsNonPositiveDepth` — in-front point projects normally; `z` of `0`, `-1`, `-1000` all return the sentinel.
- `TestPointCloudToRGBDDepthOrdering` — the behind-camera point appears nowhere in the depth map and has not clobbered the real one. Verified to fail against the unpatched source with depth `64536` instead of `1000`.
- `TestPointCloudToRGBDKeepsNearest` — two points on the same ray, nearest wins for both depth and color.

## Tickets

None

## Claude Code Prompts Used

- "Hi Claude, I would like you to take a hard look at this repo. I want you to search for bugs, mistakes, and strange choices. Please pay particular attention to the math and see if something was done wrong. Please review all the packages and outline your findings by order of severity and provide recommendations of what we should do about what you found."
- "can you create a worktree and prepare a draft PR for the critical issues, except for #8 for which you should read https://github.com/viamrobotics/rdk/pull/6310 and let me know if it is an appropriate fix?"
- "https://github.com/viamrobotics/rdk/pull/6313 is pretty complex. Can we split it in multiple cohesive PRs?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
