### PR TITLE
RSDK-14370: Fix windows paths for local module reload + other CLI

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -4111,9 +4111,9 @@ This won't work unless you have an existing installation of our GitHub app on yo
 							Usage: "hide progress of the file transfer",
 						},
 						&cli.StringFlag{
-							Name:  moduleFlagHomeDir,
-							Usage: "remote user's home directory. only necessary if you're targeting a remote machine where $HOME is not /root",
-							Value: "~",
+							Name:        moduleFlagHomeDir,
+							Usage:       "remote machine home directory under which <home>/.viam is used as the module destination",
+							DefaultText: "the machine is asked for its VIAM_HOME",
 						},
 						&cli.StringFlag{
 							Name:      moduleBuildFlagCloudConfig,

--- a/cli/client.go
+++ b/cli/client.go
@@ -113,22 +113,18 @@ type machineViamHomeArgs struct {
 }
 
 // machineViamHome resolves the target machine's VIAM_HOME directory: the --home
-// override if set, otherwise the machine's own answer over the shell service,
-// otherwise the legacy default for machines too old to answer.
-func (c *viamClient) machineViamHome(
-	ctx context.Context, cmd *cli.Command, partFqdn string, debug bool, logger logging.Logger,
-) string {
+// override if set, otherwise the machine's own answer over shellSvc, otherwise
+// the legacy default for machines too old to answer. Pass a nil shellSvc when
+// the machine could not be dialed.
+func (c *viamClient) machineViamHome(ctx context.Context, cmd *cli.Command, shellSvc shell.Service) string {
 	if args := parseStructFromCtx[machineViamHomeArgs](cmd); args.Home != "" {
 		// Intentional use of path instead of filepath: Windows understands both / and
 		// \ as path separators, and we don't want a cli running on Windows to send
 		// a path using \ to a *NIX machine.
 		return path.Join(args.Home, ".viam")
 	}
-	shellSvc, closeClient, err := c.connectToShellServiceFqdn(ctx, partFqdn, debug, logger)
-	if err == nil {
-		defer func() {
-			utils.UncheckedError(closeClient(ctx))
-		}()
+	err := errors.New("machine could not be reached")
+	if shellSvc != nil {
 		var resp map[string]interface{}
 		if resp, err = shellSvc.DoCommand(ctx, map[string]interface{}{shell.GetViamHomeCommand: true}); err == nil {
 			if home, ok := resp[shell.ViamHomeKey].(string); ok && home != "" {
@@ -137,7 +133,11 @@ func (c *viamClient) machineViamHome(
 			err = fmt.Errorf("unexpected response %v", resp)
 		}
 	}
-	debugf(cmd.Root().Writer, debug, "machine did not report its VIAM_HOME (%v); assuming %s", err, legacyViamHomeDir)
+	// A wrong guess here puts the archive and reload_path outside the machine's real
+	// VIAM_HOME, so surface the fallback instead of hiding it behind --debug.
+	warningf(cmd.Root().ErrWriter,
+		"machine did not report its VIAM_HOME (%v); assuming %s. Pass --home if that is wrong for this machine",
+		err, legacyViamHomeDir)
 	return legacyViamHomeDir
 }
 

--- a/cli/client.go
+++ b/cli/client.go
@@ -108,6 +108,39 @@ func legacyViamHomePath(src string) (string, bool) {
 	return path.Join(legacyViamHomeDir, rest), true
 }
 
+type machineViamHomeArgs struct {
+	Home string
+}
+
+// machineViamHome resolves the target machine's VIAM_HOME directory: the --home
+// override if set, otherwise the machine's own answer over the shell service,
+// otherwise the legacy default for machines too old to answer.
+func (c *viamClient) machineViamHome(
+	ctx context.Context, cmd *cli.Command, partFqdn string, debug bool, logger logging.Logger,
+) string {
+	if args := parseStructFromCtx[machineViamHomeArgs](cmd); args.Home != "" {
+		// Intentional use of path instead of filepath: Windows understands both / and
+		// \ as path separators, and we don't want a cli running on Windows to send
+		// a path using \ to a *NIX machine.
+		return path.Join(args.Home, ".viam")
+	}
+	shellSvc, closeClient, err := c.connectToShellServiceFqdn(ctx, partFqdn, debug, logger)
+	if err == nil {
+		defer func() {
+			utils.UncheckedError(closeClient(ctx))
+		}()
+		var resp map[string]interface{}
+		if resp, err = shellSvc.DoCommand(ctx, map[string]interface{}{shell.GetViamHomeCommand: true}); err == nil {
+			if home, ok := resp[shell.ViamHomeKey].(string); ok && home != "" {
+				return home
+			}
+			err = fmt.Errorf("unexpected response %v", resp)
+		}
+	}
+	debugf(cmd.Root().Writer, debug, "machine did not report its VIAM_HOME (%v); assuming %s", err, legacyViamHomeDir)
+	return legacyViamHomeDir
+}
+
 // viamClient wraps a cli.Context and provides all the CLI command functionality
 // needed to talk to the app and data services but not directly to robot parts.
 type viamClient struct {

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1590,24 +1590,27 @@ func TestMachineViamHome(t *testing.T) {
 	t.Run("machine reports its VIAM_HOME", func(t *testing.T) {
 		// the "machine" is in-process, so its shell service reports this process's ViamDotDir
 		cCtx, vc, _, _ := setupWithRunningPart(t, asc, nil, nil, nil, "token", partFqdn)
-		test.That(t, vc.machineViamHome(context.Background(), cCtx, partFqdn, false, logger),
+		shellSvc, closeClient, err := vc.connectToShellServiceFqdn(context.Background(), partFqdn, false, logger)
+		test.That(t, err, test.ShouldBeNil)
+		defer func() {
+			test.That(t, closeClient(context.Background()), test.ShouldBeNil)
+		}()
+		test.That(t, vc.machineViamHome(context.Background(), cCtx, shellSvc),
 			test.ShouldEqual, utils.ViamDotDir)
 	})
 
 	t.Run("--home override skips asking the machine", func(t *testing.T) {
 		cCtx, vc, _, _ := setup(asc, nil, nil, map[string]any{moduleFlagHomeDir: "/home/pi"}, "token")
-		// no dialOverride is set, so reaching for the machine would fail loudly
-		test.That(t, vc.machineViamHome(context.Background(), cCtx, partFqdn, false, logger),
+		// a nil shellSvc proves the override resolves without consulting the machine
+		test.That(t, vc.machineViamHome(context.Background(), cCtx, nil),
 			test.ShouldEqual, "/home/pi/.viam")
 	})
 
-	t.Run("unreachable machine falls back to the legacy home", func(t *testing.T) {
-		cCtx, vc, _, _ := setupWithRunningPart(t, asc, nil, nil, nil, "token", partFqdn)
-		vc.dialOverride = func(context.Context, string, []rpc.DialOption, logging.Logger) (*client.RobotClient, error) {
-			return nil, errors.New("machine offline")
-		}
-		test.That(t, vc.machineViamHome(context.Background(), cCtx, partFqdn, false, logger),
+	t.Run("unreachable machine falls back to the legacy home with a warning", func(t *testing.T) {
+		cCtx, vc, _, errOut := setup(asc, nil, nil, nil, "token")
+		test.That(t, vc.machineViamHome(context.Background(), cCtx, nil),
 			test.ShouldEqual, legacyViamHomeDir)
+		test.That(t, strings.Join(errOut.messages, ""), test.ShouldContainSubstring, "did not report its VIAM_HOME")
 	})
 }
 

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1582,6 +1582,35 @@ func TestLegacyViamHomePath(t *testing.T) {
 	test.That(t, ok, test.ShouldBeFalse)
 }
 
+func TestMachineViamHome(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	partFqdn := uuid.NewString()
+	asc := &inject.AppServiceClient{}
+
+	t.Run("machine reports its VIAM_HOME", func(t *testing.T) {
+		// the "machine" is in-process, so its shell service reports this process's ViamDotDir
+		cCtx, vc, _, _ := setupWithRunningPart(t, asc, nil, nil, nil, "token", partFqdn)
+		test.That(t, vc.machineViamHome(context.Background(), cCtx, partFqdn, false, logger),
+			test.ShouldEqual, utils.ViamDotDir)
+	})
+
+	t.Run("--home override skips asking the machine", func(t *testing.T) {
+		cCtx, vc, _, _ := setup(asc, nil, nil, map[string]any{moduleFlagHomeDir: "/home/pi"}, "token")
+		// no dialOverride is set, so reaching for the machine would fail loudly
+		test.That(t, vc.machineViamHome(context.Background(), cCtx, partFqdn, false, logger),
+			test.ShouldEqual, "/home/pi/.viam")
+	})
+
+	t.Run("unreachable machine falls back to the legacy home", func(t *testing.T) {
+		cCtx, vc, _, _ := setupWithRunningPart(t, asc, nil, nil, nil, "token", partFqdn)
+		vc.dialOverride = func(context.Context, string, []rpc.DialOption, logging.Logger) (*client.RobotClient, error) {
+			return nil, errors.New("machine offline")
+		}
+		test.That(t, vc.machineViamHome(context.Background(), cCtx, partFqdn, false, logger),
+			test.ShouldEqual, legacyViamHomeDir)
+	})
+}
+
 func TestCreateOAuthAppAction(t *testing.T) {
 	createOAuthAppFunc := func(ctx context.Context, in *apppb.CreateOAuthAppRequest,
 		opts ...grpc.CallOption,

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -1632,6 +1632,10 @@ func reloadModuleActionInner(
 		buildPath = manifest.Build.Path
 	}
 
+	// destination for the module archive on the machine; empty for cloud builds
+	// and local reloads, which don't shell-copy an archive over.
+	var dest string
+
 	// For cloud builds, the machine downloads the package directly from the cloud.
 	// Skip the shell copy and go straight to configure.
 	if cloudBuild {
@@ -1675,7 +1679,8 @@ func reloadModuleActionInner(
 		if err != nil {
 			return err
 		}
-		dest := reloadingDestination(cmd, manifest)
+		dest = reloadingDestination(manifest,
+			vc.machineViamHome(ctx, cmd, part.Part.Fqdn, globalArgs.Debug, logger))
 
 		if err := pm.Start("upload"); err != nil {
 			return err
@@ -1720,7 +1725,7 @@ func reloadModuleActionInner(
 	}
 	var newPart *apppb.RobotPart
 	newPart, needsRestart, err = configureModule(
-		ctx, cmd, vc, manifest, part.Part, args.Local, cloudBuild, reloadUser(vc.conf), args.Annotation, reloadTime.Unix())
+		ctx, cmd, vc, manifest, part.Part, args.Local, cloudBuild, reloadUser(vc.conf), args.Annotation, reloadTime.Unix(), dest)
 	// if the module has been configured, the cached response we have may no longer accurately reflect
 	// the update, so we set the updated `part.Part`
 	if newPart != nil {
@@ -1783,15 +1788,12 @@ func reloadModuleActionInner(
 	return nil
 }
 
-type reloadingDestinationArgs struct {
-	Home string
-}
-
-// this chooses a destination path for the module archive.
-func reloadingDestination(cmd *cli.Command, manifest *ModuleManifest) string {
-	args := parseStructFromCtx[reloadingDestinationArgs](cmd)
-	return filepath.Join(args.Home,
-		".viam", config.PackagesDirName+config.LocalPackagesSuffix,
+// this chooses a destination path for the module archive under the machine's
+// VIAM_HOME (see machineViamHome). Uses path (not filepath) so a Windows CLI
+// never sends backslashes to the machine.
+func reloadingDestination(manifest *ModuleManifest, viamHome string) string {
+	return path.Join(viamHome,
+		config.PackagesDirName+config.LocalPackagesSuffix,
 		utils.SanitizePath(localizeModuleID(manifest.ModuleID)+"-"+manifest.Build.Path))
 }
 

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -29,6 +29,7 @@ import (
 	buildpb "go.viam.com/api/app/build/v1"
 	v1 "go.viam.com/api/app/packages/v1"
 	apppb "go.viam.com/api/app/v1"
+	goutils "go.viam.com/utils"
 	"go.viam.com/utils/rpc"
 	"golang.org/x/exp/maps"
 
@@ -1679,13 +1680,39 @@ func reloadModuleActionInner(
 		if err != nil {
 			return err
 		}
-		dest = reloadingDestination(manifest,
-			vc.machineViamHome(ctx, cmd, part.Part.Fqdn, globalArgs.Debug, logger))
+		// Dial once; the VIAM_HOME query and the first copy attempt share the
+		// connection. Copy retries dial fresh, since a retry usually follows a
+		// connection-level failure.
+		shellSvc, closeShellSvc, dialErr := vc.connectToShellServiceFqdn(ctx, part.Part.Fqdn, globalArgs.Debug, logger)
+		if dialErr != nil {
+			shellSvc = nil
+		}
+		shellSvcConsumed := dialErr != nil
+		defer func() {
+			if !shellSvcConsumed {
+				goutils.UncheckedError(closeShellSvc(ctx))
+			}
+		}()
+		dest = reloadingDestination(manifest, vc.machineViamHome(ctx, cmd, shellSvc))
 
 		if err := pm.Start("upload"); err != nil {
 			return err
 		}
 		copyFunc := func() error {
+			if !shellSvcConsumed {
+				// copyFilesToMachineInner closes the connection it is handed.
+				shellSvcConsumed = true
+				return vc.copyFilesToMachineInner(
+					ctx,
+					shellSvc,
+					closeShellSvc,
+					false, // allowRecursion
+					false, // preserve
+					[]string{buildPath},
+					dest,
+					true, // noProgress
+				)
+			}
 			return vc.copyFilesToFqdn(
 				ctx,
 				part.Part.Fqdn,

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -895,3 +895,15 @@ func TestCreateGitArchive(t *testing.T) {
 		test.That(t, files, test.ShouldResemble, []string{".gitignore", "main.go"})
 	})
 }
+
+func TestReloadingDestination(t *testing.T) {
+	manifest := &ModuleManifest{
+		ModuleID: "viam-labs:test-module",
+		Build:    &manifestBuildInfo{Path: "module.tar.gz"},
+	}
+	// forward slashes regardless of the CLI's platform: the path is for the machine
+	test.That(t, reloadingDestination(manifest, "/opt/viam"),
+		test.ShouldEqual, "/opt/viam/packages-local/viam-labs_test-module-module.tar.gz")
+	test.That(t, reloadingDestination(manifest, legacyViamHomeDir),
+		test.ShouldEqual, "~/.viam/packages-local/viam-labs_test-module-module.tar.gz")
+}

--- a/cli/module_reload.go
+++ b/cli/module_reload.go
@@ -29,7 +29,7 @@ const (
 // Uses optimistic concurrency control with last_known_update to avoid overwriting concurrent changes.
 func configureModule(
 	ctx context.Context, cmd *cli.Command, vc *viamClient, manifest *ModuleManifest, part *apppb.RobotPart,
-	local, cloudReload bool, reloadUser, annotation string, reloadUnixTS int64,
+	local, cloudReload bool, reloadUser, annotation string, reloadUnixTS int64, remoteDest string,
 ) (*apppb.RobotPart, bool, error) {
 	if manifest == nil {
 		return part, false, fmt.Errorf("reconfiguration requires valid manifest json passed to --%s", moduleFlagPath)
@@ -48,7 +48,7 @@ func configureModule(
 			return err
 		}
 		cfgJSON, needsRestart, err = mutateModuleConfig(
-			cmd, cfgJSON, *manifest, local, cloudReload, reloadUser, annotation, reloadUnixTS)
+			cmd, cfgJSON, *manifest, local, cloudReload, reloadUser, annotation, reloadUnixTS, remoteDest)
 		if err != nil {
 			return err
 		}
@@ -84,6 +84,7 @@ func mutateModuleConfig(
 	reloadUser string,
 	annotation string,
 	reloadUnixTS int64,
+	remoteDest string,
 ) (string, bool, error) {
 	var needsRestart bool
 
@@ -98,15 +99,20 @@ func mutateModuleConfig(
 
 	var absEntrypoint string
 	var err error
-	if local {
+	switch {
+	case local:
 		// This flag means that viam server is running on the same machine running the CLI
 		// Does not indicate module type (registry vs local)
 		absEntrypoint, err = filepath.Abs(manifest.Entrypoint)
 		if err != nil {
 			return "", false, err
 		}
-	} else {
-		absEntrypoint = reloadingDestination(cmd, &manifest)
+	case remoteDest != "":
+		absEntrypoint = remoteDest
+	default:
+		// cloud reload: never written to the config (reload_path is deleted below),
+		// only compared against a stale reload_path, so don't consult the machine.
+		absEntrypoint = reloadingDestination(&manifest, legacyViamHomeDir)
 	}
 
 	args, err := getGlobalArgs(cmd)

--- a/cli/module_reload_test.go
+++ b/cli/module_reload_test.go
@@ -416,7 +416,7 @@ func TestMutateModuleConfig(t *testing.T) {
 	expectedVersion := "latest-with-prerelease"
 	expectedEntrypoint, err := filepath.Abs(manifest.Entrypoint)
 	test.That(t, err, test.ShouldBeNil)
-	remoteReloadPath := filepath.Join(".viam", "packages-local", "viam-labs_test-module-module.tar.gz")
+	remoteReloadPath := "/opt/viam/packages-local/viam-labs_test-module-module.tar.gz"
 	testUser := "test@viam.com"
 	testReloadUnixTS := time.Date(2024, 3, 18, 12, 0, 0, 0, time.UTC).Unix()
 
@@ -445,7 +445,7 @@ func TestMutateModuleConfig(t *testing.T) {
 			"reload_path":    manifest.Entrypoint,
 			"reload_enabled": true,
 		}})
-		cfg, needsRestart, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS)
+		cfg, needsRestart, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS, "")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, needsRestart, test.ShouldBeTrue)
 		test.That(t, mod(cfg, 0).Get("reload_user").String(), test.ShouldEqual, testUser)
@@ -460,7 +460,7 @@ func TestMutateModuleConfig(t *testing.T) {
 			"reload_path":    manifest.Entrypoint,
 			"reload_enabled": false,
 		}})
-		cfg, needsRestart, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS)
+		cfg, needsRestart, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS, "")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, needsRestart, test.ShouldBeFalse)
 		test.That(t, mod(cfg, 0).Get("reload_enabled").Bool(), test.ShouldBeTrue)
@@ -476,7 +476,7 @@ func TestMutateModuleConfig(t *testing.T) {
 			"reload_path":    "incorrect/path",
 			"reload_enabled": false,
 		}})
-		cfg, needsRestart, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS)
+		cfg, needsRestart, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS, "")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, needsRestart, test.ShouldBeFalse)
 		test.That(t, mod(cfg, 0).Get("reload_path").String(), test.ShouldEqual, expectedEntrypoint)
@@ -491,7 +491,7 @@ func TestMutateModuleConfig(t *testing.T) {
 			"type":      string(rdkConfig.ModuleTypeRegistry),
 			"module_id": manifest.ModuleID,
 		}})
-		cfg, needsRestart, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS)
+		cfg, needsRestart, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS, "")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, needsRestart, test.ShouldBeFalse)
 		test.That(t, mod(cfg, 0).Get("reload_path").String(), test.ShouldEqual, expectedEntrypoint)
@@ -502,7 +502,7 @@ func TestMutateModuleConfig(t *testing.T) {
 
 	t.Run("insert_when_missing", func(t *testing.T) {
 		cfg := cfgWithModules(t, []map[string]any{})
-		cfg, _, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS)
+		cfg, _, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS, "")
 		test.That(t, err, test.ShouldBeNil)
 		assertInsertedModule(t, cfg, 0, expectedEntrypoint)
 	})
@@ -513,7 +513,7 @@ func TestMutateModuleConfig(t *testing.T) {
 			"type":      string(rdkConfig.ModuleTypeLocal),
 			"module_id": manifest.ModuleID,
 		}})
-		cfg, _, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS)
+		cfg, _, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS, "")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, len(gjson.Get(cfg, "modules").Array()), test.ShouldEqual, 2)
 		assertInsertedModule(t, cfg, 1, expectedEntrypoint)
