### PR TITLE
RSDK-14365 - cli: don't gate tunneling on a resource refresh

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -4137,7 +4137,8 @@ func (c *viamClient) robotPartTunnel(ctx context.Context, cmd *cli.Command, args
 	// check, which probes ResourceNames and would tear an open tunnel down.
 	// ensureTunnelPortAllowed reconnects on its own when it needs to.
 	robotClient, err := c.connectToRobot(dialCtx, fqdn, rpcOpts, globalArgs.Debug, logger,
-		client.WithoutInitialRefresh())
+		client.WithoutInitialRefresh(), client.WithCheckConnectedEvery(0),
+	)
 	if err != nil {
 		return err
 	}

--- a/cli/client.go
+++ b/cli/client.go
@@ -4028,7 +4028,9 @@ func RobotsPartTunnelAction(ctx context.Context, cmd *cli.Command, args robotsPa
 }
 
 // connectToMachineDirectly dials a machine at an explicit address without contacting app.viam.com,
-// authenticating with the machine api-key in args.
+// authenticating with the machine api-key in args. Skips resource enumeration entirely - initial
+// refresh, periodic refresh and connection check: the sole caller tunnels, which needs nothing
+// but the robot service.
 func connectToMachineDirectly(ctx context.Context, cmd *cli.Command, args robotsPartTunnelArgs) (*client.RobotClient, error) {
 	globalArgs, err := getGlobalArgs(cmd)
 	if err != nil {
@@ -4054,7 +4056,8 @@ func connectToMachineDirectly(ctx context.Context, cmd *cli.Command, args robots
 		return nil, err
 	}
 
-	robotClient, err := client.New(ctx, args.Address, logger, client.WithDialOptions(rpcOpts...))
+	robotClient, err := client.New(ctx, args.Address, logger, client.WithDialOptions(rpcOpts...),
+		client.WithoutInitialRefresh(), client.WithRefreshEvery(0), client.WithCheckConnectedEvery(0))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not connect to machine part")
 	}
@@ -4125,7 +4128,11 @@ func (c *viamClient) robotPartTunnel(ctx context.Context, cmd *cli.Command, args
 		return err
 	}
 
-	robotClient, err := c.connectToRobot(dialCtx, fqdn, rpcOpts, globalArgs.Debug, logger)
+	// Tunneling needs only the robot service, so skip the initial refresh - and the connection
+	// check, which probes ResourceNames and would tear an open tunnel down.
+	// ensureTunnelPortAllowed reconnects on its own when it needs to.
+	robotClient, err := c.connectToRobot(dialCtx, fqdn, rpcOpts, globalArgs.Debug, logger,
+		client.WithoutInitialRefresh())
 	if err != nil {
 		return err
 	}
@@ -5610,6 +5617,7 @@ func (c *viamClient) connectToRobot(
 	rpcOpts []rpc.DialOption,
 	debug bool,
 	logger logging.Logger,
+	extraOpts ...client.RobotClientOption,
 ) (*client.RobotClient, error) {
 	if debug {
 		printf(c.c.Root().Writer, "Establishing connection...")
@@ -5624,7 +5632,11 @@ func (c *viamClient) connectToRobot(
 	clientOpts := []client.RobotClientOption{
 		client.WithDialOptions(rpcOpts...),
 		client.WithCheckConnectedEvery(globalArgs.CheckConnectedEvery),
+		// CLI commands read the resource list once after connecting and never re-read it, so a
+		// periodic refresh is pure churn - and error noise when enumeration is what's failing.
+		client.WithRefreshEvery(0),
 	}
+	clientOpts = append(clientOpts, extraOpts...)
 	robotClient, err := client.New(dialCtx, fqdn, logger, clientOpts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not connect to machine part")

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -445,8 +445,10 @@ func New(ctx context.Context, address string, clientLogger logging.ZapCompatible
 	}
 
 	// refresh once to hydrate the robot.
-	if err := rc.Refresh(ctx); err != nil {
-		return nil, multierr.Combine(err, rc.conn.Close())
+	if !rOpts.skipInitialRefresh {
+		if err := rc.Refresh(ctx); err != nil {
+			return nil, multierr.Combine(err, rc.conn.Close())
+		}
 	}
 
 	var refreshTime time.Duration

--- a/robot/client/client_options.go
+++ b/robot/client/client_options.go
@@ -43,6 +43,9 @@ type robotClientOpts struct {
 
 	modName string
 
+	// skipInitialRefresh skips the resource refresh New otherwise requires before returning.
+	skipInitialRefresh bool
+
 	// doNotWaitForRunning allows connecting to still-initializing machines
 	// without waiting for it to reach the running state. Note that robot clients
 	// in production (not in a testing environment) will already allow connecting
@@ -140,6 +143,15 @@ func WithDialOptions(opts ...rpc.DialOption) RobotClientOption {
 func WithDoNotWaitForRunning() RobotClientOption {
 	return newFuncRobotClientOption(func(o *robotClientOpts) {
 		o.doNotWaitForRunning = true
+	})
+}
+
+// WithoutInitialRefresh returns a RobotClientOption that skips the resource refresh New
+// otherwise has to complete before returning. Resources stay unknown until a periodic refresh
+// succeeds, so this only suits callers that talk to the robot service directly, such as tunneling.
+func WithoutInitialRefresh() RobotClientOption {
+	return newFuncRobotClientOption(func(o *robotClientOpts) {
+		o.skipInitialRefresh = true
 	})
 }
 

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -892,6 +892,45 @@ func TestClientRefresh(t *testing.T) {
 	})
 }
 
+// TestClientWithoutInitialRefresh covers RSDK-14365: a machine that can be reached but
+// whose resources can't be enumerated is still usable by callers that don't need them.
+func TestClientWithoutInitialRefresh(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	listener, err := net.Listen("tcp", "localhost:0")
+	test.That(t, err, test.ShouldBeNil)
+	gServer := grpc.NewServer()
+	pb.RegisterRobotServiceServer(gServer, &mockRPCSubtypesImplemented{
+		ResourceNamesFunc: func(*pb.ResourceNamesRequest) (*pb.ResourceNamesResponse, error) {
+			return nil, context.Canceled
+		},
+	})
+
+	go gServer.Serve(listener)
+	defer gServer.Stop()
+
+	// no background refresh/reconnect, so ResourceNames is only called when we ask for it
+	opts := []RobotClientOption{WithRefreshEvery(0), WithCheckConnectedEvery(0)}
+
+	_, err = New(context.Background(), listener.Addr().String(), logger, opts...)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "error updating resources")
+
+	client, err := New(context.Background(), listener.Addr().String(), logger,
+		append(opts, WithoutInitialRefresh())...)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, client.Close(context.Background()), test.ShouldBeNil)
+	}()
+
+	// resources are unknown, but the robot service itself is reachable
+	test.That(t, client.ResourceNames(), test.ShouldBeEmpty)
+	_, err = client.ResourceByName(arm.Named("arm1"))
+	test.That(t, err, test.ShouldBeError, resource.NewNotFoundError(arm.Named("arm1")))
+	mStatus, err := client.MachineStatus(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, mStatus.State, test.ShouldEqual, robot.StateRunning)
+}
+
 func TestClientDisconnect(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	listener, err := net.Listen("tcp", "localhost:0")


### PR DESCRIPTION
## Problem

`client.New` would not return unless its initial resource refresh succeeded, and `shell`, `cp`, `tunnel` and `get-ftdc` all route through it. On a machine that dials fine but can't enumerate resources, all four failed with the same `error updating resources: context canceled` — so the `tunnel` workaround recommended during the incident behind RSDK-14365 was never a real alternative.

## Change

- New `client.WithoutInitialRefresh()` option, which skips the hydrating `Refresh` in `client.New`. Everything else — dial, connect, machine-status wait — is unchanged, and resources still populate on any later refresh.
- Both tunnel paths use it: `robotPartTunnel` and `connectToMachineDirectly` (the `--address --key-id --key` path, which previously couldn't work offline either since it also went through `client.New`). Tunneling needs only the robot service's `Tunnel`/`ListTunnels` RPCs.
- Both also pass `WithCheckConnectedEvery(0)`. The connection check's health probe *is* `ResourceNames`, so on the machine we're fixing it marks the client disconnected and re-dials every second — and `connectWithLock` closes the conn before re-dialing, which would kill an open tunnel. `ensureTunnelPortAllowed` already calls `Connect` itself when it needs to, so the one place tunneling depends on reconnect still works.
- `connectToRobot` now sets `WithRefreshEvery(0)` for every CLI robot client: all six callers read the resource list once right after connecting and never re-read it, so the periodic `ResourceNames` + `ResourceRPCSubtypes` + reflection round trip was pure churn — most visibly during a long interactive `shell` session.

`shell`, `cp` and `get-ftdc` still discover the shell service through `ResourceNames` and still fail when that fails. That's deliberate: `tunnel` is now the genuine alternative, and RSDK-14408 tracks giving those three an explicit `--shell-service`-style escape hatch. A default-name fallback was prototyped here and dropped — it silently guessed which resource you reached and couldn't handle non-default service names.

## Trade-off

Disabling the connection check also disables reconnect, so a tunnel to a healthy machine no longer re-dials if the machine restarts mid-session; you rerun the command. There's no configuration that keeps reconnect while ignoring `ResourceNames`, because the probe is the thing that's broken.

## Testing

`TestClientWithoutInitialRefresh` stands up a robot service whose `ResourceNames` always errors and asserts that `client.New` still fails without the option, succeeds with it, reaches the robot service (`MachineStatus`), and keeps returning `NotFound` from `ResourceByName` since resources are genuinely unknown.

`go test ./cli/ ./robot/client/` passes; `make lint-go`'s pinned golangci-lint produces no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)