### PR TITLE
RSDK-14398 resource: don't log while holding the graph write lock

### DIFF
--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -652,18 +652,30 @@ func (g *Graph) remove(node Name) {
 // by RemoveMarked.
 func (g *Graph) MarkForRemoval(toMark *Graph) {
 	toMark.mu.Lock()
-	defer toMark.mu.Unlock()
 	g.mu.Lock()
-	defer g.mu.Unlock()
+	nodes := slices.Collect(toMark.nodes.Values())
+	g.mu.Unlock()
+	toMark.mu.Unlock()
 
-	for v := range toMark.nodes.Values() {
-		v.MarkForRemoval()
+	// Mark outside of the graph locks. Marking transitions node state, which can log, and a
+	// log write blocks until the log consumer accepts it; blocking there while holding the
+	// write lock would stall every reader of the graph.
+	for _, node := range nodes {
+		node.MarkForRemoval()
 	}
 }
 
 // RemoveMarked removes previously marked nodes from the graph and returns
 // all the resources removed that should now be closed by the caller.
 func (g *Graph) RemoveMarked() []Resource {
+	// See ResolveDependencies for why logging waits until the write lock is released.
+	var missingNodes []Name
+	defer func() {
+		for _, name := range missingNodes {
+			g.logger.Errorw("invariant: expected to find node during removal", "name", name)
+		}
+	}()
+
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
@@ -677,7 +689,7 @@ func (g *Graph) RemoveMarked() []Resource {
 		rNode, ok := g.nodes.Get(name)
 		if !ok {
 			// will never happen
-			g.logger.Errorw("invariant: expected to find node during removal", "name", name)
+			missingNodes = append(missingNodes, name)
 			continue
 		}
 		if rNode.MarkedForRemoval() {
@@ -837,6 +849,17 @@ func (g *Graph) ReverseTopologicalSortInLevels() [][]Name {
 // known way of reaching this state. Other unknown paths may still reach this state, and
 // this pass would not recover a dependent stranded that way.
 func (g *Graph) ResolveDependencies(logger logging.Logger) error {
+	// Log lines are collected here and emitted once the write lock is released. A log
+	// write blocks until the log consumer accepts it, so logging while holding the write
+	// lock can stall every reader of the graph. Deferred calls run in LIFO order, so this
+	// one runs after the unlock below.
+	var deferredLogs []func()
+	defer func() {
+		for _, emitLog := range deferredLogs {
+			emitLog()
+		}
+	}()
+
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
@@ -853,7 +876,9 @@ func (g *Graph) ResolveDependencies(logger logging.Logger) error {
 			tryResolve := func() (Name, bool) {
 				if dep == nodeName.String() {
 					allErrs = multierr.Combine(errors.Errorf("node cannot depend on itself: %q", nodeName))
-					logger.Errorw("node cannot depend on itself", "name", nodeName)
+					deferredLogs = append(deferredLogs, func() {
+						logger.Errorw("node cannot depend on itself", "name", nodeName)
+					})
 					return Name{}, false
 				}
 				if resName, err := NewFromString(dep); err == nil {
@@ -868,24 +893,30 @@ func (g *Graph) ResolveDependencies(logger logging.Logger) error {
 				case 1:
 					if nodeNames[0].String() == nodeName.String() {
 						allErrs = multierr.Combine(errors.Errorf("node cannot depend on itself: %q", nodeName))
-						logger.Errorw("node cannot depend on itself", "name", nodeName)
+						deferredLogs = append(deferredLogs, func() {
+							logger.Errorw("node cannot depend on itself", "name", nodeName)
+						})
 						return Name{}, false
 					}
-					logger.Debugw(
-						"dependency resolved for resource",
-						"name", nodeName,
-						"dependency", nodeNames[0],
-					)
+					deferredLogs = append(deferredLogs, func() {
+						logger.Debugw(
+							"dependency resolved for resource",
+							"name", nodeName,
+							"dependency", nodeNames[0],
+						)
+					})
 					return nodeNames[0], true
 				default:
 					allErrs = multierr.Combine(
 						allErrs,
 						errors.Errorf("conflicting names for resource %q: %v", nodeName, NamesToStrings(nodeNames)))
-					logger.Errorw(
-						"cannot resolve dependency for resource due to multiple matching names",
-						"name", nodeName,
-						"conflicts", NamesToStrings(nodeNames),
-					)
+					deferredLogs = append(deferredLogs, func() {
+						logger.Errorw(
+							"cannot resolve dependency for resource due to multiple matching names",
+							"name", nodeName,
+							"conflicts", NamesToStrings(nodeNames),
+						)
+					})
 				}
 				return Name{}, false
 			}
@@ -901,12 +932,14 @@ func (g *Graph) ResolveDependencies(logger logging.Logger) error {
 					resolved = false
 				} else if err := g.addChild(nodeName, resolvedName); err != nil {
 					allErrs = multierr.Combine(allErrs, err)
-					logger.Errorw(
-						"error adding dependency for resource as a child to parent",
-						"name", nodeName,
-						"parent", resolvedName,
-						"error", err,
-					)
+					deferredLogs = append(deferredLogs, func() {
+						logger.Errorw(
+							"error adding dependency for resource as a child to parent",
+							"name", nodeName,
+							"parent", resolvedName,
+							"error", err,
+						)
+					})
 					resolved = false
 				}
 			}

--- a/resource/resource_graph_test.go
+++ b/resource/resource_graph_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap/zapcore"
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/logging"
@@ -1278,6 +1279,69 @@ func shouldMatchMultipleNodesErr(actual interface{}, expected ...interface{}) st
 		}
 	}
 	return ""
+}
+
+// lockProbeAppender records, for every log line written through it, whether the graph write
+// lock was held at the time.
+type lockProbeAppender struct {
+	graph             *Graph
+	writes            int
+	writesWhileLocked int
+}
+
+func (a *lockProbeAppender) Write(zapcore.Entry, []zapcore.Field) error {
+	a.writes++
+	if a.graph.mu.TryRLock() {
+		a.graph.mu.RUnlock()
+	} else {
+		a.writesWhileLocked++
+	}
+	return nil
+}
+
+func (a *lockProbeAppender) Sync() error { return nil }
+
+// TestGraphDoesNotLogWhileHoldingWriteLock verifies that graph mutations emit their log lines
+// after releasing the write lock. A log write blocks until the log consumer accepts it, so
+// logging under the write lock stalls every reader of the graph for that long.
+func TestGraphDoesNotLogWhileHoldingWriteLock(t *testing.T) {
+	t.Run("ResolveDependencies", func(t *testing.T) {
+		g := NewGraph(logging.NewTestLogger(t))
+		probe := &lockProbeAppender{graph: g}
+		logger := logging.NewTestLogger(t)
+		logger.AddAppender(probe)
+
+		// "a" depends on itself and on the short name "c", which two remote resources claim.
+		name1 := NewName(APINamespaceRDK.WithComponentType("aapi"), "a")
+		test.That(t, g.AddNode(name1, NewUnconfiguredGraphNode(Config{}, []string{"a", "c"})), test.ShouldBeNil)
+		name2 := NewName(APINamespaceRDK.WithComponentType("aapi"), "rem1:c")
+		test.That(t, g.AddNode(name2, NewUnconfiguredGraphNode(Config{}, nil)), test.ShouldBeNil)
+		name3 := NewName(APINamespaceRDK.WithComponentType("aapi"), "rem2:c")
+		test.That(t, g.AddNode(name3, NewUnconfiguredGraphNode(Config{}, nil)), test.ShouldBeNil)
+
+		test.That(t, g.ResolveDependencies(logger), test.ShouldNotBeNil)
+		test.That(t, probe.writes, test.ShouldBeGreaterThan, 0)
+		test.That(t, probe.writesWhileLocked, test.ShouldEqual, 0)
+	})
+
+	t.Run("MarkForRemoval", func(t *testing.T) {
+		g := NewGraph(logging.NewTestLogger(t))
+		probe := &lockProbeAppender{graph: g}
+		logger := logging.NewTestLogger(t)
+		logger.AddAppender(probe)
+
+		name := NewName(APINamespaceRDK.WithComponentType("aapi"), "a")
+		node := NewUnconfiguredGraphNode(Config{}, nil)
+		node.InitializeLogger(logger, "a")
+		test.That(t, g.AddNode(name, node), test.ShouldBeNil)
+
+		// A node in the configuring state cannot transition to removing, which logs a warning.
+		g.MarkForRemoval(g.Clone())
+
+		test.That(t, node.MarkedForRemoval(), test.ShouldBeTrue)
+		test.That(t, probe.writes, test.ShouldBeGreaterThan, 0)
+		test.That(t, probe.writesWhileLocked, test.ShouldEqual, 0)
+	})
 }
 
 // TestResolveDependenciesSkipsDependencyMarkedForRemoval verifies that ResolveDependencies does


### PR DESCRIPTION
## Problem

Three `resource.Graph` methods emitted log lines while holding the graph write lock (`g.mu.Lock()`):

- `ResolveDependencies` — `Errorw` on self-dependencies and conflicting names (plus a `Debugw` per resolved dependency); runs at the top of every `completeConfig` pass.
- `MarkForRemoval` — `v.MarkForRemoval()` per node → `transitionTo`/`incrementLogicalClock` → can `Warnw`/`Debugw`.
- `RemoveMarked` — `Errorw` on an invariant violation.

Log writes are unbounded: they block on whatever consumes stdout/journald, and all loggers share the same appender. A stalled log consumer therefore held the graph write lock for as long as the write blocked, and every graph reader stalled with it — which, per RSDK-14397, is every RPC (`ResourceNames`, `ResourceRPCSubtypes`, `GetMachineStatus`, ...).

## Fix

Collect the messages and emit them after releasing the lock, following the precedent of `GraphNode.LogAndSetLastError` (unlock, then log):

- `ResolveDependencies` and `RemoveMarked` buffer their log lines and flush them in a deferred call registered before the unlock, so it runs after the lock is released.
- `MarkForRemoval` snapshots the nodes under the graph locks and marks them after releasing, since marking transitions node state and can log. The resource manager already calls `GraphNode.MarkForRemoval` outside the graph lock elsewhere.

No log line is dropped or reordered relative to the others in the same call.

## Test

`TestGraphDoesNotLogWhileHoldingWriteLock` attaches an appender that probes `g.mu.TryRLock()` on every log write and asserts no line is written while the write lock is held, for both `ResolveDependencies` (self-dependency + conflicting names) and `MarkForRemoval`. It fails on `main` and passes with this change.

`go test ./resource/... -race` passes.

Key: RSDK-14398

Co-authored by Claude agent for Jira.