### PR TITLE
RSDK-14400 - web: serve pprof named profiles

### DIFF
--- a/robot/web/debug_test.go
+++ b/robot/web/debug_test.go
@@ -63,6 +63,10 @@ func TestDebugEndpointsGatedByWebProfile(t *testing.T) {
 		test.That(t, code, test.ShouldNotEqual, http.StatusOK)
 		test.That(t, body, test.ShouldNotContainSubstring, "Types of profiles available")
 
+		code, body = get(t, base+"/debug/pprof/goroutine?debug=1")
+		test.That(t, code, test.ShouldNotEqual, http.StatusOK)
+		test.That(t, body, test.ShouldNotContainSubstring, "goroutine profile")
+
 		code, body = get(t, base+"/debug/graph?layout=text")
 		test.That(t, code, test.ShouldNotEqual, http.StatusOK)
 		test.That(t, body, test.ShouldNotContainSubstring, dot)
@@ -74,6 +78,29 @@ func TestDebugEndpointsGatedByWebProfile(t *testing.T) {
 		code, body := get(t, base+"/debug/pprof/")
 		test.That(t, code, test.ShouldEqual, http.StatusOK)
 		test.That(t, body, test.ShouldContainSubstring, "Types of profiles available")
+
+		// The index is also reachable without the trailing slash (via a redirect).
+		code, body = get(t, base+"/debug/pprof")
+		test.That(t, code, test.ShouldEqual, http.StatusOK)
+		test.That(t, body, test.ShouldContainSubstring, "Types of profiles available")
+
+		// Named profiles are served by pprof.Index off the trailing path segment.
+		code, body = get(t, base+"/debug/pprof/goroutine?debug=1")
+		test.That(t, code, test.ShouldEqual, http.StatusOK)
+		test.That(t, body, test.ShouldContainSubstring, "goroutine profile")
+
+		for _, profile := range []string{"heap", "allocs", "block", "mutex", "threadcreate"} {
+			code, body = get(t, base+"/debug/pprof/"+profile+"?debug=1")
+			test.That(t, code, test.ShouldEqual, http.StatusOK)
+			test.That(t, body, test.ShouldNotBeEmpty)
+		}
+
+		// Profiles with dedicated handlers still work.
+		code, _ = get(t, base+"/debug/pprof/cmdline")
+		test.That(t, code, test.ShouldEqual, http.StatusOK)
+
+		code, _ = get(t, base+"/debug/pprof/symbol")
+		test.That(t, code, test.ShouldEqual, http.StatusOK)
 
 		code, body = get(t, base+"/debug/graph?layout=text")
 		test.That(t, code, test.ShouldEqual, http.StatusOK)

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -816,11 +816,18 @@ func (svc *webService) initMux(options weboptions.Options) *goji.Mux {
 	// registered when the web profile option is enabled (via the `enable_web_profile`
 	// config field or the `--webprofile` command line flag).
 	if options.Pprof {
-		mux.HandleFunc(pat.New("/debug/pprof/"), pprof.Index)
+		mux.HandleFunc(pat.New("/debug/pprof"), func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/debug/pprof/", http.StatusMovedPermanently)
+		})
 		mux.HandleFunc(pat.New("/debug/pprof/cmdline"), pprof.Cmdline)
 		mux.HandleFunc(pat.New("/debug/pprof/profile"), pprof.Profile)
 		mux.HandleFunc(pat.New("/debug/pprof/symbol"), pprof.Symbol)
 		mux.HandleFunc(pat.New("/debug/pprof/trace"), pprof.Trace)
+		// pprof.Index serves both the profile listing and the named profiles (goroutine,
+		// heap, ...) that it parses out of the request path, so it must be registered with
+		// a wildcard. Routes are matched in registration order, so it goes after the
+		// handlers above, which pprof.Index does not know how to serve.
+		mux.HandleFunc(pat.New("/debug/pprof/*"), pprof.Index)
 
 		// serve resource graph visualization
 		// TODO: accept params to display different formats


### PR DESCRIPTION
## Problem

`robot/web/web.go` registered the pprof index with goji's `pat.New("/debug/pprof/")`. `pat` only wildcards when a pattern ends in `/*`, so only the exact index path resolved. `pprof.Index` serves named profiles by parsing the trailing path segment, but no request ever reached it with one, so those requests fell through to the catch-all gRPC handler:

```
/debug/pprof/          -> 200
/debug/pprof/goroutine -> 400
/debug/pprof           -> 400
```

`cmdline`, `profile`, `symbol` and `trace` have dedicated handlers and worked; `goroutine`, `heap`, `block`, `mutex`, `allocs` and `threadcreate` were unreachable. The goroutine dump is the most useful artifact for diagnosing a stalled machine, and it could not be fetched from one.

## Change

- Register `pprof.Index` at `pat.New("/debug/pprof/*")` so it receives the full path and can dispatch named profiles. It is registered *after* `cmdline`/`profile`/`symbol`/`trace` because goji matches routes in registration order and `pprof.Index` does not know how to serve those four.
- Redirect `/debug/pprof` to `/debug/pprof/`, matching what `net/http`'s `ServeMux` does for the stdlib registration.
- These routes remain gated behind the web profile option (`enable_web_profile` / `--webprofile`); this change does not alter that gating. Whether pprof should be on by default on the local bind address is a separate decision and was left alone here.

## Testing

Extended `TestDebugEndpointsGatedByWebProfile` to cover the named profiles (`goroutine`, `heap`, `allocs`, `block`, `mutex`, `threadcreate`), the trailing-slash-less index, and the dedicated `cmdline`/`symbol` handlers, plus a negative case for `goroutine` when the web profile is disabled. The new assertions fail on `main` and pass with the fix; `go test ./robot/web/...` passes.

Key: RSDK-14400

Co-authored by Claude agent for Jira.