### PR TITLE
RSDK-11354 Preserve non-0o600 cached config file perms when overwritten

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -263,7 +263,22 @@ func (c *Config) StoreToCache() error {
 	}
 	reader := bytes.NewReader(c.toCache)
 	path := getCloudCacheFilePath(c.Cloud.ID)
-	return artifact.AtomicStore(path, reader, c.Cloud.ID)
+
+	// New cache files are created with permissions 0o600, but overwriting preserves any
+	// existing permissions. A user may relax the cached config's permissions (e.g. to
+	// 0o666) to allow alternating viam-server runs between root and non-root users.
+	var existingInfo os.FileInfo
+	if info, err := os.Stat(path); err == nil {
+		existingInfo = info
+	}
+
+	if err := artifact.AtomicStore(path, reader, c.Cloud.ID); err != nil {
+		return err
+	}
+	if existingInfo != nil && existingInfo.Mode().Perm() != 0o600 {
+		return os.Chmod(path, existingInfo.Mode().Perm())
+	}
+	return nil
 }
 
 // UnmarshalJSON unmarshals JSON into the config and adjusts some

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -405,6 +406,43 @@ func TestReadFromCloudMarksUnprocessableConfigMalformed(t *testing.T) {
 	test.That(t, IsMalformedConfigError(err), test.ShouldBeTrue)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "config was malformed")
 	test.That(t, cfg, test.ShouldBeNil)
+}
+
+func TestStoreToCachePreservesPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission bits are not meaningful on Windows")
+	}
+	logger := logging.NewTestLogger(t)
+	ctx := context.Background()
+	cfg, err := FromReader(ctx, "", strings.NewReader(`{}`), logger, nil)
+	test.That(t, err, test.ShouldBeNil)
+
+	const cacheID = "forCachingPermsTest"
+	cfgToCache := &Config{Cloud: &Cloud{ID: cacheID}}
+	cfgToCache.SetToCache(cfg)
+	path := getCloudCacheFilePath(cacheID)
+	clearCache(cacheID)
+	defer clearCache(cacheID)
+
+	// fresh cache files are created with permissions 0o600
+	test.That(t, cfgToCache.StoreToCache(), test.ShouldBeNil)
+	info, err := os.Stat(path)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, info.Mode().Perm(), test.ShouldEqual, os.FileMode(0o600))
+
+	// overwriting a cache file whose permissions were relaxed preserves them
+	test.That(t, os.Chmod(path, 0o666), test.ShouldBeNil)
+	test.That(t, cfgToCache.StoreToCache(), test.ShouldBeNil)
+	info, err = os.Stat(path)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, info.Mode().Perm(), test.ShouldEqual, os.FileMode(0o666))
+
+	// overwriting a cache file with default permissions keeps 0o600
+	test.That(t, os.Chmod(path, 0o600), test.ShouldBeNil)
+	test.That(t, cfgToCache.StoreToCache(), test.ShouldBeNil)
+	info, err = os.Stat(path)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, info.Mode().Perm(), test.ShouldEqual, os.FileMode(0o600))
 }
 
 func TestStoreToCache(t *testing.T) {


### PR DESCRIPTION
RSDK-11354

## What

Changes `Config.StoreToCache` to preserve the permissions of an existing cached cloud config file when overwriting it. New cache files are still created with permissions 0o600, but if a cache file already exists with a mode other than 0o600, that mode is re-applied after the atomic overwrite.

## Why

The cached cloud config is rewritten on every successful config sync, and `artifact.AtomicStore` always resets it to 0o600 owned by the writing user. This breaks a debugging workflow that alternates `viam-server` runs between root and a non-root user: after a root run, the cache file is root-owned with `0o600`, and the subsequent non-root run fails with a permission error when reading the cached config.

With this change, a user can explicitly relax the cache file's permissions (e.g. `chmod 666`) once, and the relaxed mode survives subsequent overwrites — allowing root ↔ non-root restarts without further intervention. The secure-by-default behavior is untouched: fresh cache files remain `0o600`, and files left at `0o600` stay there.

## Testing

  - Adds `TestStoreToCachePreservesPermissions` in config/reader_test.go, covering all three behaviors: a fresh cache file is created with 0o600; an existing file relaxed to 0o666 keeps 0o666 after StoreToCache overwrites it; and a file at the default 0o600 remains 0o600
  - Manually tested that root/non-root alternation works on MacOS

[Description generated by Claude 🤖]