### PR TITLE
Add mise step to tests_go task

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,6 +271,9 @@ jobs:
           echo "GITHUB_X_PR_BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
           echo "GITHUB_X_PR_BASE_REF=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
 
+      - name: Install toolchain
+        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518
+
       - name: Chown
         run: chown -R testbot:testbot .
 


### PR DESCRIPTION
Same as #6360 but adding mise to the task that runs the actual go tests. Needed because that task eventually ends up executing the `tool-install` make target, which includes calls to mise in #6358 