### PR TITLE
[APP-17380b] Add `viam data export sequence`

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -156,6 +156,9 @@ const (
 	dataFlagIndexName                      = "index-name"
 	dataFlagIndexSpecFile                  = "index-path"
 	dataFlagLimit                          = "limit"
+	dataFlagSequenceID                     = "sequence-id"
+	dataFlagOnlyTabular                    = "only-tabular"
+	dataFlagOnlyBinary                     = "only-binary"
 
 	datapipelineFlagSchedule       = "schedule"
 	datapipelineFlagEnableBackfill = "enable-backfill"
@@ -1443,6 +1446,49 @@ Note: There is no progress meter while copying is in progress.
 								},
 							},
 							Action: createActionCommandWithT[dataExportTabularArgs](DataExportTabularAction),
+						},
+						{
+							Name:      "sequence",
+							Usage:     "download all data belonging to a single sequence",
+							UsageText: createUsageText("data export sequence", []string{generalFlagDestination, dataFlagSequenceID}, true, false),
+							Description: "Downloads everything a single sequence references. For each resource the sequence " +
+								"covers, exports that resource's tabular data over the sequence's capture interval to " +
+								"<destination>/tabular/<resource-name>-<method-name>.ndjson, then downloads the sequence's " +
+								"binary data into <destination>/binary/data and <destination>/binary/metadata. " +
+								"Use --only-tabular or --only-binary to export just one of the two.",
+							Flags: []cli.Flag{
+								&cli.StringFlag{
+									Name:      generalFlagDestination,
+									Required:  true,
+									Usage:     "output directory for downloaded data",
+									TakesFile: true,
+								},
+								&cli.StringFlag{
+									Name:     dataFlagSequenceID,
+									Required: true,
+									Usage:    "ID of the sequence to export",
+								},
+								&cli.UintFlag{
+									Name:      dataFlagParallelDownloads,
+									Usage:     "number of binary download requests to make in parallel",
+									Value:     defaultParallelBinaryDownloads,
+									Validator: mustBePositiveUint(dataFlagParallelDownloads),
+								},
+								&cli.UintFlag{
+									Name:  dataFlagTimeout,
+									Usage: "number of seconds to wait for large binary file downloads",
+									Value: 30,
+								},
+								&cli.BoolFlag{
+									Name:  dataFlagOnlyTabular,
+									Usage: "export only the sequence's tabular data; no binary data will be downloaded",
+								},
+								&cli.BoolFlag{
+									Name:  dataFlagOnlyBinary,
+									Usage: "export only the sequence's binary data; no tabular data will be downloaded",
+								},
+							},
+							Action: createActionCommandWithT[dataExportSequenceArgs](DataExportSequenceAction),
 						},
 					},
 				},