@@ -521,10 +521,28 @@ func TestMutateModuleConfig(t *testing.T) {
 
 	c = newTestContext(t, map[string]any{})
 	t.Run("remote_insert", func(t *testing.T) {
+		// remote reload: the destination was resolved against the machine's VIAM_HOME
+		// by the caller and must be stored verbatim.
 		cfg := cfgWithModules(t, []map[string]any{})
-		cfg, _, err := mutateModuleConfig(c, cfg, manifest, false, false, testUser, "", testReloadUnixTS)
+		cfg, _, err := mutateModuleConfig(c, cfg, manifest, false, false, testUser, "", testReloadUnixTS, remoteReloadPath)
 		test.That(t, err, test.ShouldBeNil)
 		assertInsertedModule(t, cfg, 0, remoteReloadPath)
+	})
+
+	t.Run("remote_no_dest_assumes_legacy_home", func(t *testing.T) {
+		// cloud reload passes no destination; the legacy ~/.viam path is used only to
+		// compare against a stale reload_path, never stored (reload_path is deleted).
+		cfg := cfgWithModules(t, []map[string]any{{
+			"type":           string(rdkConfig.ModuleTypeRegistry),
+			"module_id":      manifest.ModuleID,
+			"reload_path":    "~/.viam/packages-local/viam-labs_test-module-module.tar.gz",
+			"reload_enabled": true,
+		}})
+		cfg, needsRestart, err := mutateModuleConfig(c, cfg, manifest, false, false, testUser, "", testReloadUnixTS, "")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, needsRestart, test.ShouldBeTrue)
+		test.That(t, mod(cfg, 0).Get("reload_path").String(), test.ShouldEqual,
+			"~/.viam/packages-local/viam-labs_test-module-module.tar.gz")
 	})
 
 	t.Run("preserves_field_order", func(t *testing.T) {
@@ -533,7 +551,7 @@ func TestMutateModuleConfig(t *testing.T) {
 		cfg := `{"network":{"fqdn":"x"},"components":[{"name":"c1"}],` +
 			`"modules":[{"type":"registry","module_id":"viam-labs:test-module",` +
 			`"name":"viam-labs_test-module","version":"1.2.3","reload_path":"/bin/mod","reload_enabled":true}]}`
-		got, _, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS)
+		got, _, err := mutateModuleConfig(c, cfg, manifest, true, false, testUser, "", testReloadUnixTS, "")
 		test.That(t, err, test.ShouldBeNil)
 		// Top-level key order is unchanged.
 		var topKeys []string
@@ -840,7 +858,7 @@ func TestConfigureModuleNeedsRestart(t *testing.T) {
 		}})
 		cmd, vc, _, _ := setup(mockClient(t, part), nil, &inject.BuildServiceClient{},
 			map[string]any{moduleFlagLocal: true}, "token")
