### PR TITLE
cli: add TokenFromCache for reusing `viam login` in client tools

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -492,27 +492,17 @@ func (c *viamClient) ensureLoggedInInner(ctx context.Context) error {
 		return errors.New("not logged in: run the following command to login:\n\tviam login")
 	}
 
-	authToken, ok := c.conf.Auth.(*token)
-	if ok && authToken.isExpired() {
-		if !authToken.canRefresh() {
+	// Refresh (and persist) an expired user login before dialing. Uses the same
+	// helper as (*Config).Token/ConnectToApp so there is a single refresh path;
+	// API-key logins return ErrAPIKeyLogin and need no refresh.
+	if _, err := c.conf.refreshTokenIfExpired(ctx, c.authFlow); err != nil && !errors.Is(err, ErrAPIKeyLogin) {
+		if errors.Is(err, errTokenExpired) {
 			utils.UncheckedError(c.logout())
 			return errors.New("token expired and cannot refresh, logging out. Please log in again")
 		}
-
-		// expired.
-		newToken, err := c.authFlow.refreshToken(ctx, authToken)
-		if err != nil {
-			debugFlag := globalArgs.Debug
-			debugf(c.c.Root().Writer, debugFlag, "Token refresh error: %v", err)
-			utils.UncheckedError(c.logout()) // clear cache if failed to refresh
-			return errors.New("error while refreshing token, logging out. Please log in again")
-		}
-
-		// write token to config.
-		c.conf.Auth = newToken
-		if err := storeConfigToCache(c.conf); err != nil {
-			return err
-		}
+		debugf(c.c.Root().Writer, globalArgs.Debug, "Token refresh error: %v", err)
+		utils.UncheckedError(c.logout()) // clear cache if failed to refresh
+		return errors.New("error while refreshing token, logging out. Please log in again")
 	}
 
 	rpcOpts, err := c.conf.DialOptions()

--- a/cli/config.go
+++ b/cli/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -202,6 +203,12 @@ func ConnectToMachine(ctx context.Context, hostname string, logger logging.Logge
 		return nil, err
 	}
 
+	// Renew an expired `viam login` before dialing so callers get the same
+	// auto-refresh behavior as ordinary CLI commands; API keys are left as-is.
+	if err := c.ensureFreshToken(ctx, newCLIAuthFlow(io.Discard, true)); err != nil {
+		return nil, err
+	}
+
 	dopts, err := c.DialOptions()
 	if err != nil {
 		return nil, err
@@ -219,6 +226,12 @@ func ConnectToMachine(ctx context.Context, hostname string, logger logging.Logge
 func ConnectToApp(ctx context.Context, logger logging.Logger) (*appClient.ViamClient, error) {
 	c, err := ConfigFromCache(nil)
 	if err != nil {
+		return nil, err
+	}
+
+	// Renew an expired `viam login` before dialing so callers get the same
+	// auto-refresh behavior as ordinary CLI commands; API keys are left as-is.
+	if err := c.ensureFreshToken(ctx, newCLIAuthFlow(io.Discard, true)); err != nil {
 		return nil, err
 	}
 

--- a/cli/token.go
+++ b/cli/token.go
@@ -12,6 +12,10 @@ import (
 // bearer access token; authenticate them with (*Config).DialOptions instead.
 var ErrAPIKeyLogin = errors.New("cached credentials are an API key, which has no bearer token; use Config.DialOptions instead")
 
+// errTokenExpired is returned by the refresh helpers when the cached token has
+// expired and holds no refresh token to renew it with.
+var errTokenExpired = errors.New("cached token has expired and cannot be refreshed; run `viam login`")
+
 // TokenFromCache loads the CLI's cached credentials (written by `viam login`)
 // and returns a bearer access token for authenticating with app.viam.com — for
 // example as an "authorization: Bearer <token>" gRPC/HTTP header.
@@ -39,29 +43,57 @@ func TokenFromCache(ctx context.Context) (string, error) {
 // token. TokenFromCache is the usual entry point; use this when you already
 // hold a Config from ConfigFromCache.
 func (conf *Config) Token(ctx context.Context) (string, error) {
-	authToken, ok := conf.Auth.(*token)
-	if !ok {
-		return "", ErrAPIKeyLogin
-	}
-
-	if !authToken.isExpired() {
-		return authToken.AccessToken, nil
-	}
-	if !authToken.canRefresh() {
-		return "", errors.New("cached token has expired and cannot be refreshed; run `viam login`")
-	}
-
 	// refreshToken only uses the flow's HTTP client together with the token's
 	// own token_url/client_id, so the (prod) auth-domain constants baked into
 	// newCLIAuthFlow are not consulted here.
-	newToken, err := newCLIAuthFlow(io.Discard, true).refreshToken(ctx, authToken)
+	newToken, err := conf.refreshTokenIfExpired(ctx, newCLIAuthFlow(io.Discard, true))
 	if err != nil {
+		if errors.Is(err, ErrAPIKeyLogin) || errors.Is(err, errTokenExpired) {
+			return "", err
+		}
 		return "", errors.Wrap(err, "refreshing expired token (run `viam login` to re-authenticate)")
+	}
+	return newToken.AccessToken, nil
+}
+
+// refreshTokenIfExpired returns the config's cached user token, refreshing it
+// against the given auth flow and persisting the result to the cache when it
+// has expired. It returns ErrAPIKeyLogin when the config holds an API key
+// rather than a user login, and errTokenExpired when the token has expired but
+// carries no refresh token. This is the single place the CLI renews a cached
+// login, shared by (*Config).Token and the connect/ensureLoggedIn paths.
+func (conf *Config) refreshTokenIfExpired(ctx context.Context, flow *authFlow) (*token, error) {
+	authToken, ok := conf.Auth.(*token)
+	if !ok {
+		return nil, ErrAPIKeyLogin
+	}
+
+	if !authToken.isExpired() {
+		return authToken, nil
+	}
+	if !authToken.canRefresh() {
+		return nil, errTokenExpired
+	}
+
+	newToken, err := flow.refreshToken(ctx, authToken)
+	if err != nil {
+		return nil, err
 	}
 
 	conf.Auth = newToken
 	if err := storeConfigToCache(conf); err != nil {
-		return "", errors.Wrap(err, "caching refreshed token")
+		return nil, errors.Wrap(err, "caching refreshed token")
 	}
-	return newToken.AccessToken, nil
+	return newToken, nil
+}
+
+// ensureFreshToken refreshes and persists an expired cached user token so that
+// DialOptions builds authentication material from a valid token. API-key
+// configs need no refresh and are left untouched.
+func (conf *Config) ensureFreshToken(ctx context.Context, flow *authFlow) error {
+	_, err := conf.refreshTokenIfExpired(ctx, flow)
+	if errors.Is(err, ErrAPIKeyLogin) {
+		return nil
+	}
+	return err
 }

--- a/cli/token.go
+++ b/cli/token.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"context"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// ErrAPIKeyLogin is returned by TokenFromCache and (*Config).Token when the
+// cached credentials are an API key rather than a user login. API keys have no
+// bearer access token; authenticate them with (*Config).DialOptions instead.
+var ErrAPIKeyLogin = errors.New("cached credentials are an API key, which has no bearer token; use Config.DialOptions instead")
+
+// TokenFromCache loads the CLI's cached credentials (written by `viam login`)
+// and returns a bearer access token for authenticating with app.viam.com — for
+// example as an "authorization: Bearer <token>" gRPC/HTTP header.
+//
+// If the cached token has expired it is refreshed against the stored token
+// endpoint and the refreshed credentials are written back to the cache, so
+// callers get the same auto-refresh behavior as ordinary CLI commands without
+// needing a *cli.Command. This lets tools reuse a developer's `viam login`
+// instead of asking for a token or an API key.
+//
+// Only user logins are supported; API-key logins return ErrAPIKeyLogin — use
+// ConfigFromCache together with (*Config).DialOptions (or ConnectToMachine)
+// for those.
+func TokenFromCache(ctx context.Context) (string, error) {
+	conf, err := ConfigFromCache(nil)
+	if err != nil {
+		return "", err
+	}
+	return conf.Token(ctx)
+}
+
+// Token returns a bearer access token for a user login, refreshing and
+// persisting the cached credentials if the current token has expired. It
+// returns ErrAPIKeyLogin if the config holds an API key instead of a user
+// token. TokenFromCache is the usual entry point; use this when you already
+// hold a Config from ConfigFromCache.
+func (conf *Config) Token(ctx context.Context) (string, error) {
+	authToken, ok := conf.Auth.(*token)
+	if !ok {
+		return "", ErrAPIKeyLogin
+	}
+
+	if !authToken.isExpired() {
+		return authToken.AccessToken, nil
+	}
+	if !authToken.canRefresh() {
+		return "", errors.New("cached token has expired and cannot be refreshed; run `viam login`")
+	}
+
+	// refreshToken only uses the flow's HTTP client together with the token's
+	// own token_url/client_id, so the (prod) auth-domain constants baked into
+	// newCLIAuthFlow are not consulted here.
+	newToken, err := newCLIAuthFlow(io.Discard, true).refreshToken(ctx, authToken)
+	if err != nil {
+		return "", errors.Wrap(err, "refreshing expired token (run `viam login` to re-authenticate)")
+	}
+
+	conf.Auth = newToken
+	if err := storeConfigToCache(conf); err != nil {
+		return "", errors.Wrap(err, "caching refreshed token")
+	}
+	return newToken.AccessToken, nil
+}

--- a/cli/token_test.go
+++ b/cli/token_test.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/utils"
+)
+
+// makeIDToken builds an unsigned JWT whose claims carry the given email/sub, so
+// refreshToken -> buildToken -> userDataFromIDToken can extract a user from it.
+func makeIDToken(t *testing.T, email, sub string) string {
+	t.Helper()
+	enc := func(v any) string {
+		b, err := json.Marshal(v)
+		test.That(t, err, test.ShouldBeNil)
+		return base64.RawURLEncoding.EncodeToString(b)
+	}
+	header := enc(map[string]string{"alg": "none", "typ": "JWT"})
+	payload := enc(map[string]string{"email": email, "sub": sub})
+	return header + "." + payload + "."
+}
+
+func TestConfigTokenNotExpired(t *testing.T) {
+	conf := &Config{Auth: &token{
+		AccessToken: "live-access-token",
+		TokenType:   tokenTypeUserOAuthToken,
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}}
+
+	got, err := conf.Token(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, got, test.ShouldEqual, "live-access-token")
+}
+
+func TestConfigTokenAPIKey(t *testing.T) {
+	conf := &Config{Auth: &apiKey{KeyID: "abc", KeyCrypto: "def"}}
+
+	_, err := conf.Token(context.Background())
+	test.That(t, err, test.ShouldBeError, ErrAPIKeyLogin)
+}
+
+func TestConfigTokenExpiredNoRefresh(t *testing.T) {
+	conf := &Config{Auth: &token{
+		AccessToken: "stale",
+		TokenType:   tokenTypeUserOAuthToken,
+		ExpiresAt:   time.Now().Add(-time.Hour),
+		// no refresh_token/token_url/client_id -> canRefresh() is false
+	}}
+
+	_, err := conf.Token(context.Background())
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "viam login")
+}
+
+func TestConfigTokenRefreshAndPersist(t *testing.T) {
+	// Redirect the CLI cache to a temp dir so the refreshed token is persisted
+	// there instead of the developer's real ~/.viam.
+	origViamDotDir := utils.ViamDotDir
+	utils.ViamDotDir = t.TempDir()
+	t.Cleanup(func() { utils.ViamDotDir = origViamDotDir })
+
+	var hits atomic.Int32
+	var gotGrant, gotRefresh string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		test.That(t, r.ParseForm(), test.ShouldBeNil)
+		gotGrant = r.Form.Get("grant_type")
+		gotRefresh = r.Form.Get("refresh_token")
+		resp := tokenResponse{
+			AccessToken:  "fresh-access-token",
+			RefreshToken: "fresh-refresh-token",
+			IDToken:      makeIDToken(t, "who@example.com", "user-123"),
+			ExpiresIn:    3600,
+			TokenType:    tokenTypeUserOAuthToken,
+		}
+		test.That(t, json.NewEncoder(w).Encode(resp), test.ShouldBeNil)
+	}))
+	defer srv.Close()
+
+	conf := &Config{
+		BaseURL: "https://app.viam.com:443",
+		Auth: &token{
+			AccessToken:  "stale-access-token",
+			RefreshToken: "old-refresh-token",
+			TokenType:    tokenTypeUserOAuthToken,
+			TokenURL:     srv.URL,
+			ClientID:     "client-123",
+			ExpiresAt:    time.Now().Add(-time.Hour),
+		},
+	}
+
+	got, err := conf.Token(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, got, test.ShouldEqual, "fresh-access-token")
+	test.That(t, hits.Load(), test.ShouldEqual, 1)
+	test.That(t, gotGrant, test.ShouldEqual, "refresh_token")
+	test.That(t, gotRefresh, test.ShouldEqual, "old-refresh-token")
+
+	// The refreshed token must have been written back to the cache: reloading
+	// it and asking again returns the fresh token without a second refresh.
+	reloaded, err := ConfigFromCache(nil)
+	test.That(t, err, test.ShouldBeNil)
+	got2, err := reloaded.Token(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, got2, test.ShouldEqual, "fresh-access-token")
+	test.That(t, hits.Load(), test.ShouldEqual, 1)
+}
+
+func TestTokenFromCache(t *testing.T) {
+	origViamDotDir := utils.ViamDotDir
+	utils.ViamDotDir = t.TempDir()
+	t.Cleanup(func() { utils.ViamDotDir = origViamDotDir })
+
+	conf := &Config{
+		BaseURL: "https://app.viam.com:443",
+		Auth: &token{
+			AccessToken: "cached-access-token",
+			TokenType:   tokenTypeUserOAuthToken,
+			ExpiresAt:   time.Now().Add(time.Hour),
+			// User.Email must be set for ConfigFromCache to parse it as a token.
+			User: userData{Email: "who@example.com"},
+		},
+	}
+	test.That(t, storeConfigToCache(conf), test.ShouldBeNil)
+
+	got, err := TokenFromCache(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, got, test.ShouldEqual, "cached-access-token")
+}


### PR DESCRIPTION
Add cli.TokenFromCache and (*Config).Token so external tools can source a bearer access token from the developer's cached `viam login` instead of requiring a token or an API key. Expired tokens are refreshed (via the existing refreshToken flow) and written back to the cache, giving callers the same auto-refresh behavior as ordinary CLI commands without needing a *cli.Command. API-key logins return ErrAPIKeyLogin.