### PR TITLE
pointcloud: make Plane.Distance return an error for a degenerate plane

### DIFF
--- a/pointcloud/plane.go
+++ b/pointcloud/plane.go
@@ -1,19 +1,27 @@
 package pointcloud
 
 import (
+	"errors"
 	"math"
 
 	"github.com/golang/geo/r3"
 )
 
+// ErrDegeneratePlane is returned by Plane.Distance when the plane's normal has no direction, so no
+// point has a defined distance from it. A Plane can legitimately be in this state: NewEmptyPlane
+// builds one, and a voxel plane starts out with a zero normal until one is estimated.
+var ErrDegeneratePlane = errors.New("plane has a zero-length normal, distance is undefined")
+
 // Plane defines a planar object in a 3D space.
 type Plane interface {
-	Equation() [4]float64                  // Returns an array of the plane equation [0]x + [1]y + [2]z + [3] = 0.
-	Normal() r3.Vector                     // The normal vector of the plane, could point "up" or "down".
-	Center() r3.Vector                     // The center point of the plane (the planes are not infinite).
-	Offset() float64                       //  the [3] term in the equation of the plane.
-	PointCloud() (PointCloud, error)       // Returns the underlying pointcloud that makes up the plane.
-	Distance(p r3.Vector) float64          // The distance of a point p from the nearest point on the plane.
+	Equation() [4]float64            // Returns an array of the plane equation [0]x + [1]y + [2]z + [3] = 0.
+	Normal() r3.Vector               // The normal vector of the plane, could point "up" or "down".
+	Center() r3.Vector               // The center point of the plane (the planes are not infinite).
+	Offset() float64                 //  the [3] term in the equation of the plane.
+	PointCloud() (PointCloud, error) // Returns the underlying pointcloud that makes up the plane.
+	// Distance returns the signed distance of a point p from the nearest point on the plane, or
+	// ErrDegeneratePlane if the plane's normal has no direction.
+	Distance(p r3.Vector) (float64, error)
 	Intersect(p0, p1 r3.Vector) *r3.Vector // The intersection point of the plane with line defined by p0,p1. return nil if parallel.
 }
 
@@ -71,9 +79,13 @@ func (p *pointcloudPlane) Equation() [4]float64 {
 	return p.equation
 }
 
