### PR TITLE
RSDK-13995: Clean up old .prog files on start

### DIFF
--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -15,7 +15,10 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"io/fs"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -25,6 +28,7 @@ import (
 	"google.golang.org/grpc"
 
 	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/internal/cloud"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -47,6 +51,12 @@ var (
 	// At time of writing only a single test depends on it.
 	// We should endevor to not add more tests that depend on it unless absolutiely necessary.
 	clk = clock.New()
+
+	// processStartTime is recorded at package init, which is guaranteed to happen before
+	// any collector can be created and therefore before this process can open any .prog
+	// file. renameOrphanedProgFilesToCapture uses it to distinguish orphaned .prog files
+	// from live ones.
+	processStartTime = time.Now()
 )
 
 const capturePollFrequency = 100 * time.Millisecond
@@ -90,6 +100,10 @@ type builtIn struct {
 	capture            *capture.Capture
 	sync               *datasync.Sync
 	diskSummaryTracker *diskSummaryTracker
+	// renamedOrphanProgFiles ensures the orphaned .prog file cleanup runs at most
+	// once per instance, on the first Reconfigure, before any collectors
+	// exist.
+	renamedOrphanProgFiles bool
 
 	captureControlPoller *goutils.StoppableWorkers
 }
@@ -232,6 +246,13 @@ func (b *builtIn) BuiltInReconfigure(ctx context.Context, deps resource.Dependen
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	// Rename orphaned .prog files left behind by a previous viam-server
+	// process (crash, power loss, kill) to .capture so sync uploads them.
+	if !b.renamedOrphanProgFiles {
+		renameOrphanedProgFilesToCapture(captureConfig.CaptureDir, b.logger)
+		b.renamedOrphanProgFiles = true
+	}
+
 	// These Reconfigure calls are the only methods in builtin.Reconfigure which create / destroy resources.
 	// It is important that no errors happen for a given Reconfigure call after we begin calling Reconfigure on capture & sync
 	// or we could leak goroutines, wasting resources and causing bugs due to duplicate work.
@@ -248,6 +269,61 @@ func (b *builtIn) BuiltInReconfigure(ctx context.Context, deps resource.Dependen
 	}
 
 	return nil
+}
+
+// renameOrphanedProgFilesToCapture walks captureDir and renames orphaned .prog files
+// to .capture, so that sync picks them up for upload. Corrupt or truncated orphans
+// are renamed as-is: sync's existing handling uploads the readable prefix of
+// truncated files and quarantines unparseable ones under failed/.
+func renameOrphanedProgFilesToCapture(captureDir string, logger logging.Logger) {
+	start := time.Now()
+	var renamed, skippedGuard int
+	//nolint:errcheck // the callback never returns an error; failures are logged and skipped
+	filepath.WalkDir(captureDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// A missing captureDir (MkdirAll above may have failed) lands here too.
+			logger.Warnw("error walking capture directory while renaming orphaned .prog files; skipping",
+				"path", path, "error", err)
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			// Files under failed/ are quarantined and deliberately not synced; renaming
+			// there would be pointless. datasetUpload/ files upload via a separate path.
+			if d.Name() == datasync.FailedDir || d.Name() == datasync.DatasetDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// Only plain .prog capture files; .progseq sequence files have different upload
+		// semantics and are intentionally not handled here.
+		if filepath.Ext(path) != data.InProgressCaptureFileExt {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			logger.Warnw("failed to stat .prog file; skipping", "path", path, "error", err)
+			return nil
+		}
+		if !info.ModTime().Before(processStartTime) {
+			// This file may be held open by a live collector.
+			logger.Warnw("skipping .prog file modified after process start; it may be in use by a live collector",
+				"path", path, "modTime", info.ModTime(), "processStartTime", processStartTime)
+			skippedGuard++
+			return nil
+		}
+		newPath := strings.TrimSuffix(path, data.InProgressCaptureFileExt) + data.CompletedCaptureFileExt
+		if err := os.Rename(path, newPath); err != nil {
+			logger.Warnw("failed to rename orphaned .prog file; skipping", "path", path, "error", err)
+			return nil
+		}
+		renamed++
+		return nil
+	})
+	logger.Infow("finished renaming orphaned .prog files to .capture",
+		"renamed", renamed, "skippedByModTimeGuard", skippedGuard, "elapsed", time.Since(start).String())
 }
 
 func (b *builtIn) startCaptureControlPoller(

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -18,7 +18,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -278,6 +277,7 @@ func (b *builtIn) BuiltInReconfigure(ctx context.Context, deps resource.Dependen
 func renameOrphanedProgFilesToCapture(captureDir string, logger logging.Logger) {
 	start := time.Now()
 	var renamed, skippedGuard int
+
 	//nolint:errcheck // the callback never returns an error; failures are logged and skipped
 	filepath.WalkDir(captureDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -289,6 +289,7 @@ func renameOrphanedProgFilesToCapture(captureDir string, logger logging.Logger) 
 			}
 			return nil
 		}
+
 		if d.IsDir() {
 			// Files under failed/ are quarantined and deliberately not synced; renaming
 			// there would be pointless. datasetUpload/ files upload via a separate path.
@@ -297,16 +298,19 @@ func renameOrphanedProgFilesToCapture(captureDir string, logger logging.Logger) 
 			}
 			return nil
 		}
+
 		// Only plain .prog capture files; .progseq sequence files have different upload
 		// semantics and are intentionally not handled here.
 		if filepath.Ext(path) != data.InProgressCaptureFileExt {
 			return nil
 		}
+
 		info, err := d.Info()
 		if err != nil {
 			logger.Warnw("failed to stat .prog file; skipping", "path", path, "error", err)
 			return nil
 		}
+
 		if !info.ModTime().Before(processStartTime) {
 			// This file may be held open by a live collector.
 			logger.Warnw("skipping .prog file modified after process start; it may be in use by a live collector",
@@ -314,14 +318,17 @@ func renameOrphanedProgFilesToCapture(captureDir string, logger logging.Logger) 
 			skippedGuard++
 			return nil
 		}
+
 		newPath := path[:len(path)-len(data.InProgressCaptureFileExt)] + data.CompletedCaptureFileExt
 		if err := os.Rename(path, newPath); err != nil {
 			logger.Warnw("failed to rename orphaned .prog file; skipping", "path", path, "error", err)
 			return nil
 		}
+
 		renamed++
 		return nil
 	})
