### PR TITLE
ci: stop Slack notifier firing on skipped release jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,8 +143,11 @@ jobs:
   license_finder:
     uses: viamrobotics/rdk/.github/workflows/license_finder.yml@main
 
+  # Name the states we want rather than negating success(): a `needs` job that is
+  # skipped (release gating above) is also "not success", which made !success()
+  # fire on green runs.
   slack-workflow-status:
-    if: ${{ !success() && inputs.release_type != 'pr' && !inputs.no_prod_upload }}
+    if: ${{ (failure() || cancelled()) && inputs.release_type != 'pr' && !inputs.no_prod_upload }}
     name: Post Workflow Status To Slack
     needs:
       - test


### PR DESCRIPTION
## Problem

`#team-devops` is getting green **"Success"** messages from a notifier that should only fire on failures — e.g. [run #5472](https://github.com/viamrobotics/rdk/actions/runs/32064437230).

## Why

The gate was `!success()`. At job level `success()` means *all* `needs` have result `success`, so `!success()` is true for `failure`, `cancelled` **and `skipped`**.

That was safe when it landed (#5525) — the notifier's `needs` had no `if:` and could never be skipped. Then #6083 added release skip gating, making `staticbuild-deploy` — a direct `need` — skippable.

So on any push touching only non-release workflow YAML:

1. `changes` outputs `release=false` (correct — no release needed)
2. `staticbuild-deploy` is skipped
3. `!success()` → true, because `skipped` != `success`
4. Notifier posts, reporting the run's real conclusion: success

Confirmed on #5472 (changed `.github/workflows/test.yml` only): all jobs `success`, 7 release jobs `skipped`, run conclusion `success`.

Also worth knowing: a status function in an `if:` removes the default "skip me if a dependency was skipped" behavior, which is why the job ran at all instead of skipping alongside `staticbuild-deploy`.

## Fix

Name the states we want instead of negating success. Keeps the cancelled-run coverage from #5525.

```diff
- if: ${{ !success() && ... }}
+ if: ${{ (failure() || cancelled()) && ... }}
```

`failure()` ignores skipped deps, so green runs stay quiet and real failures still page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)