-// Distance calculates the distance from the plane to the input point.
-func (p *pointcloudPlane) Distance(pt r3.Vector) float64 {
-	return (p.equation[0]*pt.X + p.equation[1]*pt.Y + p.equation[2]*pt.Z + p.equation[3]) / pt.Norm()
+// Distance calculates the signed distance from the plane to the input point.
+func (p *pointcloudPlane) Distance(pt r3.Vector) (float64, error) {
+	normalNorm := p.Normal().Norm()
+	if normalNorm == 0 {
+		return 0, ErrDegeneratePlane
+	}
+	return (p.equation[0]*pt.X + p.equation[1]*pt.Y + p.equation[2]*pt.Z + p.equation[3]) / normalNorm, nil
 }
 
 // Intersect calculates the intersection point of the plane with line defined by p0,p1. return nil if parallel.

--- a/pointcloud/plane_test.go
+++ b/pointcloud/plane_test.go
@@ -1,6 +1,7 @@
 package pointcloud
 
 import (
+	"errors"
 	"math"
 	"testing"
 
@@ -18,8 +19,10 @@ func TestEmptyPlane(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, cloud, test.ShouldNotBeNil)
 	test.That(t, cloud.Size(), test.ShouldEqual, 0)
+	// An empty plane has no normal direction, so no point has a distance from it.
 	pt := r3.Vector{1, 2, 3}
-	test.That(t, plane.Distance(pt), test.ShouldEqual, 0)
+	_, err = plane.Distance(pt)
+	test.That(t, errors.Is(err, ErrDegeneratePlane), test.ShouldBeTrue)
 }
 
 func TestNewPlane(t *testing.T) {
@@ -45,7 +48,43 @@ func TestNewPlane(t *testing.T) {
 	test.That(t, cloud, test.ShouldNotBeNil)
 	test.That(t, cloud.Size(), test.ShouldEqual, 4)
 	pt := r3.Vector{-1, -1, 1}
-	test.That(t, math.Abs(plane.Distance(pt)), test.ShouldAlmostEqual, math.Sqrt(3))
+	dist, err := plane.Distance(pt)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, math.Abs(dist), test.ShouldAlmostEqual, math.Sqrt(3))
+}
+
+// Distance must divide by |normal|, not by |pt|. Note that TestNewPlane cannot detect the
+// difference: its probe point satisfies |pt| == |normal|, where the two divisors coincide.
+func TestPlaneDistanceNormalizesByNormal(t *testing.T) {
+	// z = 0, normal already unit length, so the distance is just the z coordinate.
+	plane := NewPlaneWithCenter(NewBasicPointCloud(0), [4]float64{0, 0, 1, 0}, r3.Vector{})
+	for _, tc := range []struct {
+		pt       r3.Vector
+		expected float64
+	}{
+		{r3.Vector{0, 0, 5}, 5},
+		// Invariant: the distance depends only on the offset from the plane, never on how far
+		// along the plane the point sits.
+		{r3.Vector{100, 0, 5}, 5},
+		{r3.Vector{1000, 1000, 5}, 5},
+		{r3.Vector{0, 0, -7}, -7}, // signed
+		{r3.Vector{1000, 1000, 500}, 500},
+		{r3.Vector{0, 0, 0}, 0}, // origin: numerator and |pt| are both zero
+	} {
+		dist, err := plane.Distance(tc.pt)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, dist, test.ShouldAlmostEqual, tc.expected, 1e-9)
+	}
+
+	// Un-normalized plane equation: 2x+2y-2z = 0 is the same plane as x+y-z = 0.
+	unnormalized := NewPlaneWithCenter(NewBasicPointCloud(0), [4]float64{2, 2, -2, 0}, r3.Vector{})
+	normalized := NewPlaneWithCenter(NewBasicPointCloud(0), [4]float64{1, 1, -1, 0}, r3.Vector{})
+	probe := r3.Vector{3, -4, 11}
+	dUn, err := unnormalized.Distance(probe)
+	test.That(t, err, test.ShouldBeNil)
+	dN, err := normalized.Distance(probe)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, dUn, test.ShouldAlmostEqual, dN, 1e-9)
 }
 
 func TestIntersect(t *testing.T) {

--- a/pointcloud/voxel.go
+++ b/pointcloud/voxel.go
@@ -101,14 +101,19 @@ func (p *voxelPlane) Equation() [4]float64 {
 	return equation
 }
 
-// DistToPlane computes the distance between a point a plane with given normal vector and offset.
-func (p *voxelPlane) Distance(pt r3.Vector) float64 {
-	num := math.Abs(pt.Dot(p.normal) + p.offset)
-	d := 0.
-	if denom := p.normal.Norm(); denom > 0.0001 {
-		d = num / denom
+// Distance computes the distance between a point and a plane with given normal vector and offset.
+//
+// TODO(RSDK): this returns the absolute distance while pointcloudPlane.Distance returns a signed one,
+// so the two implementations of Plane disagree. SplitPointCloudByPlane branches on the sign and would
+// put every point on one side when handed a voxel plane.
+func (p *voxelPlane) Distance(pt r3.Vector) (float64, error) {
+	denom := p.normal.Norm()
+	// A voxel starts life with a zero normal and only gets a real one once enough points land in it,
+	// so an undersized or degenerate voxel reaches here routinely.
+	if denom <= 0.0001 {
+		return 0, ErrDegeneratePlane
 	}
-	return d
+	return math.Abs(pt.Dot(p.normal)+p.offset) / denom, nil
 }
 
 // Voxel is the structure to store data relevant to Voxel operations in point clouds.
@@ -322,8 +327,12 @@ func (vg *VoxelGrid) VoxelHistogram(w, h int, name string) (image.Image, error) 
 				vox.Center = GetVoxelCenter(vox.Positions())
 				vox.Normal = estimatePlaneNormalFromPoints(vox.Positions())
 				vox.Offset = GetOffset(vox.Center, vox.Normal)
-				vox.Residual = GetResidual(vox.Positions(), vox.GetPlane())
-				variable = GetWeight(vox.Positions(), vg.lam, vox.Residual)
+				// On a degenerate plane `variable` keeps the sentinel this loop already uses for
+				// voxels with no usable plane, rather than a weight derived from nothing.
+				if residual, err := GetResidual(vox.Positions(), vox.GetPlane()); err == nil {
+					vox.Residual = residual
+					variable = GetWeight(vox.Positions(), vg.lam, vox.Residual)
+				}
 			}
 			hist.Fill(variable, 1)
 		}
@@ -338,8 +347,10 @@ func (vg *VoxelGrid) VoxelHistogram(w, h int, name string) (image.Image, error) 
 				vox.Center = GetVoxelCenter(vox.Positions())
 				vox.Normal = estimatePlaneNormalFromPoints(vox.Positions())
 				vox.Offset = GetOffset(vox.Center, vox.Normal)
-				vox.Residual = GetResidual(vox.Positions(), vox.GetPlane())
-				variable = vox.Residual
+				if residual, err := GetResidual(vox.Positions(), vox.GetPlane()); err == nil {
+					vox.Residual = residual
+					variable = vox.Residual
+				}
 			}
 			hist.Fill(variable, 1)
 		}
