### PR TITLE
control: fix PID auto-tuner gain computation

### DIFF
--- a/control/pid.go
+++ b/control/pid.go
@@ -361,8 +361,8 @@ func (p *pidTuner) relayUltimateGainAndPeriod(stepPwr float64) (kU, pU float64, 
 	for i := range nPeaks {
 		a += math.Abs(p.pPeakH[i] - p.pPeakL[i])
 	}
-	// Mean peak-to-peak swing, halved to get the oscillation amplitude. Dividing by nPeaks+1
-	// understated it, which inflated kU by (nPeaks+1)/nPeaks -- a factor of 2 for a single peak pair.
+	// Mean peak-to-peak swing, halved to give the oscillation amplitude. The divisor is nPeaks, not
+	// nPeaks+1; kU is inversely proportional to this, so an off-by-one scales every gain.
 	a /= 2.0 * float64(nPeaks)
 	if a == 0 {
 		return 0, 0, errors.Errorf("PID auto-tuning measured a zero-amplitude oscillation using method %s", p.tuneMethod)
@@ -435,8 +435,7 @@ func (p *pidTuner) pidTunerStep(pv float64, logger logging.Logger) (float64, boo
 		if len(p.stepRsp) > 20 && r < p.ssRValue {
 			p.tS = time.Now()
 			p.lastR = time.Now()
-			// Average the most recent samples, which are the ones at steady state. The loop index was
-			// previously absent from the subscript, so this summed a single sample five times.
+			// Average the most recent samples, which are the ones at steady state.
 			// len(stepRsp) > 20 is guaranteed by the enclosing condition.
 			const ssWindow = 5
 			p.avgSpeedSS = 0.0

--- a/control/pid.go
+++ b/control/pid.go
@@ -294,17 +294,23 @@ type pidTuner struct {
 }
 
 // reference for computation: https://en.wikipedia.org/wiki/Ziegler%E2%80%93Nichols_method#cite_note-1
-func (p *pidTuner) computeGains() {
+func (p *pidTuner) computeGains() error {
 	stepPwr := p.limUp * p.stepPct
-	i := 0
-	a := 0.0
-	for ; i < int(math.Min(float64(len(p.pPeakH)), float64(len(p.pPeakL)))); i++ {
-		a += math.Abs(p.pPeakH[i] - p.pPeakL[i])
+
+	// The Cohen-Coons methods derive their gains from the step response (ccT2, ccT3, avgSpeedSS) and
+	// never touch kU or pU. They are also computed at the end of the step phase, before tC is known,
+	// so validating the relay quantities for them would reject every Cohen-Coons run.
+	if p.tuneMethod == tuneMethodCohenCoonsPI || p.tuneMethod == tuneMethodCohenCoonsPID {
+		return p.computeCohenCoonsGains(stepPwr)
 	}
-	a /= (2.0 * float64(i+1))
-	d := 0.5 * stepPwr
-	kU := (4 * d) / (math.Pi * a)
-	pU := (p.tC * 2.0).Seconds()
+
+	kU, pU, err := p.relayUltimateGainAndPeriod(stepPwr)
+	if err != nil {
+		return err
+	}
+
+	// Cohen-Coons returned above.
+	//nolint: exhaustive
 	switch p.tuneMethod {
 	case tuneMethodZiegerNicholsPI:
 		p.kP = 0.4545 * kU
@@ -334,28 +340,67 @@ func (p *pidTuner) computeGains() {
 		p.kP = 0.4545 * kU
 		p.kI = 0.2066 * (kU / pU)
 		p.kD = 0.0721 * kU * pU
-	case tuneMethodCohenCoonsPI:
-		t1 := (p.ccT2.Seconds() - math.Log(2.0)*p.ccT3.Seconds()) / (1.0 - math.Log(2.0))
-		tau := p.ccT3.Seconds() - t1
-		tauD := t1
-		K := (p.avgSpeedSS / stepPwr)
-		r := tauD / tau
-		p.kP = (1.0 / (K * r)) * (0.9 + r/12)
-		p.kI = p.kP / (tauD) * (30 + 3*r) / (9 + 20*r)
-	case tuneMethodCohenCoonsPID:
-		t1 := (p.ccT2.Seconds() - math.Log(2.0)*p.ccT3.Seconds()) / (1.0 - math.Log(2.0))
-		tau := p.ccT3.Seconds() - t1
-		tauD := t1
-		K := (p.avgSpeedSS / stepPwr)
-		r := tauD / tau
-		p.kP = (1.0 / (K * r)) * (4.0/3.0 + r/4)
-		p.kI = p.kP / (tauD) * (32 + 6*r) / (13 + 8*r)
-		p.kD = p.kP / (4 * tauD / (11 + 2*r))
 	default: // ziegler nichols PI is the default
 		p.kP = 0.4545 * kU
 		p.kI = 0.5454 * (kU / pU)
 		p.kD = 0.0
 	}
+	return nil
+}
+
+// relayUltimateGainAndPeriod derives the ultimate gain and oscillation period from the peaks
+// bracketed during the relay phase.
+func (p *pidTuner) relayUltimateGainAndPeriod(stepPwr float64) (kU, pU float64, err error) {
+	nPeaks := min(len(p.pPeakH), len(p.pPeakL))
+	if nPeaks == 0 {
+		// The relay phase can end on its 4 second timeout without ever bracketing a peak. Bailing here
+		// keeps the divisions below from writing +Inf gains into the config.
+		return 0, 0, errors.Errorf("PID auto-tuning found no oscillation peaks using method %s", p.tuneMethod)
+	}
+	a := 0.0
+	for i := range nPeaks {
+		a += math.Abs(p.pPeakH[i] - p.pPeakL[i])
+	}
+	// Mean peak-to-peak swing, halved to get the oscillation amplitude. Dividing by nPeaks+1
+	// understated it, which inflated kU by (nPeaks+1)/nPeaks -- a factor of 2 for a single peak pair.
+	a /= 2.0 * float64(nPeaks)
+	if a == 0 {
+		return 0, 0, errors.Errorf("PID auto-tuning measured a zero-amplitude oscillation using method %s", p.tuneMethod)
+	}
+	// tC comes from pidTunerFindTCat, which returns 0 when no sample crossed the threshold.
+	pU = (p.tC * 2.0).Seconds()
+	if pU == 0 {
+		return 0, 0, errors.Errorf("PID auto-tuning measured a zero oscillation period using method %s", p.tuneMethod)
+	}
+	d := 0.5 * stepPwr
+	return (4 * d) / (math.Pi * a), pU, nil
+}
+
+// computeCohenCoonsGains derives gains from the open-loop step response rather than from a relay
+// oscillation. Reference: https://en.wikipedia.org/wiki/PID_controller#Cohen-Coon_parameters
+func (p *pidTuner) computeCohenCoonsGains(stepPwr float64) error {
+	if stepPwr == 0 {
+		return errors.New("PID auto-tuning cannot use Cohen-Coons with a zero step power")
+	}
+	t1 := (p.ccT2.Seconds() - math.Log(2.0)*p.ccT3.Seconds()) / (1.0 - math.Log(2.0))
+	tau := p.ccT3.Seconds() - t1
+	tauD := t1
+	K := p.avgSpeedSS / stepPwr
+	if tau == 0 || tauD == 0 || K == 0 {
+		return errors.Errorf(
+			"PID auto-tuning could not characterize the step response using method %s (tau %v, deadtime %v, gain %v)",
+			p.tuneMethod, tau, tauD, K)
+	}
+	r := tauD / tau
+	if p.tuneMethod == tuneMethodCohenCoonsPID {
+		p.kP = (1.0 / (K * r)) * (4.0/3.0 + r/4)
+		p.kI = p.kP / tauD * (32 + 6*r) / (13 + 8*r)
+		p.kD = p.kP / (4 * tauD / (11 + 2*r))
+		return nil
+	}
+	p.kP = (1.0 / (K * r)) * (0.9 + r/12)
+	p.kI = p.kP / tauD * (30 + 3*r) / (9 + 20*r)
+	return nil
 }
 
 func pidTunerFindTCat(speeds []float64, times []time.Time, speed float64) time.Duration {
@@ -390,16 +435,22 @@ func (p *pidTuner) pidTunerStep(pv float64, logger logging.Logger) (float64, boo
 		if len(p.stepRsp) > 20 && r < p.ssRValue {
 			p.tS = time.Now()
 			p.lastR = time.Now()
+			// Average the most recent samples, which are the ones at steady state. The loop index was
+			// previously absent from the subscript, so this summed a single sample five times.
+			// len(stepRsp) > 20 is guaranteed by the enclosing condition.
+			const ssWindow = 5
 			p.avgSpeedSS = 0.0
-			for i := 0; i < 5; i++ {
-				p.avgSpeedSS += p.stepRsp[len(p.stepRsp)-6]
+			for i := range ssWindow {
+				p.avgSpeedSS += p.stepRsp[len(p.stepRsp)-ssWindow+i]
 			}
-			p.avgSpeedSS /= 5
+			p.avgSpeedSS /= ssWindow
 			if p.tuneMethod == tuneMethodCohenCoonsPI || p.tuneMethod == tuneMethodCohenCoonsPID {
 				p.out = 0.0
 				p.ccT2 = pidTunerFindTCat(p.stepRsp, p.stepRespT, 0.5*p.avgSpeedSS)
 				p.ccT3 = pidTunerFindTCat(p.stepRsp, p.stepRespT, 0.632*p.avgSpeedSS)
-				p.computeGains()
+				if err := p.computeGains(); err != nil {
+					logger.Error(err)
+				}
 				p.currentPhase = end
 			} else {
 				p.out = stepPwr + 0.5*stepPwr
@@ -434,7 +485,9 @@ func (p *pidTuner) pidTunerStep(pv float64, logger logging.Logger) (float64, boo
 		p.pPv = pv
 		if time.Since(p.tS) > 4*time.Second {
 			p.out = 0
-			p.computeGains()
+			if err := p.computeGains(); err != nil {
+				logger.Error(err)
+			}
 			p.currentPhase = end
 		}
 		return p.out, false

--- a/control/pid_test.go
+++ b/control/pid_test.go
@@ -3,6 +3,7 @@ package control
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -244,4 +245,61 @@ func TestPIDMixedAutoTuningDoesNotPanic(t *testing.T) {
 	test.That(t, func() {
 		pid.Next(ctx, []*Signal{s}, time.Millisecond*10)
 	}, test.ShouldNotPanic)
+}
+
+func TestPIDTunerComputeGains(t *testing.T) {
+	// Ziegler-Nichols: kU = 4d/(pi*a) where d = 0.5*stepPwr and a is the mean oscillation amplitude.
+	// With limUp 100 and stepPct 0.5, stepPwr = 50 and d = 25.
+	newTuner := func(peaksH, peaksL []float64, tC time.Duration) *pidTuner {
+		return &pidTuner{
+			limUp: 100, stepPct: 0.5,
+			tuneMethod: tuneMethodZiegerNicholsPI,
+			pPeakH:     peaksH, pPeakL: peaksL, tC: tC,
+		}
+	}
+
+	t.Run("amplitude is the mean over the peak pairs", func(t *testing.T) {
+		// One pair, peak-to-peak swing of 10, so a = 5.
+		p := newTuner([]float64{10}, []float64{0}, time.Second)
+		test.That(t, p.computeGains(), test.ShouldBeNil)
+		expectedKU := (4 * 25.0) / (math.Pi * 5.0)
+		test.That(t, p.kP, test.ShouldAlmostEqual, 0.4545*expectedKU, 1e-9)
+
+		// Two identical pairs must give the same amplitude, and so the same gains. Dividing by
+		// nPeaks+1 instead of nPeaks made this depend on the number of peaks observed.
+		p2 := newTuner([]float64{10, 10}, []float64{0, 0}, time.Second)
+		test.That(t, p2.computeGains(), test.ShouldBeNil)
+		test.That(t, p2.kP, test.ShouldAlmostEqual, p.kP, 1e-9)
+	})
+
+	t.Run("degenerate relay results are rejected", func(t *testing.T) {
+		// No peaks bracketed: previously divided by zero and wrote +Inf gains.
+		p := newTuner(nil, nil, time.Second)
+		err := p.computeGains()
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "no oscillation peaks")
+		test.That(t, math.IsInf(p.kP, 0), test.ShouldBeFalse)
+
+		// Flat oscillation.
+		p = newTuner([]float64{5}, []float64{5}, time.Second)
+		test.That(t, p.computeGains().Error(), test.ShouldContainSubstring, "zero-amplitude")
+
+		// tC never established.
+		p = newTuner([]float64{10}, []float64{0}, 0)
+		test.That(t, p.computeGains().Error(), test.ShouldContainSubstring, "zero oscillation period")
+	})
+
+	t.Run("cohen-coons does not require relay quantities", func(t *testing.T) {
+		// Cohen-Coons runs before tC is known, so it must not be rejected for a zero tC.
+		p := &pidTuner{
+			limUp: 100, stepPct: 0.5,
+			tuneMethod: tuneMethodCohenCoonsPID,
+			avgSpeedSS: 40,
+			ccT2:       2 * time.Second,
+			ccT3:       3 * time.Second,
+		}
+		test.That(t, p.computeGains(), test.ShouldBeNil)
+		test.That(t, p.kP, test.ShouldNotAlmostEqual, 0.0)
+		test.That(t, math.IsInf(p.kP, 0) || math.IsNaN(p.kP), test.ShouldBeFalse)
+	})
 }

--- a/control/pid_test.go
+++ b/control/pid_test.go
@@ -265,15 +265,15 @@ func TestPIDTunerComputeGains(t *testing.T) {
 		expectedKU := (4 * 25.0) / (math.Pi * 5.0)
 		test.That(t, p.kP, test.ShouldAlmostEqual, 0.4545*expectedKU, 1e-9)
 
-		// Two identical pairs must give the same amplitude, and so the same gains. Dividing by
-		// nPeaks+1 instead of nPeaks made this depend on the number of peaks observed.
+		// Two identical pairs must give the same amplitude, and so the same gains: the result must
+		// not depend on how many peaks were observed.
 		p2 := newTuner([]float64{10, 10}, []float64{0, 0}, time.Second)
 		test.That(t, p2.computeGains(), test.ShouldBeNil)
 		test.That(t, p2.kP, test.ShouldAlmostEqual, p.kP, 1e-9)
 	})
 
 	t.Run("degenerate relay results are rejected", func(t *testing.T) {
-		// No peaks bracketed: previously divided by zero and wrote +Inf gains.
+		// No peaks bracketed: the amplitude would be zero and kU infinite.
 		p := newTuner(nil, nil, time.Second)
 		err := p.computeGains()
 		test.That(t, err, test.ShouldNotBeNil)


### PR DESCRIPTION
## Summary

Three defects in the PID auto-tuner, all of which produce plausible-looking gains that get written into the robot config. Anyone who has used auto-tune has gains derived from at least the first two.

From the audit that produced #6314–#6319.

## Changes

### 1. The steady-state speed estimate averaged one sample five times

```go
for i := 0; i < 5; i++ {
    p.avgSpeedSS += p.stepRsp[len(p.stepRsp)-6]   // i never used
}
p.avgSpeedSS /= 5
```

The loop index is missing from the subscript. `avgSpeedSS` feeds the Cohen-Coons process gain and all three relay-phase thresholds (`ccT2`, `ccT3`, `tC`), so a single noisy sample drove the whole characterisation. Now averages the last five samples.

### 2. The oscillation amplitude was divided by `2*(n+1)` instead of `2*n`

```go
a /= (2.0 * float64(i+1))   // i == n after the loop
```

This understated the amplitude and so inflated the ultimate gain `kU = 4d/(πa)`. It also made the gains depend on **how many peaks happened to be observed** for an identical oscillation:

| peak pairs (swing 10 each) | old `kU` | correct `kU` | inflation |
| --- | --- | --- | --- |
| 1 | 12.732 | 6.366 | **2.00×** |
| 2 | 9.549 | 6.366 | 1.50× |
| 3 | 8.488 | 6.366 | 1.33× |

Every gain in every Ziegler-Nichols and Tyreus-Luyben variant is a direct multiple of `kU`, so all of them were proportionally too aggressive.

### 3. No guard against a degenerate relay result

The relay phase ends on a 4-second timeout whether or not it bracketed any peaks. With no peaks, `a` was `0` and `kU = 4d/0 = +Inf`; every gain became `Inf` or `NaN` and was written into `PIDSets` and logged as "PID GAINS CALCULATED". Now `computeGains` returns an error, which is logged, and the gains are left at zero.

Zero peaks, zero amplitude and zero period are each rejected with a distinct message.

### Structure

`computeGains` now dispatches Cohen-Coons to its own path. Those methods derive gains from the step response and are computed at the end of the step phase — **before `tC` is assigned** — so validating the relay quantities for them would have rejected every Cohen-Coons run. That ordering is easy to miss; it is the reason for the split rather than a flat guard. Cohen-Coons also gained guards for its own divisions (`tau`, `tauD`, `K`).

## Testing

`go test ./control/...` passes. `golangci-lint` clean.

Added `TestPIDTunerComputeGains`, which had no coverage at all before:
- amplitude is the mean over peak pairs, and **two identical oscillations give identical gains** regardless of peak count — the invariant defect 2 broke
- `kU` matches `4d/(πa)` for a known input
- no peaks / zero amplitude / zero period are each rejected, and no `Inf` reaches the gains
- Cohen-Coons still computes with `tC` unset

The signature change means these tests cannot be compiled against the unpatched source to demonstrate failure. The `kU` inflation is instead quantified in the table above, computed directly from the old and new expressions.

### Not covered

The `avgSpeedSS` fix is not directly unit-tested — it lives inside `pidTunerStep`, which needs >20 samples and wall-clock progression. The defect is unambiguous from the source (an unused loop variable), but a test would need the tuner state machine to be driveable in fake time. Worth a follow-up.

Separately, `basicPID.Next` still logs "PID GAINS CALCULATED" and copies the gains out when tuning ends, even if `computeGains` failed and left them at zero. Threading a failure flag through is a behavioural change to the tuning handshake and belongs in its own PR.

## Tickets

None

## Claude Code Prompts Used

- "Hi Claude, I would like you to take a hard look at this repo. I want you to search for bugs, mistakes, and strange choices. Please pay particular attention to the math and see if something was done wrong. Please review all the packages and outline your findings by order of severity and provide recommendations of what we should do about what you found."
- "Can you work on the remaining findings following the priority order you have outlined? Make sure to use a different branch and create a separate draft PR for each of the ones that can be separated."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
