### PR TITLE
spatialmath: compare orientation difference as an angle, not a squared angle

### DIFF
--- a/spatialmath/orientation.go
+++ b/spatialmath/orientation.go
@@ -31,6 +31,7 @@ func OrientationAlmostEqual(o1, o2 Orientation) bool {
 }
 
 // OrientationAlmostEqualEps will return a bool describing whether 2 poses have approximately the same orientation.
+// epsilon is the maximum angle between the two orientations, in radians.
 func OrientationAlmostEqualEps(o1, o2 Orientation, epsilon float64) bool {
 	if o1 == nil {
 		return o2 == nil
@@ -38,7 +39,9 @@ func OrientationAlmostEqualEps(o1, o2 Orientation, epsilon float64) bool {
 		return false
 	}
 
-	return QuatToR3AA(QuatBetween(o1, o2)).Norm2() < epsilon
+	// Norm, not Norm2: the R3 axis-angle vector's length is the rotation angle, and epsilon is an angle.
+	// Comparing the squared length against it made the effective tolerance sqrt(epsilon) instead.
+	return QuatToR3AA(QuatBetween(o1, o2)).Norm() < epsilon
 }
 
 // QuatBetween returns the rotation quaternion from o1 to o2 as a raw quat.Number.

--- a/spatialmath/orientation.go
+++ b/spatialmath/orientation.go
@@ -39,8 +39,6 @@ func OrientationAlmostEqualEps(o1, o2 Orientation, epsilon float64) bool {
 		return false
 	}
 
-	// Norm, not Norm2: the R3 axis-angle vector's length is the rotation angle, and epsilon is an
-	// angle. Squaring one side of this comparison makes the effective tolerance sqrt(epsilon).
 	return QuatToR3AA(QuatBetween(o1, o2)).Norm() < epsilon
 }
 

--- a/spatialmath/orientation.go
+++ b/spatialmath/orientation.go
@@ -39,8 +39,8 @@ func OrientationAlmostEqualEps(o1, o2 Orientation, epsilon float64) bool {
 		return false
 	}
 
-	// Norm, not Norm2: the R3 axis-angle vector's length is the rotation angle, and epsilon is an angle.
-	// Comparing the squared length against it made the effective tolerance sqrt(epsilon) instead.
+	// Norm, not Norm2: the R3 axis-angle vector's length is the rotation angle, and epsilon is an
+	// angle. Squaring one side of this comparison makes the effective tolerance sqrt(epsilon).
 	return QuatToR3AA(QuatBetween(o1, o2)).Norm() < epsilon
 }
 

--- a/spatialmath/orientation_test.go
+++ b/spatialmath/orientation_test.go
@@ -178,3 +178,30 @@ func TestQuatBetweenNoAllocs(t *testing.T) {
 	})
 	test.That(t, allocs, test.ShouldEqual, 0)
 }
+
+// The epsilon is an angle in radians. It was previously compared against the squared length of the
+// R3 axis-angle vector, which made the effective tolerance sqrt(epsilon) — 100x looser than the
+// documented 1e-4 rad, so orientations up to ~0.573 degrees apart compared equal.
+func TestOrientationAlmostEqualEpsIsAnAngle(t *testing.T) {
+	zero := NewZeroOrientation()
+
+	for _, tc := range []struct {
+		deg   float64
+		equal bool
+	}{
+		{0.001, true},
+		{0.005, true},  // just inside 1e-4 rad
+		{0.0057, true}, // 1e-4 rad is 0.00573 deg
+		{0.01, false},  // outside, and well inside the old 0.573 deg threshold
+		{0.1, false},
+		{0.573, false}, // exactly the old (incorrect) boundary
+	} {
+		rotated := &R4AA{Theta: utils.DegToRad(tc.deg), RX: 0, RY: 0, RZ: 1}
+		test.That(t, OrientationAlmostEqual(zero, rotated), test.ShouldEqual, tc.equal)
+	}
+
+	// The explicit-epsilon form takes the tolerance directly in radians.
+	oneDeg := &R4AA{Theta: utils.DegToRad(1), RX: 0, RY: 0, RZ: 1}
+	test.That(t, OrientationAlmostEqualEps(zero, oneDeg, utils.DegToRad(1.1)), test.ShouldBeTrue)
+	test.That(t, OrientationAlmostEqualEps(zero, oneDeg, utils.DegToRad(0.9)), test.ShouldBeFalse)
+}

