### PR TITLE
RSDK-14386 camera: flaky test fix TestGrandRemoteRebooting port re-bind

### DIFF
--- a/components/camera/client_test.go
+++ b/components/camera/client_test.go
@@ -1079,8 +1079,12 @@ func TestGrandRemoteRebooting(t *testing.T) {
 		},
 	}
 
-	// Create a robot with a single fake camera.
-	options2, _, addr2 := robottestutils.CreateBaseOptionsAndListener(t)
+	// Create a robot with a single fake camera. Hold remote-2's port so it stays bound when
+	// remote-2 is closed below and the second instance can reuse the exact same socket, with
+	// no window for another process to claim the port in between.
+	options2, lis2, addr2 := robottestutils.CreateBaseOptionsAndListener(t)
+	hold2 := testutils.HoldPort(t, lis2)
+	options2.Network.Listener = hold2
 	remote2Ctx, remoteRobot2, remoteWebSvc2 := setupRealRobotWithOptions(t, remoteCfg2, logger.Sublogger("remote-2"), options2)
 
 	remoteCfg1 := &config.Config{
@@ -1197,14 +1201,12 @@ Loop:
 	// remote-1 which can be detectd
 	// by the fact that sub.Terminated.Done() is always the path this test goes down
 
-	logger.Infow("old robot address", "address", addr2)
-	tcpAddr, ok := options2.Network.Listener.Addr().(*net.TCPAddr)
-	test.That(t, ok, test.ShouldBeTrue)
-	newListener, err := net.ListenTCP("tcp", &net.TCPAddr{Port: tcpAddr.Port})
-	test.That(t, err, test.ShouldBeNil)
-	options2.Network.Listener = newListener
+	// Re-arm the held listener so the second instance of remote-2 comes up on the very same
+	// socket the first instance used. The port was never released, so there was no chance for
+	// it to be claimed in the meantime.
+	hold2.Rearm(t)
 
-	logger.Infof("setting up new robot at address %s", newListener.Addr().String())
+	logger.Infof("setting up new robot at address %s", addr2)
 
 	remote2CtxSecond, remoteRobot2Second, remoteWebSvc2Second := setupRealRobotWithOptions(
 		t,


### PR DESCRIPTION
## Problem

`TestGrandRemoteRebooting` intermittently fails at `components/camera/client_test.go:1204`:

```
Expected: nil
Actual:   'listen tcp :37311: bind: address already in use'
```

The test simulates a grand-remote reboot: it closes `remote-2`'s robot/web service and then brings a second instance up on the same address. To do that it read the port off the (now closed) listener and re-bound it with `net.ListenTCP("tcp", &net.TCPAddr{Port: tcpAddr.Port})`.

The port comes from `robottestutils.CreateBaseOptionsAndListener`, i.e. an OS-assigned ephemeral port. Between closing the first listener and re-binding, the port is free, so anything else on the machine (another concurrently running test binary reserving a random listener, or an outbound connection grabbing the same ephemeral port) can claim it. When that happens, the re-bind fails with `EADDRINUSE` and the test fails.

## Fix

Use the existing `testutils.HoldPort` helper, which keeps the socket bound across a server restart: its `Close` arms a past deadline (unblocking `Accept` so the server shuts down cleanly) instead of closing the socket, and `Rearm` clears the deadline before the next server serves on it. The port is therefore never released mid-test and there is no window for another process to claim it. `HoldPort` also registers cleanup that truly closes the socket at test end (previously the re-bound listener was leaked).

This matches how other tests in this repo already restart a server on the same address (`robot/impl/robot_reconfigure_remote_test.go`, `robot/impl/local_robot_test.go`, `robot/client/client_test.go`).

## Testing

- `go test ./components/camera/ -run TestGrandRemoteRebooting -count=5` — pass
- `go test ./components/camera/ -race -run TestGrandRemoteRebooting -count=3` — pass
- `go test ./components/camera/ -run 'TestMultiplexOverRemoteConnection|TestMultiplexOverMultiHopRemoteConnection|TestWhyMustTimeoutOnReadRTP|TestGrandRemoteRebooting|TestRTPPassthroughWithoutWebRTC'` — pass

(Other tests in the package/sub-packages could not run in this sandbox because artifact downloads from `storage.googleapis.com` are blocked; those failures are environmental and unrelated.)

Key: RSDK-14386

Co-authored by Claude agent for Jira.