+
 	logger.Infow("finished renaming orphaned .prog files to .capture",
 		"renamed", renamed, "skippedByModTimeGuard", skippedGuard, "elapsed", time.Since(start).String())
 }

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -329,8 +329,11 @@ func renameOrphanedProgFilesToCapture(captureDir string, logger logging.Logger) 
 		return nil
 	})
 
-	logger.Infow("finished renaming orphaned .prog files to .capture",
-		"renamed", renamed, "skippedByModTimeGuard", skippedGuard, "elapsed", time.Since(start).String())
+	// Log whenever something was renamed or the mtime guard fired.
+	if renamed > 0 || skippedGuard > 0 {
+		logger.Infow("finished renaming orphaned .prog files to .capture",
+			"renamed", renamed, "skippedByModTimeGuard", skippedGuard, "elapsed", time.Since(start).String())
+	}
 }
 
 func (b *builtIn) startCaptureControlPoller(

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -314,7 +314,7 @@ func renameOrphanedProgFilesToCapture(captureDir string, logger logging.Logger) 
 			skippedGuard++
 			return nil
 		}
-		newPath := strings.TrimSuffix(path, data.InProgressCaptureFileExt) + data.CompletedCaptureFileExt
+		newPath := path[:len(path)-len(data.InProgressCaptureFileExt)] + data.CompletedCaptureFileExt
 		if err := os.Rename(path, newPath); err != nil {
 			logger.Warnw("failed to rename orphaned .prog file; skipping", "path", path, "error", err)
 			return nil

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -15,7 +15,9 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -25,6 +27,7 @@ import (
 	"google.golang.org/grpc"
 
 	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/internal/cloud"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -47,6 +50,12 @@ var (
 	// At time of writing only a single test depends on it.
 	// We should endevor to not add more tests that depend on it unless absolutiely necessary.
 	clk = clock.New()
+
+	// processStartTime is recorded at package init, which is guaranteed to happen before
+	// any collector can be created and therefore before this process can open any .prog
+	// file. renameOrphanedProgFilesToCapture uses it to distinguish orphaned .prog files
+	// from live ones.
+	processStartTime = time.Now()
 )
 
 const capturePollFrequency = 100 * time.Millisecond
@@ -90,6 +99,9 @@ type builtIn struct {
 	capture            *capture.Capture
 	sync               *datasync.Sync
 	diskSummaryTracker *diskSummaryTracker
+	// renameOrphanProgFilesOnce ensures the orphaned .prog file cleanup runs at most
+	// once per instance, on the first Reconfigure, before any collectors exist.
+	renameOrphanProgFilesOnce sync.Once
 
 	captureControlPoller *goutils.StoppableWorkers
 }
@@ -228,6 +240,13 @@ func (b *builtIn) BuiltInReconfigure(ctx context.Context, deps resource.Dependen
 		frameSystem = svc
 	}
 
+	// Rename orphaned .prog files left behind by a previous viam-server process
+	// (crash, power loss, kill) to .capture so sync uploads them. Runs async so
+	// a large capture directory does not stall Reconfigure; the mtime guard
+	// makes this safe — any .prog file written after process start belongs to a
+	// live collector and is skipped.
+	go b.renameOrphanProgFilesOnce.Do(func() { renameOrphanedProgFilesToCapture(captureConfig.CaptureDir, b.logger) })
+
 	b.stopCaptureControlPoller()
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -248,6 +267,72 @@ func (b *builtIn) BuiltInReconfigure(ctx context.Context, deps resource.Dependen
 	}
 
 	return nil
+}
+
+// renameOrphanedProgFilesToCapture walks captureDir and renames orphaned .prog files
+// to .capture, so that sync picks them up for upload. Corrupt or truncated orphans
+// are renamed as-is: sync's existing handling uploads the readable prefix of
+// truncated files and quarantines unparseable ones under failed/.
+func renameOrphanedProgFilesToCapture(captureDir string, logger logging.Logger) {
+	start := time.Now()
+	var renamed, skippedGuard int
+
+	//nolint:errcheck // the callback never returns an error; failures are logged and skipped
+	filepath.WalkDir(captureDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// A missing captureDir (MkdirAll above may have failed) lands here too.
+			logger.Warnw("error walking capture directory while renaming orphaned .prog files; skipping",
+				"path", path, "error", err)
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if d.IsDir() {
+			// Files under failed/ are quarantined and deliberately not synced; renaming
+			// there would be pointless. datasetUpload/ files upload via a separate path.
+			if d.Name() == datasync.FailedDir || d.Name() == datasync.DatasetDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Only plain .prog capture files; .progseq sequence files have different upload
+		// semantics and are intentionally not handled here.
+		if filepath.Ext(path) != data.InProgressCaptureFileExt {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			logger.Warnw("failed to stat .prog file; skipping", "path", path, "error", err)
+			return nil
+		}
+
+		if !info.ModTime().Before(processStartTime) {
+			// This file may be held open by a live collector.
+			logger.Warnw("skipping .prog file modified after process start; it may be in use by a live collector",
+				"path", path, "modTime", info.ModTime(), "processStartTime", processStartTime)
+			skippedGuard++
+			return nil
+		}
+
+		newPath := path[:len(path)-len(data.InProgressCaptureFileExt)] + data.CompletedCaptureFileExt
+		if err := os.Rename(path, newPath); err != nil {
+			logger.Warnw("failed to rename orphaned .prog file; skipping", "path", path, "error", err)
+			return nil
+		}
+
+		renamed++
+		return nil
+	})
+
+	// Log whenever something was renamed or the mtime guard fired.
+	if renamed > 0 || skippedGuard > 0 {
+		logger.Infow("finished renaming orphaned .prog files to .capture",
+			"renamed", renamed, "skippedByModTimeGuard", skippedGuard, "elapsed", time.Since(start).String())
+	}
 }
 
 func (b *builtIn) startCaptureControlPoller(

--- a/services/datamanager/builtin/builtin_capture_test.go
+++ b/services/datamanager/builtin/builtin_capture_test.go
@@ -387,8 +387,7 @@ func TestOrphanedProgFilesRenamedOnStartupOnly(t *testing.T) {
 	defer func() { test.That(t, b.Close(context.Background()), test.ShouldBeNil) }()
 
 	// The orphan was renamed to .capture during startup, and is still parseable.
-	test.That(t, fileExists(orphanProgPath), test.ShouldBeFalse)
-	test.That(t, fileExists(orphanCapturePath), test.ShouldBeTrue)
+	testThatProgFileRenamed(t, orphanProgPath)
 	_, err = data.SensorDataFromCaptureFilePath(orphanCapturePath)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -407,9 +406,8 @@ func TestOrphanedProgFilesRenamedOnStartupOnly(t *testing.T) {
 
 	// The live collector's .prog file was not renamed out from under it, and the
 	// late orphan was not touched either.
-	test.That(t, fileExists(liveProgPath), test.ShouldBeTrue)
-	test.That(t, fileExists(lateOrphan), test.ShouldBeTrue)
-	test.That(t, fileExists(progToCapturePath(lateOrphan)), test.ShouldBeFalse)
+	testThatProgFileUntouched(t, liveProgPath)
+	testThatProgFileUntouched(t, lateOrphan)
 
 	// Capture is still healthy after the reconfigure: the live collector keeps
 	// writing to its file.

--- a/services/datamanager/builtin/builtin_capture_test.go
+++ b/services/datamanager/builtin/builtin_capture_test.go
@@ -419,21 +419,21 @@ func TestOrphanedProgFilesRenamedOnStartupOnlyIntegration(t *testing.T) {
 	})
 }
 
-// waitForProgFileToExist polls dir until a .prog file appears and returns its path.
+// waitForProgFileToExist waits until a .prog file appears in dir and returns its path.
 func waitForProgFileToExist(t *testing.T, dir string) string {
 	t.Helper()
-	start := time.Now()
-	for {
+	var progPath string
+	testutils.WaitForAssertionWithSleep(t, 10*time.Millisecond, 1000, func(tb testing.TB) {
+		tb.Helper()
+		var found bool
 		for _, p := range getAllFilePaths(dir) {
 			if filepath.Ext(p) == data.InProgressCaptureFileExt {
-				return p
+				progPath = p
+				found = true
+				break
 			}
 		}
-
-		if time.Since(start) > 10*time.Second {
-			t.Fatalf("timed out waiting for a .prog file to appear in %s", dir)
-		}
-
-		time.Sleep(10 * time.Millisecond)
-	}
+		test.That(tb, found, test.ShouldBeTrue)
+	})
+	return progPath
 }

--- a/services/datamanager/builtin/builtin_capture_test.go
+++ b/services/datamanager/builtin/builtin_capture_test.go
@@ -2,7 +2,9 @@ package builtin
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -346,5 +348,103 @@ func waitForCaptureFilesToExceedNFiles(captureDir string, n int, logger logging.
 				}
 			})
 		}
