### PR TITLE
apt e2e: fix version check failing under pipefail

### DIFF
--- a/etc/apt-e2e.sh
+++ b/etc/apt-e2e.sh
@@ -5,6 +5,12 @@
 # catches up after an upload.
 set -euo pipefail
 
+# Artifact Registry republishes the signed index (InRelease/Packages)
+# asynchronously after an upload, so a freshly released version can be briefly
+# absent from the repo even though the upload itself succeeded. Wait it out.
+ATTEMPTS=20
+SLEEP_SECONDS=30
+
 apt-get update -qq
 apt-get install -yqq curl gpg ca-certificates >/dev/null
 
@@ -12,22 +18,44 @@ curl -fsSL https://us-apt.pkg.dev/doc/repo-signing-key.gpg | gpg --dearmor -o /u
 echo "deb [signed-by=/usr/share/keyrings/viam.gpg] https://us-apt.pkg.dev/projects/static-file-server-310021 viam main" \
 	> /etc/apt/sources.list.d/viam.list
 
-for attempt in $(seq 1 10); do
-	apt-get update -qq
-	if [ -z "${EXPECTED_VERSION:-}" ] || apt-cache policy viam-cli | grep -qF "$EXPECTED_VERSION"; then
-		break
-	fi
-	if [ "$attempt" = 10 ]; then
-		echo "version $EXPECTED_VERSION never appeared in the repo" >&2
-		exit 1
-	fi
-	sleep 30
-done
+apt-get update -qq
+
+if [ -n "${EXPECTED_VERSION:-}" ]; then
+	for attempt in $(seq 1 "$ATTEMPTS"); do
+		# Capture before matching. Piping into `grep -q` makes grep exit on the
+		# first match, killing apt-cache with SIGPIPE (141); `set -o pipefail`
+		# then reports the pipeline as failed even though the match succeeded.
+		policy=$(apt-cache policy viam-cli)
+
+		# Match on Candidate rather than mere presence in the version table:
+		# Candidate is the version `apt-get install viam-cli` will actually pick,
+		# and it keeps 1.2.0 from matching an unrelated 21.2.01.
+		case $policy in
+		*"Candidate: $EXPECTED_VERSION"*) break ;;
+		esac
+
+		if [ "$attempt" = "$ATTEMPTS" ]; then
+			echo "version $EXPECTED_VERSION never appeared in the repo; apt-cache policy reported:" >&2
+			echo "$policy" >&2
+			exit 1
+		fi
+
+		sleep "$SLEEP_SECONDS"
+		apt-get update -qq
+	done
+fi
 
 apt-get install -yqq viam-cli >/dev/null
 viam version
 if [ -n "${EXPECTED_VERSION:-}" ]; then
-	viam version | grep -qF "$EXPECTED_VERSION"
+	installed=$(viam version)
+	case $installed in
+	*"$EXPECTED_VERSION"*) ;;
+	*)
+		echo "installed viam reports '$installed', expected $EXPECTED_VERSION" >&2
+		exit 1
+		;;
+	esac
 fi
 
 # `viam update` must go through apt and leave dpkg-owned files untouched


### PR DESCRIPTION
## Failure

`cli / viam-cli-apt-e2e` failed the v1.2.0 release on both attempts:

```
version 1.2.0 never appeared in the repo
```

False failure. `viam-cli 1.2.0` published correctly and is installable. `InRelease` is stamped `Date: Tue, 04 Aug 2026 18:04:00 UTC`, ~8s after `make deb-cli-upload` finished, and lists 1.2.0. Not an indexing lag.

## Cause

`etc/apt-e2e.sh` runs under `set -euo pipefail`. The wait loop was:

```bash
apt-cache policy viam-cli | grep -qF "$EXPECTED_VERSION"
```

`grep -q` exits on first match, closing the pipe while `apt-cache` still has a pending write. `apt-cache` dies with SIGPIPE (141), and `pipefail` returns the rightmost non-zero status. A successful match is reported as a failure, so the loop never breaks.

