### PR TITLE
RSDK-14386 components/camera: flaky test fix TestGrandRemoteRebooting "address already in use"

### DIFF
--- a/components/camera/client_test.go
+++ b/components/camera/client_test.go
@@ -1079,8 +1079,14 @@ func TestGrandRemoteRebooting(t *testing.T) {
 		},
 	}
 
-	// Create a robot with a single fake camera.
-	options2, _, addr2 := robottestutils.CreateBaseOptionsAndListener(t)
+	// Create a robot with a single fake camera. remote-2 is shut down and brought back up on
+	// the same address later in this test. Hold its port so that it stays bound while remote-2
+	// is down: the port is an OS assigned ephemeral one, so otherwise anything else on the
+	// machine (another test binary reserving a random listener, an outgoing connection) can
+	// claim it in the meantime and binding it again fails with "address already in use".
+	options2, lis2, addr2 := robottestutils.CreateBaseOptionsAndListener(t)
+	hold2 := testutils.HoldPort(t, lis2)
+	options2.Network.Listener = hold2
 	remote2Ctx, remoteRobot2, remoteWebSvc2 := setupRealRobotWithOptions(t, remoteCfg2, logger.Sublogger("remote-2"), options2)
 
 	remoteCfg1 := &config.Config{
@@ -1197,14 +1203,12 @@ Loop:
 	// remote-1 which can be detectd
 	// by the fact that sub.Terminated.Done() is always the path this test goes down
 
-	logger.Infow("old robot address", "address", addr2)
-	tcpAddr, ok := options2.Network.Listener.Addr().(*net.TCPAddr)
-	test.That(t, ok, test.ShouldBeTrue)
-	newListener, err := net.ListenTCP("tcp", &net.TCPAddr{Port: tcpAddr.Port})
-	test.That(t, err, test.ShouldBeNil)
-	options2.Network.Listener = newListener
+	// Re-arm the held listener so the second instance of remote-2 serves on the very same
+	// socket the first instance used. The port was never released, so there was no window for
+	// something else to claim it.
+	hold2.Rearm(t)
 
-	logger.Infof("setting up new robot at address %s", newListener.Addr().String())
+	logger.Infof("setting up new robot at address %s", addr2)
 
 	remote2CtxSecond, remoteRobot2Second, remoteWebSvc2Second := setupRealRobotWithOptions(
 		t,


### PR DESCRIPTION
## Problem

`TestGrandRemoteRebooting` intermittently fails at `components/camera/client_test.go:1204`:

```
Expected: nil
Actual:   'listen tcp :37311: bind: address already in use'
```

The test simulates a grand-remote reboot: it closes `remote-2`'s robot and web service, waits for RTP packets to drain, and then brings a second instance of `remote-2` up on the same address. To do that it read the port off the (now closed) listener and re-bound it:

```go
newListener, err := net.ListenTCP("tcp", &net.TCPAddr{Port: tcpAddr.Port})
```

The port comes from `robottestutils.CreateBaseOptionsAndListener`, i.e. an OS assigned ephemeral port. Closing remote-2 releases it, and it stays free for the ~0.5-1s the packet-drain loop runs, so anything else on the machine can claim it before the re-bind: another concurrently running test binary reserving a random listener, or an outgoing connection (remote-1 retries its dead remote every second, and outbound connections take local ports from the same ephemeral range). When that happens the re-bind returns `EADDRINUSE` and the test fails.

## Fix

Use the existing `testutils.HoldPort` helper. Its `Close` arms a past deadline — which unblocks `Accept` so `http.Server.Shutdown` still stops the server cleanly — instead of closing the socket, so the port is never released mid-test and there is no window for anything else to claim it. `Rearm` clears the deadline before the second instance serves on the very same socket. `HoldPort` also registers cleanup that truly closes the socket at test end, so the previously leaked re-bound listener goes away too.

This is how other tests in the repo already restart a server on the same address (`robot/client/client_test.go`, `robot/impl/robot_reconfigure_remote_test.go`, `robot/impl/local_robot_test.go`, `robot/impl/optional_dependencies_test.go`).

## Testing

- `go test ./components/camera/ -run TestGrandRemoteRebooting -count=5` — pass
- `go test ./components/camera/ -race -run TestGrandRemoteRebooting -count=2` — pass
- `go test ./components/camera/ -run 'TestClient$|TestClientProperties|TestClientWithInterceptor|TestRTPPassthroughWithoutWebRTC|TestMultiplexOverRemoteConnection|TestMultiplexOverMultiHopRemoteConnection|TestWhyMustTimeoutOnReadRTP|TestGrandRemoteRebooting'` — pass
- `golangci-lint run --config=./etc/.golangci.yaml ./components/camera/...` — clean

The remaining tests in the package (e.g. `TestCameraWithNoProjector`) could not run in this sandbox because `go.viam.com/utils/artifact` downloads are blocked; that is environmental and unrelated.

## Note

#6334 is an earlier, equivalent fix for this same ticket that is still open and awaiting review — this investigation independently landed on the same `HoldPort` approach. Only one of the two needs to merge; feel free to close whichever is redundant.

Key: RSDK-14386

Co-authored by Claude agent for Jira.