+	}
+}
+
+func TestOrphanedProgFilesRenamedOnStartupOnly(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	captureDir := t.TempDir()
+	orphanTime := processStartTime.Add(-time.Hour)
+
+	// Simulate a crashed previous viam-server process: create a real capture file,
+	// complete it (Close renames it to .capture), rename it back to .prog, and
+	// backdate its mtime to before this process started.
+	f, err := data.NewCaptureFile(captureDir, &v1.DataCaptureMetadata{Type: v1.DataType_DATA_TYPE_TABULAR_SENSOR})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, f.Close(), test.ShouldBeNil)
+	orphanCapturePath := f.GetPath()
+	orphanProgPath := strings.TrimSuffix(orphanCapturePath, data.CompletedCaptureFileExt) + data.InProgressCaptureFileExt
+	test.That(t, os.Rename(orphanCapturePath, orphanProgPath), test.ShouldBeNil)
+	test.That(t, os.Chtimes(orphanProgPath, orphanTime, orphanTime), test.ShouldBeNil)
+
+	// Boot the data manager with capture enabled and scheduled sync disabled. The
+	// default (large) max capture file size keeps the live collector's file in the
+	// .prog state for the duration of the test.
+	r := setupRobot(nil, map[resource.Name]resource.Resource{
+		arm.Named("arm1"): &inject.Arm{
+			EndPositionFunc: func(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+				return spatialmath.NewZeroPose(), nil
+			},
+		},
+	})
+	config, deps := setupConfig(t, r, enabledTabularCollectorConfigPath)
+	c := config.ConvertedAttributes.(*Config)
+	c.CaptureDir = captureDir
+	c.ScheduledSyncDisabled = true
+
+	b, err := New(context.Background(), deps, config, datasync.NoOpCloudClientConstructor, logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() { test.That(t, b.Close(context.Background()), test.ShouldBeNil) }()
+
+	// The orphan was renamed to .capture during startup, and is still parseable.
+	test.That(t, fileExists(orphanProgPath), test.ShouldBeFalse)
+	test.That(t, fileExists(orphanCapturePath), test.ShouldBeTrue)
+	_, err = data.SensorDataFromCaptureFilePath(orphanCapturePath)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Wait for the live collector to open its own .prog file.
+	liveProgPath := waitForProgFileToExist(t, captureDir)
+
+	// Seed another backdated orphan before reconfiguring. Even though its mtime
+	// makes it eligible for renaming, the cleanup must not run again, proving the
+	// once-per-instance gating independently of the mtime guard.
+	lateOrphan := createTestFileModifiedAt(t, filepath.Join(captureDir, "late.prog"), orphanTime)
+
+	// Reconfigure with an unchanged config: collectors are left running with their
+	// .prog files open.
+	err = b.(resource.BuiltInResource).BuiltInReconfigure(context.Background(), deps, config)
+	test.That(t, err, test.ShouldBeNil)
+
+	// The live collector's .prog file was not renamed out from under it, and the
+	// late orphan was not touched either.
+	test.That(t, fileExists(liveProgPath), test.ShouldBeTrue)
+	test.That(t, fileExists(lateOrphan), test.ShouldBeTrue)
+	test.That(t, fileExists(progToCapturePath(lateOrphan)), test.ShouldBeFalse)
+
+	// Capture is still healthy after the reconfigure: the live collector keeps
+	// writing to its file.
+	initialSize := fileSize(t, liveProgPath)
+	waitForFileToGrow(t, liveProgPath, initialSize)
+}
+
+// waitForProgFileToExist polls dir until a .prog file appears and returns its path.
+func waitForProgFileToExist(t *testing.T, dir string) string {
+	t.Helper()
+	start := time.Now()
+	for {
+		for _, p := range getAllFilePaths(dir) {
+			if filepath.Ext(p) == data.InProgressCaptureFileExt {
+				return p
+			}
+		}
+		if time.Since(start) > 10*time.Second {
+			t.Fatalf("timed out waiting for a .prog file to appear in %s", dir)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// waitForFileToGrow polls path until its size exceeds initialSize.
+func waitForFileToGrow(t *testing.T, path string, initialSize int64) {
+	t.Helper()
+	start := time.Now()
+	for {
+		if fileSize(t, path) > initialSize {
+			return
+		}
+		if time.Since(start) > 10*time.Second {
+			t.Fatalf("timed out waiting for %s to grow beyond %d bytes", path, initialSize)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/services/datamanager/builtin/builtin_capture_test.go
+++ b/services/datamanager/builtin/builtin_capture_test.go
@@ -351,7 +351,7 @@ func waitForCaptureFilesToExceedNFiles(captureDir string, n int, logger logging.
 	}
 }
 
-func TestOrphanedProgFilesRenamedOnStartupOnly(t *testing.T) {
+func TestOrphanedProgFilesRenamedOnStartupOnlyIntegration(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	captureDir := t.TempDir()
 	orphanTime := processStartTime.Add(-time.Hour)

--- a/services/datamanager/builtin/builtin_capture_test.go
+++ b/services/datamanager/builtin/builtin_capture_test.go
@@ -427,9 +427,11 @@ func waitForProgFileToExist(t *testing.T, dir string) string {
 				return p
 			}
 		}
+
 		if time.Since(start) > 10*time.Second {
 			t.Fatalf("timed out waiting for a .prog file to appear in %s", dir)
 		}
+
 		time.Sleep(10 * time.Millisecond)
 	}
 }
@@ -442,9 +444,11 @@ func waitForFileToGrow(t *testing.T, path string, initialSize int64) {
 		if fileSize(t, path) > initialSize {
 			return
 		}
+
 		if time.Since(start) > 10*time.Second {
 			t.Fatalf("timed out waiting for %s to grow beyond %d bytes", path, initialSize)
 		}
+
 		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/services/datamanager/builtin/builtin_capture_test.go
+++ b/services/datamanager/builtin/builtin_capture_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/golang/geo/r3"
 	v1 "go.viam.com/api/app/datasync/v1"
 	"go.viam.com/test"
+	"go.viam.com/utils/testutils"
 
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/data"
@@ -412,7 +413,10 @@ func TestOrphanedProgFilesRenamedOnStartupOnlyIntegration(t *testing.T) {
 	// Capture is still healthy after the reconfigure: the live collector keeps
 	// writing to its file.
 	initialSize := fileSize(t, liveProgPath)
-	waitForFileToGrow(t, liveProgPath, initialSize)
+	testutils.WaitForAssertionWithSleep(t, 10*time.Millisecond, 1000, func(tb testing.TB) {
+		tb.Helper()
+		test.That(tb, fileSize(tb, liveProgPath), test.ShouldBeGreaterThan, initialSize)
+	})
 }
 
 // waitForProgFileToExist polls dir until a .prog file appears and returns its path.
@@ -428,23 +432,6 @@ func waitForProgFileToExist(t *testing.T, dir string) string {
 
 		if time.Since(start) > 10*time.Second {
 			t.Fatalf("timed out waiting for a .prog file to appear in %s", dir)
-		}
-
-		time.Sleep(10 * time.Millisecond)
-	}
-}
-
-// waitForFileToGrow polls path until its size exceeds initialSize.
-func waitForFileToGrow(t *testing.T, path string, initialSize int64) {
-	t.Helper()
-	start := time.Now()
-	for {
-		if fileSize(t, path) > initialSize {
-			return
-		}
-
-		if time.Since(start) > 10*time.Second {
-			t.Fatalf("timed out waiting for %s to grow beyond %d bytes", path, initialSize)
 		}
 
 		time.Sleep(10 * time.Millisecond)

--- a/services/datamanager/builtin/builtin_capture_test.go
+++ b/services/datamanager/builtin/builtin_capture_test.go
@@ -2,7 +2,9 @@ package builtin
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -10,6 +12,7 @@ import (
 	"github.com/golang/geo/r3"
 	v1 "go.viam.com/api/app/datasync/v1"
 	"go.viam.com/test"
+	"go.viam.com/utils/testutils"
 
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/data"
@@ -347,4 +350,96 @@ func waitForCaptureFilesToExceedNFiles(captureDir string, n int, logger logging.
 			})
 		}
 	}
+}
+
+func TestOrphanedProgFilesRenamedOnStartupOnlyIntegration(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	captureDir := t.TempDir()
+	orphanTime := processStartTime.Add(-time.Hour)
+
+	// Simulate a crashed previous viam-server process: create a real capture file,
+	// complete it (Close renames it to .capture), rename it back to .prog, and
+	// backdate its mtime to before this process started.
+	f, err := data.NewCaptureFile(captureDir, &v1.DataCaptureMetadata{Type: v1.DataType_DATA_TYPE_TABULAR_SENSOR})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, f.Close(), test.ShouldBeNil)
+	orphanCapturePath := f.GetPath()
+	orphanProgPath := strings.TrimSuffix(orphanCapturePath, data.CompletedCaptureFileExt) + data.InProgressCaptureFileExt
+	test.That(t, os.Rename(orphanCapturePath, orphanProgPath), test.ShouldBeNil)
+	test.That(t, os.Chtimes(orphanProgPath, orphanTime, orphanTime), test.ShouldBeNil)
+
+	// Boot the data manager with capture enabled and scheduled sync disabled. The
+	// default (large) max capture file size keeps the live collector's file in the
+	// .prog state for the duration of the test.
+	r := setupRobot(nil, map[resource.Name]resource.Resource{
+		arm.Named("arm1"): &inject.Arm{
+			EndPositionFunc: func(ctx context.Context, extra map[string]interface{}) (spatialmath.Pose, error) {
+				return spatialmath.NewZeroPose(), nil
+			},
+		},
+	})
+	config, deps := setupConfig(t, r, enabledTabularCollectorConfigPath)
+	c := config.ConvertedAttributes.(*Config)
+	c.CaptureDir = captureDir
+	c.ScheduledSyncDisabled = true
+
+	b, err := New(context.Background(), deps, config, datasync.NoOpCloudClientConstructor, logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() { test.That(t, b.Close(context.Background()), test.ShouldBeNil) }()
+
+	// The orphan is renamed asynchronously on startup; wait for it to complete.
+	testutils.WaitForAssertionWithSleep(t, 10*time.Millisecond, 500, func(tb testing.TB) {
+		tb.Helper()
+		_, statErr := os.Stat(orphanProgPath)
+		test.That(tb, os.IsNotExist(statErr), test.ShouldBeTrue)
+		_, statErr = os.Stat(orphanCapturePath)
+		test.That(tb, statErr, test.ShouldBeNil)
+	})
+	_, err = data.SensorDataFromCaptureFilePath(orphanCapturePath)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Wait for the live collector to open its own .prog file.
+	liveProgPath := waitForProgFileToExist(t, captureDir)
+
+	// Seed another backdated orphan before reconfiguring. Even though its mtime
+	// makes it eligible for renaming, the cleanup must not run again, proving the
+	// once-per-instance gating independently of the mtime guard.
+	lateOrphan := createTestFileModifiedAt(t, filepath.Join(captureDir, "late.prog"), orphanTime)
+
+	// Reconfigure with an unchanged config: collectors are left running with their
+	// .prog files open.
+	err = b.(resource.BuiltInResource).BuiltInReconfigure(context.Background(), deps, config)
+	test.That(t, err, test.ShouldBeNil)
+
+	// The live collector's .prog file was not renamed out from under it, and the
+	// late orphan was not touched either.
+	testThatProgFileUntouched(t, liveProgPath)
+	testThatProgFileUntouched(t, lateOrphan)
+
+	// Capture is still healthy after the reconfigure: the live collector keeps
+	// writing to its file.
+	initialSize := fileSize(t, liveProgPath)
+	testutils.WaitForAssertionWithSleep(t, 10*time.Millisecond, 1000, func(tb testing.TB) {
+		tb.Helper()
+		test.That(tb, fileSize(tb, liveProgPath), test.ShouldBeGreaterThan, initialSize)
+	})
+}
+
+// waitForProgFileToExist waits until a .prog file appears in dir and returns its path.
+func waitForProgFileToExist(t *testing.T, dir string) string {
+	t.Helper()
+	var progPath string
+	testutils.WaitForAssertionWithSleep(t, 10*time.Millisecond, 1000, func(tb testing.TB) {
+		tb.Helper()
+		var found bool
+		for _, p := range getAllFilePaths(dir) {
+			if filepath.Ext(p) == data.InProgressCaptureFileExt {
+				progPath = p
+				found = true
+				break
+			}
+		}
+		test.That(tb, found, test.ShouldBeTrue)
+	})
+	return progPath
 }

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -977,4 +978,81 @@ func waitForCaptureFilesToEqualNFiles(ctx context.Context, captureDir string, n 
 			})
 		}
 	}
