### PR TITLE
control: fix nil pointer dereference in MIMO PID auto-tuning

### DIFF
--- a/control/pid.go
+++ b/control/pid.go
@@ -68,8 +68,10 @@ func (p *basicPID) Next(ctx context.Context, x []*Signal, dt time.Duration) ([]*
 
 		// For each PID Set and its respective Tuner Object, Step through an iteration of tuning until done.
 		for i := 0; i < len(p.PIDSets); i++ {
-			// if we do not need to tune this signal, skip to the next signal
-			if !p.tuners[i].tuning {
+			// if we do not need to tune this signal, skip to the next signal.
+			// tuners[i] is nil for any PID set that was fully configured (see NeedsAutoTuning), and getTuning()
+			// is true as soon as *any* set is tuning, so the nil check has to come first.
+			if p.tuners[i] == nil || !p.tuners[i].tuning {
 				continue
 			}
 			out, done := p.tuners[i].pidTunerStep(math.Abs(x[0].GetSignalValueAt(i)), p.logger)

--- a/control/pid_test.go
+++ b/control/pid_test.go
@@ -213,3 +213,35 @@ func TestPIDMultiTuner(t *testing.T) {
 		pid.tuners[signalIndex].tuning = false
 	}
 }
+
+// A MIMO PID where only some sets need auto-tuning leaves the remaining tuners nil. getTuning()
+// reports true as soon as any one set is tuning, so Next() walks every index and used to
+// dereference the nil tuners belonging to the fully-configured sets.
+func TestPIDMixedAutoTuningDoesNotPanic(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+	cfg := BlockConfig{
+		Name: "PID1",
+		Attribute: utils.AttributeMap{
+			// first set is fully configured (tuner stays nil), second needs tuning
+			"PIDSets": []*PIDConfig{{P: .12, I: .22, D: .11}, {P: 0, I: 0, D: 0}},
+		},
+		Type:      "PID",
+		DependsOn: []string{"A", "B"},
+	}
+	pid, err := loop.newPID(cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	b, ok := pid.(*basicPID)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, b.tuners[0], test.ShouldBeNil)
+	test.That(t, b.tuners[1], test.ShouldNotBeNil)
+	test.That(t, b.GetTuning(), test.ShouldBeTrue)
+
+	s := makeSignals("A", "endpoint", 2)
+	s.SetSignalValueAt(0, 10.0)
+	s.SetSignalValueAt(1, 10.0)
+	test.That(t, func() {
+		pid.Next(ctx, []*Signal{s}, time.Millisecond*10)
+	}, test.ShouldNotPanic)
+}


### PR DESCRIPTION
## Summary

A MIMO PID block that mixes fully-configured PID sets with sets that need auto-tuning panics with a nil pointer dereference on its first control-loop tick.

## Changes

- **control**: `basicPID.Next` dereferenced `p.tuners[i]` for every PID set. Tuners are only allocated for sets where `NeedsAutoTuning()` is true (all of P, I and D zero), so `tuners[i]` is nil for any configured set. `getTuning()` returns true as soon as *any* set is tuning, so the loop then walked every index — including the nil ones. Added the nil check ahead of the `.tuning` read.

`getTuning()` already guards with `if tuner != nil`; `Next()` was the one place that didn't.

## Testing

`go test ./control/...` passes. `golangci-lint` clean.

Added `TestPIDMixedAutoTuningDoesNotPanic` in `control/pid_test.go`: a two-set MIMO PID where the first set is fully configured and the second needs tuning. Asserts the tuner slice is shaped as expected (`tuners[0]` nil, `tuners[1]` non-nil, `GetTuning()` true) and that `Next()` does not panic. Verified to fail against the unpatched source with `runtime error: invalid memory address or nil pointer dereference`.

## Tickets

None

## Claude Code Prompts Used

- "Hi Claude, I would like you to take a hard look at this repo. I want you to search for bugs, mistakes, and strange choices. Please pay particular attention to the math and see if something was done wrong. Please review all the packages and outline your findings by order of severity and provide recommendations of what we should do about what you found."
- "can you create a worktree and prepare a draft PR for the critical issues, except for # 8 for which you should read https://github.com/viamrobotics/rdk/pull/6310 and let me know if it is an appropriate fix?"
- "https://github.com/viamrobotics/rdk/pull/6313 is pretty complex. Can we split it in multiple cohesive PRs?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
