### PR TITLE
utils: normalize AngleDiffDeg before folding about 180

### DIFF
--- a/utils/math.go
+++ b/utils/math.go
@@ -32,9 +32,17 @@ func RadToDeg(radians float64) float64 {
 }
 
 // AngleDiffDeg returns the closest difference from the two given
-// angles. The arguments are commutative.
+// angles, in the range [0, 180]. The arguments are commutative and
+// need not be normalized to [0, 360).
 func AngleDiffDeg(a1, a2 float64) float64 {
-	return float64(180) - math.Abs(math.Abs(a1-a2)-float64(180))
+	// The separation has to be wrapped into [0, 360) before folding it about 180. Folding the raw
+	// separation returned a negative "difference" for any pair more than 360 apart, e.g. -10 for
+	// (0, 370) and -350 for (720, 10).
+	diff := math.Mod(math.Abs(a1-a2), 360)
+	if diff > 180 {
+		diff = 360 - diff
+	}
+	return diff
 }
 
 // AntiCWDeg flips the given degrees as if you were to start at 0 and

--- a/utils/math.go
+++ b/utils/math.go
@@ -35,9 +35,8 @@ func RadToDeg(radians float64) float64 {
 // angles, in the range [0, 180]. The arguments are commutative and
 // need not be normalized to [0, 360).
 func AngleDiffDeg(a1, a2 float64) float64 {
-	// The separation has to be wrapped into [0, 360) before folding it about 180. Folding the raw
-	// separation returned a negative "difference" for any pair more than 360 apart, e.g. -10 for
-	// (0, 370) and -350 for (720, 10).
+	// Folding about 180 is only valid once the separation is inside one revolution; folding a raw
+	// separation greater than 360 yields a negative result.
 	diff := math.Mod(math.Abs(a1-a2), 360)
 	if diff > 180 {
 		diff = 360 - diff

--- a/utils/math_test.go
+++ b/utils/math_test.go
@@ -83,8 +83,7 @@ func TestAngleDiffDeg(t *testing.T) {
 		{0, 360, 0},
 		{350, 20, 30},
 		{20, 350, 30},
-		// Inputs outside [0, 360) must still fold into [0, 180]. These returned negative
-		// values before the separation was wrapped.
+		// Inputs outside [0, 360) must still fold into [0, 180].
 		{0, 370, 10},
 		{370, 0, 10},
 		{720, 10, 10},
@@ -94,7 +93,7 @@ func TestAngleDiffDeg(t *testing.T) {
 		{0, -370, 10},
 		{-180, 180, 0},
 		{1080, 0, 0},
-		// Sanity: the result is never negative and never exceeds 180.
+		// |-1000 - 1000| mod 360 is 200, which folds to 160.
 		{-1000, 1000, 160},
 	} {
 		t.Run(fmt.Sprintf("|%f-%f|=%f", tc.a1, tc.a2, tc.expected), func(t *testing.T) {

--- a/utils/math_test.go
+++ b/utils/math_test.go
@@ -83,6 +83,19 @@ func TestAngleDiffDeg(t *testing.T) {
 		{0, 360, 0},
 		{350, 20, 30},
 		{20, 350, 30},
+		// Inputs outside [0, 360) must still fold into [0, 180]. These returned negative
+		// values before the separation was wrapped.
+		{0, 370, 10},
+		{370, 0, 10},
+		{720, 10, 10},
+		{10, 720, 10},
+		{400, 30, 10},
+		{-370, 0, 10},
+		{0, -370, 10},
+		{-180, 180, 0},
+		{1080, 0, 0},
+		// Sanity: the result is never negative and never exceeds 180.
+		{-1000, 1000, 160},
 	} {
 		t.Run(fmt.Sprintf("|%f-%f|=%f", tc.a1, tc.a2, tc.expected), func(t *testing.T) {
 			test.That(t, AngleDiffDeg(tc.a1, tc.a2), test.ShouldEqual, tc.expected)


### PR DESCRIPTION
## Summary

`AngleDiffDeg` returns **negative** values for angles more than one revolution apart. An angular difference must lie in `[0, 180]`.

```
AngleDiffDeg(  0, 370) = -10
AngleDiffDeg(720,  10) = -350
AngleDiffDeg(400,  30) = -10
```

From the audit that produced #6314–#6323.

## Why this is fixed rather than deleted

It has no callers inside this repository, so under the delete-vs-fix rule it would be a removal candidate. But a code search across `viamrobotics`, `viam-modules` and `viam-labs` found a **real external consumer**: `viam-labs/stevebriskin-projects` (`rovie/go/rovie.go`) calls it three times, on yaw and heading values:

```go
diff_des := utils.AngleDiffDeg(d.Yaw_desired, stop_deg)
diff_real := utils.AngleDiffDeg(d.Yaw_real, stop_deg)
degDiff := utils.AngleDiffDeg(desired, heading)
```

Heading and yaw are exactly the quantities that drift outside `[0, 360)`, so it gets repaired.

## The bug

```go
return float64(180) - math.Abs(math.Abs(a1-a2)-float64(180))
```

Folding about 180 is only valid once the separation is inside one revolution. `|a1-a2|` was used raw, so a separation of 370 folded to `180 - |370-180| = -10`.

Now the separation is wrapped into `[0, 360)` first, then folded. The function stays commutative, and behaviour is unchanged for inputs already within one revolution of each other — which is why this went unnoticed.

## Testing

`go test ./...` across the whole repo passes; `golangci-lint` clean.

Extended the existing table with out-of-range inputs: `(0, 370)`, `(720, 10)`, `(400, 30)`, `(-370, 0)`, `(-180, 180)`, `(1080, 0)`, `(-1000, 1000)`, plus the commuted forms. Six of the new cases fail against the unpatched source, returning `-10`, `-350` and similar.

## Tickets

None

## Claude Code Prompts Used

- "Hi Claude, I would like you to take a hard look at this repo. I want you to search for bugs, mistakes, and strange choices..."
- "Can you work on the remaining findings following the priority order you have outlined? ... Whenever you find code that seems to have 'zero production callers' try to search for usage under other repos in the viamrobotics, viam-modules, and viam-labs Github organizations. If no usage is found anywhere, and if the code has existed for over 6 months delete it, otherwise fix it"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