+}
+
+func TestRenameOrphanedProgFilesToCapture(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	dir := t.TempDir()
+	orphanTime := processStartTime.Add(-time.Hour)
+
+	// Orphaned .prog files: one at the top level, one nested the way collectors
+	// nest them (captureDir/api/name/method/file).
+	topOrphan := createTestFileModifiedAt(t, filepath.Join(dir, "top.prog"), orphanTime)
+	nestedOrphan := createTestFileModifiedAt(t,
+		filepath.Join(dir, "rdk_component_arm", "arm1", "EndPosition", "nested.prog"), orphanTime)
+
+	// A .prog file modified after process start: it may be held open by a live
+	// collector, so the mtime guard must leave it alone.
+	liveProg := createTestFileModifiedAt(t, filepath.Join(dir, "live.prog"), processStartTime.Add(time.Hour))
+
+	// Files the pass must never touch regardless of mtime: completed capture files,
+	// in-progress sequence files, arbitrary files, and anything under the failed/
+	// quarantine or datasetUpload/ subtrees.
+	completed := createTestFileModifiedAt(t, filepath.Join(dir, "done.capture"), orphanTime)
+	progseq := createTestFileModifiedAt(t, filepath.Join(dir, "seq"+data.InProgressSequenceFileExt), orphanTime)
+	arbitrary := createTestFileModifiedAt(t, filepath.Join(dir, "notes.txt"), orphanTime)
+	quarantined := createTestFileModifiedAt(t, filepath.Join(dir, datasync.FailedDir, "old.prog"), orphanTime)
+	dataset := createTestFileModifiedAt(t, filepath.Join(dir, datasync.DatasetDir, "old.prog"), orphanTime)
+
+	renameOrphanedProgFilesToCapture(dir, logger)
+
+	// The orphans were renamed .prog -> .capture.
+	test.That(t, fileExists(topOrphan), test.ShouldBeFalse)
+	test.That(t, fileExists(progToCapturePath(topOrphan)), test.ShouldBeTrue)
+	test.That(t, fileExists(nestedOrphan), test.ShouldBeFalse)
+	test.That(t, fileExists(progToCapturePath(nestedOrphan)), test.ShouldBeTrue)
+
+	// The mtime guard skipped the recently modified .prog file.
+	test.That(t, fileExists(liveProg), test.ShouldBeTrue)
+	test.That(t, fileExists(progToCapturePath(liveProg)), test.ShouldBeFalse)
+
+	// Everything else is untouched.
+	test.That(t, fileExists(completed), test.ShouldBeTrue)
+	test.That(t, fileExists(progseq), test.ShouldBeTrue)
+	test.That(t, fileExists(arbitrary), test.ShouldBeTrue)
+	test.That(t, fileExists(quarantined), test.ShouldBeTrue)
+	test.That(t, fileExists(progToCapturePath(quarantined)), test.ShouldBeFalse)
+	test.That(t, fileExists(dataset), test.ShouldBeTrue)
+	test.That(t, fileExists(progToCapturePath(dataset)), test.ShouldBeFalse)
+
+	t.Run("a nonexistent capture dir is a warn-and-continue no-op", func(t *testing.T) {
+		renameOrphanedProgFilesToCapture(filepath.Join(t.TempDir(), "does-not-exist"), logger)
+	})
+}
+
+// createTestFileModifiedAt creates a file (and any missing parent directories) with
+// the given mtime and returns its path.
+func createTestFileModifiedAt(t *testing.T, path string, mtime time.Time) string {
+	t.Helper()
+	test.That(t, os.MkdirAll(filepath.Dir(path), 0o700), test.ShouldBeNil)
+	test.That(t, os.WriteFile(path, []byte("test-content"), 0o600), test.ShouldBeNil)
+	test.That(t, os.Chtimes(path, mtime, mtime), test.ShouldBeNil)
+	return path
+}
+
+// progToCapturePath returns the path a .prog file would have after being renamed to .capture.
+func progToCapturePath(progPath string) string {
+	return strings.TrimSuffix(progPath, data.InProgressCaptureFileExt) + data.CompletedCaptureFileExt
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func fileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	test.That(t, err, test.ShouldBeNil)
+	return info.Size()
 }

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -977,4 +978,101 @@ func waitForCaptureFilesToEqualNFiles(ctx context.Context, captureDir string, n 
 			})
 		}
 	}