-		_, needsRestart, err := configureModule(context.Background(), cmd, vc, manifest, part, true, false, testUser, "", testReloadUnixTS)
+		_, needsRestart, err := configureModule(context.Background(), cmd, vc, manifest, part, true, false, testUser, "", testReloadUnixTS, "")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, needsRestart, test.ShouldBeTrue)
 	})
@@ -849,7 +867,7 @@ func TestConfigureModuleNeedsRestart(t *testing.T) {
 		part := makePart(t, []any{})
 		cmd, vc, _, _ := setup(mockClient(t, part), nil, &inject.BuildServiceClient{},
 			map[string]any{moduleFlagLocal: true}, "token")
-		_, needsRestart, err := configureModule(context.Background(), cmd, vc, manifest, part, true, false, testUser, "", testReloadUnixTS)
+		_, needsRestart, err := configureModule(context.Background(), cmd, vc, manifest, part, true, false, testUser, "", testReloadUnixTS, "")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, needsRestart, test.ShouldBeFalse)
 	})
@@ -865,7 +883,7 @@ func TestConfigureModuleNeedsRestart(t *testing.T) {
 		}})
 		cmd, vc, _, _ := setup(mockClient(t, part), nil, &inject.BuildServiceClient{},
 			map[string]any{moduleFlagLocal: true}, "token")
