### PR TITLE
control: fix guaranteed panic configuring an encoderToRPM block

### DIFF
--- a/control/encoder_speed.go
+++ b/control/encoder_speed.go
@@ -2,6 +2,7 @@ package control
 
 import (
 	"context"
+	"math"
 	"sync"
 	"time"
 
@@ -43,7 +44,24 @@ func (b *encoderToRPM) reset() error {
 	if len(b.cfg.DependsOn) != 1 {
 		return errors.Errorf("invalid number of inputs for encoderToRPM block %s expected 1 got %d", b.cfg.Name, len(b.cfg.DependsOn))
 	}
-	b.ticksPerRevolution = b.cfg.Attribute["ticks_per_revolution"].(int) // default 0
+	// Block configs are decoded from JSON, so every number arrives as a float64 and a plain .(int)
+	// assertion would panic on any real config.
+	switch ticks := b.cfg.Attribute["ticks_per_revolution"].(type) {
+	case int:
+		b.ticksPerRevolution = ticks
+	case float64:
+		if ticks != math.Trunc(ticks) {
+			return errors.Errorf("encoderToRPM block %s ticks_per_revolution must be a whole number, got %v", b.cfg.Name, ticks)
+		}
+		b.ticksPerRevolution = int(ticks)
+	default:
+		return errors.Errorf("encoderToRPM block %s ticks_per_revolution must be a number, got %T",
+			b.cfg.Name, b.cfg.Attribute["ticks_per_revolution"])
+	}
+	// Guarding here rather than in Next keeps the divide-by-zero out of the control loop entirely.
+	if b.ticksPerRevolution == 0 {
+		return errors.Errorf("encoderToRPM block %s ticks_per_revolution must be nonzero", b.cfg.Name)
+	}
 	b.prevEncCount = 0
 	b.y = make([]*Signal, 1)
 	b.y[0] = makeSignal(b.cfg.Name, b.cfg.Type)

--- a/control/encoder_speed_test.go
+++ b/control/encoder_speed_test.go
@@ -1,0 +1,45 @@
+package control
+
+import (
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/utils"
+)
+
+func TestEncoderSpeedConfig(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	for _, tc := range []struct {
+		name  string
+		ticks interface{}
+		err   string
+	}{
+		// Block configs are decoded from JSON, so numbers arrive as float64 rather than int.
+		{"json float64", float64(1000), ""},
+		{"native int", 1000, ""},
+		{"non-integral", 10.5, "must be a whole number"},
+		{"wrong type", "1000", "must be a number"},
+		{"zero", float64(0), "must be nonzero"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := BlockConfig{
+				Name:      "E1",
+				Type:      "encoderToRpm",
+				Attribute: utils.AttributeMap{"ticks_per_revolution": tc.ticks},
+				DependsOn: []string{"A"},
+			}
+			var blk Block
+			var err error
+			test.That(t, func() { blk, err = newEncoderSpeed(cfg, logger) }, test.ShouldNotPanic)
+			if tc.err == "" {
+				test.That(t, err, test.ShouldBeNil)
+				test.That(t, blk.(*encoderToRPM).ticksPerRevolution, test.ShouldEqual, 1000)
+			} else {
+				test.That(t, err, test.ShouldNotBeNil)
+				test.That(t, err.Error(), test.ShouldContainSubstring, tc.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The `encoderToRPM` control block panics for any config that actually reaches it, which makes the block unusable.

## Changes

- **control**: `encoderToRPM.reset()` did `b.cfg.Attribute["ticks_per_revolution"].(int)`. `BlockConfig.Attribute` is a `utils.AttributeMap` (`map[string]interface{}`) populated from `json:"attributes"`, and JSON numbers always decode to `float64` — so the unchecked assertion panicked on every real config. Nothing in the tree sets the key programmatically, so there is no path where it held an `int`.
- Accept either `int` or a whole `float64`, and return an error rather than panicking on a non-integral or non-numeric value.
- Reject `ticks_per_revolution == 0` in `reset()`. The previous `// default 0` comment was aspirational: zero reached `Next()` and produced a division by zero, i.e. `±Inf` RPM fed into the control loop. Failing at configuration time keeps that out of the loop entirely.

## Testing

`go test ./control/...` passes. `golangci-lint` clean.

Added `control/encoder_speed_test.go` — a table over the config shapes:

| input | expected |
| --- | --- |
| `float64(1000)` (what JSON produces) | accepted |
| `int(1000)` | accepted |
| `10.5` | error, "must be a whole number" |
| `"1000"` | error, "must be a number" |
| `float64(0)` | error, "must be nonzero" |

Each case asserts construction does not panic. Verified to fail against the unpatched source with `interface conversion: interface {} is float64, not int`.

## Tickets

None

## Claude Code Prompts Used

- "Hi Claude, I would like you to take a hard look at this repo. I want you to search for bugs, mistakes, and strange choices. Please pay particular attention to the math and see if something was done wrong. Please review all the packages and outline your findings by order of severity and provide recommendations of what we should do about what you found."
- "can you create a worktree and prepare a draft PR for the critical issues, except for # 8 for which you should read https://github.com/viamrobotics/rdk/pull/6310 and let me know if it is an appropriate fix?"
- "https://github.com/viamrobotics/rdk/pull/6313 is pretty complex. Can we split it in multiple cohesive PRs?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
