### PR TITLE
pointcloud: measure to the neighbour's plane in LabelNonPlanarVoxels

### DIFF
--- a/pointcloud/voxel.go
+++ b/pointcloud/voxel.go
@@ -101,11 +101,15 @@ func (p *voxelPlane) Equation() [4]float64 {
 	return equation
 }
 
+// minPlaneNormalNorm is the shortest normal a voxel plane can have and still define an orientation.
+// A voxel starts out with a zero normal and only gets a real one once enough points land in it.
+const minPlaneNormalNorm = 0.0001
+
 // DistToPlane computes the distance between a point a plane with given normal vector and offset.
 func (p *voxelPlane) Distance(pt r3.Vector) float64 {
 	num := math.Abs(pt.Dot(p.normal) + p.offset)
 	d := 0.
-	if denom := p.normal.Norm(); denom > 0.0001 {
+	if denom := p.normal.Norm(); denom > minPlaneNormalNorm {
 		d = num / denom
 	}
 	return d

--- a/pointcloud/voxel_segmentation.go
+++ b/pointcloud/voxel_segmentation.go
@@ -2,6 +2,7 @@ package pointcloud
 
 import (
 	"container/list"
+	"math"
 	"sort"
 
 	"github.com/golang/geo/r3"
@@ -146,19 +147,31 @@ func (vg *VoxelGrid) LabelNonPlanarVoxels(unlabeledVoxels []VoxelCoords, dTh flo
 	for _, k := range unlabeledVoxels {
 		vox := vg.Voxels[k]
 		vox.PointLabels = make([]int, len(vox.Points))
-		nbVoxels := vg.GetAdjacentVoxels(vox)
-		plane := vox.GetPlane()
+		// Collect the labelled neighbours' planes once per voxel: GetPlane allocates, and the loop
+		// below visits every neighbour for every point. Neighbours whose normal is too short to define
+		// an orientation are dropped, because Distance reports 0 for them and they would win every
+		// comparison.
+		type neighborPlane struct {
+			label int
+			plane Plane
+		}
+		var nbPlanes []neighborPlane
+		for _, nb := range vg.GetAdjacentVoxels(vox) {
+			voxNb := vg.Voxels[nb]
+			if voxNb.Label > 0 && voxNb.Normal.Norm() > minPlaneNormalNorm {
+				nbPlanes = append(nbPlanes, neighborPlane{label: voxNb.Label, plane: voxNb.GetPlane()})
+			}
+		}
 		for i, pt := range vox.Positions() {
-			dMin := 100000.0
+			dMin := math.Inf(1)
 			outLabel := 0
-			for _, nb := range nbVoxels {
-				voxNb := vg.Voxels[nb]
-				if voxNb.Label > 0 {
-					d := plane.Distance(pt)
-					if d < dMin {
-						dMin = d
-						outLabel = voxNb.Label
-					}
+			for _, nb := range nbPlanes {
+				// The distance is to the neighbour's plane. Measuring against this voxel's own plane
+				// gives a value that does not vary with the neighbour, so the nearest one is never
+				// found -- and this voxel is unlabelled precisely because its own plane is not usable.
+				if d := nb.plane.Distance(pt); d < dMin {
+					dMin = d
+					outLabel = nb.label
 				}
 			}
 			if dMin < dTh {

--- a/pointcloud/voxel_segmentation_test.go
+++ b/pointcloud/voxel_segmentation_test.go
@@ -90,3 +90,66 @@ func TestVoxelPlaneSegmentationCube(t *testing.T) {
 	// Labeling should find 6 planes
 	test.That(t, vg.maxLabel, test.ShouldEqual, 6)
 }
+
+// A point in an unlabelled voxel must take the label of the nearest labelled neighbour's plane.
+// Measuring against the unlabelled voxel's own plane instead yields a distance that does not vary
+// with the neighbour, so the nearest is never found and the label is whichever neighbour the map
+// happened to yield first.
+func TestLabelNonPlanarVoxelsUsesNeighborPlanes(t *testing.T) {
+	pt := r3.Vector{X: 0, Y: 0, Z: 0}
+	planeAt := func(offset float64) (r3.Vector, float64) {
+		// normal +Z with the given offset puts the plane |offset| away from a point on the XY origin
+		return r3.Vector{X: 0, Y: 0, Z: 1}, offset
+	}
+
+	vg := &VoxelGrid{Voxels: map[VoxelCoords]*Voxel{}, voxelSize: 1, lam: 0.1}
+
+	// The unlabelled voxel holds the point. Its own plane is deliberately far away, so relying on it
+	// leaves the point below no threshold at all.
+	target := NewVoxel(VoxelCoords{0, 0, 0})
+	target.Points[pt] = NewBasicData()
+	target.Normal, target.Offset = planeAt(-50)
+	vg.Voxels[target.Key] = target
+
+	// Two labelled neighbours: label 1 is nearer (1mm), label 2 is further (10mm).
+	near := NewVoxel(VoxelCoords{1, 0, 0})
+	near.Label = 1
+	near.Normal, near.Offset = planeAt(-1)
+	vg.Voxels[near.Key] = near
+
+	far := NewVoxel(VoxelCoords{-1, 0, 0})
+	far.Label = 2
+	far.Normal, far.Offset = planeAt(-10)
+	vg.Voxels[far.Key] = far
+
+	vg.LabelNonPlanarVoxels([]VoxelCoords{target.Key}, 5.0)
+
+	test.That(t, len(target.PointLabels), test.ShouldEqual, 1)
+	test.That(t, target.PointLabels[0], test.ShouldEqual, 1)
+}
+
+// A labelled neighbour with no usable normal must not win the nearest-plane comparison just because
+// Distance reports 0 for it.
+func TestLabelNonPlanarVoxelsSkipsDegenerateNeighbors(t *testing.T) {
+	pt := r3.Vector{X: 0, Y: 0, Z: 0}
+	vg := &VoxelGrid{Voxels: map[VoxelCoords]*Voxel{}, voxelSize: 1, lam: 0.1}
+
+	target := NewVoxel(VoxelCoords{0, 0, 0})
+	target.Points[pt] = NewBasicData()
+	// Far own-plane, as in the test above, so this case is not decided by map iteration order.
+	target.Normal, target.Offset = r3.Vector{X: 0, Y: 0, Z: 1}, -50
+	vg.Voxels[target.Key] = target
+
+	degenerate := NewVoxel(VoxelCoords{1, 0, 0})
+	degenerate.Label = 7
+	degenerate.Normal = r3.Vector{} // never estimated
+	vg.Voxels[degenerate.Key] = degenerate
+
+	usable := NewVoxel(VoxelCoords{-1, 0, 0})
+	usable.Label = 3
+	usable.Normal, usable.Offset = r3.Vector{X: 0, Y: 0, Z: 1}, -2
+	vg.Voxels[usable.Key] = usable
+
+	vg.LabelNonPlanarVoxels([]VoxelCoords{target.Key}, 5.0)
+	test.That(t, target.PointLabels[0], test.ShouldEqual, 3)
+}


### PR DESCRIPTION
## Summary

`LabelNonPlanarVoxels` measured the distance to the **unlabelled voxel's own plane** instead of to each labelled neighbour's plane, so the "nearest surrounding plane" search never actually compared anything. Points took whichever label the neighbour map happened to yield first.

Found while auditing `pointcloud/`; recorded as TODOs in the now-closed #6328 and split out here as promised.

## The bug

```go
plane := vox.GetPlane()                  // the unlabelled voxel's own plane, hoisted above the loop
for i, pt := range vox.Positions() {
    dMin := 100000.0
    outLabel := 0
    for _, nb := range nbVoxels {
        voxNb := vg.Voxels[nb]
        if voxNb.Label > 0 {
            d := plane.Distance(pt)      // does not vary with nb
            if d < dMin {
                dMin = d
                outLabel = voxNb.Label
            }
        }
    }
```

`d` is invariant in the `nb` loop, so:

- the first labelled neighbour sets `dMin = d`;
- every later neighbour evaluates `d < d`, which is false;
- `outLabel` is therefore the **first** labelled neighbour found, and `vg.Voxels` is a map, so which one that is varies between runs.

It is also the wrong plane on its own terms. This function only runs on voxels left unlabelled by `LabelVoxels` — i.e. voxels whose own plane was not good enough to label — and the doc comment says the intent is "the minimum distance of a point to one of the **surrounding** plane".

## Changes

- **Measure to each labelled neighbour's plane** (`voxNb.GetPlane()`), which is what makes the minimum meaningful.
- **Skip neighbours whose normal is too short to define an orientation.** `voxelPlane.Distance` returns `0` in that case, so a degenerate neighbour would win every comparison and hand out its label unconditionally. This is newly reachable: before this change the neighbours' planes were never consulted at all. Note a labelled voxel *can* be degenerate — `LabelVoxels` gates on `Weight > wTh`, and a PCA failure yields residual `0`, hence a non-zero weight.
- **Gather the neighbours' planes once per voxel** instead of once per point. `GetPlane` allocates a `[]VoxelCoords` sized to the voxel's point count, and the inner loop runs for every point.
- `dMin` starts at `math.Inf(1)` rather than the magic `100000.0`, and the `0.0001` degeneracy threshold is now the named `minPlaneNormalNorm`, shared between `voxelPlane.Distance` and the new check.

No public signature changes.

## Testing

`go test ./...` across the whole repo passes. `golangci-lint` clean.

Two tests added, both constructing a grid with one unlabelled voxel and two labelled neighbours:

- **`TestLabelNonPlanarVoxelsUsesNeighborPlanes`** — neighbours at 1mm and 10mm, threshold 5mm; the point must take the *nearer* neighbour's label. Fails deterministically against the unpatched source (`Expected: '1' Actual: '0'`).
- **`TestLabelNonPlanarVoxelsSkipsDegenerateNeighbors`** — a labelled neighbour with no estimated normal must not beat a usable one 2mm away. I confirmed the guard is load-bearing by removing only that condition from the fixed code: the test then fails 5 runs out of 5.

Both give the unlabelled voxel a deliberately far own-plane so neither outcome depends on map iteration order.

## One thing I got wrong earlier

When I first reported this I also claimed the comparison used a signed distance where it wanted a magnitude. That is **not** true here: `vox.GetPlane()` returns a `*voxelPlane`, and `voxelPlane.Distance` already returns `math.Abs(...)`. Only `pointcloudPlane.Distance` is signed. Nothing to fix on that count, and no change in this PR relates to it.

The two implementations of `Plane.Distance` do still disagree on sign, which matters for `SplitPointCloudByPlane` — that is a separate issue, untouched here.

## Tickets

None

## Claude Code Prompts Used

- "Can you explain the trade-off for https://github.com/viamrobotics/rdk/pull/6325 of this section: ..."
- "Let's abandon #6328. Close it. Deal with the LabelNonPlanarVoxels bugs in a separate PR"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
