### PR TITLE
APP-16939 - jobmanager: reset gRPC reflection stream after each job invocation

### DIFF
--- a/robot/jobmanager/jobmanager.go
+++ b/robot/jobmanager/jobmanager.go
@@ -168,10 +168,12 @@ func (jm *JobManager) Close() error {
 
 // createDescriptorSourceAndgRPCMethod sets up a DescriptorSource for grpc translations
 // and sets up parts of the grpc method string that will be invoked later.
+// The refClient is returned (not Reset here) because the returned DescriptorSource is
+// backed by it and the caller keeps using it through InvokeRPC; the caller Resets it.
 func (jm *JobManager) createDescriptorSourceAndgRPCMethod(
 	res resource.Resource,
 	method string,
-) (grpcurl.DescriptorSource, string, string, error) {
+) (grpcurl.DescriptorSource, *grpcreflect.Client, string, string, error) {
 	refCtx := metadata.NewOutgoingContext(jm.ctx, nil)
 	refClient := grpcreflect.NewClientV1Alpha(refCtx, reflectpb.NewServerReflectionClient(jm.conn))
 	// TODO(RSDK-9718)
@@ -184,7 +186,7 @@ func (jm *JobManager) createDescriptorSourceAndgRPCMethod(
 	resourceType = strings.ReplaceAll(resourceType, "_", "")
 	services, err := descSource.ListServices()
 	if err != nil {
-		return nil, "", "", err
+		return nil, refClient, "", "", err
 	}
 	var grpcService string
 	for _, srv := range services {
@@ -194,9 +196,9 @@ func (jm *JobManager) createDescriptorSourceAndgRPCMethod(
 		}
 	}
 	if grpcService == "" {
-		return nil, "", "", errors.Errorf("could not find a service for type: %s", resourceType)
+		return nil, refClient, "", "", errors.Errorf("could not find a service for type: %s", resourceType)
 	}
-	return descSource, grpcService, method, nil
+	return descSource, refClient, grpcService, method, nil
 }
 
 // createJobFunction returns a function that the job scheduler puts on its queue.
@@ -230,7 +232,12 @@ func (jm *JobManager) createJobFunction(jc config.JobConfig, continuous bool) fu
 			return nil
 		}
 
-		descSource, grpcService, grpcMethod, err := jm.createDescriptorSourceAndgRPCMethod(res, jc.Method)
+		descSource, refClient, grpcService, grpcMethod, err := jm.createDescriptorSourceAndgRPCMethod(res, jc.Method)
+		// Reset the reflection stream; otherwise each invocation leaks one on the shared jm.conn
+		// until it hits MaxConcurrentStreams and jobs stop running (APP-16939).
+		if refClient != nil {
+			defer refClient.Reset()
+		}
 		if err != nil {
 			jobLogger.CWarnw(jm.ctx, "grpc setup failed", "error", err)
 			return err

--- a/robot/jobmanager/jobmanager_test.go
+++ b/robot/jobmanager/jobmanager_test.go
@@ -83,7 +83,7 @@ func TestReflectionStreamNotLeaked(t *testing.T) {
 	go func() { utils.UncheckedError(server.Serve(lis)) }()
 	defer server.Stop()
 
-	//nolint:staticcheck // grpc.NewClient equivalent; keep the test dependency-free.
+	
 	rawConn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	test.That(t, err, test.ShouldBeNil)
 	defer func() { utils.UncheckedError(rawConn.Close()) }()

--- a/robot/jobmanager/jobmanager_test.go
+++ b/robot/jobmanager/jobmanager_test.go
@@ -1,0 +1,118 @@
+package jobmanager
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"github.com/viamrobotics/webrtc/v3"
+	commonpb "go.viam.com/api/common/v1"
+	pb "go.viam.com/api/component/sensor/v1"
+	"go.viam.com/test"
+	"go.viam.com/utils"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/reflection"
+
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/testutils/inject"
+)
+
+// The stream grpcreflect.NewClientV1Alpha opens; leaked one-per-invocation without Reset.
+const reflectionInfoMethod = "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo"
+
+// streamCounter tracks the high-water mark of concurrently-open reflection streams.
+type streamCounter struct {
+	current       atomic.Int64
+	maxConcurrent atomic.Int64
+}
+
+func (sc *streamCounter) intercept(
+	srv any,
+	ss grpc.ServerStream,
+	info *grpc.StreamServerInfo,
+	handler grpc.StreamHandler,
+) error {
+	if info.FullMethod != reflectionInfoMethod {
+		return handler(srv, ss)
+	}
+	cur := sc.current.Add(1)
+	for {
+		observed := sc.maxConcurrent.Load()
+		if cur <= observed || sc.maxConcurrent.CompareAndSwap(observed, cur) {
+			break
+		}
+	}
+	defer sc.current.Add(-1)
+	return handler(srv, ss)
+}
+
+// sensorServer lets reflection resolve the service so GetReadings runs the real job code path.
+type sensorServer struct {
+	pb.UnimplementedSensorServiceServer
+}
+
+func (sensorServer) GetReadings(context.Context, *commonpb.GetReadingsRequest) (*commonpb.GetReadingsResponse, error) {
+	return &commonpb.GetReadingsResponse{}, nil
+}
+
+// grpcConn adapts *grpc.ClientConn to the rpc.ClientConn the JobManager expects.
+type grpcConn struct {
+	*grpc.ClientConn
+}
+
+func (grpcConn) PeerConn() *webrtc.PeerConnection { return nil }
+
+// TestReflectionStreamNotLeaked guards APP-16939: each job invocation opens a reflection stream,
+// and without refClient.Reset() they pile up on the shared conn until it hits MaxConcurrentStreams
+// and jobs stop running. Reverting the Reset makes maxConcurrent climb to `iterations`.
+func TestReflectionStreamNotLeaked(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	ctx := context.Background()
+
+	counter := &streamCounter{}
+	server := grpc.NewServer(grpc.StreamInterceptor(counter.intercept))
+	pb.RegisterSensorServiceServer(server, sensorServer{})
+	reflection.Register(server)
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	test.That(t, err, test.ShouldBeNil)
+	go func() { utils.UncheckedError(server.Serve(lis)) }()
+	defer server.Stop()
+
+	//nolint:staticcheck // grpc.NewClient equivalent; keep the test dependency-free.
+	rawConn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	test.That(t, err, test.ShouldBeNil)
+	defer func() { utils.UncheckedError(rawConn.Close()) }()
+
+	injectSensor := inject.NewSensor("sensor")
+
+	jm := &JobManager{
+		logger:      logger.Sublogger("job_manager"),
+		getResource: func(string) (resource.Resource, error) { return injectSensor, nil },
+		ctx:         ctx,
+		conn:        grpcConn{rawConn},
+	}
+
+	jc := config.JobConfig{
+		JobConfigData: config.JobConfigData{
+			Name:     "leak-check",
+			Schedule: "continuous",
+			Resource: "sensor",
+			Method:   "GetReadings",
+		},
+	}
+
+	// non-continuous: each call is one invocation, as the scheduler fires a duration/cron job.
+	runJob := jm.createJobFunction(jc, false)
+
+	const iterations = 25
+	for i := 0; i < iterations; i++ {
+		test.That(t, runJob(ctx), test.ShouldBeNil)
+	}
+
+	test.That(t, counter.maxConcurrent.Load(), test.ShouldBeLessThanOrEqualTo, int64(1))
+}

--- a/robot/jobmanager/jobmanager_test.go
+++ b/robot/jobmanager/jobmanager_test.go
@@ -83,7 +83,6 @@ func TestReflectionStreamNotLeaked(t *testing.T) {
 	go func() { utils.UncheckedError(server.Serve(lis)) }()
 	defer server.Stop()
 
-	
 	rawConn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	test.That(t, err, test.ShouldBeNil)
 	defer func() { utils.UncheckedError(rawConn.Close()) }()


### PR DESCRIPTION
## Problem (APP-16939)

Scheduled jobs would run reliably at first, then intermittently stop, requiring a power cycle of the Pi — and stay flaky afterward.

Root cause: for any job whose `Method` is not `DoCommand`, `createDescriptorSourceAndgRPCMethod` created a fresh `grpcreflect` client on **every invocation** and never called `Reset()`. Each invocation leaked an open `ServerReflectionInfo` stream on the single shared connection back to the parent server. The streams accumulate until they hit the server's `MaxConcurrentStreams` limit; after that, new RPCs stall and jobs silently stop running until the process (or the whole Pi) is restarted. `DoCommand` jobs return before the reflection path and were unaffected.

Every other reflection-client call site in the repo resets it (`module/server.go`, `robot/client/client.go`); the job manager was the one that didn't.

## Fix

Return the reflection client from `createDescriptorSourceAndgRPCMethod` and `defer refClient.Reset()` in the caller, after `InvokeRPC` is done. It's returned rather than reset inside the helper because the returned `DescriptorSource` is backed by that client and the caller keeps using it through `InvokeRPC` — resetting inside would close the stream too early (and re-leak a fresh one).

## Test

`TestReflectionStreamNotLeaked` stands up a real reflection-serving gRPC server, counts the high-water mark of concurrently-open reflection streams, and drives the actual job code path 25 times.

- **With the fix:** max concurrent reflection streams stays at 1.
- **Without the fix (verified by reverting):** climbs until the connection maxes out — reproducing the production failure.