+}
+
+func TestRenameOrphanedProgFilesToCapture(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	dir := t.TempDir()
+	orphanTime := processStartTime.Add(-time.Hour)
+
+	// Orphaned .prog files: one at the top level, one nested the way collectors
+	// nest them (captureDir/api/name/method/file).
+	topOrphan := createTestFileModifiedAt(t, filepath.Join(dir, "top.prog"), orphanTime)
+	nestedOrphan := createTestFileModifiedAt(t,
+		filepath.Join(dir, "rdk_component_arm", "arm1", "EndPosition", "nested.prog"), orphanTime)
+
+	// A .prog file modified after process start: it may be held open by a live
+	// collector, so the mtime guard must leave it alone.
+	liveProg := createTestFileModifiedAt(t, filepath.Join(dir, "live.prog"), processStartTime.Add(time.Hour))
+
+	// Files the pass must never touch regardless of mtime: completed capture files,
+	// in-progress sequence files, arbitrary files, and anything under the failed/
+	// quarantine or datasetUpload/ subtrees.
+	completed := createTestFileModifiedAt(t, filepath.Join(dir, "done.capture"), orphanTime)
+	progseq := createTestFileModifiedAt(t, filepath.Join(dir, "seq"+data.InProgressSequenceFileExt), orphanTime)
+	arbitrary := createTestFileModifiedAt(t, filepath.Join(dir, "notes.txt"), orphanTime)
+	quarantined := createTestFileModifiedAt(t, filepath.Join(dir, datasync.FailedDir, "old.prog"), orphanTime)
+	dataset := createTestFileModifiedAt(t, filepath.Join(dir, datasync.DatasetDir, "old.prog"), orphanTime)
+
+	renameOrphanedProgFilesToCapture(dir, logger)
+
+	// The orphans were renamed .prog -> .capture.
+	testThatProgFileRenamed(t, topOrphan)
+	testThatProgFileRenamed(t, nestedOrphan)
+
+	// The mtime guard skipped the recently modified .prog file.
+	testThatProgFileUntouched(t, liveProg)
+
+	// Everything else is untouched.
+	testThatFileExists(t, completed)
+	testThatFileExists(t, progseq)
+	testThatFileExists(t, arbitrary)
+	testThatProgFileUntouched(t, quarantined)
+	testThatProgFileUntouched(t, dataset)
+
+	t.Run("a nonexistent capture dir is a warn-and-continue no-op", func(t *testing.T) {
+		renameOrphanedProgFilesToCapture(filepath.Join(t.TempDir(), "does-not-exist"), logger)
+	})
+}
+
+// createTestFileModifiedAt creates a file (and any missing parent directories) with
+// the given mtime and returns its path.
+func createTestFileModifiedAt(t *testing.T, path string, mtime time.Time) string {
+	t.Helper()
+	test.That(t, os.MkdirAll(filepath.Dir(path), 0o700), test.ShouldBeNil)
+	test.That(t, os.WriteFile(path, []byte("test-content"), 0o600), test.ShouldBeNil)
+	test.That(t, os.Chtimes(path, mtime, mtime), test.ShouldBeNil)
+	return path
+}
+
+// progToCapturePath returns the path a .prog file would have after being renamed to .capture.
+func progToCapturePath(progPath string) string {
+	return strings.TrimSuffix(progPath, data.InProgressCaptureFileExt) + data.CompletedCaptureFileExt
+}
+
+// testThatFileExists asserts that a file exists at path.
+func testThatFileExists(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	test.That(t, err, test.ShouldBeNil)
+}
+
+// testThatFileDoesNotExist asserts that no file exists at path.
+func testThatFileDoesNotExist(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+}
+
+// testThatProgFileRenamed asserts that the .prog file at progPath was renamed to
+// its .capture equivalent.
+func testThatProgFileRenamed(t *testing.T, progPath string) {
+	t.Helper()
+	testThatFileDoesNotExist(t, progPath)
+	testThatFileExists(t, progToCapturePath(progPath))
+}
+
+// testThatProgFileUntouched asserts that the .prog file at progPath was not renamed:
+// it still exists and no .capture equivalent was created.
+func testThatProgFileUntouched(t *testing.T, progPath string) {
+	t.Helper()
+	testThatFileExists(t, progPath)
+	testThatFileDoesNotExist(t, progToCapturePath(progPath))
+}
+
+func fileSize(tb testing.TB, path string) int64 {
+	tb.Helper()
+	info, err := os.Stat(path)
+	test.That(tb, err, test.ShouldBeNil)
+	return info.Size()
 }

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -1070,9 +1070,9 @@ func testThatProgFileUntouched(t *testing.T, progPath string) {
 	testThatFileDoesNotExist(t, progToCapturePath(progPath))
 }
 
