### PR TITLE
motionplan: stop unnamed geometries in opposing sets sharing a name

### DIFF
--- a/motionplan/collision.go
+++ b/motionplan/collision.go
@@ -145,11 +145,14 @@ func checkCollisionsHinted(
 	hint *atomic.Pointer[[2]string],
 	logger logging.Logger,
 ) ([]Collision, float64, error) {
-	ggMap, err := createUniqueCollisionMap(gg)
+	// Both maps must be built from one namer: the name is what every check below treats as
+	// geometry identity, so two distinct unnamed geometries must never end up sharing one.
+	namer := &collisionNamer{}
+	ggMap, err := createCollisionMap(gg, namer)
 	if err != nil {
 		return nil, math.Inf(-1), err
 	}
-	otherMap, err := createUniqueCollisionMap(other)
+	otherMap, err := createCollisionMap(other, namer)
 	if err != nil {
 		return nil, math.Inf(-1), err
 	}
@@ -269,22 +272,51 @@ func makeAllowedCollisionsLookup(allowedCollisions []Collision) map[[2]string]bo
 	return ignoreList
 }
 
-func createUniqueCollisionMap(geoms []spatialmath.Geometry) (map[string]spatialmath.Geometry, error) {
-	unnamedCnt := 0
-	geomMap := make(map[string]spatialmath.Geometry, len(geoms))
+// collisionNamer hands out the name a geometry is known by for the duration of one collision check.
+// Labelled geometries keep their label; unlabelled ones get a synthetic name.
+//
+// The synthetic name is memoized per geometry rather than drawn from a per-slice counter. Everything
+// downstream — the allowed-collision lookup, the `seen` dedup, the self-comparison skip and the
+// reported Collision pair — treats the name as the geometry's identity. A per-slice counter restarts
+// at zero for each set, so the first unlabelled geometry of one set and the first of the other both
+// became "unnamedCollisionGeometry_0"; skipCollisionCheck then read that as a geometry being compared
+// against itself and skipped the pair, silently missing a real collision.
+type collisionNamer struct {
+	synthesized map[spatialmath.Geometry]string
+}
 
+// name is safe to call across both sets of a check: the same geometry always resolves to the same
+// name, so a geometry present in both sets is still recognised as itself.
+func (n *collisionNamer) name(geom spatialmath.Geometry) string {
+	if label := geom.Label(); label != "" {
+		return label
+	}
+	if n.synthesized == nil {
+		n.synthesized = make(map[spatialmath.Geometry]string)
+	} else if existing, ok := n.synthesized[geom]; ok {
+		return existing
+	}
+	// Every Geometry implementation has pointer receivers, so the interface value is comparable
+	// and compares by identity.
+	synthetic := unnamedCollisionGeometryPrefix + strconv.Itoa(len(n.synthesized))
+	n.synthesized[geom] = synthetic
+	return synthetic
+}
+
+func createCollisionMap(geoms []spatialmath.Geometry, namer *collisionNamer) (map[string]spatialmath.Geometry, error) {
+	geomMap := make(map[string]spatialmath.Geometry, len(geoms))
 	for _, geom := range geoms {
-		label := geom.Label()
-		if label == "" {
-			label = unnamedCollisionGeometryPrefix + strconv.Itoa(unnamedCnt)
-			unnamedCnt++
-		}
+		label := namer.name(geom)
 		if _, present := geomMap[label]; present {
 			return nil, referenceframe.NewDuplicateGeometryNameError(label)
 		}
 		geomMap[label] = geom
 	}
 	return geomMap, nil
+}
+
+func createUniqueCollisionMap(geoms []spatialmath.Geometry) (map[string]spatialmath.Geometry, error) {
+	return createCollisionMap(geoms, &collisionNamer{})
 }
 
 func skipCollisionCheck(allowed, seen map[[2]string]bool, xName, yName string) bool {

--- a/motionplan/collision.go
+++ b/motionplan/collision.go
@@ -275,12 +275,11 @@ func makeAllowedCollisionsLookup(allowedCollisions []Collision) map[[2]string]bo
 // collisionNamer hands out the name a geometry is known by for the duration of one collision check.
 // Labelled geometries keep their label; unlabelled ones get a synthetic name.
 //
-// The synthetic name is memoized per geometry rather than drawn from a per-slice counter. Everything
-// downstream — the allowed-collision lookup, the `seen` dedup, the self-comparison skip and the
-// reported Collision pair — treats the name as the geometry's identity. A per-slice counter restarts
-// at zero for each set, so the first unlabelled geometry of one set and the first of the other both
-// became "unnamedCollisionGeometry_0"; skipCollisionCheck then read that as a geometry being compared
-// against itself and skipped the pair, silently missing a real collision.
+// Everything downstream — the allowed-collision lookup, the `seen` dedup, the self-comparison skip in
+// skipCollisionCheck and the reported Collision pair — treats the name as the geometry's identity. A
+// synthetic name therefore has to be unique per geometry and stable across both sets of a check,
+// which is why it is memoized per geometry rather than drawn from a per-slice counter: a counter
+// restarts at zero for each set and would hand one name to a geometry in each.
 type collisionNamer struct {
 	synthesized map[spatialmath.Geometry]string
 }

--- a/motionplan/collision_test.go
+++ b/motionplan/collision_test.go
@@ -245,9 +245,9 @@ func TestCollisionEarlyExit(t *testing.T) {
 	test.That(t, len(collisions), test.ShouldBeGreaterThan, 1)
 }
 
-// Two distinct unlabelled geometries, one in each set, used to be handed the same synthetic name.
-// skipCollisionCheck reads matching names as "this geometry vs itself" and skips the pair, so an
-// overlapping obstacle was reported as no collision at all.
+// skipCollisionCheck reads matching names as "this geometry vs itself" and skips the pair, so two
+// distinct unlabelled geometries must never share a synthetic name; if they do, an overlapping
+// obstacle is silently reported as no collision at all.
 func TestUnnamedGeometriesInOpposingSets(t *testing.T) {
 	bc, err := spatial.NewBox(spatial.NewZeroPose(), r3.Vector{2, 2, 2}, "")
 	test.That(t, err, test.ShouldBeNil)

--- a/motionplan/collision_test.go
+++ b/motionplan/collision_test.go
@@ -244,3 +244,34 @@ func TestCollisionEarlyExit(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(collisions), test.ShouldBeGreaterThan, 1)
 }
+
+// Two distinct unlabelled geometries, one in each set, used to be handed the same synthetic name.
+// skipCollisionCheck reads matching names as "this geometry vs itself" and skips the pair, so an
+// overlapping obstacle was reported as no collision at all.
+func TestUnnamedGeometriesInOpposingSets(t *testing.T) {
+	bc, err := spatial.NewBox(spatial.NewZeroPose(), r3.Vector{2, 2, 2}, "")
+	test.That(t, err, test.ShouldBeNil)
+
+	// Fully overlapping, both unlabelled, in opposing sets.
+	moving := bc.Transform(spatial.NewZeroPose())
+	moving.SetLabel("")
+	obstacle := bc.Transform(spatial.NewZeroPose())
+	obstacle.SetLabel("")
+
+	collisions, _, err := checkCollisionsHinted(
+		[]spatial.Geometry{moving}, []spatial.Geometry{obstacle},
+		nil, defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t),
+	)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(collisions), test.ShouldEqual, 1)
+	// The two must not have been given the same name.
+	test.That(t, collisions[0].name1, test.ShouldNotEqual, collisions[0].name2)
+
+	// A geometry genuinely present in both sets is still skipped as a self-comparison.
+	selfCollisions, _, err := checkCollisionsHinted(
+		[]spatial.Geometry{moving}, []spatial.Geometry{moving},
+		nil, defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t),
+	)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, selfCollisions, test.ShouldBeEmpty)
+}


