### PR TITLE
RSDK-14428 - fail fast when a machine is offline

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -5671,6 +5671,9 @@ func (c *viamClient) connectToRobot(
 	clientOpts := []client.RobotClientOption{
 		client.WithDialOptions(rpcOpts...),
 		client.WithCheckConnectedEvery(globalArgs.CheckConnectionInterval),
+		// The default retries immediately with no backoff, multiplying the wait when the machine
+		// is offline - the common failure here. One attempt keeps the command responsive.
+		client.WithInitialDialAttempts(1),
 		// CLI commands read the resource list once after connecting and never re-read it, so a
 		// periodic refresh is pure churn - and error noise when enumeration is what's failing.
 		client.WithRefreshEvery(0),

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -632,7 +632,7 @@ func (rc *RobotClient) connectWithLock(ctx context.Context) error {
 			// Signaling was not reachable at all, so the client itself is likely offline. Say so
 			// rather than returning a chain of timeouts.
 			case errors.Is(err, context.DeadlineExceeded) && dialUnreachableErr(grpcErr):
-				const connTimeoutURL = "https://docs.viam.com/dev/tools/common-errors/#conn-time-out"
+				const connTimeoutURL = "https://docs.viam.com/monitor/common-errors/#conn-time-out"
 				return fmt.Errorf("failed to connect to machine within time limit. check network connection, whether the viam-server is running, " +
 					"and try again. see " + connTimeoutURL + " for troubleshooting steps")
 			default:

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -77,6 +77,10 @@ var (
 	// resources, applied per call rather than across the set.
 	defaultResourcesTimeout = 5 * time.Second
 
+	// localFallbackDialTimeout bounds the direct gRPC dial attempted after a WebRTC dial fails with
+	// NotFound. It covers an mDNS lookup (up to a second per candidate) as well as the dial itself.
+	localFallbackDialTimeout = 8 * time.Second
+
 	// latencyPingNum controls the amount of times a gRPC request will be sent to the server
 	// to measure the latency of the connection. The latency is only measured in case
 	// WithNetworkStats option is specified by the client.
@@ -547,6 +551,23 @@ func (rc *RobotClient) Connect(ctx context.Context) error {
 	return nil
 }
 
+// dialUnreachableErr reports whether a direct gRPC dial failed only because the machine could not
+// be reached - it timed out, or mDNS turned up no candidate. Which one comes back depends on
+// whether mDNS ran, so either alone qualifies; any other error in the chain is one the caller
+// needs to see.
+func dialUnreachableErr(err error) bool {
+	errs := multierr.Errors(err)
+	if len(errs) == 0 {
+		return false
+	}
+	for _, e := range errs {
+		if !errors.Is(e, context.DeadlineExceeded) && !errors.Is(e, rpc.ErrMDNSNoCandidatesFound) {
+			return false
+		}
+	}
+	return true
+}
+
 func (rc *RobotClient) connectWithLock(ctx context.Context) error {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
@@ -587,35 +608,36 @@ func (rc *RobotClient) connectWithLock(ctx context.Context) error {
 		// we add this flag to partially override the above override.
 		dialOptionsGRPCOnly[1] = rpc.WithDialMulticastDNSOptions(rpc.DialMulticastDNSOptions{Disable: false})
 
-		grpcConn, grpcErr := grpc.Dial(ctx, rc.address, dialLogger, dialOptionsGRPCOnly...)
+		// A NotFound from the WebRTC dial means signaling is reachable but the machine is not
+		// registered with it, leaving only a local route - and a local dial that works, works fast.
+		// Past that, the dial is just retrying an unreachable address until the default deadline.
+		grpcCtx := ctx
+		if status.Code(err) == codes.NotFound {
+			var cancel context.CancelFunc
+			grpcCtx, cancel = context.WithTimeout(ctx, localFallbackDialTimeout)
+			defer cancel()
+		}
+
+		grpcConn, grpcErr := grpc.Dial(grpcCtx, rc.address, dialLogger, dialOptionsGRPCOnly...)
 		if grpcErr == nil {
 			conn = grpcConn
 			err = nil
 		} else {
-			// A NotFound error from the WebRTC dial means that the client is able to reach
-			// the signaling server but the machine is not. If the machine is running viam-server but not connected to the signaling server,
-			// it is expected to only be available to clients on the same network. If the errors returned from grpc dials are timeouts or mDNS
-			// failing to find a candidate, it implies that the machine is not connected to the same network the client is.
-			// In that case, filtering out the errors from grpc dials should reduce noise and give clients a clearer idea of what to do next.
-			if statusErr := status.Convert(err); statusErr != nil &&
-				statusErr.Code() == codes.NotFound &&
-				errors.Is(grpcErr, rpc.ErrMDNSNoCandidatesFound) &&
-				errors.Is(grpcErr, context.DeadlineExceeded) {
+			switch {
+			// Signaling is reachable but the machine is not registered with it, and it is not on
+			// our network either. The WebRTC error already says the machine is offline; the dial
+			// error only adds noise.
+			case status.Code(err) == codes.NotFound && dialUnreachableErr(grpcErr):
 				return err
-			}
-			// A context.DeadlineExceeded from the WebRTC dial implies the client is unable to reach
-			// the signaling server, which likely means that the client is offline. In that case, if the errors returned from
-			// grpc dials are also timeouts or mDNS failing to find a candidate, we should remind clients to double-check their internet
-			// connection and that the machine is on. This should be more helpful than simply returning a chain of context.DeadlineExceeded
-			// and candidate not found errors.
-			const connTimeoutURL = "https://docs.viam.com/dev/tools/common-errors/#conn-time-out"
-			if errors.Is(err, context.DeadlineExceeded) &&
-				errors.Is(grpcErr, context.DeadlineExceeded) &&
-				errors.Is(grpcErr, rpc.ErrMDNSNoCandidatesFound) {
+			// Signaling was not reachable at all, so the client itself is likely offline. Say so
+			// rather than returning a chain of timeouts.
+			case errors.Is(err, context.DeadlineExceeded) && dialUnreachableErr(grpcErr):
+				const connTimeoutURL = "https://docs.viam.com/dev/tools/common-errors/#conn-time-out"
 				return fmt.Errorf("failed to connect to machine within time limit. check network connection, whether the viam-server is running, " +
 					"and try again. see " + connTimeoutURL + " for troubleshooting steps")
+			default:
+				err = multierr.Combine(err, grpcErr)
 			}
-			err = multierr.Combine(err, grpcErr)
 		}
 	}
 	if err != nil {

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -2627,3 +2627,30 @@ func TestUploadDataFromPath(t *testing.T) {
 	test.That(t, capturedMD.GetTags(), test.ShouldResemble, []string{"tag1"})
 	test.That(t, capturedExtra, test.ShouldResemble, map[string]interface{}{"foo": "bar"})
 }
+
+func TestDialUnreachableErr(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"deadline exceeded", context.DeadlineExceeded, true},
+		{"no mDNS candidates", rpc.ErrMDNSNoCandidatesFound, true},
+		{"both", multierr.Combine(context.DeadlineExceeded, rpc.ErrMDNSNoCandidatesFound), true},
+		{"wrapped", fmt.Errorf("dialing: %w", context.DeadlineExceeded), true},
+		{"unrelated", errors.New("connection refused"), false},
+		{"canceled", context.Canceled, false},
+		{"nil", nil, false},
+		// goutils folds the mDNS failure into every bare-domain dial error, so an informative
+		// failure always arrives alongside it and must not be read as unreachable.
+		{
+			"informative alongside mDNS",
+			multierr.Combine(rpc.ErrInsecureWithCredentials, rpc.ErrMDNSNoCandidatesFound),
+			false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			test.That(t, dialUnreachableErr(tc.err), test.ShouldEqual, tc.expected)
+		})
+	}
+}

--- a/robot/web/request_counter.go
+++ b/robot/web/request_counter.go
@@ -27,7 +27,7 @@ import (
 )
 
 // ReqLimitExceededURL is the URL for the troubleshooting steps for request limit exceeded errors.
-const ReqLimitExceededURL = "https://docs.viam.com/dev/tools/common-errors/#req-limit-exceeded"
+const ReqLimitExceededURL = "https://docs.viam.com/monitor/common-errors/#req-limit-exceeded"
 
 // RequestLimitExceededError is an error returned when a request is rejected
 // because it would exceed the limit for concurrent requests to a given


### PR DESCRIPTION
Dialing an offline machine took ~57s before `viam machine part shell` reported it, and printed a raw multierr chain instead of the "host appears to be offline" message the code already has. Each attempt was ~26s — ~5.5s for the WebRTC dial, which gets the definitive `NotFound` answer from signaling, then ~20s for the direct-gRPC fallback — and it ran three times.

**CLI dials once** (`cli/client.go`). The default three attempts have no backoff, so they cannot change a deterministic "not registered with signaling" answer.

**Cap the fallback dial at 8s when WebRTC returned `NotFound`** (`robot/client/client.go`). A machine's cloud FQDN resolves to its LAN IPs, which refuse instantly from off-network — but `grpc.WithBlock()` retries that refusal until the 20s deadline. Once signaling says the machine is not registered, only the LAN is left, and a local dial that works completes well inside 8s (the budget also covers the mDNS lookup).

**Make the friendly errors reachable** (`robot/client/client.go`). Both special cases required `rpc.ErrMDNSNoCandidatesFound` *and* a timeout in the chain, but the sentinel only appears when mDNS ran — and the CLI disables mDNS for OAuth tokens (RSDK-12818), so neither could ever match. `dialUnreachableErr` accepts either error alone, but rejects a chain containing anything else: goutils folds the mDNS failure into every bare-domain dial error, so a plain OR would swallow real failures like `ErrInsecureWithCredentials`.

Offline dials now fail in ~13.5s with the intended message.

**Scope:** `connectWithLock` is shared, so the cap also applies to remotes dialing a cloud FQDN; the residual risk is a slow-but-reachable local machine reported as offline, and a LAN handshake is milliseconds. Modules dial their parent over a unix socket and are unaffected. Follow-ups left out (opt-in `FailOnNonTempDialError` in goutils, skipping the CLI fallback entirely) are in RSDK-14428.

**Testing:** `TestDialUnreachableErr` covers the predicate; build, `gofmt`, and `golangci-lint` clean on the changed files; `go test ./cli/ -run "TestReload|TestShell|TestAddShell"` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)