@@ -507,7 +518,14 @@ func NewVoxelGridFromPointCloud(pc PointCloud, voxelSize, lam float64) *VoxelGri
 		if len(vox.Points) > 5 {
 			vox.Normal = estimatePlaneNormalFromPoints(vox.Positions())
 			vox.Offset = GetOffset(vox.Center, vox.Normal)
-			vox.Residual = GetResidual(vox.Positions(), vox.GetPlane())
+			residual, err := GetResidual(vox.Positions(), vox.GetPlane())
+			if err != nil {
+				// PCA can fail to find a normal even above the point threshold, e.g. for collinear
+				// points. An infinite residual is the honest answer and drives GetWeight's
+				// exp(-residual^2) term to zero, so the voxel carries no weight.
+				residual = math.Inf(1)
+			}
+			vox.Residual = residual
 			vox.Weight = GetWeight(vox.Positions(), lam, vox.Residual)
 		}
 	}

--- a/pointcloud/voxel_helpers.go
+++ b/pointcloud/voxel_helpers.go
@@ -62,15 +62,20 @@ func GetOffset(center, normal r3.Vector) float64 {
 	return -normal.Dot(center)
 }
 
-// GetResidual computes the mean fitting error of points to a given plane.
-func GetResidual(points []r3.Vector, plane Plane) float64 {
+// GetResidual computes the mean fitting error of points to a given plane. It returns
+// ErrDegeneratePlane if the plane has no normal direction, since there is no fitting error to report
+// against a plane that does not exist.
+func GetResidual(points []r3.Vector, plane Plane) (float64, error) {
 	dist := 0.
 	for _, pt := range points {
-		d := plane.Distance(pt)
+		d, err := plane.Distance(pt)
+		if err != nil {
+			return 0, err
+		}
 		dist += d * d
 	}
 	dist /= float64(len(points))
-	return math.Sqrt(dist)
+	return math.Sqrt(dist), nil
 }
 
 // GetVoxelCoordinates computes voxel coordinates in VoxelGrid Axes.

--- a/pointcloud/voxel_segmentation.go
+++ b/pointcloud/voxel_segmentation.go
@@ -149,12 +149,20 @@ func (vg *VoxelGrid) LabelNonPlanarVoxels(unlabeledVoxels []VoxelCoords, dTh flo
 		nbVoxels := vg.GetAdjacentVoxels(vox)
 		plane := vox.GetPlane()
 		for i, pt := range vox.Positions() {
+			// A voxel with no estimated normal has no plane to measure against, so none of its points
+			// can be assigned to a neighbouring label.
+			d, err := plane.Distance(pt)
+			if err != nil {
+				continue
+			}
 			dMin := 100000.0
 			outLabel := 0
 			for _, nb := range nbVoxels {
 				voxNb := vg.Voxels[nb]
 				if voxNb.Label > 0 {
-					d := plane.Distance(pt)
+					// TODO(RSDK): d is the distance to this voxel's own plane and does not vary with nb,
+					// so after the first labelled neighbour this comparison can never succeed and
+					// outLabel is always the first one found. It likely wants voxNb.GetPlane().
 					if d < dMin {
 						dMin = d
 						outLabel = voxNb.Label

--- a/pointcloud/voxel_test.go
+++ b/pointcloud/voxel_test.go
@@ -1,6 +1,7 @@
 package pointcloud
 
 import (
+	"errors"
 	"math/rand"
 	"testing"
 
@@ -101,8 +102,20 @@ func TestGetVoxelCenterWeightResidual(t *testing.T) {
 		points:    nil,
 		voxelKeys: nil,
 	}
-	res := GetResidual(points, plane)
-	test.ShouldAlmostEqual(res, 0.0)
+	res, err := GetResidual(points, plane)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, res, test.ShouldAlmostEqual, 0.0, 1e-9)
+}
+
+// A voxel plane with no estimated normal reports its degeneracy rather than a zero distance, which
+// would otherwise read as "every point lies exactly on the plane".
+func TestVoxelPlaneDegenerate(t *testing.T) {
+	plane := &voxelPlane{normal: r3.Vector{}, center: r3.Vector{}, offset: 0}
+	_, err := plane.Distance(r3.Vector{1, 2, 3})
+	test.That(t, errors.Is(err, ErrDegeneratePlane), test.ShouldBeTrue)
+
+	_, err = GetResidual([]r3.Vector{{X: 1}, {X: 2}}, plane)
+	test.That(t, errors.Is(err, ErrDegeneratePlane), test.ShouldBeTrue)
 }
 
 func TestGetVoxelCoordinates(t *testing.T) {

--- a/vision/segmentation/plane_segmentation.go
+++ b/vision/segmentation/plane_segmentation.go
@@ -407,7 +407,11 @@ func SplitPointCloudByPlane(cloud pc.PointCloud, plane pc.Plane) (pc.PointCloud,
 	aboveCloud, belowCloud := pc.NewBasicEmpty(), pc.NewBasicEmpty()
 	var err error
 	cloud.Iterate(0, 0, func(pt r3.Vector, d pc.Data) bool {
-		dist := plane.Distance(pt)
+		var dist float64
+		dist, err = plane.Distance(pt)
+		if err != nil {
+			return false
+		}
 		if plane.Equation()[2] > 0.0 {
 			dist = -dist
 		}
@@ -429,7 +433,11 @@ func ThresholdPointCloudByPlane(cloud pc.PointCloud, plane pc.Plane, threshold f
 	thresholdCloud := pc.NewBasicEmpty()
 	var err error
 	cloud.Iterate(0, 0, func(pt r3.Vector, d pc.Data) bool {
-		dist := plane.Distance(pt)
+		var dist float64
+		dist, err = plane.Distance(pt)
+		if err != nil {
+			return false
+		}
 		if math.Abs(dist) <= threshold {
 			err = thresholdCloud.Set(pt, d)
 		}


### PR DESCRIPTION
## Summary

**Alternative to #6325 — pick one, not both.**

Same underlying bug: `pointcloudPlane.Distance` divided `ax+by+cz+d` by the length of the **query point** instead of the length of the plane's **normal**, so a point 5mm from `z=0` reported `5.0` at the origin, `0.05` at `x=100` and `0.0035` at `(1000,1000)`.

The difference is how the degenerate case is expressed. #6325 returns `+Inf` as a sentinel; this PR changes the signature to `Distance(p r3.Vector) (float64, error)` and makes every caller handle it.

## Why this might be preferable to #6325

A degenerate plane is not exotic. There are three routes to one:

1. `NewEmptyPlane` — what `SegmentPlane` and `SegmentPlaneWRTGround` return when the cloud has ≤ 3 points.
2. `estimatePlaneNormalFromPoints` returns `r3.Vector{}` when gonum's PCA fails (`voxel_helpers.go:26-28`).
3. `NewVoxel` / `NewVoxelFromPoint` initialise `Normal: r3.Vector{}` — every voxel is degenerate until a normal is estimated.

Before this change, all three read as **distance 0**, i.e. "this point lies exactly on the plane". `GetResidual` reported a *perfect fit* for a plane that does not exist, which is the worst possible direction for a routine that ranks candidate planes by residual. A sentinel float fixes the ranking but still lets a caller ignore the case; an error makes it unrepresentable.

## Changes

- **`Plane.Distance` → `(float64, error)`**, returning the new exported `ErrDegeneratePlane` when the normal has no direction. The interface method also now documents that the distance is *signed*.
- **`pointcloudPlane.Distance`**: divides by `|normal|`; errors on a zero normal.
- **`voxelPlane.Distance`**: already divided by the normal's length, so it was correct all along. It gains the error return in place of silently returning `0`, keeping its existing `1e-4` degeneracy threshold.

Every call site handles it:

| call site | handling |
| --- | --- |
| `GetResidual` | propagates — there is no fitting error to report against a plane that does not exist |
| `NewVoxelGridFromPointCloud` | records an infinite residual, which drives `GetWeight`'s `exp(-residual²)` term to zero, so the voxel carries no weight |
| `VoxelHistogram` (both branches) | leaves the `-9.0` / `-999.0` no-usable-plane sentinel the loop already uses |
| `LabelNonPlanarVoxels` | skips points whose voxel has no plane |
| `SplitPointCloudByPlane` | already returned an error; now surfaces it |
| `ThresholdPointCloudByPlane` | same |

`GetResidual`'s signature also becomes `(float64, error)`. That is the main cost of this approach — see below.

## Trade-offs versus #6325

**In favour of this PR**

- Degeneracy is in the type, so a new caller cannot forget it.
- No magic value to reason about, and no risk of `Inf` propagating into arithmetic (`Inf - Inf = NaN`).
- Callers that genuinely cannot proceed now say so instead of quietly returning an empty or full cloud.

**Against**

- **Wider blast radius**: 7 files versus 2, and it changes two exported signatures (`Plane.Distance`, `GetResidual`) — a **breaking change** for anyone outside this repo implementing `Plane` or calling either.
- **Two call sites cannot propagate**, so the explicitness stops there and becomes a local policy decision anyway: `NewVoxelGridFromPointCloud` returns `*VoxelGrid` with no error, and `LabelNonPlanarVoxels` returns nothing. Changing those signatures would cascade into `radius_clustering_voxel.go` and beyond, which felt out of proportion.
- **`SplitPointCloudByPlane` / `ThresholdPointCloudByPlane` now fail** where they previously returned an empty result for an empty plane. That is arguably correct, but it is a behaviour change on two exported functions, and callers currently passing a `NewEmptyPlane` will start seeing errors.
- More verbose at each call site for a condition that is rare in the `pointcloudPlane` case.

#6325 is the smaller, non-breaking option; this one is the structurally sounder one. I don't think one is obviously right — it depends on how much you care about the exported-API break.

## Testing

`go test ./...` across the whole repo passes. `golangci-lint` clean on `./pointcloud/...` and `./vision/...`.

- `TestPlaneDistanceNormalizesByNormal` — distance is invariant to position along the plane, is signed, handles the origin, and matches for `2x+2y-2z=0` and `x+y-z=0`. Verified to fail against the unpatched divisor (`Expected '1' to almost equal '5'`).
- `TestEmptyPlane` — now asserts `errors.Is(err, ErrDegeneratePlane)`.
- `TestVoxelPlaneDegenerate` — a voxel plane with no estimated normal reports degeneracy through both `Distance` and `GetResidual`.

## Two pre-existing bugs recorded, not fixed

Both in `LabelNonPlanarVoxels`, which I had to touch. I added TODOs rather than changing behaviour:

- `d := plane.Distance(pt)` sat inside the neighbour loop but does not vary with `nb`, so after the first labelled neighbour the `d < dMin` comparison can never succeed and `outLabel` is always the first one found. It likely wants `voxNb.GetPlane()`.
- The comparison uses the signed distance with `dMin` seeded at `100000`, so a point far on the negative side wins. It likely wants `math.Abs`.

Happy to split those into their own PR.

## Tickets

None

## Claude Code Prompts Used

- "Can you explain the trade-off for https://github.com/viamrobotics/rdk/pull/6325 of this section: ..."
- "Can you create an alternative PR to https://github.com/viamrobotics/rdk/pull/6325 where we change the signature to `Distance() (float64, error)` and handle the edge case explicitly everywhere?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