-		_, needsRestart, err := configureModule(context.Background(), cmd, vc, manifest, part, true, false, testUser, "", testReloadUnixTS)
+		_, needsRestart, err := configureModule(context.Background(), cmd, vc, manifest, part, true, false, testUser, "", testReloadUnixTS, "")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, needsRestart, test.ShouldBeFalse)
 	})
@@ -881,7 +899,7 @@ func TestConfigureModuleNeedsRestart(t *testing.T) {
 		}})
 		cmd, vc, _, _ := setup(mockClient(t, part), nil, &inject.BuildServiceClient{},
 			map[string]any{moduleFlagLocal: true}, "token")
-		_, needsRestart, err := configureModule(context.Background(), cmd, vc, manifest, part, true, false, testUser, "", testReloadUnixTS)
+		_, needsRestart, err := configureModule(context.Background(), cmd, vc, manifest, part, true, false, testUser, "", testReloadUnixTS, "")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, needsRestart, test.ShouldBeFalse)
 	})
@@ -911,7 +929,7 @@ func TestConfigureModuleNeedsRestart(t *testing.T) {
 		}
 		cmd, vc, _, _ := setup(client, nil, &inject.BuildServiceClient{},
 			map[string]any{moduleFlagLocal: true}, "token")
-		_, needsRestart, err := configureModule(context.Background(), cmd, vc, manifest, part, true, false, testUser, "", testReloadUnixTS)
+		_, needsRestart, err := configureModule(context.Background(), cmd, vc, manifest, part, true, false, testUser, "", testReloadUnixTS, "")
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, needsRestart, test.ShouldBeTrue)
 		test.That(t, updateCount, test.ShouldEqual, 1)