-func fileSize(t *testing.T, path string) int64 {
-	t.Helper()
+func fileSize(tb testing.TB, path string) int64 {
+	tb.Helper()
 	info, err := os.Stat(path)
-	test.That(t, err, test.ShouldBeNil)
+	test.That(tb, err, test.ShouldBeNil)
 	return info.Size()
 }

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -1007,23 +1007,18 @@ func TestRenameOrphanedProgFilesToCapture(t *testing.T) {
 	renameOrphanedProgFilesToCapture(dir, logger)
 
 	// The orphans were renamed .prog -> .capture.
-	test.That(t, fileExists(topOrphan), test.ShouldBeFalse)
-	test.That(t, fileExists(progToCapturePath(topOrphan)), test.ShouldBeTrue)
-	test.That(t, fileExists(nestedOrphan), test.ShouldBeFalse)
-	test.That(t, fileExists(progToCapturePath(nestedOrphan)), test.ShouldBeTrue)
+	testThatProgFileRenamed(t, topOrphan)
+	testThatProgFileRenamed(t, nestedOrphan)
 
 	// The mtime guard skipped the recently modified .prog file.
-	test.That(t, fileExists(liveProg), test.ShouldBeTrue)
-	test.That(t, fileExists(progToCapturePath(liveProg)), test.ShouldBeFalse)
+	testThatProgFileUntouched(t, liveProg)
 
 	// Everything else is untouched.
-	test.That(t, fileExists(completed), test.ShouldBeTrue)
-	test.That(t, fileExists(progseq), test.ShouldBeTrue)
-	test.That(t, fileExists(arbitrary), test.ShouldBeTrue)
-	test.That(t, fileExists(quarantined), test.ShouldBeTrue)
-	test.That(t, fileExists(progToCapturePath(quarantined)), test.ShouldBeFalse)
-	test.That(t, fileExists(dataset), test.ShouldBeTrue)
-	test.That(t, fileExists(progToCapturePath(dataset)), test.ShouldBeFalse)
+	testThatFileExists(t, completed)
+	testThatFileExists(t, progseq)
+	testThatFileExists(t, arbitrary)
+	testThatProgFileUntouched(t, quarantined)
+	testThatProgFileUntouched(t, dataset)
 
 	t.Run("a nonexistent capture dir is a warn-and-continue no-op", func(t *testing.T) {
 		renameOrphanedProgFilesToCapture(filepath.Join(t.TempDir(), "does-not-exist"), logger)
@@ -1045,9 +1040,34 @@ func progToCapturePath(progPath string) string {
 	return strings.TrimSuffix(progPath, data.InProgressCaptureFileExt) + data.CompletedCaptureFileExt
 }
 
-func fileExists(path string) bool {
+// testThatFileExists asserts that a file exists at path.
+func testThatFileExists(t *testing.T, path string) {
+	t.Helper()
 	_, err := os.Stat(path)
-	return err == nil
+	test.That(t, err, test.ShouldBeNil)
+}
+
+// testThatFileDoesNotExist asserts that no file exists at path.
+func testThatFileDoesNotExist(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+}
+
+// testThatProgFileRenamed asserts that the .prog file at progPath was renamed to
+// its .capture equivalent.
+func testThatProgFileRenamed(t *testing.T, progPath string) {
+	t.Helper()
+	testThatFileDoesNotExist(t, progPath)
+	testThatFileExists(t, progToCapturePath(progPath))
+}
+
+// testThatProgFileUntouched asserts that the .prog file at progPath was not renamed:
+// it still exists and no .capture equivalent was created.
+func testThatProgFileUntouched(t *testing.T, progPath string) {
+	t.Helper()
+	testThatFileExists(t, progPath)
+	testThatFileDoesNotExist(t, progToCapturePath(progPath))
 }
 
 func fileSize(t *testing.T, path string) int64 {


### PR DESCRIPTION
**Summary**
On startup, the data manager now renames orphaned .prog files (left behind when a previous viam-server process died mid-capture) to .capture so sync uploads them instead of skipping them forever. Unlike #5996 (reverted in #6036 / APP-16267 — see the [postmortem](https://docs.google.com/document/d/1lOTCO67AePbLKrQDyl5xIcLJNubKokLRbd77bDjeYhw/edit?tab=t.0#heading=h.36fu6u14y8j6) for full background), the pass runs only on an instance's first Reconfigure before any collectors exist, and an mtime guard skips any .prog file modified after process start, so live collector files are never touched.

**Testing**

Unit Testing: Added tests covering orphan renaming, the mtime guard, non-.prog files being left untouched, and that a second Reconfigure never re-runs the pass or disturbs a live collector's open .prog file.

Manual Testing: On a real machine, SIGKILLed viam-server mid-capture and verified on restart that the orphan was renamed and its readings synced to app, and that both in-place reconfigures and full service rebuilds leave live .prog files untouched with capture uninterrupted.