### PR TITLE
Install mise and mise managed tools in ci lint run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -325,6 +325,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.event.ref }}
           allow-unsafe-pr-checkout: true
+
+      - name: Install toolchain
+        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518
+
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod


### PR DESCRIPTION
This just adds `jdx/mise-action` to the lint task of the ci workflow. This won't do anything on its own but merging it will allow the CI run in #6358 to pass. I manually kicked off a run with these changes to confirm the mise action works even though a mise config file doesn't exist [here][1].

[1]: https://github.com/viamrobotics/rdk/actions/runs/32048504935