--- a/spatialmath/orientation_test.go
+++ b/spatialmath/orientation_test.go
@@ -179,9 +179,8 @@ func TestQuatBetweenNoAllocs(t *testing.T) {
 	test.That(t, allocs, test.ShouldEqual, 0)
 }
 
-// The epsilon is an angle in radians. It was previously compared against the squared length of the
-// R3 axis-angle vector, which made the effective tolerance sqrt(epsilon) — 100x looser than the
-// documented 1e-4 rad, so orientations up to ~0.573 degrees apart compared equal.
+// The epsilon is an angle in radians, so the boundary sits at defaultAngleEpsilon itself rather than
+// at its square root. 0.573 deg is sqrt(1e-4) rad and has to compare unequal.
 func TestOrientationAlmostEqualEpsIsAnAngle(t *testing.T) {
 	zero := NewZeroOrientation()
 
@@ -192,9 +191,9 @@ func TestOrientationAlmostEqualEpsIsAnAngle(t *testing.T) {
 		{0.001, true},
 		{0.005, true},  // just inside 1e-4 rad
 		{0.0057, true}, // 1e-4 rad is 0.00573 deg
-		{0.01, false},  // outside, and well inside the old 0.573 deg threshold
+		{0.01, false},  // outside
 		{0.1, false},
-		{0.573, false}, // exactly the old (incorrect) boundary
+		{0.573, false}, // sqrt(1e-4) rad
 	} {
 		rotated := &R4AA{Theta: utils.DegToRad(tc.deg), RX: 0, RY: 0, RZ: 1}
 		test.That(t, OrientationAlmostEqual(zero, rotated), test.ShouldEqual, tc.equal)


### PR DESCRIPTION
## Summary

`OrientationAlmostEqualEps` compared a **squared** angle against an epsilon documented as an angle, so the real tolerance was `sqrt(epsilon)` — 100× looser than intended. The default made orientations up to **0.573°** apart compare equal, against a documented 0.0057°.

From the audit that produced #6314–#6318.

## The bug

```go
return QuatToR3AA(QuatBetween(o1, o2)).Norm2() < epsilon
```

`r3.Vector.Norm2()` is the squared norm. The R3 axis-angle vector's length *is* the rotation angle, so the comparison should use `Norm()`. Measured against the unpatched code:

| difference | `OrientationAlmostEqual` |
| --- | --- |
| 0.570° | `true` |
| 0.600° | `false` |

The crossover sits at exactly `sqrt(1e-4) = 1e-2` rad, not the `1e-4` rad the constant documents:

> `// If two angles differ by less than this amount, we consider them the same`

This also silently loosened every geometry `almostEqual` — `box.go`, `sphere.go`, `capsule.go` and `cylinder.go` all pass `1e-6` through `PoseAlmostEqualEps` intending millimetres, and got a `1e-3` rad (0.057°) angular tolerance out of it.

## Changes

- **spatialmath/orientation.go**: `Norm2()` → `Norm()`, and documented that `epsilon` is an angle in radians.

## Testing

**`go test ./...` across the entire repo passes.** This is the result worth checking: the change tightens the tolerance 100×, and I expected latent failures in motion planning or geometry comparison. There are none. I verified this with an explicit `FAIL`/compile-error grep rather than relying on filtering `ok` lines.

`golangci-lint` clean.

Added `TestOrientationAlmostEqualEpsIsAnAngle`, which pins the boundary at the documented `1e-4` rad and explicitly asserts that `0.573°` — the old, incorrect threshold — now compares unequal. Verified to fail against the unpatched source.

### Note for reviewers

`PoseAlmostEqualEps(a, b, epsilon)` still applies one epsilon to both position (mm) and orientation (radians). That conflation is a separate design wart and I left it alone deliberately — splitting it into two parameters touches every call site and belongs in its own change. This PR only fixes the squared-vs-linear defect.

## Tickets

None

## Claude Code Prompts Used

- "Hi Claude, I would like you to take a hard look at this repo. I want you to search for bugs, mistakes, and strange choices. Please pay particular attention to the math and see if something was done wrong. Please review all the packages and outline your findings by order of severity and provide recommendations of what we should do about what you found."
- "Can you work on the remaining findings following the priority order you have outlined? Make sure to use a different branch and create a separate draft PR for each of the ones that can be separated."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
