### PR TITLE
[APP-17380c] Show live progress while a sequence exports

### DIFF
--- a/cli/data.go
+++ b/cli/data.go
@@ -43,6 +43,9 @@ const (
 
 	defaultParallelBinaryDownloads = 100
 
+	// tabularProgressEveryNRows is how often a tabular export reports its running row count.
+	tabularProgressEveryNRows = 100
+
 	dataCommandAdd    = "add"
 	dataCommandRemove = "remove"
 
@@ -1113,7 +1116,7 @@ func (c *viamClient) tabularData(dest string, request *datapb.ExportTabularDataR
 	}
 
 	fmt.Fprintf(c.c.Root().Writer, "Downloading..") //nolint:errcheck
-	_, err := c.tabularDataToFile(filepath.Join(dest, dataFileName), request, c.c.Root().Writer)
+	_, err := c.tabularDataToFile(filepath.Join(dest, dataFileName), request, c.c.Root().Writer, nil)
 	return err
 }
 
@@ -1121,8 +1124,9 @@ func (c *viamClient) tabularData(dest string, request *datapb.ExportTabularDataR
 // The parent directory must already exist. Returns the number of rows written.
 //
 // progressOut gets one '.' per attempt and a closing newline; pass io.Discard for no output.
+// onRows, if set, is called with the running row count every tabularProgressEveryNRows rows.
 func (c *viamClient) tabularDataToFile(
-	dataFilePath string, request *datapb.ExportTabularDataRequest, progressOut io.Writer,
+	dataFilePath string, request *datapb.ExportTabularDataRequest, progressOut io.Writer, onRows func(rows int),
 ) (int, error) {
 	var rows int
 	for count := 0; count < maxRetryCount; count++ {
@@ -1218,6 +1222,9 @@ func (c *viamClient) tabularDataToFile(
 						return exportErr
 					}
 					rows++
+					if onRows != nil && rows%tabularProgressEveryNRows == 0 {
+						onRows(rows)
+					}
 				case err := <-errChan:
 					exportErr = err
 					return err

--- a/cli/data_sequence_export.go
+++ b/cli/data_sequence_export.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"maps"
 	"path/filepath"
@@ -120,16 +121,22 @@ func (c *viamClient) exportSequenceTabular(
 			Interval:        interval,
 		}
 
-		// Name the resource before the export starts so it is on screen while the work runs, then
-		// add the row count below it. io.Discard because that writer's only output is a dot per
-		// retry attempt, which the count supersedes.
+		// The resource line is static; only the short count row below it is redrawn, which keeps
+		// that on one visual row where a carriage return works.
 		printf(c.c.Root().Writer, "  %s %s", resource.GetResourceName(), resource.GetMethodName())
-		rows, err := c.tabularDataToFile(filepath.Join(tabularDir, names[i]), request, io.Discard)
+		line := newProgressLine(c.c.Root().Writer, "    ",
+			func(rows int) string { return fmt.Sprintf("%d %s", rows, pluralize(rows, "row")) })
+		line.start("starting download...")
+
+		// io.Discard for the writer: its only output is a dot per retry attempt, which the row
+		// count supersedes. Progress comes through onRows instead.
+		rows, err := c.tabularDataToFile(filepath.Join(tabularDir, names[i]), request, io.Discard, line.update)
 		if err != nil {
+			line.abandon()
 			return errors.Wrapf(err, "failed to export tabular data for resource %q method %q",
 				resource.GetResourceName(), resource.GetMethodName())
 		}
-		printf(c.c.Root().Writer, "    %d %s", rows, pluralize(rows, "row"))
+		line.finish(rows)
 	}
 	return nil
 }
@@ -254,21 +261,26 @@ func (c *viamClient) exportSequenceBinary(
 		})
 	}
 
+	line := newProgressLine(c.c.Root().Writer, "  ", func(files int) string { return fmt.Sprintf("%d %s", files, pluralize(files, "file")) })
 	download := func(ctx context.Context, id string) error {
 		if err := c.downloadBinary(ctx, binaryDst, timeout, id); err != nil {
 			return err
 		}
-		downloaded.Add(1)
+		total := downloaded.Add(1)
 
 		progressMu.Lock()
 		defer progressMu.Unlock()
 		countByResource[resourceOf[id]]++
+		line.update(int(total))
 		return nil
 	}
 
 	printf(c.c.Root().Writer, "")
 	printf(c.c.Root().Writer, "Binary data (%s/):", sequenceBinaryExportDir)
