### PR TITLE
RSDK-14336 robot/impl: flaky test fix TestCrashedModuleModelReregisteredAfterRecovery

### DIFF
--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -2470,19 +2470,28 @@ func TestCrashedModuleModelReregisteredAfterRecovery(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 
 	// Assert that restoring the testmodule binary makes h start working again
-	// after the auto-restart code succeeds.
+	// after the auto-restart code succeeds. The background restart loop only
+	// retries every oueRestartInterval and a single restart (process start plus
+	// the WebRTC ready handshake) can itself take several seconds, so wait
+	// generously for the module to recover before asserting its resources are
+	// re-added.
 	err = os.Rename(testPath+".disabled", testPath)
 	test.That(t, err, test.ShouldBeNil)
-	testutils.WaitForAssertionWithSleep(t, time.Second, 20, func(tb testing.TB) {
+	testutils.WaitForAssertionWithSleep(t, time.Second, 60, func(tb testing.TB) {
 		tb.Helper()
 		test.That(tb, logs.FilterMessage("Module resources to be re-added after module restart").Len(),
 			test.ShouldEqual, 1)
 	})
 
-	h, err = r.ResourceByName(generic.Named("h"))
-	test.That(t, err, test.ShouldBeNil)
-	_, err = h.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
-	test.That(t, err, test.ShouldBeNil)
+	// The log above is emitted before the orphaned resources are actually
+	// re-added, so poll until 'h' is usable again.
+	testutils.WaitForAssertionWithSleep(t, time.Second, 20, func(tb testing.TB) {
+		tb.Helper()
+		res, err := r.ResourceByName(generic.Named("h"))
+		test.That(tb, err, test.ShouldBeNil)
+		_, err = res.DoCommand(ctx, map[string]any{"command": "get_num_reconfigurations"})
+		test.That(tb, err, test.ShouldBeNil)
+	})
 
 	// Also assert that testmodule's resources were reregistered and
 	// test that a new resource in the config gets built successfully.


### PR DESCRIPTION
## Problem

`TestCrashedModuleModelReregisteredAfterRecovery` intermittently fails with:

```
local_robot_test.go:2468: Expected: '1'
    Actual:   '0'
```

i.e. the wait for `Module resources to be re-added after module restart` timed out.

From the failure logs, the test was not asserting anything wrong — it just ran out of time:

- The module crashed and the first restart attempt failed (binary renamed away by the test), so the restart loop waits `oueRestartInterval` (5s) before retrying.
- The test restores the binary and then only waits 20s for recovery.
- The retried restart started the process at `14:53:08.28`, but on that (heavily loaded macOS) runner the module took ~39s to get to `server listening` / respond to the ready request (`Waiting for module to complete restart and re-registration` warnings at 2s/5s/10s/15s).
- The 20s budget expired at `14:53:24` and the assertion failed with `0`; the restart would have completed at ~`14:53:47` had the test not already torn the robot down.

## Fix

- Bump the recovery wait from 20s to 60s, matching the equivalent waits in `TestCrashedModuleDependentRecovery` / `TestCrashedModuleDependentRecoveryAfterFailedFirstConstruction` (fixed the same way in #6277). A single restart attempt (5s retry interval + process start + WebRTC ready handshake) can legitimately take tens of seconds on a loaded CI machine.
- Poll for helper `h` to be usable again instead of asserting immediately after the log appears. The `Module resources to be re-added after module restart` log is emitted in `modmanager` *before* `handleOrphanedResources` actually re-adds the resources, so the immediate `DoCommand` assertion was racy.

No production code changes; the test's semantics are unchanged.

## Testing

Only the wait budgets/polling in this test changed. Note: the Go toolchain required by `go.mod` (1.25.10) and several dependency zips could not be fetched in this sandbox (egress allowlist blocks the module/toolchain downloads), so verification is left to CI.

Key: RSDK-14336

Co-authored by Claude agent for Jira.