### PR TITLE
RSDK-14413 Generate value instead of pointer receiver for Golang Validate modules

### DIFF
--- a/cli/module_generate/_templates/go/DEVELOPER_GUIDE.md
+++ b/cli/module_generate/_templates/go/DEVELOPER_GUIDE.md
@@ -24,12 +24,12 @@ The generated `module.go` file contains the scaffolding for your resource. You w
    - **First return:** required dependencies (other resources that must exist)  
    - **Second return:** optional dependencies (resources that are nice to have but not required)  
    - `path` is provided by the runtime and indicates **where this resource appears in the JSON config**, e.g., `"components.0"`. Use it in error messages to show which resource has a problem.
-   - **WARNING:** `Validate` should only inspect the config — mutations to it will do nothing. Fill in any default values in your resource's constructor function instead.
+   - Note: `Validate` receives a copy of the config — mutations to it will do nothing. Fill in any default values in your resource's constructor function instead.
 
 Example:
 
 ```go
-func (cfg *Config) Validate(path string) ([]string, []string, error) {
+func (cfg Config) Validate(path string) ([]string, []string, error) {
     if cfg.Camera == "" {
         return nil, nil, fmt.Errorf("%s: missing required field 'camera'", path)
     }
@@ -40,13 +40,13 @@ func (cfg *Config) Validate(path string) ([]string, []string, error) {
 2. **`new<ModuleName><ModelName>(...)`**
    - Automatically called by the runtime after validation.
    - Takes a generic `rawConf` from the robot’s JSON config.  
-   - Converts it into a typed `*Config`.
+   - Converts it into a typed `Config`.
    - Passes the config to `New<ModelName>` to create the resource instance.
    - You usually won’t edit this function. 
 
 3. **`New<ModelName>(...)`**
    - Your actual constructor.
-   - Receives the already-parsed `*Config`. 
+   - Receives the already-parsed `Config`. 
    - Sets up the logger, config, and any initial state.
    - You can add hardware initialization or background tasks here.
    - Returns the fully constructed resource instance.

--- a/cli/module_generate/_templates/go/DEVELOPER_GUIDE.md
+++ b/cli/module_generate/_templates/go/DEVELOPER_GUIDE.md
@@ -24,6 +24,7 @@ The generated `module.go` file contains the scaffolding for your resource. You w
    - **First return:** required dependencies (other resources that must exist)  
    - **Second return:** optional dependencies (resources that are nice to have but not required)  
    - `path` is provided by the runtime and indicates **where this resource appears in the JSON config**, e.g., `"components.0"`. Use it in error messages to show which resource has a problem.
+   - **WARNING:** `Validate` should only inspect the config — mutations to it will do nothing. Fill in any default values in your resource's constructor function instead.
 
 Example:
 

--- a/cli/module_generate/_templates/go/cmd/cli/tmpl-main.go
+++ b/cli/module_generate/_templates/go/cmd/cli/tmpl-main.go
@@ -24,7 +24,7 @@ func realMain() error {
 
 	cfg := {{.ModuleLowercase}}.Config{}
 
-	thing, err := {{.ModuleLowercase}}.New{{.ModelPascal}}(ctx, deps, {{.ResourceSubtypeAlias}}.Named("foo"), &cfg, logger)
+	thing, err := {{.ModuleLowercase}}.New{{.ModelPascal}}(ctx, deps, {{.ResourceSubtypeAlias}}.Named("foo"), cfg, logger)
 	if err != nil {
 		return err
 	}

--- a/cli/module_generate/_templates/go/tmpl-module.go
+++ b/cli/module_generate/_templates/go/tmpl-module.go
@@ -42,8 +42,12 @@ type Config struct {
 //
 // The `path` parameter indicates
 // where this resource appears in the machine's JSON configuration
-// (for example, "components.0"). You can use it in error messages 
+// (for example, "components.0"). You can use it in error messages
 // to indicate which resource has a problem.
+//
+// WARNING: Validate should only inspect the config; mutations to it will do
+// nothing. Fill in any default values in your resource's constructor function
+// instead.
 func (cfg *Config) Validate(path string) ([]string, []string, error) {
 	// Add config validation code here
 	return nil, nil, nil

--- a/cli/module_generate/_templates/go/tmpl-module.go
+++ b/cli/module_generate/_templates/go/tmpl-module.go
@@ -11,7 +11,7 @@ var (
 
 func init() {
 	resource.Register{{ .ResourceType}}({{.ResourceSubtype}}.API, {{.ModelPascal}},
-		resource.Registration[{{if eq .ResourceSubtype "generic"}}resource.Resource{{else}}{{if eq .ResourceType "component"}}{{.ResourceSubtype}}.{{.ResourceSubtypePascal}}{{else}}{{.ResourceSubtype}}.Service{{end}}{{end}}, *Config]{
+		resource.Registration[{{if eq .ResourceSubtype "generic"}}resource.Resource{{else}}{{if eq .ResourceType "component"}}{{.ResourceSubtype}}.{{.ResourceSubtypePascal}}{{else}}{{.ResourceSubtype}}.Service{{end}}{{end}}, Config]{
 			Constructor: new{{.ModulePascal}}{{.ModelPascal}},
 		},
 	)
@@ -29,7 +29,7 @@ type Config struct {
 			MinDeg *float64 `json:"min_angle_deg,omitempty"`
 		}
 
-	If your model does not need a config, replace *Config in the init
+	If your model does not need a config, replace Config in the init
 	function with resource.NoNativeConfig
 	*/
 }
@@ -45,10 +45,10 @@ type Config struct {
 // (for example, "components.0"). You can use it in error messages
 // to indicate which resource has a problem.
 //
-// WARNING: Validate should only inspect the config; mutations to it will do
+// Note: Validate receives a copy of the config; mutations to it will do
 // nothing. Fill in any default values in your resource's constructor function
 // instead.
-func (cfg *Config) Validate(path string) ([]string, []string, error) {
+func (cfg Config) Validate(path string) ([]string, []string, error) {
 	// Add config validation code here
 	return nil, nil, nil
 }
@@ -60,14 +60,14 @@ type {{.ModuleCamel}}{{.ModelPascal}} struct {
 	name   resource.Name
 
 	logger logging.Logger
-	cfg    *Config
+	cfg    Config
 
 	cancelCtx  context.Context
 	cancelFunc func()
 }
 
 func new{{.ModulePascal}}{{.ModelPascal}}(ctx context.Context, deps resource.Dependencies, rawConf resource.Config, logger logging.Logger) ({{if eq .ResourceSubtype "generic"}}resource.Resource{{else}}{{if eq .ResourceType "component"}}{{.ResourceSubtype}}.{{.ResourceSubtypePascal}}{{else}}{{.ResourceSubtype}}.Service{{end}}{{end}}, error) {
-	conf, err := resource.NativeConfig[*Config](rawConf)
+	conf, err := resource.NativeConfig[Config](rawConf)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func new{{.ModulePascal}}{{.ModelPascal}}(ctx context.Context, deps resource.Dep
 }
 
 // New{{.ModelPascal}} for local testing
-func New{{.ModelPascal}}(ctx context.Context, deps resource.Dependencies, name resource.Name, conf *Config, logger logging.Logger) ({{if eq .ResourceSubtype "generic"}}resource.Resource{{else}}{{if eq .ResourceType "component"}}{{.ResourceSubtype}}.{{.ResourceSubtypePascal}}{{else}}{{.ResourceSubtype}}.Service{{end}}{{end}}, error) {
+func New{{.ModelPascal}}(ctx context.Context, deps resource.Dependencies, name resource.Name, conf Config, logger logging.Logger) ({{if eq .ResourceSubtype "generic"}}resource.Resource{{else}}{{if eq .ResourceType "component"}}{{.ResourceSubtype}}.{{.ResourceSubtypePascal}}{{else}}{{.ResourceSubtype}}.Service{{end}}{{end}}, error) {
 
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 

--- a/cli/module_generate/_templates/python/src/models/tmpl-resource.py
+++ b/cli/module_generate/_templates/python/src/models/tmpl-resource.py
@@ -29,6 +29,10 @@ class {{ .ModelPascal  }}({{ .ResourceSubtypePascal }}, EasyResource):
         """This method allows you to validate the configuration object received from the machine,
         as well as to return any required dependencies or optional dependencies based on that `config`.
 
+        Note: validate_config should only inspect the config; mutations to it
+        will do nothing. Fill in any default values in your resource's
+        constructor (or reconfigure) instead.
+
         Args:
             config (ComponentConfig): The configuration for this resource
 

--- a/cli/module_generate/scripts/tmpl-module
+++ b/cli/module_generate/scripts/tmpl-module
@@ -12,7 +12,7 @@ var (
 
 func init() {
 	resource.Register{{ .Module.ResourceTypePascal}}({{.Module.ResourceSubtypeAlias}}.API, {{.Module.ModelPascal}},
-		resource.Registration[{{if eq .Module.ResourceSubtype "generic"}}resource.Resource{{else}}{{if eq .Module.ResourceType "component"}}{{.Module.ResourceSubtypeAlias}}.{{.Module.ResourceSubtypePascal}}{{else}}{{.Module.ResourceSubtype}}.Service{{end}}{{end}}, *{{.ConfigType}}]{
+		resource.Registration[{{if eq .Module.ResourceSubtype "generic"}}resource.Resource{{else}}{{if eq .Module.ResourceType "component"}}{{.Module.ResourceSubtypeAlias}}.{{.Module.ResourceSubtypePascal}}{{else}}{{.Module.ResourceSubtype}}.Service{{end}}{{end}}, {{.ConfigType}}]{
 			Constructor: new{{.Module.ModulePascal}}{{.Module.ModelPascal}},
 		},
 	)
@@ -30,7 +30,7 @@ type {{.ConfigType}} struct {
 			MinDeg *float64 `json:"min_angle_deg,omitempty"`
 		}
 
-	If your model does not need a config, replace *{{.ConfigType}} in the init
+	If your model does not need a config, replace {{.ConfigType}} in the init
 	function with resource.NoNativeConfig
 	*/
 }
@@ -45,7 +45,11 @@ type {{.ConfigType}} struct {
 // where this resource appears in the machine's JSON configuration
 // (for example, "components.0"). You can use it in error messages
 // to indicate which resource has a problem.
-func (cfg *{{.ConfigType}}) Validate(path string) ([]string, []string, error) {
+//
+// Note: Validate receives a copy of the config; mutations to it will do
+// nothing. Fill in any default values in your resource's constructor function
+// instead.
+func (cfg {{.ConfigType}}) Validate(path string) ([]string, []string, error) {
 	// Add config validation code here
 	 return nil, nil, nil
 }
@@ -57,14 +61,14 @@ type {{.ModelType}} struct {
 	name   resource.Name
 
 	logger logging.Logger
-	cfg    *{{.ConfigType}}
+	cfg    {{.ConfigType}}
 
 	cancelCtx  context.Context
 	cancelFunc func()
 }
 
 func new{{.Module.ModulePascal}}{{.Module.ModelPascal}}(ctx context.Context, deps resource.Dependencies, rawConf resource.Config, logger logging.Logger) ({{if eq .Module.ResourceSubtype "generic"}}resource.Resource{{else}}{{if eq .Module.ResourceType "component"}}{{.Module.ResourceSubtypeAlias}}.{{.Module.ResourceSubtypePascal}}{{else}}{{.Module.ResourceSubtype}}.Service{{end}}{{end}}, error) {
-	conf, err := resource.NativeConfig[*{{.ConfigType}}](rawConf)
+	conf, err := resource.NativeConfig[{{.ConfigType}}](rawConf)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +77,7 @@ func new{{.Module.ModulePascal}}{{.Module.ModelPascal}}(ctx context.Context, dep
 
 }
 
-func New{{.Module.ModelPascal}}(ctx context.Context, deps resource.Dependencies, name resource.Name, conf *{{.ConfigType}}, logger logging.Logger) ({{if eq .Module.ResourceSubtype "generic"}}resource.Resource{{else}}{{if eq .Module.ResourceType "component"}}{{.Module.ResourceSubtypeAlias}}.{{.Module.ResourceSubtypePascal}}{{else}}{{.Module.ResourceSubtype}}.Service{{end}}{{end}}, error) {
+func New{{.Module.ModelPascal}}(ctx context.Context, deps resource.Dependencies, name resource.Name, conf {{.ConfigType}}, logger logging.Logger) ({{if eq .Module.ResourceSubtype "generic"}}resource.Resource{{else}}{{if eq .Module.ResourceType "component"}}{{.Module.ResourceSubtypeAlias}}.{{.Module.ResourceSubtypePascal}}{{else}}{{.Module.ResourceSubtype}}.Service{{end}}{{end}}, error) {
 
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 


### PR DESCRIPTION
RSDK-14413

## What

Generates `Validate` methods for Golang modules with value receivers instead of pointer receivers. Also adds some noted warnings that attempts to mutate the receiver in `Validate` to add defaults will do nothing (although now it's pretty obvious from the lack of `*`).

## Why

Users have been known to do attempt to mutate the `*Config` in `Validate` in order to fill in default values.