### PR DESCRIPTION
## Summary

Two distinct unlabelled geometries — one in the moving set, one in the obstacle set — were handed the same synthetic name, and the collision checker reads matching names as "this geometry versus itself" and skips the pair. **Two fully overlapping obstacles reported zero collisions.**

Safety-relevant false negative in collision avoidance. From the audit that produced #6314–#6317.

## The bug

`createUniqueCollisionMap` was called once per slice, and its `unnamedCnt` counter restarted at zero each time:

```go
label = unnamedCollisionGeometryPrefix + strconv.Itoa(unnamedCnt)
```

So the first unlabelled geometry of `gg` and the first of `other` both became `unnamedCollisionGeometry_0`. The name is what every check downstream treats as geometry identity — the allowed-collision lookup, the `seen` dedup, the reported `Collision` pair, and critically `skipCollisionCheck`:

```go
// Skip comparing a geometry to itself
if xName == yName {
    return true
}
```

Colliding names also made the disjointness probe conclude the two sets overlap, needlessly allocating the `seen` map.

## Changes

- **motionplan/collision.go**: added `collisionNamer`, which memoizes the synthetic name per geometry instead of drawing from a per-slice counter, and share one namer across both sets. The same geometry always resolves to the same name, so a geometry genuinely present in both sets is still recognised as itself; two distinct geometries never share a name.

Every `Geometry` implementation uses pointer receivers, so the interface value is comparable and keys the memo table by identity.

`createUniqueCollisionMap` is retained as a thin single-set wrapper over the new `createCollisionMap`.

## Testing

`go test ./motionplan/... ./services/motion/...` passes. `golangci-lint` clean.

Added `TestUnnamedGeometriesInOpposingSets`, which covers both halves of the invariant:
- two overlapping unlabelled geometries in opposing sets produce exactly one collision, with distinct names
- a geometry genuinely present in both sets is still skipped as a self-comparison

Verified to fail against the unpatched source: `Expected: '1' Actual: '0'` — the collision was missed entirely.

The existing `unnamed geometries` subtest covered the within-one-set case, which already worked; the cross-set case was the gap.

## Tickets

None

## Claude Code Prompts Used

- "Hi Claude, I would like you to take a hard look at this repo. I want you to search for bugs, mistakes, and strange choices. Please pay particular attention to the math and see if something was done wrong. Please review all the packages and outline your findings by order of severity and provide recommendations of what we should do about what you found."
- "Can you work on the remaining findings following the priority order you have outlined? Make sure to use a different branch and create a separate draft PR for each of the ones that can be separated."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
