### PR TITLE
Fix: Emit start activity on module restart

### DIFF
--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1056,7 +1056,7 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) error {
 	}
 	mod.registerResourceModels(mgr)
 	// so activity observers can tell recovery from a module that stayed down
-	mod.logger.Activity("module", "start", "module", mod.cfg.Name)
+	mod.logger.Activity("module", "start", "module", mod.cfg.Name, "reason", "restart")
 	mgr.setModuleStatusReady(mod.cfg.Name)
 	success = true
 	return nil

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -1055,6 +1055,8 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) error {
 		mgr.modPeerConnTracker.Add(mod.cfg.Name, pc)
 	}
 	mod.registerResourceModels(mgr)
+	// so activity observers can tell recovery from a module that stayed down
+	mod.logger.Activity("module", "start", "module", mod.cfg.Name)
 	mgr.setModuleStatusReady(mod.cfg.Name)
 	success = true
 	return nil


### PR DESCRIPTION
I missed the `attemptRestart` path when adding activity logs, this just adds in a start log. Makes the logs cleaner and the frontend work easier.