### PR TITLE
[APP-17380a] Fix two hangs and tidy count messages in the data CLI

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -446,6 +446,16 @@ func createBeforeCommandWithT[T any](
 	}
 }
 
+// mustBePositiveUint builds a flag Validator that rejects an explicit 0.
+func mustBePositiveUint(flagName string) func(uint) error {
+	return func(v uint) error {
+		if v == 0 {
+			return fmt.Errorf("--%s must be greater than 0", flagName)
+		}
+		return nil
+	}
+}
+
 // createUsageText is a helper for formatting UsageTexts. The created UsageText
 // contains "viam", the command, requiredFlags, "[other options]" if unrequiredOptions
 // is true, "<command> [command options]" if subcommand is true, and all passed-in
@@ -1338,9 +1348,10 @@ Note: There is no progress meter while copying is in progress.
 											TakesFile: true,
 										},
 										&cli.UintFlag{
-											Name:  dataFlagParallelDownloads,
-											Usage: "number of download requests to make in parallel",
-											Value: 100,
+											Name:      dataFlagParallelDownloads,
+											Usage:     "number of download requests to make in parallel",
+											Value:     defaultParallelBinaryDownloads,
+											Validator: mustBePositiveUint(dataFlagParallelDownloads),
 										},
 										&cli.UintFlag{
 											Name:  dataFlagTimeout,
@@ -1923,9 +1934,10 @@ Note: There is no progress meter while copying is in progress.
 							Usage: "option to include only the JSON Lines files for local testing; no binary data will be downloaded",
 						},
 						&cli.UintFlag{
-							Name:  dataFlagParallelDownloads,
-							Usage: "number of download requests to make in parallel",
-							Value: 100,
+							Name:      dataFlagParallelDownloads,
+							Usage:     "number of download requests to make in parallel",
+							Value:     defaultParallelBinaryDownloads,
+							Validator: mustBePositiveUint(dataFlagParallelDownloads),
 						},
 						&cli.UintFlag{
 							Name:  dataFlagTimeout,

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+	"go.viam.com/test"
+)
+
+// uintFlagsNamed returns every cli.UintFlag called <name> anywhere in the command tree, so a test
+// can assert against all of them without naming the commands that carry it.
+func uintFlagsNamed(cmds []*cli.Command, name string) []*cli.UintFlag {
+	var found []*cli.UintFlag
+	for _, cmd := range cmds {
+		for _, f := range cmd.Flags {
+			if uintFlag, ok := f.(*cli.UintFlag); ok && uintFlag.Name == name {
+				found = append(found, uintFlag)
+			}
+		}
+		found = append(found, uintFlagsNamed(cmd.Commands, name)...)
+	}
+	return found
+}
+
+// TestParallelFlagRejectsZero asserts every --parallel flag rejects an explicit 0 while leaving
+// its default intact. Searching the tree (rather than naming the commands)
+// means future --parallel flags added without the validator will fail here.
+func TestParallelFlagRejectsZero(t *testing.T) {
+	flags := uintFlagsNamed(NewApp(io.Discard, io.Discard).Commands, dataFlagParallelDownloads)
+	// Guards the search itself: if it stops finding flags, the loop below asserts nothing.
+	test.That(t, len(flags), test.ShouldBeGreaterThan, 0)
+
+	for _, flag := range flags {
+		test.That(t, flag.Validator, test.ShouldNotBeNil)
+		test.That(t, flag.Validator(0), test.ShouldBeError,
+			fmt.Errorf("--%s must be greater than 0", dataFlagParallelDownloads))
+		// Whatever default the flag carries has to survive its own validator.
+		test.That(t, flag.Validator(1), test.ShouldBeNil)
+		test.That(t, flag.Validator(flag.Value), test.ShouldBeNil)
+	}
+}

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -78,6 +78,8 @@ func buildTestFlags(m map[string]any) []cli.Flag {
 		switch v := val.(type) {
 		case int:
 			flags = append(flags, &cli.IntFlag{Name: name, Value: v})
+		case uint:
+			flags = append(flags, &cli.UintFlag{Name: name, Value: v})
 		case string:
 			flags = append(flags, &cli.StringFlag{Name: name, Value: v})
 		case bool:

--- a/cli/data.go
+++ b/cli/data.go
@@ -41,6 +41,8 @@ const (
 	logEveryN     = 100
 	maxLimit      = 100
 
+	defaultParallelBinaryDownloads = 100
+
 	dataCommandAdd    = "add"
 	dataCommandRemove = "remove"
 
@@ -227,12 +229,12 @@ func DataTagActionByFilter(ctx context.Context, cmd *cli.Command, args dataTagBy
 
 	switch cmd.Name {
 	case dataCommandAdd:
-		if err := client.dataAddTagsToBinaryByFilter(filter, args.Tags); err != nil {
+		if err := client.dataAddTagsToBinaryByFilter(ctx, filter, args.Tags); err != nil {
 			return err
 		}
 		return nil
 	case dataCommandRemove:
-		if err := client.dataRemoveTagsFromBinaryByFilter(filter, args.Tags); err != nil {
+		if err := client.dataRemoveTagsFromBinaryByFilter(ctx, filter, args.Tags); err != nil {
 			return err
 		}
 		return nil
@@ -453,7 +455,7 @@ func (c *viamClient) dataExportBinaryIDsAction(ctx context.Context, args dataExp
 	if len(args.BinaryDataIDs) > 0 {
 		result := c.downloadBinary(ctx, args.Destination, args.Timeout, args.BinaryDataIDs...)
 		if result == nil { // nil result means success
-			printf(c.c.Root().Writer, "Downloaded %d files", len(args.BinaryDataIDs))
+			printf(c.c.Root().Writer, "Downloaded %d %s", len(args.BinaryDataIDs), pluralize(len(args.BinaryDataIDs), "file"))
 		}
 		return result
 	}
@@ -624,7 +626,7 @@ func (c *viamClient) dataQueryBinaryAction(ctx context.Context, args dataQueryBi
 		return errors.Wrap(err, "error writing query results")
 	}
 	if filePath != "" {
-		printf(c.c.Root().Writer, "Wrote %d results to %s", written, filePath)
+		printf(c.c.Root().Writer, "Wrote %d %s to %s", written, pluralize(int(written), "result"), filePath)
 	}
 	return nil
 }
@@ -688,20 +690,20 @@ func writeQueryResults(w io.Writer, dest string, rows [][]byte) error {
 	}
 
 	if filePath != "" {
-		printf(w, "Wrote %d rows to %s", len(rows), filePath)
+		printf(w, "Wrote %d %s to %s", len(rows), pluralize(len(rows), "row"), filePath)
 	}
 	return nil
 }
 
 // BinaryData downloads binary data matching filter to dst.
 func (c *viamClient) binaryData(ctx context.Context, dst string, filter *datapb.Filter, parallelDownloads, timeout uint) error {
-	return c.performActionOnBinaryDataFromFilter(
-		func(id string) error {
+	return c.performActionOnBinaryDataFromFilter(ctx,
+		func(ctx context.Context, id string) error {
 			return c.downloadBinary(ctx, dst, timeout, id)
 		},
 		filter, parallelDownloads,
 		func(i int32) {
-			printf(c.c.Root().Writer, "Downloaded %d files", i)
+			printf(c.c.Root().Writer, "Downloaded %d %s", i, pluralize(int(i), "file"))
 		},
 	)
 }
@@ -710,14 +712,15 @@ func (c *viamClient) binaryData(ctx context.Context, dst string, filter *datapb.
 // a filter in batches and then performs actionOnBinaryData on each binary data in parallel.
 // Each time `logEveryN` actions have been performed, the printStatement logs a statement that takes in as
 // input how much binary data has been processed thus far.
-func (c *viamClient) performActionOnBinaryDataFromFilter(actionOnBinaryData func(string) error,
+func (c *viamClient) performActionOnBinaryDataFromFilter(ctx context.Context,
+	actionOnBinaryData func(ctx context.Context, id string) error,
 	filter *datapb.Filter, parallelActions uint, printStatement func(int32),
 ) error {
 	ids := make(chan string, parallelActions)
 	// Give channel buffer of 1+parallelActions because that is the number of goroutines that may be passing an
 	// error into this channel (1 get ids routine + parallelActions worker routines).
 	errs := make(chan error, 1+parallelActions)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	var wg sync.WaitGroup
 
@@ -734,20 +737,20 @@ func (c *viamClient) performActionOnBinaryDataFromFilter(actionOnBinaryData func
 	}()
 
 	// Read from ids and perform the action on the binary data for each id.
-	var downloadWG sync.WaitGroup
+	var actionWG sync.WaitGroup
 	var numFilesProcessed atomic.Int32
 
 	for i := uint(0); i < parallelActions; i++ {
-		downloadWG.Add(1)
+		actionWG.Add(1)
 		go func() {
-			defer downloadWG.Done()
+			defer actionWG.Done()
 			for {
 				select {
 				case id, ok := <-ids:
 					if !ok {
 						return
 					}
-					err := actionOnBinaryData(id)
+					err := actionOnBinaryData(ctx, id)
 					if err != nil {
 						errs <- err
 						cancel()
@@ -764,7 +767,7 @@ func (c *viamClient) performActionOnBinaryDataFromFilter(actionOnBinaryData func
 		}()
 	}
 	wg.Wait()
-	downloadWG.Wait()
+	actionWG.Wait()
 	if numFilesProcessed.Load()%logEveryN != 0 {
 		printStatement(numFilesProcessed.Load())
 	}
@@ -779,13 +782,17 @@ func (c *viamClient) performActionOnBinaryDataFromFilter(actionOnBinaryData func
 
 // getMatchingBinaryIDs queries client for all BinaryData matching filter, and passes each of their ids into ids.
 func getMatchingBinaryIDs(ctx context.Context, client datapb.DataServiceClient, filter *datapb.Filter,
-	ids chan string, limit uint,
+	ids chan<- string, limit uint,
 ) error {
 	defer close(ids)
 	return forEachBinaryDataByFilter(ctx, client, filter, uint64(limit),
 		func(bd *datapb.BinaryData) (bool, error) {
-			ids <- bd.GetMetadata().GetBinaryDataId()
-			return false, nil
+			select {
+			case ids <- bd.GetMetadata().GetBinaryDataId():
+				return false, nil
+			case <-ctx.Done():
+				return false, ctx.Err()
+			}
 		})
 }
 
@@ -855,9 +862,14 @@ func (c *viamClient) downloadBinary(ctx context.Context, dst string, timeout uin
 
 	data := resp.GetData()
 
+	numExpectedResponses := len(ids)
+	numReceivedResponses := len(data)
 	// Loop through responses and download each file
-	if len(data) != len(ids) {
-		return errors.Errorf("expected %d responses for %d files, received %d responses", len(ids), len(ids), len(data))
+	if numExpectedResponses != numReceivedResponses {
+		return errors.Errorf("expected %d %s for %d %s, received %d %s",
+			numExpectedResponses, pluralize(numExpectedResponses, "response"),
+			numExpectedResponses, pluralize(numExpectedResponses, "file"),
+			numReceivedResponses, pluralize(numReceivedResponses, "response"))
 	}
 
 	for i, datum := range data {
@@ -1114,10 +1126,10 @@ func (c *viamClient) tabularData(dest string, request *datapb.ExportTabularDataR
 				}
 			}()
 
+			fmt.Fprintf(c.c.Root().Writer, ".") //nolint:errcheck // Adds '.' to 'Downloading..' output.
+
 			go func() {
 				defer close(dataRowChan)
-				fmt.Fprintf(c.c.Root().Writer, ".") //nolint:errcheck // Adds '.' to 'Downloading..' output.
-
 				stream, err := c.dataClient.ExportTabularData(ctx, request)
 				if err != nil {
 					errChan <- errors.Wrap(err, "failed to export tabular data")
@@ -1226,36 +1238,37 @@ func (c *viamClient) deleteBinaryData(filter *datapb.Filter) error {
 	if err != nil {
 		return errors.Wrapf(err, serverErrorMessage)
 	}
-	printf(c.c.Root().Writer, "Deleted %d files", resp.GetDeletedCount())
+	deleted := int(resp.GetDeletedCount())
+	printf(c.c.Root().Writer, "Deleted %d %s", deleted, pluralize(deleted, "file"))
 	return nil
 }
 
-func (c *viamClient) dataAddTagsToBinaryByFilter(filter *datapb.Filter, tags []string) error {
+func (c *viamClient) dataAddTagsToBinaryByFilter(ctx context.Context, filter *datapb.Filter, tags []string) error {
 	parallelActions := uint(100)
-	return c.performActionOnBinaryDataFromFilter(
-		func(id string) error {
-			_, err := c.dataClient.AddTagsToBinaryDataByIDs(context.Background(),
+	return c.performActionOnBinaryDataFromFilter(ctx,
+		func(ctx context.Context, id string) error {
+			_, err := c.dataClient.AddTagsToBinaryDataByIDs(ctx,
 				&datapb.AddTagsToBinaryDataByIDsRequest{Tags: tags, BinaryDataIds: []string{id}})
 			return errors.Wrapf(err, serverErrorMessage)
 		},
 		filter, parallelActions,
 		func(i int32) {
-			printf(c.c.Root().Writer, "Added tags to %d files", i)
+			printf(c.c.Root().Writer, "Added tags to %d %s", i, pluralize(int(i), "file"))
 		},
 	)
 }
 
-func (c *viamClient) dataRemoveTagsFromBinaryByFilter(filter *datapb.Filter, tags []string) error {
+func (c *viamClient) dataRemoveTagsFromBinaryByFilter(ctx context.Context, filter *datapb.Filter, tags []string) error {
 	parallelActions := uint(100)
-	return c.performActionOnBinaryDataFromFilter(
-		func(id string) error {
-			_, err := c.dataClient.RemoveTagsFromBinaryDataByIDs(context.Background(),
+	return c.performActionOnBinaryDataFromFilter(ctx,
+		func(ctx context.Context, id string) error {
+			_, err := c.dataClient.RemoveTagsFromBinaryDataByIDs(ctx,
 				&datapb.RemoveTagsFromBinaryDataByIDsRequest{Tags: tags, BinaryDataIds: []string{id}})
 			return errors.Wrapf(err, serverErrorMessage)
 		},
 		filter, parallelActions,
 		func(i int32) {
-			printf(c.c.Root().Writer, "Removed tags from %d files", i)
+			printf(c.c.Root().Writer, "Removed tags from %d %s", i, pluralize(int(i), "file"))
 		},
 	)
 }
@@ -1289,7 +1302,8 @@ func (c *viamClient) deleteTabularData(orgID string, deleteOlderThanDays int) er
 	if err != nil {
 		return errors.Wrapf(err, serverErrorMessage)
 	}
-	printf(c.c.Root().Writer, "Deleted %d datapoints", resp.GetDeletedCount())
+	deleted := int(resp.GetDeletedCount())
+	printf(c.c.Root().Writer, "Deleted %d %s", deleted, pluralize(deleted, "datapoint"))
 	return nil
 }
 
@@ -1345,8 +1359,8 @@ func DataAddToDatasetByFilter(ctx context.Context, cmd *cli.Command, args dataAd
 func (c *viamClient) dataAddToDatasetByFilter(ctx context.Context, filter *datapb.Filter, datasetID string) error {
 	parallelActions := uint(100)
 
-	return c.performActionOnBinaryDataFromFilter(
-		func(id string) error {
+	return c.performActionOnBinaryDataFromFilter(ctx,
+		func(ctx context.Context, id string) error {
 			var err error
 			for attempt := 0; attempt < maxRetryCount; attempt++ {
 				if attempt > 0 {
@@ -1369,7 +1383,7 @@ func (c *viamClient) dataAddToDatasetByFilter(ctx context.Context, filter *datap
 		},
 		filter, parallelActions,
 		func(i int32) {
-			printf(c.c.Root().Writer, "Added %d files to dataset ID %s", i, datasetID)
+			printf(c.c.Root().Writer, "Added %d %s to dataset ID %s", i, pluralize(int(i), "file"), datasetID)
 		})
 }
 
@@ -1432,15 +1446,15 @@ func (c *viamClient) dataRemoveFromDatasetByFilter(ctx context.Context, filter *
 	}
 	parallelActions := uint(100)
 
-	return c.performActionOnBinaryDataFromFilter(
-		func(id string) error {
+	return c.performActionOnBinaryDataFromFilter(ctx,
+		func(ctx context.Context, id string) error {
 			_, err := c.dataClient.RemoveBinaryDataFromDatasetByIDs(ctx,
 				&datapb.RemoveBinaryDataFromDatasetByIDsRequest{DatasetId: datasetID, BinaryDataIds: []string{id}})
 			return err
 		},
 		filter, parallelActions,
 		func(i int32) {
-			printf(c.c.Root().Writer, "Removed %d files from dataset ID %s", i, datasetID)
+			printf(c.c.Root().Writer, "Removed %d %s from dataset ID %s", i, pluralize(int(i), "file"), datasetID)
 		})
 }
 

--- a/cli/data.go
+++ b/cli/data.go
@@ -773,9 +773,19 @@ func (c *viamClient) performActionOnBinaryDataFromFilter(ctx context.Context,
 	}
 	close(errs)
 
-	var allErrs error
+	// A failing worker cancels the run, so the producer reports context.Canceled on its way out.
+	// That is our own doing, and appending it next to the real cause only obscures it. It still
+	// gets returned when nothing else went wrong, which is how a caller-cancelled run surfaces.
+	var allErrs, canceled error
 	for err := range errs {
+		if errors.Is(err, context.Canceled) {
+			canceled = err
+			continue
+		}
 		allErrs = multierr.Append(allErrs, err)
+	}
+	if allErrs == nil {
+		return canceled
 	}
 	return allErrs
 }

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -374,6 +374,9 @@ func echoBinaryDataByIDs(_ context.Context, in *datapb.BinaryDataByIDsRequest, _
 // records the filter it was asked with.
 type binaryFilterFake struct {
 	pages [][]string
+	// repeat serves the first page forever, so the producer never runs out of ids to send.
+	repeat   bool
+	byIDsErr error
 
 	mu     sync.Mutex
 	call   int
@@ -389,56 +392,59 @@ func (f *binaryFilterFake) client() *inject.DataServiceClient {
 			f.filter = in.GetDataRequest().GetFilter()
 
 			resp := &datapb.BinaryDataByFilterResponse{}
-			if f.call < len(f.pages) {
-				for _, id := range f.pages[f.call] {
+			if page := f.call; f.repeat || page < len(f.pages) {
+				if f.repeat {
+					page = 0
+				}
+				for _, id := range f.pages[page] {
 					resp.Data = append(resp.Data, &datapb.BinaryData{Metadata: binaryMeta(id)})
 				}
 			}
 			f.call++
 			return resp, nil
 		},
-		BinaryDataByIDsFunc: echoBinaryDataByIDs,
-	}
-}
-
-// Guards the shared performActionOnBinaryDataIDs driver the sequence export also runs on.
-func TestDataExportBinaryFromFilter(t *testing.T) {
-	fake := &binaryFilterFake{pages: [][]string{{"bin-1", "bin-2"}, {"bin-3"}}}
-	_, ac, out, _ := setup(&inject.AppServiceClient{}, fake.client(), nil, nil, "token")
-
-	dst := t.TempDir()
-	err := ac.binaryData(context.Background(), dst, &datapb.Filter{PartId: "p1"}, 4, 0)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, fake.filter.GetPartId(), test.ShouldEqual, "p1")
-
-	for _, id := range []string{"bin-1", "bin-2", "bin-3"} {
-		path := dataFilePath(dst, filenameForDownload(binaryMeta(id)), ".jpg")
-		test.That(t, mustReadFile(t, path), test.ShouldResemble, []byte("bytes-"+id))
-	}
-	test.That(t, strings.Join(out.messages, ""), test.ShouldContainSubstring, "Downloaded 3 files")
-}
-
-// When an action fails the workers cancel and return, so a producer still sending must abort too
-// or the command hangs. Times out if getMatchingBinaryIDs stops selecting on ctx.
-func TestDataExportBinaryCancelsProducerOnActionError(t *testing.T) {
-	page := &datapb.BinaryDataByFilterResponse{}
-	for range 10 {
-		page.Data = append(page.Data, &datapb.BinaryData{Metadata: binaryMeta("bin-1")})
-	}
-	dsc := &inject.DataServiceClient{
-		BinaryDataByFilterFunc: func(_ context.Context, _ *datapb.BinaryDataByFilterRequest, _ ...grpc.CallOption,
-		) (*datapb.BinaryDataByFilterResponse, error) {
-			return page, nil // never exhausts, so the producer always has more to send
+		BinaryDataByIDsFunc: func(ctx context.Context, in *datapb.BinaryDataByIDsRequest, opts ...grpc.CallOption,
+		) (*datapb.BinaryDataByIDsResponse, error) {
+			if f.byIDsErr != nil {
+				return nil, f.byIDsErr
+			}
+			return echoBinaryDataByIDs(ctx, in, opts...)
 		},
 	}
-	cCtx, ac, _, _ := setup(&inject.AppServiceClient{}, dsc, nil, nil, "token")
-	_ = cCtx
+}
 
-	err := ac.performActionOnBinaryDataFromFilter(context.Background(),
-		func(context.Context, string) error { return errors.New("action failed") },
-		&datapb.Filter{PartId: "p1"}, 2, func(int32) {})
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "action failed")
+func TestDataExportBinaryAction(t *testing.T) {
+	t.Run("downloads every id the filter matches", func(t *testing.T) {
+		fake := &binaryFilterFake{pages: [][]string{{"bin-1", "bin-2"}, {"bin-3"}}}
+		cCtx, ac, out, _ := setup(&inject.AppServiceClient{}, fake.client(), nil,
+			map[string]any{generalFlagPartID: "p1"}, "token")
+
+		dst := t.TempDir()
+		err := ac.dataExportBinaryAction(context.Background(), cCtx, dataExportBinaryArgs{Destination: dst, Parallel: 4})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, fake.filter.GetPartId(), test.ShouldEqual, "p1")
+
+		for _, id := range []string{"bin-1", "bin-2", "bin-3"} {
+			path := dataFilePath(dst, filenameForDownload(binaryMeta(id)), ".jpg")
+			test.That(t, mustReadFile(t, path), test.ShouldResemble, []byte("bytes-"+id))
+		}
+		test.That(t, strings.Join(out.messages, ""), test.ShouldContainSubstring, "Downloaded 3 files")
+	})
+
+	t.Run("reports a download failure instead of hanging", func(t *testing.T) {
+		fake := &binaryFilterFake{
+			pages:    [][]string{{"bin-1", "bin-2", "bin-3", "bin-4"}},
+			repeat:   true,
+			byIDsErr: errors.New("download failed"),
+		}
+		cCtx, ac, _, _ := setup(&inject.AppServiceClient{}, fake.client(), nil,
+			map[string]any{generalFlagPartID: "p1"}, "token")
+
+		err := ac.dataExportBinaryAction(context.Background(), cCtx,
+			dataExportBinaryArgs{Destination: t.TempDir(), Parallel: 2})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "download failed")
+	})
 }
 
 func TestDataQueryBinaryAction(t *testing.T) {

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -444,6 +444,8 @@ func TestDataExportBinaryAction(t *testing.T) {
 			dataExportBinaryArgs{Destination: t.TempDir(), Parallel: 2})
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "download failed")
+		// The cancellation is this function's own, so it should not ride along with the cause.
+		test.That(t, err.Error(), test.ShouldNotContainSubstring, "context canceled")
 	})
 }
 

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -349,6 +350,95 @@ func TestDataSourceTypeToProto(t *testing.T) {
 				name, tabularDataByMQLDataSourceTypes))
 		}
 	})
+}
+
+func binaryMeta(id string) *datapb.BinaryMetadata {
+	return &datapb.BinaryMetadata{BinaryDataId: id, FileName: id + ".jpg", FileExt: ".jpg"}
+}
+
+// echoBinaryDataByIDs returns one datum per requested id, with bytes when the caller asks for them.
+func echoBinaryDataByIDs(_ context.Context, in *datapb.BinaryDataByIDsRequest, _ ...grpc.CallOption,
+) (*datapb.BinaryDataByIDsResponse, error) {
+	resp := &datapb.BinaryDataByIDsResponse{}
+	for _, id := range in.GetBinaryDataIds() {
+		datum := &datapb.BinaryData{Metadata: binaryMeta(id)}
+		if in.GetIncludeBinary() {
+			datum.Binary = []byte("bytes-" + id)
+		}
+		resp.Data = append(resp.Data, datum)
+	}
+	return resp, nil
+}
+
+// binaryFilterFake serves one page of ids per BinaryDataByFilter call, then empty pages, and
+// records the filter it was asked with.
+type binaryFilterFake struct {
+	pages [][]string
+
+	mu     sync.Mutex
+	call   int
+	filter *datapb.Filter
+}
+
+func (f *binaryFilterFake) client() *inject.DataServiceClient {
+	return &inject.DataServiceClient{
+		BinaryDataByFilterFunc: func(_ context.Context, in *datapb.BinaryDataByFilterRequest, _ ...grpc.CallOption,
+		) (*datapb.BinaryDataByFilterResponse, error) {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			f.filter = in.GetDataRequest().GetFilter()
+
+			resp := &datapb.BinaryDataByFilterResponse{}
+			if f.call < len(f.pages) {
+				for _, id := range f.pages[f.call] {
+					resp.Data = append(resp.Data, &datapb.BinaryData{Metadata: binaryMeta(id)})
+				}
+			}
+			f.call++
+			return resp, nil
+		},
+		BinaryDataByIDsFunc: echoBinaryDataByIDs,
+	}
+}
+
+// Guards the shared performActionOnBinaryDataIDs driver the sequence export also runs on.
+func TestDataExportBinaryFromFilter(t *testing.T) {
+	fake := &binaryFilterFake{pages: [][]string{{"bin-1", "bin-2"}, {"bin-3"}}}
+	_, ac, out, _ := setup(&inject.AppServiceClient{}, fake.client(), nil, nil, "token")
+
+	dst := t.TempDir()
+	err := ac.binaryData(context.Background(), dst, &datapb.Filter{PartId: "p1"}, 4, 0)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fake.filter.GetPartId(), test.ShouldEqual, "p1")
+
+	for _, id := range []string{"bin-1", "bin-2", "bin-3"} {
+		path := dataFilePath(dst, filenameForDownload(binaryMeta(id)), ".jpg")
+		test.That(t, mustReadFile(t, path), test.ShouldResemble, []byte("bytes-"+id))
+	}
+	test.That(t, strings.Join(out.messages, ""), test.ShouldContainSubstring, "Downloaded 3 files")
+}
+
+// When an action fails the workers cancel and return, so a producer still sending must abort too
+// or the command hangs. Times out if getMatchingBinaryIDs stops selecting on ctx.
+func TestDataExportBinaryCancelsProducerOnActionError(t *testing.T) {
+	page := &datapb.BinaryDataByFilterResponse{}
+	for range 10 {
+		page.Data = append(page.Data, &datapb.BinaryData{Metadata: binaryMeta("bin-1")})
+	}
+	dsc := &inject.DataServiceClient{
+		BinaryDataByFilterFunc: func(_ context.Context, _ *datapb.BinaryDataByFilterRequest, _ ...grpc.CallOption,
+		) (*datapb.BinaryDataByFilterResponse, error) {
+			return page, nil // never exhausts, so the producer always has more to send
+		},
+	}
+	cCtx, ac, _, _ := setup(&inject.AppServiceClient{}, dsc, nil, nil, "token")
+	_ = cCtx
+
+	err := ac.performActionOnBinaryDataFromFilter(context.Background(),
+		func(context.Context, string) error { return errors.New("action failed") },
+		&datapb.Filter{PartId: "p1"}, 2, func(int32) {})
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "action failed")
 }
 
 func TestDataQueryBinaryAction(t *testing.T) {

--- a/cli/dataset.go
+++ b/cli/dataset.go
@@ -118,8 +118,8 @@ func (c *viamClient) mergeDatasets(orgID, newDatasetName string, datasetIDs []st
 	if err != nil {
 		return errors.Wrapf(err, "received error from server")
 	}
-	printf(c.c.Root().Writer, "Successfully merged %d datasets into new dataset '%s' with ID: %s",
-		len(datasetIDs), newDatasetName, resp.GetDatasetId())
+	printf(c.c.Root().Writer, "Successfully merged %d %s into new dataset '%s' with ID: %s",
+		len(datasetIDs), pluralize(len(datasetIDs), "dataset"), newDatasetName, resp.GetDatasetId())
 	return nil
 }
 
@@ -286,8 +286,8 @@ func (c *viamClient) downloadDataset(
 		return fmt.Errorf("%s does not match any dataset IDs", datasetID)
 	}
 
-	return c.performActionOnBinaryDataFromFilter(
-		func(id string) error {
+	return c.performActionOnBinaryDataFromFilter(ctx,
+		func(ctx context.Context, id string) error {
 			var downloadErr error
 			var datasetFilePath string
 			if !onlyJSONLines {
@@ -302,7 +302,7 @@ func (c *viamClient) downloadDataset(
 			DatasetId: datasetID,
 		}, parallelDownloads,
 		func(i int32) {
-			printf(c.c.Root().Writer, "Downloaded %d files", i)
+			printf(c.c.Root().Writer, "Downloaded %d %s", i, pluralize(int(i), "file"))
 		},
 	)
 }

--- a/cli/dataset_sequence_export.go
+++ b/cli/dataset_sequence_export.go
@@ -86,9 +86,6 @@ func (c *viamClient) downloadSequenceBinaryBlobs(
 	if err := os.MkdirAll(binaryDir, 0o700); err != nil {
 		return errors.Wrapf(err, "could not create %s", binaryDir)
 	}
-	if parallel == 0 {
-		parallel = 100
-	}
 
 	printf(c.c.Root().Writer, "Downloading binary blobs to %s", binaryDir)
 
@@ -121,7 +118,7 @@ func (c *viamClient) downloadSequenceBinaryBlobs(
 					return
 				}
 				if n := done.Add(1); n%100 == 0 {
-					printf(c.c.Root().Writer, "Downloaded %d binary blobs", n)
+					printf(c.c.Root().Writer, "Downloaded %d %s", n, pluralize(int(n), "binary blob"))
 				}
 			}
 		}()
@@ -136,7 +133,8 @@ func (c *viamClient) downloadSequenceBinaryBlobs(
 		allErrs = multierr.Append(allErrs, e)
 	}
 	if allErrs == nil {
-		printf(c.c.Root().Writer, "Done — wrote %d binary blobs to %s", done.Load(), binaryDir)
+		wrote := int(done.Load())
+		printf(c.c.Root().Writer, "Done — wrote %d %s to %s", wrote, pluralize(wrote, "binary blob"), binaryDir)
 	}
 	return allErrs
 }

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -113,3 +113,13 @@ func parseTimeString(timeStr string) (*timestamppb.Timestamp, error) {
 func formatStringForOutput(protoString, prefixToTrim string) string {
 	return strings.ToLower(strings.TrimPrefix(protoString, prefixToTrim))
 }
+
+// pluralize returns the form of noun that agrees with count, plural for everything but exactly
+// one. Only regular nouns are covered; an irregular one needs its own handling rather than a
+// second parameter here.
+func pluralize(count int, noun string) string {
+	if count == 1 {
+		return noun
+	}
+	return noun + "s"
+}


### PR DESCRIPTION
Three independent fixes to `data export binary`, `dataset export`, and the data tag commands. Split out of the `data export sequence` work that surfaced them; none of it depends on that feature.

Stacked: this is 1 of 3. `APP-17380b` (the feature) and `APP-17380c` (live progress) build on it.

## Reject `--parallel=0`

`--parallel` is a uint flag with no validation, so `0` was accepted — zero workers, and the producer blocks forever on a channel nobody drains. Instead of checking for 0 and replacing with the default, better to reject as invalid.

Rejected at the flag now, via a `Validator` on all three `--parallel` flags — urfave runs these only on values the user actually set, so defaults are untouched.

## Second hang: a failed download

A download that failed partway through a large export hung instead of reporting the error. Workers cancel and exit on failure, but `getMatchingBinaryIDs` sent into the id channel without watching for cancellation, so the producer blocked forever on a buffer nobody was draining and the real cause never came out of `errs`. It selects on ctx now.

## Pass a context to the binary data action

`actionOnBinaryData` only took an id, so cancelling a run didn't stop in-flight work — `dataAddToDatasetByFilter`'s backoff would keep sleeping up to 8s after the export already failed, and two of the six call sites were on `context.Background()` outright. `performActionOnBinaryDataFromFilter` takes a ctx now. Internal only until the root ctx is cancellable, but once someone swaps it for a `signal.NotifyContext`, this is already wired for it.

## Pluralized counts

Messages said "1 files" throughout. Adds `pluralize` and applies it to the `%d files` style messages across `data.go` and `dataset.go`.

## Testing

- `TestDataExportBinaryCancelsProducerOnActionError` drives a failure through a result set larger than the channel buffer and times out if `getMatchingBinaryIDs` stops selecting on ctx.
- `TestParallelFlagRejectsZero` searches the command tree, so a `--parallel` added later without a validator fails it.
- `TestDataExportBinaryAction` covers the filter path end to end: paging, downloads, and the filter actually reaching the server.

Checked each fix by putting the bug back — both hangs time out, and stripping the validators fails on the nil check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)