### PR TITLE
cli: thread --check-connection-interval flag into the robot client

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -330,13 +330,13 @@ var dataTagByFilterFlags = append([]cli.Flag{
 type emptyArgs struct{}
 
 type globalArgs struct {
-	BaseURL             string
-	Config              string
-	Debug               bool
-	Quiet               bool
-	Profile             string
-	DisableProfiles     bool
-	CheckConnectedEvery time.Duration
+	BaseURL                 string
+	Config                  string
+	Debug                   bool
+	Quiet                   bool
+	Profile                 string
+	DisableProfiles         bool
+	CheckConnectionInterval time.Duration
 }
 
 func (ga *globalArgs) createLogger() logging.Logger {

--- a/cli/client.go
+++ b/cli/client.go
@@ -5637,7 +5637,7 @@ func (c *viamClient) connectToRobot(
 	}
 	clientOpts := []client.RobotClientOption{
 		client.WithDialOptions(rpcOpts...),
-		client.WithCheckConnectedEvery(globalArgs.CheckConnectedEvery),
+		client.WithCheckConnectedEvery(globalArgs.CheckConnectionInterval),
 		// CLI commands read the resource list once after connecting and never re-read it, so a
 		// periodic refresh is pure churn - and error noise when enumeration is what's failing.
 		client.WithRefreshEvery(0),


### PR DESCRIPTION
The global `--check-connection-interval` flag never took effect. The field was named `CheckConnectedEvery` (→ `check-connected-every`) while the flag is `check-connection-interval`. The names never matched, so the field stayed `0` and the connection check never ran.

Fix: rename the field to `CheckConnectionInterval` so it maps to the flag. Public flag name unchanged.