### PR TITLE
pointcloud: normalize plane distance by the normal, not the query point

### DIFF
--- a/pointcloud/plane.go
+++ b/pointcloud/plane.go
@@ -73,14 +73,10 @@ func (p *pointcloudPlane) Equation() [4]float64 {
 
 // Distance calculates the signed distance from the plane to the input point.
 func (p *pointcloudPlane) Distance(pt r3.Vector) float64 {
-	// ax+by+cz+d is normalized by the length of the plane's normal (a,b,c), not by the length of the
-	// query point. Dividing by the query point scaled the result by its distance from the origin,
-	// so the same offset from the plane measured differently depending on where in space it was.
 	normalNorm := p.Normal().Norm()
 	if normalNorm == 0 {
-		// A degenerate plane (all-zero equation, e.g. NewEmptyPlane) contains no points. Reporting
-		// an infinite distance keeps threshold and residual callers from treating everything as
-		// lying on it.
+		// An all-zero equation (NewEmptyPlane) describes no plane. +Inf rather than 0 so that
+		// threshold and residual callers treat it as containing nothing rather than everything.
 		return math.Inf(1)
 	}
 	return (p.equation[0]*pt.X + p.equation[1]*pt.Y + p.equation[2]*pt.Z + p.equation[3]) / normalNorm

--- a/pointcloud/plane.go
+++ b/pointcloud/plane.go
@@ -71,9 +71,19 @@ func (p *pointcloudPlane) Equation() [4]float64 {
 	return p.equation
 }
 
-// Distance calculates the distance from the plane to the input point.
+// Distance calculates the signed distance from the plane to the input point.
 func (p *pointcloudPlane) Distance(pt r3.Vector) float64 {
-	return (p.equation[0]*pt.X + p.equation[1]*pt.Y + p.equation[2]*pt.Z + p.equation[3]) / pt.Norm()
+	// ax+by+cz+d is normalized by the length of the plane's normal (a,b,c), not by the length of the
+	// query point. Dividing by the query point scaled the result by its distance from the origin,
+	// so the same offset from the plane measured differently depending on where in space it was.
+	normalNorm := p.Normal().Norm()
+	if normalNorm == 0 {
+		// A degenerate plane (all-zero equation, e.g. NewEmptyPlane) contains no points. Reporting
+		// an infinite distance keeps threshold and residual callers from treating everything as
+		// lying on it.
+		return math.Inf(1)
+	}
+	return (p.equation[0]*pt.X + p.equation[1]*pt.Y + p.equation[2]*pt.Z + p.equation[3]) / normalNorm
 }
 
 // Intersect calculates the intersection point of the plane with line defined by p0,p1. return nil if parallel.

--- a/pointcloud/plane_test.go
+++ b/pointcloud/plane_test.go
@@ -18,8 +18,36 @@ func TestEmptyPlane(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, cloud, test.ShouldNotBeNil)
 	test.That(t, cloud.Size(), test.ShouldEqual, 0)
+	// A degenerate plane contains nothing, so nothing is near it.
 	pt := r3.Vector{1, 2, 3}
-	test.That(t, plane.Distance(pt), test.ShouldEqual, 0)
+	test.That(t, math.IsInf(plane.Distance(pt), 1), test.ShouldBeTrue)
+}
+
+// Distance normalizes by the length of the plane's normal, not by the length of the query point.
+// The two coincide only when |pt| happens to equal |normal| -- which is exactly the case
+// TestNewPlane picks, so that test passes under either formula.
+func TestPlaneDistanceNormalizesByNormal(t *testing.T) {
+	// z = 0, normal already unit length, so the distance is just the z coordinate.
+	plane := NewPlaneWithCenter(NewBasicPointCloud(0), [4]float64{0, 0, 1, 0}, r3.Vector{})
+	for _, tc := range []struct {
+		pt       r3.Vector
+		expected float64
+	}{
+		{r3.Vector{0, 0, 5}, 5},
+		{r3.Vector{100, 0, 5}, 5},     // distance must not shrink as the point leaves the origin
+		{r3.Vector{1000, 1000, 5}, 5}, //
+		{r3.Vector{0, 0, -7}, -7},     // signed
+		{r3.Vector{1000, 1000, 500}, 500},
+		{r3.Vector{0, 0, 0}, 0}, // on the plane at the origin: was 0/0 = NaN
+	} {
+		test.That(t, plane.Distance(tc.pt), test.ShouldAlmostEqual, tc.expected, 1e-9)
+	}
+
+	// Un-normalized plane equation: 2x+2y-2z = 0 is the same plane as x+y-z = 0.
+	unnormalized := NewPlaneWithCenter(NewBasicPointCloud(0), [4]float64{2, 2, -2, 0}, r3.Vector{})
+	normalized := NewPlaneWithCenter(NewBasicPointCloud(0), [4]float64{1, 1, -1, 0}, r3.Vector{})
+	probe := r3.Vector{3, -4, 11}
+	test.That(t, unnormalized.Distance(probe), test.ShouldAlmostEqual, normalized.Distance(probe), 1e-9)
 }
 
 func TestNewPlane(t *testing.T) {

--- a/pointcloud/plane_test.go
+++ b/pointcloud/plane_test.go
@@ -23,9 +23,8 @@ func TestEmptyPlane(t *testing.T) {
 	test.That(t, math.IsInf(plane.Distance(pt), 1), test.ShouldBeTrue)
 }
 
-// Distance normalizes by the length of the plane's normal, not by the length of the query point.
-// The two coincide only when |pt| happens to equal |normal| -- which is exactly the case
-// TestNewPlane picks, so that test passes under either formula.
+// Distance must divide by |normal|, not by |pt|. Note that TestNewPlane cannot detect the
+// difference: its probe point satisfies |pt| == |normal|, where the two divisors coincide.
 func TestPlaneDistanceNormalizesByNormal(t *testing.T) {
 	// z = 0, normal already unit length, so the distance is just the z coordinate.
 	plane := NewPlaneWithCenter(NewBasicPointCloud(0), [4]float64{0, 0, 1, 0}, r3.Vector{})
@@ -34,11 +33,13 @@ func TestPlaneDistanceNormalizesByNormal(t *testing.T) {
 		expected float64
 	}{
 		{r3.Vector{0, 0, 5}, 5},
-		{r3.Vector{100, 0, 5}, 5},     // distance must not shrink as the point leaves the origin
-		{r3.Vector{1000, 1000, 5}, 5}, //
-		{r3.Vector{0, 0, -7}, -7},     // signed
+		// Invariant: the distance depends only on the offset from the plane, never on how far
+		// along the plane the point sits.
+		{r3.Vector{100, 0, 5}, 5},
+		{r3.Vector{1000, 1000, 5}, 5},
+		{r3.Vector{0, 0, -7}, -7}, // signed
 		{r3.Vector{1000, 1000, 500}, 500},
-		{r3.Vector{0, 0, 0}, 0}, // on the plane at the origin: was 0/0 = NaN
+		{r3.Vector{0, 0, 0}, 0}, // origin: numerator and |pt| are both zero
 	} {
 		test.That(t, plane.Distance(tc.pt), test.ShouldAlmostEqual, tc.expected, 1e-9)
 	}


### PR DESCRIPTION
## Summary

`pointcloud.Plane.Distance` normalized the plane equation by the length of the **query point** instead of the length of the plane's **normal**. The reported distance therefore shrank the further the point was from the origin, and a point at the origin returned `NaN`.

Found while auditing `pointcloud/` after #6314–#6324.

## The bug

```go
return (p.equation[0]*pt.X + p.equation[1]*pt.Y + p.equation[2]*pt.Z + p.equation[3]) / pt.Norm()
```

For plane `ax+by+cz+d = 0` the point distance is `(ax+by+cz+d) / sqrt(a²+b²+c²)`.

Measured against the unpatched code, for the plane `z = 0` (unit normal, so the true distance is just `z`):

| point | true distance | reported |
| --- | --- | --- |
| `(0, 0, 5)` | 5 | **1.0** |
| `(100, 0, 5)` | 5 | **0.0499** |
| `(1000, 1000, 5)` | 5 | **0.0035** |
| `(0, 0, 0)` | 0 | **NaN** |

`vision/segmentation/plane_segmentation.go:40` already contained the correct formula, so the codebase held two implementations of the same equation that disagreed.

## Impact

- **`ThresholdPointCloudByPlane`** compares `|dist| <= threshold`. A point **500mm** from the plane at `(1000, 1000, 500)` reported `0.33`, so with a 10mm threshold it was treated as lying **on** the plane. Points far from the origin are pulled under any threshold; points near it are pushed out.
- **`GetResidual`** (plane-fit quality, drives voxel plane fitting) is scaled per-point by `1/|pt|`, so the residual is not a fitting error at all.
- **`SplitPointCloudByPlane`** only uses the sign and `|pt|` is positive, so it is unaffected — except at the origin, where `NaN` fails both comparisons and the point is silently dropped.

## Degenerate planes

`NewEmptyPlane` produces an all-zero equation, which previously yielded `0/|pt| = 0` — i.e. every point read as lying exactly on a plane that does not exist. It now returns `+Inf`, so threshold and residual callers treat a non-existent plane as containing nothing. `TestEmptyPlane` is updated accordingly.

## Testing

`go test ./...` across the whole repo passes. `golangci-lint` clean.

Added `TestPlaneDistanceNormalizesByNormal`: distance is invariant to the point's position along the plane, is signed, handles the origin, and gives the same answer for `2x+2y-2z=0` as for the identical plane `x+y-z=0`. Verified to fail against the unpatched source (`Expected '1' to almost equal '5'`).

### Why this survived

The existing `TestNewPlane` probes plane `{1,1,-1,0}` at point `(-1,-1,1)`. `|pt| = sqrt(3)` and `|normal| = sqrt(3)` — the two divisors coincide, so that assertion passes under either formula. It is the only distance assertion in the package.

## Tickets

None

## Claude Code Prompts Used

- "Hi Claude, I would like you to take a hard look at this repo. I want you to search for bugs, mistakes, and strange choices..."
- "Can you work on the remaining findings following the priority order you have outlined? ... Then audit spatialmath collision internals and audit pointcloud/"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
