### PR TITLE
RSDK-14364- CLI connection improvments: Skip ResourceRPCSubtypes and its reflection lookups, use per call budget for resource refreshes

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -4054,7 +4054,10 @@ func connectToMachineDirectly(ctx context.Context, cmd *cli.Command, args robots
 		return nil, err
 	}
 
-	robotClient, err := client.New(ctx, args.Address, logger, client.WithDialOptions(rpcOpts...))
+	robotClient, err := client.New(ctx, args.Address, logger,
+		client.WithDialOptions(rpcOpts...),
+		client.WithoutRPCSubtypes(),
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not connect to machine part")
 	}
@@ -5624,6 +5627,9 @@ func (c *viamClient) connectToRobot(
 	clientOpts := []client.RobotClientOption{
 		client.WithDialOptions(rpcOpts...),
 		client.WithCheckConnectedEvery(globalArgs.CheckConnectedEvery),
+		// the CLI only uses compiled-in APIs, so the descriptors cost a connection and buy
+		// nothing
+		client.WithoutRPCSubtypes(),
 	}
 	robotClient, err := client.New(dialCtx, fqdn, logger, clientOpts...)
 	if err != nil {

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -1951,7 +1951,10 @@ func restartModule(
 		Type:    rpc.CredentialsTypeAPIKey,
 		Payload: key.ApiKey.Key,
 	})
-	robotClient, err := client.New(ctx, part.Fqdn, logger, client.WithDialOptions(creds))
+	robotClient, err := client.New(ctx, part.Fqdn, logger,
+		client.WithDialOptions(creds),
+		client.WithoutRPCSubtypes(),
+	)
 	if err != nil {
 		return err
 	}

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -75,7 +75,7 @@ var (
 
 	// defaultResourcesTimeout is the default timeout for each call made while getting
 	// resources, applied per call rather than across the set.
-	defaultResourcesTimeout = 4 * time.Second
+	defaultResourcesTimeout = 5 * time.Second
 
 	// latencyPingNum controls the amount of times a gRPC request will be sent to the server
 	// to measure the latency of the connection. The latency is only measured in case

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -73,8 +73,9 @@ var (
 	// context.Canceled.
 	errRobotClientClosed = errors.New("robot client is closed")
 
-	// defaultResourcesTimeout is the default timeout for getting resources.
-	defaultResourcesTimeout = 5 * time.Second
+	// defaultResourcesTimeout is the default timeout for each call made while getting
+	// resources, applied per call rather than across the set.
+	defaultResourcesTimeout = 4 * time.Second
 
 	// latencyPingNum controls the amount of times a gRPC request will be sent to the server
 	// to measure the latency of the connection. The latency is only measured in case
@@ -113,6 +114,8 @@ type RobotClient struct {
 	refClient                *grpcreflect.Client
 	connected                atomic.Bool
 	rpcSubtypesUnimplemented bool
+	withoutRPCSubtypes       bool
+	resourcesTimeout         time.Duration
 
 	activeBackgroundWorkers sync.WaitGroup
 	backgroundCtx           context.Context
@@ -322,6 +325,11 @@ func New(ctx context.Context, address string, clientLogger logging.ZapCompatible
 		sessionsDisabled:    rOpts.disableSessions,
 		heartbeatCtx:        heartbeatCtx,
 		heartbeatCtxCancel:  heartbeatCtxCancel,
+		withoutRPCSubtypes:  rOpts.withoutRPCSubtypes,
+		resourcesTimeout:    defaultResourcesTimeout,
+	}
+	if rOpts.resourcesTimeout != nil && *rOpts.resourcesTimeout > 0 {
+		rc.resourcesTimeout = *rOpts.resourcesTimeout
 	}
 
 	otelStatsHandler := otelgrpc.NewClientHandler(
@@ -849,73 +857,75 @@ func (rc *RobotClient) createClient(name resource.Name) (resource.Resource, erro
 	return apiInfo.RPCClient(rc.backgroundCtx, rc.getClientConn(), rc.remoteName, name, logger)
 }
 
-func (rc *RobotClient) resources(ctx context.Context) ([]resource.Name, []resource.RPCAPI, error) {
-	// RSDK-5356 If we are in a testing environment, never apply
-	// defaultResourcesTimeout. Tests run in parallel, and if execution of a test
-	// pauses for longer than 5s, below calls to ResourceNames or
-	// ResourceRPCSubtypes can result in context errors that appear in client.New
-	// and remote logic.
-	if !testing.Testing() {
-		var cancel func()
-		ctx, cancel = contextutils.ContextWithTimeoutIfNoDeadline(ctx, defaultResourcesTimeout)
-		defer cancel()
+// resourcesCallCtx bounds one call, so a slow call cannot eat the time the next one needs.
+//
+// RSDK-5356: never bound in tests. They run in parallel, and a pause longer than the
+// timeout surfaces context errors out of client.New and remote logic.
+func (rc *RobotClient) resourcesCallCtx(ctx context.Context) (context.Context, context.CancelFunc) {
+	if testing.Testing() {
+		return ctx, func() {}
 	}
+	return contextutils.ContextWithTimeoutIfNoDeadline(ctx, rc.resourcesTimeout)
+}
 
-	resp, err := rc.client.ResourceNames(ctx, &pb.ResourceNamesRequest{})
+func (rc *RobotClient) resources(ctx context.Context) ([]resource.Name, []resource.RPCAPI, error) {
+	namesCtx, cancel := rc.resourcesCallCtx(ctx)
+	resp, err := rc.client.ResourceNames(namesCtx, &pb.ResourceNamesRequest{})
+	cancel()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var resTypes []resource.RPCAPI
-
 	resources := make([]resource.Name, 0, len(resp.Resources))
 	for _, name := range resp.Resources {
-		newName := rprotoutils.ResourceNameFromProto(name)
-		resources = append(resources, newName)
+		resources = append(resources, rprotoutils.ResourceNameFromProto(name))
 	}
 
-	// resource has previously returned an unimplemented response, skip rpc call
-	if rc.rpcSubtypesUnimplemented {
-		return resources, resTypes, nil
+	// Descriptors are only needed to invoke APIs not compiled into this binary; createClient
+	// builds everything else from the local registry.
+	if rc.withoutRPCSubtypes || rc.rpcSubtypesUnimplemented {
+		return resources, nil, nil
 	}
 
-	typesResp, err := rc.client.ResourceRPCSubtypes(ctx, &pb.ResourceRPCSubtypesRequest{})
-	if err == nil {
-		reflSource := grpcurl.DescriptorSourceFromServer(ctx, rc.refClient)
-
-		resTypes = make([]resource.RPCAPI, 0, len(typesResp.ResourceRpcSubtypes))
-		for _, resAPI := range typesResp.ResourceRpcSubtypes {
-			symDesc, err := reflSource.FindSymbol(resAPI.ProtoService)
-			if err != nil {
-				// Note: This happens right now if a client is talking to a main server
-				// that has a remote or similarly if a server is talking to a remote that
-				// has a remote. This can be solved by either integrating reflection into
-				// robot.proto or by overriding the gRPC reflection service to return
-				// reflection results from its remotes.
-				rc.Logger().
-					CDebugw(
-						ctx,
-						"failed to find symbol for resource API",
-						"api", rprotoutils.ResourceNameFromProto(resAPI.Subtype).API.String(),
-						"error", err,
-					)
-				continue
-			}
-			svcDesc, ok := symDesc.(*desc.ServiceDescriptor)
-			if !ok {
-				return nil, nil, fmt.Errorf("expected descriptor to be service descriptor but got %T", symDesc)
-			}
-			resTypes = append(resTypes, resource.RPCAPI{
-				API:  rprotoutils.ResourceNameFromProto(resAPI.Subtype).API,
-				Desc: svcDesc,
-			})
-		}
-	} else {
+	subtypesCtx, cancel := rc.resourcesCallCtx(ctx)
+	typesResp, err := rc.client.ResourceRPCSubtypes(subtypesCtx, &pb.ResourceRPCSubtypesRequest{})
+	cancel()
+	if err != nil {
 		if s, ok := status.FromError(err); !(ok && (s.Code() == codes.Unimplemented)) {
 			return nil, nil, err
 		}
 		// prevent future calls to ResourceRPCSubtypes
 		rc.rpcSubtypesUnimplemented = true
+		return resources, nil, nil
+	}
+
+	reflSource := grpcurl.DescriptorSourceFromServer(ctx, rc.refClient)
+	resTypes := make([]resource.RPCAPI, 0, len(typesResp.ResourceRpcSubtypes))
+	for _, resAPI := range typesResp.ResourceRpcSubtypes {
+		symDesc, err := reflSource.FindSymbol(resAPI.ProtoService)
+		if err != nil {
+			// Note: This happens right now if a client is talking to a main server
+			// that has a remote or similarly if a server is talking to a remote that
+			// has a remote. This can be solved by either integrating reflection into
+			// robot.proto or by overriding the gRPC reflection service to return
+			// reflection results from its remotes.
+			rc.Logger().
+				CDebugw(
+					ctx,
+					"failed to find symbol for resource API",
+					"api", rprotoutils.ResourceNameFromProto(resAPI.Subtype).API.String(),
+					"error", err,
+				)
+			continue
+		}
+		svcDesc, ok := symDesc.(*desc.ServiceDescriptor)
+		if !ok {
+			return nil, nil, fmt.Errorf("expected descriptor to be service descriptor but got %T", symDesc)
+		}
+		resTypes = append(resTypes, resource.RPCAPI{
+			API:  rprotoutils.ResourceNameFromProto(resAPI.Subtype).API,
+			Desc: svcDesc,
+		})
 	}
 
 	return resources, resTypes, nil

--- a/robot/client/client_options.go
+++ b/robot/client/client_options.go
@@ -48,6 +48,12 @@ type robotClientOpts struct {
 	// in production (not in a testing environment) will already allow connecting
 	// to still-initializing machines.
 	doNotWaitForRunning bool
+
+	// see WithoutRPCSubtypes.
+	withoutRPCSubtypes bool
+
+	// overrides defaultResourcesTimeout. See WithResourcesTimeout.
+	resourcesTimeout *time.Duration
 }
 
 // RobotClientOption configures how we set up the connection.
@@ -148,6 +154,31 @@ func WithDoNotWaitForRunning() RobotClientOption {
 func WithNetworkStats() RobotClientOption {
 	return newFuncRobotClientOption(func(o *robotClientOpts) {
 		o.withNetworkStats = true
+	})
+}
+
+// WithoutRPCSubtypes returns a RobotClientOption which skips ResourceRPCSubtypes and the
+// gRPC reflection lookups resolving its descriptors. Those dominate the cost of connecting
+// -- a round trip per API, against a cache that is cold on every new client -- and nothing
+// needed to call a resource depends on them, since createClient builds clients from the
+// compiled-in registry.
+//
+// ResourceRPCAPIs then returns nil, so this must not be used by viam-server connecting to a
+// remote, nor by modules: both invoke APIs that are not compiled in and need the
+// descriptors. It suits clients that only use compiled-in APIs, such as the CLI.
+func WithoutRPCSubtypes() RobotClientOption {
+	return newFuncRobotClientOption(func(o *robotClientOpts) {
+		o.withoutRPCSubtypes = true
+	})
+}
+
+// WithResourcesTimeout returns a RobotClientOption overriding how long each call made while
+// listing resources may take. Ignored if not positive, and only applied when the caller's
+// context carries no deadline of its own. Raise it for machines with many resources, a slow
+// link, or both.
+func WithResourcesTimeout(timeout time.Duration) RobotClientOption {
+	return newFuncRobotClientOption(func(o *robotClientOpts) {
+		o.resourcesTimeout = &timeout
 	})
 }
 

--- a/robot/client/client_rpcsubtypes_test.go
+++ b/robot/client/client_rpcsubtypes_test.go
@@ -1,0 +1,147 @@
+package client
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	pb "go.viam.com/api/robot/v1"
+	"go.viam.com/test"
+	gotestutils "go.viam.com/utils/testutils"
+	"google.golang.org/grpc"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/robot"
+	"go.viam.com/rdk/robot/server"
+	"go.viam.com/rdk/testutils/inject"
+)
+
+// TestWithoutRPCSubtypes covers RSDK-14364: a client that only uses compiled-in APIs can
+// skip the descriptors, which is what keeps the CLI able to reach a slow machine. Asserts
+// on the calls made rather than on timing, so it cannot flake.
+func TestWithoutRPCSubtypes(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+
+	var mu sync.Mutex
+	var namesCalls, apisCalls int
+	counts := func() (names, apis int) {
+		mu.Lock()
+		defer mu.Unlock()
+		return namesCalls, apisCalls
+	}
+
+	injectRobot := &inject.Robot{}
+	injectRobot.ResourceNamesFunc = func() []resource.Name {
+		mu.Lock()
+		defer mu.Unlock()
+		namesCalls++
+		return emptyResources
+	}
+	// server.ResourceRPCSubtypes is this function's only caller, so the count says whether
+	// the client made the RPC.
+	injectRobot.ResourceRPCAPIsFunc = func() []resource.RPCAPI {
+		mu.Lock()
+		defer mu.Unlock()
+		apisCalls++
+		return nil
+	}
+	injectRobot.MachineStatusFunc = func(context.Context) (robot.MachineStatus, error) {
+		return robot.MachineStatus{State: robot.StateRunning}, nil
+	}
+
+	listener := gotestutils.ReserveRandomListener(t)
+	gServer := grpc.NewServer()
+	pb.RegisterRobotServiceServer(gServer, server.New(injectRobot))
+	//nolint:errcheck
+	go gServer.Serve(listener)
+	defer gServer.Stop()
+
+	// no background refresh or connection checks, so only the client-building calls count
+	quiet := []RobotClientOption{WithRefreshEvery(0), WithCheckConnectedEvery(0)}
+
+	t.Run("descriptors are fetched by default", func(t *testing.T) {
+		namesBefore, apisBefore := counts()
+
+		client, err := New(context.Background(), listener.Addr().String(), logger, quiet...)
+		test.That(t, err, test.ShouldBeNil)
+		defer func() {
+			test.That(t, client.Close(context.Background()), test.ShouldBeNil)
+		}()
+
+		namesAfter, apisAfter := counts()
+		test.That(t, namesAfter, test.ShouldBeGreaterThan, namesBefore)
+		test.That(t, apisAfter, test.ShouldBeGreaterThan, apisBefore)
+	})
+
+	t.Run("WithoutRPCSubtypes skips them", func(t *testing.T) {
+		namesBefore, apisBefore := counts()
+
+		client, err := New(context.Background(), listener.Addr().String(), logger,
+			append(quiet, WithoutRPCSubtypes())...)
+		test.That(t, err, test.ShouldBeNil)
+		defer func() {
+			test.That(t, client.Close(context.Background()), test.ShouldBeNil)
+		}()
+
+		namesAfter, apisAfter := counts()
+		// names are still needed; they are what callers use
+		test.That(t, namesAfter, test.ShouldBeGreaterThan, namesBefore)
+		test.That(t, apisAfter, test.ShouldEqual, apisBefore)
+		test.That(t, client.ResourceRPCAPIs(), test.ShouldBeEmpty)
+	})
+}
+
+// TestResourcesTimeoutOption guards the plumbing only. The budget cannot be exercised here
+// because resourcesCallCtx never bounds under testing.Testing() (RSDK-5356); this just
+// catches the wiring being dropped.
+func TestResourcesTimeoutOption(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+
+	injectRobot := &inject.Robot{}
+	injectRobot.ResourceNamesFunc = func() []resource.Name { return emptyResources }
+	injectRobot.ResourceRPCAPIsFunc = func() []resource.RPCAPI { return nil }
+	injectRobot.MachineStatusFunc = func(context.Context) (robot.MachineStatus, error) {
+		return robot.MachineStatus{State: robot.StateRunning}, nil
+	}
+
+	listener := gotestutils.ReserveRandomListener(t)
+	gServer := grpc.NewServer()
+	pb.RegisterRobotServiceServer(gServer, server.New(injectRobot))
+	//nolint:errcheck
+	go gServer.Serve(listener)
+	defer gServer.Stop()
+
+	quiet := []RobotClientOption{WithRefreshEvery(0), WithCheckConnectedEvery(0)}
+
+	t.Run("defaults when unset", func(t *testing.T) {
+		client, err := New(context.Background(), listener.Addr().String(), logger, quiet...)
+		test.That(t, err, test.ShouldBeNil)
+		defer func() {
+			test.That(t, client.Close(context.Background()), test.ShouldBeNil)
+		}()
+		test.That(t, client.resourcesTimeout, test.ShouldEqual, defaultResourcesTimeout)
+	})
+
+	t.Run("overridden by the option", func(t *testing.T) {
+		client, err := New(context.Background(), listener.Addr().String(), logger,
+			append(quiet, WithResourcesTimeout(42*time.Second))...)
+		test.That(t, err, test.ShouldBeNil)
+		defer func() {
+			test.That(t, client.Close(context.Background()), test.ShouldBeNil)
+		}()
+		test.That(t, client.resourcesTimeout, test.ShouldEqual, 42*time.Second)
+	})
+
+	// zero would otherwise mean an already-expired context on every call
+	t.Run("non-positive is ignored", func(t *testing.T) {
+		client, err := New(context.Background(), listener.Addr().String(), logger,
+			append(quiet, WithResourcesTimeout(0))...)
+		test.That(t, err, test.ShouldBeNil)
+		defer func() {
+			test.That(t, client.Close(context.Background()), test.ShouldBeNil)
+		}()
+		test.That(t, client.resourcesTimeout, test.ShouldEqual, defaultResourcesTimeout)
+	})
+}

--- a/robot/client/client_rpcsubtypes_test.go
+++ b/robot/client/client_rpcsubtypes_test.go
@@ -54,7 +54,6 @@ func TestWithoutRPCSubtypes(t *testing.T) {
 	listener := gotestutils.ReserveRandomListener(t)
 	gServer := grpc.NewServer()
 	pb.RegisterRobotServiceServer(gServer, server.New(injectRobot))
-	//nolint:errcheck
 	go gServer.Serve(listener)
 	defer gServer.Stop()
 
@@ -109,7 +108,6 @@ func TestResourcesTimeoutOption(t *testing.T) {
 	listener := gotestutils.ReserveRandomListener(t)
 	gServer := grpc.NewServer()
 	pb.RegisterRobotServiceServer(gServer, server.New(injectRobot))
-	//nolint:errcheck
 	go gServer.Serve(listener)
 	defer gServer.Stop()
 


### PR DESCRIPTION
Fix 1 — the CLI stops paying for descriptors it never uses. New WithoutRPCSubtypes() option skips ResourceRPCSubtypes and its reflection lookups. Those are ~83% of the connect cost (measured over WebRTC on a real 167-resource machine: ~120ms of a ~144ms total, spiking to 1.4s), and nothing needed to call a resource depends on them — createClient builds from the compiled-in registry. Applied at all three CLI sites: cli/client.go ×2, cli/module_build.go.

Fix 3 — the budget is per call, not shared, and is now 4s. resourcesCallCtx bounds each call individually, so a slow ResourceNames can't consume the time ResourceRPCSubtypes needs. WithResourcesTimeout() lets a caller raise it; non-positive values are ignored.