@@ -966,14 +984,14 @@ func TestRepeatedReloadNeedsRestart(t *testing.T) {
 	// First reload: module is new, so needsRestart should be false.
 	part, err := vc.getRobotPart(context.Background(), "part-123")
 	test.That(t, err, test.ShouldBeNil)
-	_, needsRestart, err := configureModule(context.Background(), cmd, vc, manifest, part.Part, true, false, testUser, "", testReloadUnixTS)
+	_, needsRestart, err := configureModule(context.Background(), cmd, vc, manifest, part.Part, true, false, testUser, "", testReloadUnixTS, "")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, needsRestart, test.ShouldBeFalse)
 
 	// Second reload: module is already configured with correct path and enabled.
 	part, err = vc.getRobotPart(context.Background(), "part-123")
 	test.That(t, err, test.ShouldBeNil)
-	_, needsRestart, err = configureModule(context.Background(), cmd, vc, manifest, part.Part, true, false, testUser, "", testReloadUnixTS)
+	_, needsRestart, err = configureModule(context.Background(), cmd, vc, manifest, part.Part, true, false, testUser, "", testReloadUnixTS, "")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, needsRestart, test.ShouldBeTrue)
 }

--- a/cli/module_reload_test.go
+++ b/cli/module_reload_test.go
@@ -984,14 +984,16 @@ func TestRepeatedReloadNeedsRestart(t *testing.T) {
 	// First reload: module is new, so needsRestart should be false.
 	part, err := vc.getRobotPart(context.Background(), "part-123")
 	test.That(t, err, test.ShouldBeNil)
-	_, needsRestart, err := configureModule(context.Background(), cmd, vc, manifest, part.Part, true, false, testUser, "", testReloadUnixTS, "")
+	_, needsRestart, err := configureModule(context.Background(),
+		cmd, vc, manifest, part.Part, true, false, testUser, "", testReloadUnixTS, "")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, needsRestart, test.ShouldBeFalse)
 
 	// Second reload: module is already configured with correct path and enabled.
 	part, err = vc.getRobotPart(context.Background(), "part-123")
 	test.That(t, err, test.ShouldBeNil)