+	// Nothing is reported until the first file lands, which for large blobs is a long silence.
+	line.waiting("starting download...")
 	if err := c.performActionOnBinaryDataIDs(ctx, fetchIDsInto, download, parallel, func(int32) {}); err != nil {
+		line.erase()
 		return err
 	}
 	if len(countByResource) == 0 {
@@ -276,6 +288,8 @@ func (c *viamClient) exportSequenceBinary(
 		return nil
 	}
 
+	// Replace the running total with the per-resource split.
+	line.erase()
 	for _, resource := range slices.Sorted(maps.Keys(countByResource)) {
 		printf(c.c.Root().Writer, "  %s", resource)
 		printf(c.c.Root().Writer, "    %d %s", countByResource[resource], pluralize(countByResource[resource], "file"))

--- a/cli/progress_line.go
+++ b/cli/progress_line.go
@@ -11,7 +11,7 @@ import (
 // rewrites the line in place; elsewhere it writes once, when the count is final.
 //
 // Keep the prefix short. A carriage return only returns to the start of the current visual row, so
-// a line long enough to wrap cannot be redrawn -- the redraw lands beside the wrapped remainder.
+// a line long enough to wrap cannot be redrawn.
 type progressLine struct {
 	w        io.Writer
 	prefix   string
@@ -38,8 +38,7 @@ func newProgressLine(w io.Writer, prefix string, tail func(count int) string) *p
 	return l
 }
 
-// widestCount is the count assumed when checking the line fits. Counts past it are rare enough
-// that the extra column is not worth measuring for.
+// widestCount is the count assumed when checking the line fits.
 const widestCount = 999_999
 
 // fitsOneRow reports whether s stays on a single visual row. An unknown width is treated as

--- a/cli/progress_line.go
+++ b/cli/progress_line.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+)
+
+// progressLine renders one line whose only changing part is a running count. On a terminal it
+// rewrites the line in place; elsewhere it writes once, when the count is final.
+//
+// Keep the prefix short. A carriage return only returns to the start of the current visual row, so
+// a line long enough to wrap cannot be redrawn -- the redraw lands beside the wrapped remainder.
+type progressLine struct {
+	w        io.Writer
+	prefix   string
+	tail     func(count int) string // the changing part, e.g. " (1234 rows)"
+	terminal bool
+	started  bool
+	width    int // widest drawn, in runes
+	maxWidth int // terminal columns; 0 when unknown
+}
+
+func newProgressLine(w io.Writer, prefix string, tail func(count int) string) *progressLine {
+	l := &progressLine{w: w, prefix: prefix, tail: tail, terminal: isTerminalOutput()}
+	if !l.terminal {
+		return l
+	}
+	if cols, err := terminalWidth(); err == nil {
+		l.maxWidth = cols
+	}
+	// Writing once is worse than a live count, but better than scribbling over a wrapped line or
+	// truncating away the count itself.
+	if !l.fitsOneRow(prefix + tail(widestCount)) {
+		l.terminal = false
+	}
+	return l
+}
+
+// widestCount is the count assumed when checking the line fits. Counts past it are rare enough
+// that the extra column is not worth measuring for.
+const widestCount = 999_999
+
+// fitsOneRow reports whether s stays on a single visual row. An unknown width is treated as
+// fitting, since guessing wrong the other way disables the live count for everyone.
+func (l *progressLine) fitsOneRow(s string) bool {
+	return l.maxWidth <= 0 || utf8.RuneCountInString(s) < l.maxWidth
+}
+
+// render concatenates rather than formats: prefix is caller-supplied and may contain a '%'.
+func (l *progressLine) render(count int) string {
+	return l.prefix + l.tail(count)
+}
+
+// start names the work before counting begins, plus a placeholder on a terminal that the first
+// count overwrites.
+func (l *progressLine) start(placeholder string) {
+	l.started = true
+	drawn := l.prefix
+	// The placeholder is longer than any count, so it can overflow a line the count fits on.
+	if l.terminal && l.fitsOneRow(l.prefix+placeholder) {
+		drawn += placeholder
+	}
+	l.width = utf8.RuneCountInString(drawn)
+	fmt.Fprint(l.w, drawn) //nolint:errcheck
+}
+
+// waiting is start for a caller that cannot commit to the line yet, because the count may end up
+// zero. Piped, nothing would ever overwrite it, so it draws nothing.
+func (l *progressLine) waiting(placeholder string) {
+	if l.terminal {
+		l.start(placeholder)
+	}
+}
+
+func (l *progressLine) update(count int) {
+	if l.terminal {
+		fmt.Fprint(l.w, "\r"+l.padded(count)) //nolint:errcheck
+	}
+}
+
+// padded blank-fills to the widest drawn so a shorter render cannot leave an earlier one's tail
+// behind; count and tail both come from the caller, so neither is assumed to grow. Runes, not
+// display cells, so a double-width glyph costs a stray character.
+func (l *progressLine) padded(count int) string {
+	drawn := l.render(count)
+	if gap := l.width - utf8.RuneCountInString(drawn); gap > 0 {
+		drawn += strings.Repeat(" ", gap)
+	}
+	l.width = utf8.RuneCountInString(drawn)
+	return drawn
+}
+
+func (l *progressLine) finish(count int) {
+	switch {
+	case l.terminal:
+		fmt.Fprint(l.w, "\r"+l.padded(count)+"\n") //nolint:errcheck
+	case l.started:
+		// prefix is already on the line.
+		fmt.Fprint(l.w, l.tail(count)+"\n") //nolint:errcheck
+	default:
+		fmt.Fprint(l.w, l.render(count)+"\n") //nolint:errcheck
+	}
+}
+
+// abandon closes the line so whatever follows starts on its own.
+func (l *progressLine) abandon() {
+	fmt.Fprintln(l.w) //nolint:errcheck
+}
+
+// erase removes the line, for a caller replacing a running total with a fuller breakdown.
+func (l *progressLine) erase() {
+	if l.terminal {
+		fmt.Fprint(l.w, "\r"+strings.Repeat(" ", l.width)+"\r") //nolint:errcheck
+	}
+}

--- a/cli/progress_line_test.go
+++ b/cli/progress_line_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestProgressLine(t *testing.T) {
+	tail := func(n int) string { return fmt.Sprintf(" (%d %s)", n, pluralize(n, "row")) }
+	// The '%' proves prefix never reaches a format function.
+	const prefix = "  rate%s Readings: f.ndjson"
+
+	t.Run("redraws in place on a terminal", func(t *testing.T) {
+		var buf bytes.Buffer
+		line := &progressLine{w: &buf, prefix: prefix, tail: tail, terminal: true}
+		line.start("")
+		line.update(100)
+		line.finish(250)
+
+		test.That(t, buf.String(), test.ShouldEqual,
+			prefix+"\r"+prefix+" (100 rows)"+"\r"+prefix+" (250 rows)\n")
+	})
+
+	t.Run("off a terminal writes the line once", func(t *testing.T) {
+		var buf bytes.Buffer
+		line := &progressLine{w: &buf, prefix: prefix, tail: tail}
+		line.start("")
+		line.update(100) // dropped: no cursor to move
+		line.finish(250)
+
+		test.That(t, buf.String(), test.ShouldEqual, prefix+" (250 rows)\n")
+	})
+
+	t.Run("pads a shorter redraw over a longer one", func(t *testing.T) {
+		var buf bytes.Buffer
+		line := &progressLine{
+			w: &buf, terminal: true,
+			tail: func(n int) string { return strings.Repeat("x", n) },
+		}
+		line.update(5)
+		line.finish(2)
+
+		test.That(t, buf.String(), test.ShouldEqual, "\rxxxxx"+"\rxx   \n")
+	})
+
+	t.Run("the waiting placeholder is overwritten by the first count", func(t *testing.T) {
+		var buf bytes.Buffer
+		line := &progressLine{w: &buf, prefix: "  ", tail: tail, terminal: true}
+		line.waiting("starting download...")
+		line.update(2)
+
+		placeholder, redraw, found := strings.Cut(buf.String(), "\r")
+		test.That(t, found, test.ShouldBeTrue)
+		test.That(t, placeholder, test.ShouldEqual, "  starting download...")
+		test.That(t, strings.TrimRight(redraw, " "), test.ShouldEqual, "   (2 rows)")
+		// Blanked out to the placeholder's width, so none of it shows through.
+		test.That(t, len(redraw), test.ShouldEqual, len(placeholder))
+	})
+
+	t.Run("no waiting placeholder off a terminal", func(t *testing.T) {
+		var buf bytes.Buffer
+		line := &progressLine{w: &buf, prefix: "  ", tail: tail}
+		line.waiting("starting download...")
+
+		test.That(t, buf.String(), test.ShouldEqual, "")
+	})
+
+	// A carriage return only returns to the start of the current visual row, so a line long enough
+	// to wrap cannot be redrawn.
+	t.Run("detects a line too wide to redraw", func(t *testing.T) {
+		narrow := &progressLine{maxWidth: 35}
+		test.That(t, narrow.fitsOneRow("  short"), test.ShouldBeTrue)
+		test.That(t, narrow.fitsOneRow(strings.Repeat("x", 40)), test.ShouldBeFalse)
+
+		unknown := &progressLine{maxWidth: 0}
+		test.That(t, unknown.fitsOneRow(strings.Repeat("x", 200)), test.ShouldBeTrue)
+	})
+
+	// The placeholder is longer than any count, so it can overflow a line the count fits on.
+	t.Run("drops a placeholder that would wrap", func(t *testing.T) {
+		var buf bytes.Buffer
+		line := &progressLine{w: &buf, prefix: "  sensor-1 Readings", tail: tail, terminal: true, maxWidth: 35}
+		line.start(": starting download...")
+
+		test.That(t, buf.String(), test.ShouldEqual, "  sensor-1 Readings")
+	})
+
+	t.Run("writes a whole line when start was skipped", func(t *testing.T) {
+		var buf bytes.Buffer
+		line := &progressLine{w: &buf, prefix: prefix, tail: tail}
+		line.finish(1)
+
+		test.That(t, buf.String(), test.ShouldEqual, prefix+" (1 row)\n")
+	})
+}

--- a/cli/tty.go
+++ b/cli/tty.go
@@ -10,3 +10,14 @@ import (
 func isInteractive() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
+
+// isTerminalOutput reports whether stdout is connected to a terminal.
+func isTerminalOutput() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// terminalWidth reports stdout's column count.
+func terminalWidth() (int, error) {
+	cols, _, err := term.GetSize(int(os.Stdout.Fd()))
+	return cols, err
+}


### PR DESCRIPTION
The static output from #6365 names each resource, then goes quiet until that resource finishes. For a resource with a lot of rows that reads as a hang.

`progressLine` rewrites one line in place on a terminal and writes once when piped. The resource name is static; only the indented count row below it is redrawn:

```
Tabular data (tabular/):
  sensor-1 Readings
    1234 rows          <- "starting download..." until the first count, then rewrites in place
```

Tabular reports every 100 rows, binary once per completed file. The binary half shows a running file total the same way, erased and replaced by the per-resource split once it finishes.

A carriage return only returns to the start of the current visual row, so a line long enough to wrap can't be rewritten. `newProgressLine` measures the widest line it could draw against the terminal width and falls back to writing once if it wouldn't fit. The placeholder gets the same check separately, since it's longer than any count. Keeping the count on its own indented row is what makes this a non-issue in practice.

`data export tabular` is unchanged — it still prints its own `Downloading..` and per-attempt dots, and passes no callback.

Stacked: 3 of 3, on top of #6365. Based on `APP-17380b` so the diff is just this change; GitHub retargets it to `APP-17380` when #6365 merges.

## Testing

`TestProgressLine` covers the render paths as subtests:
- In-place redraw on a terminal, a single write when piped, and the whole line when `start` was skipped
- Padding a shorter redraw over a longer one, so an earlier render can't leave its tail behind
- The waiting placeholder overwritten by the first count, and not drawn at all when piped
- Both width checks: a line too wide to redraw, and a placeholder that would wrap a line the count fits on

The fixture prefix contains a `%`, so every case also proves a caller-supplied prefix never reaches a format function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)