--- a/cli/data.go
+++ b/cli/data.go
@@ -713,8 +713,23 @@ func (c *viamClient) binaryData(ctx context.Context, dst string, filter *datapb.
 // Each time `logEveryN` actions have been performed, the printStatement logs a statement that takes in as
 // input how much binary data has been processed thus far.
 func (c *viamClient) performActionOnBinaryDataFromFilter(ctx context.Context,
-	actionOnBinaryData func(ctx context.Context, id string) error,
+	actionOnBinaryData func(context.Context, string) error,
 	filter *datapb.Filter, parallelActions uint, printStatement func(int32),
+) error {
+	fetchIDsInto := func(ctx context.Context, ids chan<- string) error {
+		// If limit is too high the request can time out, so limit each call to a maximum value of 100.
+		limit := min(parallelActions, maxLimit)
+		return getMatchingBinaryIDs(ctx, c.dataClient, filter, ids, limit)
+	}
+	return c.performActionOnBinaryDataIDs(ctx, fetchIDsInto, actionOnBinaryData, parallelActions, printStatement)
+}
+
+// performActionOnBinaryDataIDs runs actionOnBinaryData across parallelActions workers over ids from
+// fetchIDsInto, which owns closing the channel. The first error cancels the rest -- both callbacks
+// get that cancellable context -- and printStatement reports every logEveryN.
+func (c *viamClient) performActionOnBinaryDataIDs(ctx context.Context,
+	fetchIDsInto func(ctx context.Context, ids chan<- string) error,
+	actionOnBinaryData func(ctx context.Context, id string) error, parallelActions uint, printStatement func(int32),
 ) error {
 	ids := make(chan string, parallelActions)
 	// Give channel buffer of 1+parallelActions because that is the number of goroutines that may be passing an
@@ -724,13 +739,11 @@ func (c *viamClient) performActionOnBinaryDataFromFilter(ctx context.Context,
 	defer cancel()
 	var wg sync.WaitGroup
 
-	// In one routine, get all IDs matching the filter and pass them into the ids channel.
+	// In one routine, get all matching IDs and pass them into the ids channel.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		// If limit is too high the request can time out, so limit each call to a maximum value of 100.
-		limit := min(parallelActions, maxLimit)
-		if err := getMatchingBinaryIDs(ctx, c.dataClient, filter, ids, limit); err != nil {
+		if err := fetchIDsInto(ctx, ids); err != nil {
 			errs <- err
 			cancel()
 		}
@@ -1100,10 +1113,21 @@ func (c *viamClient) tabularData(dest string, request *datapb.ExportTabularDataR
 	}
 
 	fmt.Fprintf(c.c.Root().Writer, "Downloading..") //nolint:errcheck
+	_, err := c.tabularDataToFile(filepath.Join(dest, dataFileName), request, c.c.Root().Writer)
+	return err
+}
 
+// tabularDataToFile streams a tabular export request into the provided dataFilePath.
+// The parent directory must already exist. Returns the number of rows written.
+//
+// progressOut gets one '.' per attempt and a closing newline; pass io.Discard for no output.
+func (c *viamClient) tabularDataToFile(
+	dataFilePath string, request *datapb.ExportTabularDataRequest, progressOut io.Writer,
+) (int, error) {
+	var rows int
 	for count := 0; count < maxRetryCount; count++ {
+		rows = 0
 		err := func() error {
-			dataFilePath := filepath.Join(dest, dataFileName)
 			dataFile, err := os.Create(dataFilePath) //nolint:gosec
 			if err != nil {
 				return errors.Wrapf(err, "could not create data file")
@@ -1136,7 +1160,7 @@ func (c *viamClient) tabularData(dest string, request *datapb.ExportTabularDataR
 				}
 			}()
 
-			fmt.Fprintf(c.c.Root().Writer, ".") //nolint:errcheck // Adds '.' to 'Downloading..' output.
+			fmt.Fprintf(progressOut, ".") //nolint:errcheck // appends to whatever line the caller opened
 
 			go func() {
 				defer close(dataRowChan)
@@ -1193,6 +1217,7 @@ func (c *viamClient) tabularData(dest string, request *datapb.ExportTabularDataR
 						exportErr = errors.Wrap(err, "error writing data")
 						return exportErr
 					}
+					rows++
 				case err := <-errChan:
 					exportErr = err
 					return err
@@ -1207,11 +1232,11 @@ func (c *viamClient) tabularData(dest string, request *datapb.ExportTabularDataR
 			continue
 		}
 
-		printf(c.c.Root().Writer, "") // newline
-		return err
+		printf(progressOut, "") // end the progress line
+		return rows, err
 	}
 
-	return nil
+	return rows, nil
 }
 
 func writeData(writer *bufio.Writer, dataRow []byte) error {

--- a/cli/data_sequence_export.go
+++ b/cli/data_sequence_export.go
@@ -1,0 +1,288 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"maps"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v3"
+	datapb "go.viam.com/api/app/data/v1"
+
+	"go.viam.com/rdk/data"
+)
+
+const (
+	sequenceTabularDir      = "tabular"
+	sequenceBinaryExportDir = "binary"
+)
+
+var unsafeFileNameChars = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+type dataExportSequenceArgs struct {
+	Destination string
+	SequenceID  string
+	Parallel    uint
+	Timeout     uint
+	OnlyTabular bool
+	OnlyBinary  bool
+}
+
+// DataExportSequenceAction is the corresponding action for 'data export sequence'.
+func DataExportSequenceAction(ctx context.Context, cmd *cli.Command, args dataExportSequenceArgs) error {
+	client, err := newViamClient(ctx, cmd)
+	if err != nil {
+		return err
+	}
+
+	return client.dataExportSequenceAction(ctx, args)
+}
+
+// dataExportSequenceAction exports a sequence's binary and tabular data.
+func (c *viamClient) dataExportSequenceAction(ctx context.Context, args dataExportSequenceArgs) error {
+	if args.OnlyTabular && args.OnlyBinary {
+		return errors.Errorf("--%s and --%s cannot both be provided", dataFlagOnlyTabular, dataFlagOnlyBinary)
+	}
+
+	resp, err := c.dataClient.GetSequence(ctx, &datapb.GetSequenceRequest{Id: args.SequenceID})
+	if err != nil {
+		return errors.Wrapf(err, "failed to look up sequence %s", args.SequenceID)
+	}
+	sequence := resp.GetSequence()
+	if sequence == nil {
+		return errors.Errorf("sequence %s not found", args.SequenceID)
+	}
+
+	if err := makeDestinationDirs(args.Destination); err != nil {
+		return errors.Wrap(err, "could not create destination directory")
+	}
+
+	printf(c.c.Root().Writer, "Exporting sequence %s to %s", sequence.GetId(), args.Destination)
+
+	tabular, binary := partitionResourcesByCaptureType(sequence.GetResources())
+	if !args.OnlyBinary {
+		if err := c.exportSequenceTabular(ctx, sequence, tabular, args.Destination); err != nil {
+			return err
+		}
+	}
+	if !args.OnlyTabular {
+		if err := c.exportSequenceBinary(ctx, sequence.GetId(), binary, args.Destination, args.Parallel, args.Timeout); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// exportSequenceTabular runs one tabular export per resource the sequence references, scoped to
+// the sequence's part and capture interval, writing each to its own NDJSON file under dst/tabular/.
+func (c *viamClient) exportSequenceTabular(
+	ctx context.Context, sequence *datapb.Sequence, resources []*datapb.SequenceResourceFilter, dst string,
+) error {
+	printf(c.c.Root().Writer, "")
+	printf(c.c.Root().Writer, "Tabular data (%s/):", sequenceTabularDir)
+
+	if len(resources) == 0 {
+		printf(c.c.Root().Writer, "  none")
+		return nil
+	}
+
+	tabularDir := filepath.Join(dst, sequenceTabularDir)
+	if err := makeDestinationDirs(tabularDir); err != nil {
+		return errors.Wrapf(err, "could not create %s", tabularDir)
+	}
+
+	interval := &datapb.CaptureInterval{Start: sequence.GetStartTime(), End: sequence.GetEndTime()}
+	names := sequenceTabularFileNames(resources)
+	for i, resource := range resources {
+		subtype, err := c.resolveResourceSubtype(ctx, sequence.GetPartId(), resource, interval)
+		if err != nil {
+			return err
+		}
+		if subtype == "" {
+			printf(c.c.Root().Writer, "  %s %s", resource.GetResourceName(), resource.GetMethodName())
+			printf(c.c.Root().Writer, "    no tabular data in the sequence's interval, skipping")
+			continue
+		}
+
+		request := &datapb.ExportTabularDataRequest{
+			PartId:          sequence.GetPartId(),
+			ResourceName:    resource.GetResourceName(),
+			ResourceSubtype: subtype,
+			MethodName:      resource.GetMethodName(),
+			Interval:        interval,
+		}
+
+		// Name the resource before the export starts so it is on screen while the work runs, then
+		// add the row count below it. io.Discard because that writer's only output is a dot per
+		// retry attempt, which the count supersedes.
+		printf(c.c.Root().Writer, "  %s %s", resource.GetResourceName(), resource.GetMethodName())
+		rows, err := c.tabularDataToFile(filepath.Join(tabularDir, names[i]), request, io.Discard)
+		if err != nil {
+			return errors.Wrapf(err, "failed to export tabular data for resource %q method %q",
+				resource.GetResourceName(), resource.GetMethodName())
+		}
+		printf(c.c.Root().Writer, "    %d %s", rows, pluralize(rows, "row"))
+	}
+	return nil
+}
+
+// partitionResourcesByCaptureType splits a sequence's resources by what their capture method
+// produces. MethodToCaptureType defaults anything it does not recognise to tabular.
+func partitionResourcesByCaptureType(
+	resources []*datapb.SequenceResourceFilter,
+) (tabular, binary []*datapb.SequenceResourceFilter) {
+	for _, resource := range resources {
+		if data.MethodToCaptureType(resource.GetMethodName()) == data.CaptureTypeBinary {
+			binary = append(binary, resource)
+			continue
+		}
+		tabular = append(tabular, resource)
+	}
+	return tabular, binary
+}
+
+// resolveResourceSubtype discovers a resource's subtype, which ExportTabularData requires but a
+// SequenceResourceFilter does not record. It asks for a single captured row matching the same
+// part, resource, method, and interval the export will use, and reads the subtype off that row's
+// CaptureMetadata. Returns "" when the resource has no tabular data in the interval.
+func (c *viamClient) resolveResourceSubtype(
+	ctx context.Context, partID string, resource *datapb.SequenceResourceFilter, interval *datapb.CaptureInterval,
+) (string, error) {
+	//nolint:staticcheck // TabularDataByFilter is deprecated, but we are using this to get the missing subtype.
+	// We can safely remove if/when we update sequence resources to record subtypes.
+	resp, err := c.dataClient.TabularDataByFilter(ctx, &datapb.TabularDataByFilterRequest{
+		DataRequest: &datapb.DataRequest{
+			Filter: &datapb.Filter{
+				PartId:        partID,
+				ComponentName: resource.GetResourceName(),
+				Method:        resource.GetMethodName(),
+				Interval:      interval,
+			},
+			Limit: 1,
+		},
+	})
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to look up the subtype of resource %q method %q",
+			resource.GetResourceName(), resource.GetMethodName())
+	}
+	for _, meta := range resp.GetMetadata() {
+		if subtype := meta.GetComponentType(); subtype != "" {
+			return subtype, nil
+		}
+	}
+	return "", nil
+}
+
+// sequenceTabularFileNames builds one NDJSON file name per resource, positionally matching
+// resources. Names are derived from the resource and method name; resources that sanitize to the
+// same string get a numeric suffix so no export silently overwrites another.
+func sequenceTabularFileNames(resources []*datapb.SequenceResourceFilter) []string {
+	names := make([]string, 0, len(resources))
+	seen := map[string]int{}
+	for _, resource := range resources {
+		var parts []string
+
+		// Sanitize name just in case. Our FE has allowed character set, but edge case - they used API to update config.
+		if name := strings.Trim(unsafeFileNameChars.ReplaceAllString(resource.GetResourceName(), "_"), "_."); name != "" {
+			parts = append(parts, name)
+		}
+		if method := resource.GetMethodName(); method != "" {
+			parts = append(parts, method)
+		}
+		if len(parts) == 0 {
+			parts = append(parts, "resource")
+		}
+
+		base := strings.Join(parts, "-")
+		seen[base]++
+		// Edge case - two sanitized names are the same => append a number to the end.
+		if n := seen[base]; n > 1 {
+			base += "-" + strconv.Itoa(n)
+		}
+		names = append(names, base+".ndjson")
+	}
+
+	return names
+}
+
+// exportSequenceBinary downloads every binary datum the sequence references into
+// <destination>/binary, using the same layout and parallel-download machinery as
+// `data export binary`, and reports the result per resource so the section reads like the
+// tabular one above it.
+func (c *viamClient) exportSequenceBinary(
+	ctx context.Context, sequenceID string, resources []*datapb.SequenceResourceFilter,
+	dst string, parallel, timeout uint,
+) error {
+	binaryDst := filepath.Join(dst, sequenceBinaryExportDir)
+
+	// resourceOf is populated while paging and read by the download workers, so both sides take
+	// progressMu. Downloads run in parallel across resources, so a per-resource line cannot update
+	// live; a single running total does that, and the per-resource split is reported at the end.
+	var progressMu sync.Mutex
+	resourceOf := map[string]string{}
+	countByResource := map[string]int{}
+	for _, resource := range resources {
+		countByResource[resourceLabel(resource.GetResourceName(), resource.GetMethodName())] = 0
+	}
+	var downloaded atomic.Int32
+
+	fetchIDsInto := func(ctx context.Context, ids chan<- string) error {
+		defer close(ids)
+		return forEachSequenceBinaryData(ctx, c.dataClient, sequenceID, func(bd *datapb.BinaryData) error {
+			id := bd.GetMetadata().GetBinaryDataId()
+
+			capture := bd.GetMetadata().GetCaptureMetadata()
+
+			progressMu.Lock()
+			resourceOf[id] = resourceLabel(capture.GetComponentName(), capture.GetMethodName())
+			progressMu.Unlock()
+
+			select {
+			case ids <- id:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		})
+	}
+
+	download := func(ctx context.Context, id string) error {
+		if err := c.downloadBinary(ctx, binaryDst, timeout, id); err != nil {
+			return err
+		}
+		downloaded.Add(1)
+
+		progressMu.Lock()
+		defer progressMu.Unlock()
+		countByResource[resourceOf[id]]++
+		return nil
+	}
+
+	printf(c.c.Root().Writer, "")
+	printf(c.c.Root().Writer, "Binary data (%s/):", sequenceBinaryExportDir)
+	if err := c.performActionOnBinaryDataIDs(ctx, fetchIDsInto, download, parallel, func(int32) {}); err != nil {
+		return err
+	}
+	if len(countByResource) == 0 {
+		printf(c.c.Root().Writer, "  none")
+		return nil
+	}
+
+	for _, resource := range slices.Sorted(maps.Keys(countByResource)) {
+		printf(c.c.Root().Writer, "  %s", resource)
+		printf(c.c.Root().Writer, "    %d %s", countByResource[resource], pluralize(countByResource[resource], "file"))
+	}
+	return nil
+}
+
+func resourceLabel(name, method string) string {
+	return name + " " + method
+}

--- a/cli/data_sequence_export_test.go
+++ b/cli/data_sequence_export_test.go
@@ -1,0 +1,353 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	datapb "go.viam.com/api/app/data/v1"
+	"go.viam.com/test"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"go.viam.com/rdk/testutils/inject"
+)
+
+const (
+	testSequenceID    = "seq-1"
+	testSequencePart  = "part-1"
+	testSequenceStart = "2024-01-01T00:00:00Z"
+	testSequenceEnd   = "2024-01-01T01:00:00Z"
+)
+
+func testSequence(resources ...*datapb.SequenceResourceFilter) *datapb.Sequence {
+	start, _ := time.Parse(time.RFC3339, testSequenceStart)
+	end, _ := time.Parse(time.RFC3339, testSequenceEnd)
+	return &datapb.Sequence{
+		Id:        testSequenceID,
+		PartId:    testSequencePart,
+		StartTime: timestamppb.New(start),
+		EndTime:   timestamppb.New(end),
+		Resources: resources,
+	}
+}
+
+// capturedBlob is binary data as the data manager records it, with the resource it came from.
+func capturedBlob(id string) *datapb.BinaryData {
+	bd := mkBinaryData(id, ".jpg")
+	bd.Metadata.CaptureMetadata = &datapb.CaptureMetadata{ComponentName: "camera-1", MethodName: "GetImages"}
+	return bd
+}
+
+func sequenceResource(name, method string) *datapb.SequenceResourceFilter {
+	return &datapb.SequenceResourceFilter{ResourceName: name, MethodName: method}
+}
+
+// sequenceBinaryPath is where a sequence-exported binary datum lands: `data export binary`'s data/
+// layout, rooted under binary/ rather than at the top level of the destination.
+func sequenceBinaryPath(dst, id string) string {
+	return dataFilePath(filepath.Join(dst, sequenceBinaryExportDir), filenameForDownload(binaryMeta(id)), ".jpg")
+}
+
+// seqFake serves the RPCs a sequence export makes and records what it was asked for. Only the
+// fields a test cares about need setting; the rest behave benignly.
+type seqFake struct {
+	sequence *datapb.Sequence
+	binary   []*datapb.BinaryData
+	// pages, when set, serves GetSequenceBinaryData by page token instead of binary.
+	pages map[string]*datapb.GetSequenceBinaryDataResponse
+
+	// subtype maps a resource name to its subtype; "" means it has no tabular data. Defaults to
+	// deriving one from the name, so a test can tell which lookup fed which export.
+	subtype    func(resource string) string
+	subtypeErr error
+	exportErr  error
+	binaryErr  error
+
+	mu       sync.Mutex
+	exported []*datapb.ExportTabularDataRequest
+	lookedUp []string
+	tokens   []string
+}
+
+func (f *seqFake) client(t *testing.T) (*viamClient, *testWriter) {
+	t.Helper()
+	dsc := &inject.DataServiceClient{
+		GetSequenceFunc:           f.getSequence,
+		TabularDataByFilterFunc:   f.subtypeLookup,
+		ExportTabularDataFunc:     f.exportStream,
+		GetSequenceBinaryDataFunc: f.binaryPage,
+		BinaryDataByIDsFunc:       echoBinaryDataByIDs,
+	}
+	_, ac, out, _ := setup(&inject.AppServiceClient{}, dsc, nil, nil, "token")
+	return ac, out
+}
+
+func (f *seqFake) getSequence(_ context.Context, in *datapb.GetSequenceRequest, _ ...grpc.CallOption,
+) (*datapb.GetSequenceResponse, error) {
+	if f.sequence == nil || in.GetId() != f.sequence.GetId() {
+		return &datapb.GetSequenceResponse{}, nil
+	}
+	return &datapb.GetSequenceResponse{Sequence: f.sequence}, nil
+}
+
+// subtypeLookup is the only reason this fake answers TabularDataByFilter.
+//
+//nolint:staticcheck
+func (f *seqFake) subtypeLookup(_ context.Context, in *datapb.TabularDataByFilterRequest, _ ...grpc.CallOption,
+) (*datapb.TabularDataByFilterResponse, error) {
+	if f.subtypeErr != nil {
+		return nil, f.subtypeErr
+	}
+	name := in.GetDataRequest().GetFilter().GetComponentName()
+
+	f.mu.Lock()
+	f.lookedUp = append(f.lookedUp, name)
+	f.mu.Unlock()
+
+	subtype := "rdk:component:" + name
+	if f.subtype != nil {
+		subtype = f.subtype(name)
+	}
+	if subtype == "" {
+		return &datapb.TabularDataByFilterResponse{}, nil
+	}
+	return &datapb.TabularDataByFilterResponse{
+		Metadata: []*datapb.CaptureMetadata{{ComponentType: subtype}},
+	}, nil
+}
+
+func (f *seqFake) exportStream(_ context.Context, in *datapb.ExportTabularDataRequest, _ ...grpc.CallOption,
+) (datapb.DataService_ExportTabularDataClient, error) {
+	f.mu.Lock()
+	f.exported = append(f.exported, in)
+	f.mu.Unlock()
+
+	if f.exportErr != nil {
+		// The stream carries the error, not the call that opens it.
+		return newMockExportStream(nil, f.exportErr), nil //nolint:nilerr
+	}
+	return newMockExportStream([]*datapb.ExportTabularDataResponse{
+		{LocationId: "loc-id", ResourceName: in.GetResourceName(), MethodName: in.GetMethodName()},
+	}, nil), nil
+}
+
+func (f *seqFake) binaryPage(_ context.Context, in *datapb.GetSequenceBinaryDataRequest, _ ...grpc.CallOption,
+) (*datapb.GetSequenceBinaryDataResponse, error) {
+	if f.binaryErr != nil {
+		return nil, f.binaryErr
+	}
+	f.mu.Lock()
+	f.tokens = append(f.tokens, in.GetPageToken())
+	f.mu.Unlock()
+
+	if f.pages == nil {
+		return &datapb.GetSequenceBinaryDataResponse{Data: f.binary}, nil
+	}
+	resp, ok := f.pages[in.GetPageToken()]
+	if !ok {
+		return nil, errors.New("unexpected page token " + in.GetPageToken())
+	}
+	return resp, nil
+}
+
+type argMutator = func(*dataExportSequenceArgs)
+
+func exportArgs(dst string, mutate ...argMutator) dataExportSequenceArgs {
+	args := dataExportSequenceArgs{Destination: dst, SequenceID: testSequenceID, Parallel: 2}
+	for _, m := range mutate {
+		m(&args)
+	}
+	return args
+}
+
+func onlyTabular(a *dataExportSequenceArgs) { a.OnlyTabular = true }
+func onlyBinary(a *dataExportSequenceArgs)  { a.OnlyBinary = true }
+
+func TestSequenceTabularFileNames(t *testing.T) {
+	names := sequenceTabularFileNames([]*datapb.SequenceResourceFilter{
+		sequenceResource("camera-1", "ReadImage"),
+		sequenceResource("../../etc/passwd", "ReadImage"), // must not escape the tabular directory
+		sequenceResource("etc_passwd", "ReadImage"),       // sanitizes to the same base, so gets a suffix
+		sequenceResource("", ""),
+	})
+
+	test.That(t, names, test.ShouldResemble, []string{
+		"camera-1-ReadImage.ndjson",
+		"etc_passwd-ReadImage.ndjson",
+		"etc_passwd-ReadImage-2.ndjson",
+		"resource.ndjson",
+	})
+	for _, name := range names {
+		test.That(t, strings.Contains(name, string(filepath.Separator)), test.ShouldBeFalse)
+	}
+}
+
+func TestDataExportSequenceAction_Errors(t *testing.T) {
+	sensor := testSequence(sequenceResource("sensor-1", "Readings"))
+	for _, tc := range []struct {
+		name    string
+		fake    *seqFake
+		args    []argMutator
+		wantErr []string
+	}{
+		{
+			"both only flags", &seqFake{sequence: testSequence()},
+			[]argMutator{onlyTabular, onlyBinary},
+			[]string{"cannot both be provided"},
+		},
+		{"missing sequence", &seqFake{}, nil, []string{"not found"}},
+		{
+			"subtype lookup fails", &seqFake{sequence: sensor, subtypeErr: errors.New("lookup boom")},
+			[]argMutator{onlyTabular},
+			[]string{"sensor-1", "lookup boom"},
+		},
+		{
+			"tabular export fails", &seqFake{sequence: sensor, exportErr: errors.New("export boom")},
+			[]argMutator{onlyTabular},
+			[]string{"sensor-1", "export boom"},
+		},
+		{
+			"binary listing fails", &seqFake{sequence: testSequence(), binaryErr: errors.New("server boom")},
+			[]argMutator{onlyBinary},
+			[]string{"server boom"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ac, _ := tc.fake.client(t)
+
+			err := ac.dataExportSequenceAction(context.Background(), exportArgs(t.TempDir(), tc.args...))
+			test.That(t, err, test.ShouldNotBeNil)
+			for _, want := range tc.wantErr {
+				test.That(t, err.Error(), test.ShouldContainSubstring, want)
+			}
+		})
+	}
+}
+
+func TestDataExportSequenceAction_ExportsTabularPerResource(t *testing.T) {
+	fake := &seqFake{sequence: testSequence(
+		sequenceResource("sensor-1", "Readings"),
+		sequenceResource("power_sensor-1", "Voltage"),
+	)}
+	ac, _ := fake.client(t)
+
+	dst := t.TempDir()
+	test.That(t, ac.dataExportSequenceAction(context.Background(), exportArgs(dst, onlyTabular)), test.ShouldBeNil)
+
+	test.That(t, len(fake.exported), test.ShouldEqual, 2)
+	for _, req := range fake.exported {
+		test.That(t, req.GetPartId(), test.ShouldEqual, testSequencePart)
+		test.That(t, req.GetInterval().GetStart().AsTime().Format(time.RFC3339), test.ShouldEqual, testSequenceStart)
+		test.That(t, req.GetInterval().GetEnd().AsTime().Format(time.RFC3339), test.ShouldEqual, testSequenceEnd)
+	}
+	test.That(t, fake.exported[0].GetResourceName(), test.ShouldEqual, "sensor-1")
+	test.That(t, fake.exported[1].GetResourceName(), test.ShouldEqual, "power_sensor-1")
+
+	// Each resource carries its own resolved subtype, not one value applied to all of them.
+	test.That(t, fake.exported[0].GetResourceSubtype(), test.ShouldEqual, "rdk:component:sensor-1")
+	test.That(t, fake.exported[1].GetResourceSubtype(), test.ShouldEqual, "rdk:component:power_sensor-1")
+
+	// Each resource lands in its own file rather than overwriting a shared one.
+	test.That(t, readNDJSON(t, dst, "sensor-1-Readings.ndjson")["resourceName"], test.ShouldEqual, "sensor-1")
+	test.That(t, readNDJSON(t, dst, "power_sensor-1-Voltage.ndjson")["resourceName"], test.ShouldEqual, "power_sensor-1")
+
+	_, err := os.Stat(filepath.Join(dst, sequenceBinaryExportDir))
+	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+}
+
+func TestDataExportSequenceAction_EmptySequence(t *testing.T) {
+	fake := &seqFake{sequence: testSequence()}
+	ac, out := fake.client(t)
+
+	dst := t.TempDir()
+	test.That(t, ac.dataExportSequenceAction(context.Background(), exportArgs(dst)), test.ShouldBeNil)
+	test.That(t, len(fake.exported), test.ShouldEqual, 0)
+
+	logged := strings.Join(out.messages, "")
+	test.That(t, logged, test.ShouldContainSubstring, "Tabular data (tabular/):\n  none")
+	test.That(t, logged, test.ShouldContainSubstring, "Binary data (binary/):\n  none")
+
+	// The claim has to match the disk: nothing written, so neither directory exists.
+	for _, dir := range []string{sequenceTabularDir, sequenceBinaryExportDir} {
+		_, err := os.Stat(filepath.Join(dst, dir))
+		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+	}
+}
+
+// A binary capture method has no tabular data by definition, so it never reaches the lookup; a
+// resource that captured nothing reaches it and comes back empty. Both are skipped.
+func TestDataExportSequenceAction_SkipsResourcesWithoutTabularData(t *testing.T) {
+	fake := &seqFake{
+		sequence: testSequence(
+			sequenceResource("camera-1", "GetImages"),
+			sequenceResource("ghost-1", "Readings"),
+			sequenceResource("sensor-1", "Readings"),
+		),
+		subtype: func(resource string) string {
+			if resource == "ghost-1" {
+				return ""
+			}
+			return "rdk:component:sensor"
+		},
+	}
+	ac, out := fake.client(t)
+
+	dst := t.TempDir()
+	test.That(t, ac.dataExportSequenceAction(context.Background(), exportArgs(dst, onlyTabular)), test.ShouldBeNil)
+
+	test.That(t, fake.lookedUp, test.ShouldResemble, []string{"ghost-1", "sensor-1"})
+	test.That(t, len(fake.exported), test.ShouldEqual, 1)
+	test.That(t, fake.exported[0].GetResourceName(), test.ShouldEqual, "sensor-1")
+
+	_, err := os.Stat(filepath.Join(dst, sequenceTabularDir, "ghost-1-Readings.ndjson"))
+	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+	test.That(t, strings.Join(out.messages, ""), test.ShouldNotContainSubstring, "camera-")
+}
+
+// Every page is consumed, each request after the first carrying the token the previous response
+// returned, and the blobs land under binary/ with data/ + metadata/ beneath it.
+func TestDataExportSequenceAction_DownloadsBinaryData(t *testing.T) {
+	fake := &seqFake{
+		sequence: testSequence(sequenceResource("sensor-1", "Readings")),
+		pages: map[string]*datapb.GetSequenceBinaryDataResponse{
+			"":       {Data: []*datapb.BinaryData{capturedBlob("bd-1")}, NextPageToken: "page-2"},
+			"page-2": {Data: []*datapb.BinaryData{capturedBlob("bd-2"), capturedBlob("bd-3")}},
+		},
+	}
+	ac, out := fake.client(t)
+
+	dst := t.TempDir()
+	test.That(t, ac.dataExportSequenceAction(context.Background(), exportArgs(dst, onlyBinary)), test.ShouldBeNil)
+	test.That(t, len(fake.exported), test.ShouldEqual, 0)
+	test.That(t, fake.tokens, test.ShouldResemble, []string{"", "page-2"})
+
+	for _, id := range []string{"bd-1", "bd-2", "bd-3"} {
+		test.That(t, mustReadFile(t, sequenceBinaryPath(dst, id)), test.ShouldResemble, []byte("bytes-"+id))
+		_, err := os.Stat(filepath.Join(dst, sequenceBinaryExportDir, metadataDir, filenameForDownload(binaryMeta(id))+".json"))
+		test.That(t, err, test.ShouldBeNil)
+	}
+	for _, dir := range []string{dataDir, metadataDir} {
+		_, err := os.Stat(filepath.Join(dst, dir))
+		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+	}
+
+	test.That(t, strings.Join(out.messages, ""), test.ShouldContainSubstring,
+		"Binary data (binary/):\n  camera-1 GetImages\n    3 files")
+}
+
+// readNDJSON returns the single row the fake's export stream writes for a resource.
+func readNDJSON(t *testing.T, dst, name string) map[string]any {
+	t.Helper()
+	contents := mustReadFile(t, filepath.Join(dst, sequenceTabularDir, name))
+
+	var row map[string]any
+	test.That(t, json.NewDecoder(strings.NewReader(string(contents))).Decode(&row), test.ShouldBeNil)
+	return row
+}

--- a/cli/dataset_sequence_export.go
+++ b/cli/dataset_sequence_export.go
@@ -150,33 +150,50 @@ func (c *viamClient) streamSequenceBinaryJobs(
 		return err
 	}
 	for _, seqID := range sequenceIDs {
-		pageToken := ""
-		for {
-			resp, err := c.dataClient.GetSequenceBinaryData(ctx, &datapb.GetSequenceBinaryDataRequest{
-				SequenceId: seqID,
-				PageToken:  pageToken,
-			})
-			if err != nil {
-				return errors.Wrapf(err, "failed to list binary data for sequence %s", seqID)
+		err := forEachSequenceBinaryData(ctx, c.dataClient, seqID, func(bd *datapb.BinaryData) error {
+			job := sequenceBlobJob{
+				binaryDataID: bd.GetMetadata().GetBinaryDataId(),
+				fileExt:      bd.GetMetadata().GetFileExt(),
 			}
-			for _, bd := range resp.GetData() {
-				job := sequenceBlobJob{
-					binaryDataID: bd.GetMetadata().GetBinaryDataId(),
-					fileExt:      bd.GetMetadata().GetFileExt(),
-				}
-				select {
-				case work <- job:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+			select {
+			case work <- job:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
 			}
-			pageToken = resp.GetNextPageToken()
-			if pageToken == "" {
-				break
-			}
+		})
+		if err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// forEachSequenceBinaryData pages through every binary data record belonging to sequenceID,
+// invoking fn on each. It stops at the first error fn or the server returns.
+func forEachSequenceBinaryData(
+	ctx context.Context, client datapb.DataServiceClient, sequenceID string,
+	fn func(*datapb.BinaryData) error,
+) error {
+	pageToken := ""
+	for {
+		resp, err := client.GetSequenceBinaryData(ctx, &datapb.GetSequenceBinaryDataRequest{
+			SequenceId: sequenceID,
+			PageToken:  pageToken,
+		})
+		if err != nil {
+			return errors.Wrapf(err, "failed to list binary data for sequence %s", sequenceID)
+		}
+		for _, bd := range resp.GetData() {
+			if err := fn(bd); err != nil {
+				return err
+			}
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return nil
+		}
+	}
 }
 
 func (c *viamClient) allSequenceIDsForDataset(

--- a/testutils/inject/data_service_client.go
+++ b/testutils/inject/data_service_client.go
@@ -84,6 +84,8 @@ type DataServiceClient struct {
 		opts ...grpc.CallOption) (*datapb.RemoveSequencesFromDatasetResponse, error)
 	SequencesByDatasetIDFunc func(ctx context.Context, in *datapb.SequencesByDatasetIDRequest,
 		opts ...grpc.CallOption) (*datapb.SequencesByDatasetIDResponse, error)
+	GetSequenceBinaryDataFunc func(ctx context.Context, in *datapb.GetSequenceBinaryDataRequest,
+		opts ...grpc.CallOption) (*datapb.GetSequenceBinaryDataResponse, error)
 }
 
 // TabularDataByFilter calls the injected TabularDataByFilter or the real version.
@@ -426,4 +428,14 @@ func (client *DataServiceClient) SequencesByDatasetID(ctx context.Context, in *d
 		return client.DataServiceClient.SequencesByDatasetID(ctx, in, opts...)
 	}
 	return client.SequencesByDatasetIDFunc(ctx, in, opts...)
+}
+
+// GetSequenceBinaryData calls the injected GetSequenceBinaryData or the real version.
+func (client *DataServiceClient) GetSequenceBinaryData(ctx context.Context, in *datapb.GetSequenceBinaryDataRequest,
+	opts ...grpc.CallOption,
+) (*datapb.GetSequenceBinaryDataResponse, error) {
+	if client.GetSequenceBinaryDataFunc == nil {
+		return client.DataServiceClient.GetSequenceBinaryData(ctx, in, opts...)
+	}
+	return client.GetSequenceBinaryDataFunc(ctx, in, opts...)
 }


### PR DESCRIPTION
Exports a single sequence (binary and tabular)

Stacked: 2 of 3, on top of #6364 (`APP-17380a`). Targets the `APP-17380` integration branch, not `main`. `APP-17380c` adds live progress logging on top of this.

```
viam data export sequence --sequence-id=<id> --destination=out
```

## Extracting reusable logic

Built on the two existing export paths rather than duplicating them:

- Pulled **`tabularDataToFile`** out of `tabularData`.
- Pulled **`performActionOnBinaryDataIDs`** out of `performActionOnBinaryDataFromFilter` — so the parallel-download driver can be fed by `GetSequenceBinaryData` instead of a filter. Downloads still go through `downloadBinary`, so large-file fallback, gzip handling, and skip-already-downloaded all carry over.
- Pulled **`forEachSequenceBinaryData`** out of the dataset sequence export's paging loop.

## Resolving the resource subtype

`ExportTabularData` requires a resource subtype and a `SequenceResourceFilter` doesn't record one (yet - there is a ticket for it). It's resolved per resource: a `limit: 1` `TabularDataByFilter` scoped to the same part, resource, method, and interval the export will use, reading the subtype off that row's `CaptureMetadata`.

`TabularDataByFilter` is deprecated, but `TabularDataByMQL` felt like overkill. Removable when sequence resources record subtypes.

## Notes for review

- `--parallel` and `--timeout` apply only to the binary half; `--timeout` narrows further to the large-file HTTP fallback. Both inherited from `data export binary`.

## Testing

- ExportsTabularPerResource — one file per resource, each with its own resolved subtype, plus the sequence's part and interval on the request
- SkipsResourcesWithoutTabularData — a camera skipped by capture type without costing a lookup, and a resource that captured nothing skipped after the lookup returns empty
- DownloadsBinaryData — three blobs across two pages: each request carries the previous token, and the binary/data + binary/metadata layout holds with nothing at the top level
- EmptySequence — runs with neither --only flag, so it also covers both halves running by default
- SequenceTabularFileNames — filename sanitization: path separators can't escape tabular/, collisions get suffixed
- Errors — table: conflicting flags, missing sequence, and failures from the subtype lookup, the export, and the binary listing

**Manual testing**
Tested against the following sequences in the Data/ML Dev org:
`95fb1725-2f57-4710-b914-af68d71c4e8c`
`7f248d74-914a-4eba-b3c0-ca23ffe130af`
`katiez-sequenze` (this one has a lot of images - I let it download > 7000 of them before canceling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)