-	_, needsRestart, err = configureModule(context.Background(), cmd, vc, manifest, part.Part, true, false, testUser, "", testReloadUnixTS, "")
+	_, needsRestart, err = configureModule(context.Background(),
+		cmd, vc, manifest, part.Part, true, false, testUser, "", testReloadUnixTS, "")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, needsRestart, test.ShouldBeTrue)
 }

--- a/services/shell/builtin/builtin.go
+++ b/services/shell/builtin/builtin.go
@@ -17,6 +17,7 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/shell"
+	rutils "go.viam.com/rdk/utils"
 )
 
 func init() {
@@ -43,6 +44,15 @@ type builtIn struct {
 	resource.TriviallyReconfigurable
 	logger                  logging.Logger
 	activeBackgroundWorkers sync.WaitGroup
+}
+
+// DoCommand answers environment queries a client cannot resolve on its own,
+// e.g. the CLI asking where this machine's VIAM_HOME is before placing files.
+func (svc *builtIn) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	if _, ok := cmd[shell.GetViamHomeCommand]; ok {
+		return map[string]interface{}{shell.ViamHomeKey: rutils.ViamDotDir}, nil
+	}
+	return nil, resource.ErrDoUnimplemented
 }
 
 func (svc *builtIn) Shell(ctx context.Context, extra map[string]interface{}) (

--- a/services/shell/builtin/builtin_test.go
+++ b/services/shell/builtin/builtin_test.go
@@ -1,0 +1,25 @@
+package builtin
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/services/shell"
+	rutils "go.viam.com/rdk/utils"
+)
+
+func TestDoCommand(t *testing.T) {
+	svc, err := NewBuiltIn(shell.Named("shell1"), logging.NewTestLogger(t))
+	test.That(t, err, test.ShouldBeNil)
+
+	resp, err := svc.DoCommand(context.Background(), map[string]interface{}{shell.GetViamHomeCommand: true})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, resp[shell.ViamHomeKey], test.ShouldEqual, rutils.ViamDotDir)
+
+	_, err = svc.DoCommand(context.Background(), map[string]interface{}{"something_else": true})
+	test.That(t, err, test.ShouldBeError, resource.ErrDoUnimplemented)
+}

