### PR TITLE
Scope first_run logger under module name

### DIFF
--- a/config/module.go
+++ b/config/module.go
@@ -271,7 +271,7 @@ func (m *Module) FirstRun(
 	env map[string]string,
 	logger logging.Logger,
 ) error {
-	logger = logger.Sublogger("first_run").WithFields("module", m.Name)
+	logger = logger.Sublogger(m.Name).Sublogger("first_run").WithFields("module", m.Name)
 
 	unpackedModDir, err := m.ExeDir(localPackagesDir)
 	if err != nil {


### PR DESCRIPTION
FirstRun logs under rdk.modmanager.first_run which matches no module source in app so the log is orphaned on the machine page. This makes it hard to debug silently failing install scripts

Change the logger to rdk.modmanager.<module_name>.first_run by nesting under a per-module sublogger. App's existing matcher will link the log automatically so no other changes needed