```
$ docker run --rm debian:bookworm bash -c \
    'set -euo pipefail; apt-cache policy bash | grep -qF bash && echo MATCH || echo "NO MATCH rc=$?"'
NO MATCH rc=141

$ ... 'set +e; apt-cache policy bash | grep -qF bash; echo "PIPESTATUS=${PIPESTATUS[*]}"'
PIPESTATUS=141 0        # apt-cache SIGPIPE'd, grep matched (0)

$ ... 'apt-cache policy bash | grep -F bash >/dev/null; echo "PIPESTATUS=${PIPESTATUS[*]}"'
PIPESTATUS=0 0          # without -q, grep drains stdin, no SIGPIPE
```

It's a race, so it passed intermittently before. It now loses consistently. v1.2.0 is the first stable release this job has gated.

## Fix

- Capture output, match with `case`. Nothing piped, no SIGPIPE to misreport.
- Same fix for `viam version | grep -qF` (line 30) — identical latent bug, only unreachable because the script died first.
- Match `Candidate: $EXPECTED_VERSION` instead of a bare substring. `Candidate` is what `apt-get install viam-cli` selects.
- Retries 10 -> 20 (~5 -> ~10 min). Insurance only; GAR republished in ~8s here. Drop this hunk if you'd rather not touch it.

## Tests

All run against the live repo. `shellcheck etc/apt-e2e.sh` clean.

**Old script, current repo — fails despite 1.2.0 being present:**

```
$ docker run --rm -v "$PWD/etc/apt-e2e.sh:/apt-e2e.sh:ro" \
    -e EXPECTED_VERSION=1.2.0 debian:bookworm bash /apt-e2e.sh
version 1.2.0 never appeared in the repo
$ echo $?
1
```

Same container, at the moment the check reported "never appeared":

```
$ apt-cache policy viam-cli
viam-cli:
  Installed: (none)
  Candidate: 1.2.0
  Version table:
     1.2.0 500
        500 https://us-apt.pkg.dev/projects/static-file-server-310021 viam/main amd64 Packages
     1.1.0 500
     1.0.0 500
```

**New script — passes on both images the job uses, first attempt, no retries:**

```
$ for img in debian:bookworm ubuntu:24.04; do
    docker run --rm -v "$PWD/etc/apt-e2e.sh:/apt-e2e.sh:ro" \
      -e EXPECTED_VERSION=1.2.0 "$img" bash /apt-e2e.sh
  done

# debian:bookworm
Version 1.2.0 Git=c94e3ee7 API=v0.1.574
 ✓  Already up to date (version 1.2.0) (0s)
apt e2e OK: Version 1.2.0 Git=c94e3ee7 API=v0.1.574

# ubuntu:24.04
Version 1.2.0 Git=c94e3ee7 API=v0.1.574
 ✓  Already up to date (version 1.2.0) (0s)
apt e2e OK: Version 1.2.0 Git=c94e3ee7 API=v0.1.574
```

`Git=c94e3ee7` matches the v1.2.0 tag. Covers the full path: install, version assert, `viam update`, `dpkg -V`.

**Negative cases (run with `ATTEMPTS=2 SLEEP_SECONDS=1`) — still fails when it should:**

```
$ EXPECTED_VERSION=9.9.9    # nonexistent version
version 9.9.9 never appeared in the repo; apt-cache policy reported:
  Candidate: 1.2.0
exit=1

$ EXPECTED_VERSION=2.0      # loose substring of 1.2.0
version 2.0 never appeared in the repo; apt-cache policy reported:
exit=1
```

The `2.0` case passed under the old `grep -qF` — the `Candidate:` anchor closes that false positive.

## Effect on v1.2.0

None, and the v1.2.0 run cannot be salvaged by a re-run. The job checks out the tag, not `main`:

```
git checkout --progress --force refs/tags/v1.2.0
HEAD is now at c94e3ee
```

A re-run therefore pulls `etc/apt-e2e.sh` from the v1.2.0 tag, which still has the bug, and fails identically regardless of what is on `main`. The red X on that run is permanent short of re-cutting the tag, which is not worth doing for a cosmetic check on a release that shipped correctly.

v1.2.0 is fully published — apt, GCS binaries, and Homebrew (formula + bottles as of `d6dcabba`). No action needed on any artifact.

This fix takes effect on the next stable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)