--- a/services/shell/shell.go
+++ b/services/shell/shell.go
@@ -23,6 +23,14 @@ func init() {
 	}, newDoCommandCollector)
 }
 
+const (
+	// GetViamHomeCommand is the DoCommand key clients send to ask for the machine's
+	// VIAM_HOME directory, which only the machine itself can resolve (see ViamHomePrefix).
+	GetViamHomeCommand = "get_viam_home"
+	// ViamHomeKey is the DoCommand response key holding the machine's VIAM_HOME directory.
+	ViamHomeKey = "viam_home"
+)
+
 // A Service handles shells for a local robot.
 type Service interface {
 	resource.Resource


### PR DESCRIPTION
This branch fixes `viam module reload-local` for Windows. The CLI has been broken because it was assuming that `$VIAM_HOME` is `~/.viam`, but now it's `\opt\viam`.

While making this fix I was operating under the principle that `viam-server` should be the source of truth for `$VIAM_HOME` and that we shouldn't try to guess it on the cli side or do weird path magic on the server side (like automatically expanding `~` to `$VIAM_HOME`).

Also, the CLI also mutates the module config directly while enabling local reload, and it needs to pass an absolute path (containing `$VIAM_HOME`), so I needed some way for the CLI to find out what `$VIAM_HOME` was.

Given these constraints, the solution I came up with was to add a `DoCommand` to get `$VIAM_HOME` from the server. The CLI uses that `DoCommand` to construct the correct absolute path for the module config when local module reload is active.

Tested manually and working on Windows. Still want to test on mac/linux before merging.