### PR TITLE
Composable APIs: one model serving multiple co-equal APIs

### DIFF
--- a/components/arm/arm.go
+++ b/components/arm/arm.go
@@ -229,6 +229,13 @@ func FromProvider(provider resource.Provider, name string) (Arm, error) {
 	return resource.FromProvider[Arm](provider, Named(name))
 }
 
+// FromResource extracts an Arm from a resource that may be a multi-API (composite) resource. This is
+// the open-world access path: it works whether res is a plain arm client or a composite that serves
+// the arm API alongside others.
+func FromResource(res resource.Resource) (Arm, error) {
+	return resource.FromResourceForAPI[Arm](res, API)
+}
+
 // NamesFromRobot is a helper for getting all arm names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/audioin/audioin.go
+++ b/components/audioin/audioin.go
@@ -68,6 +68,11 @@ func FromProvider(provider resource.Provider, name string) (AudioIn, error) {
 	return resource.FromProvider[AudioIn](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (AudioIn, error) {
+	return resource.FromResourceForAPI[AudioIn](res, API)
+}
+
 // NamesFromRobot is a helper for getting all AudioIn names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/audioout/audioout.go
+++ b/components/audioout/audioout.go
@@ -49,6 +49,11 @@ func FromProvider(provider resource.Provider, name string) (AudioOut, error) {
 	return resource.FromProvider[AudioOut](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (AudioOut, error) {
+	return resource.FromResourceForAPI[AudioOut](res, API)
+}
+
 // NamesFromRobot is a helper for getting all AudioIn names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/base/base.go
+++ b/components/base/base.go
@@ -172,6 +172,11 @@ func FromProvider(provider resource.Provider, name string) (Base, error) {
 	return resource.FromProvider[Base](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Base, error) {
+	return resource.FromResourceForAPI[Base](res, API)
+}
+
 // NamesFromRobot is a helper for getting all base names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/board/board.go
+++ b/components/board/board.go
@@ -212,6 +212,11 @@ func FromProvider(provider resource.Provider, name string) (Board, error) {
 	return resource.FromProvider[Board](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Board, error) {
+	return resource.FromResourceForAPI[Board](res, API)
+}
+
 // NamesFromRobot is a helper for getting all board names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/button/button.go
+++ b/components/button/button.go
@@ -80,6 +80,11 @@ func FromProvider(provider resource.Provider, name string) (Button, error) {
 	return resource.FromProvider[Button](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Button, error) {
+	return resource.FromResourceForAPI[Button](res, API)
+}
+
 // NamesFromRobot is a helper for getting all gripper names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/camera/camera.go
+++ b/components/camera/camera.go
@@ -348,6 +348,11 @@ func FromProvider(provider resource.Provider, name string) (Camera, error) {
 	return resource.FromProvider[Camera](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Camera, error) {
+	return resource.FromResourceForAPI[Camera](res, API)
+}
+
 // NamesFromRobot is a helper for getting all camera names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/encoder/encoder.go
+++ b/components/encoder/encoder.go
@@ -146,6 +146,11 @@ func FromProvider(provider resource.Provider, name string) (Encoder, error) {
 	return resource.FromProvider[Encoder](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Encoder, error) {
+	return resource.FromResourceForAPI[Encoder](res, API)
+}
+
 // NamesFromRobot is a helper for getting all encoder names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/gantry/gantry.go
+++ b/components/gantry/gantry.go
@@ -141,6 +141,11 @@ func FromProvider(provider resource.Provider, name string) (Gantry, error) {
 	return resource.FromProvider[Gantry](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Gantry, error) {
+	return resource.FromResourceForAPI[Gantry](res, API)
+}
+
 // NamesFromRobot is a helper for getting all gantry names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/generic/generic.go
+++ b/components/generic/generic.go
@@ -61,6 +61,11 @@ func FromProvider(provider resource.Provider, name string) (resource.Resource, e
 	return resource.FromProvider[resource.Resource](provider, Named(name))
 }
 
+// FromResource extracts the generic API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (resource.Resource, error) {
+	return resource.FromResourceForAPI[resource.Resource](res, API)
+}
+
 // NamesFromRobot is a helper for getting all generic names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/gripper/gripper.go
+++ b/components/gripper/gripper.go
@@ -116,6 +116,11 @@ func FromProvider(provider resource.Provider, name string) (Gripper, error) {
 	return resource.FromProvider[Gripper](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Gripper, error) {
+	return resource.FromResourceForAPI[Gripper](res, API)
+}
+
 // NamesFromRobot is a helper for getting all gripper names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/input/input.go
+++ b/components/input/input.go
@@ -216,6 +216,11 @@ func FromProvider(provider resource.Provider, name string) (Controller, error) {
 	return resource.FromProvider[Controller](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Controller, error) {
+	return resource.FromResourceForAPI[Controller](res, API)
+}
+
 // NamesFromRobot is a helper for getting all input controller names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/motor/motor.go
+++ b/components/motor/motor.go
@@ -196,6 +196,11 @@ func FromProvider(provider resource.Provider, name string) (Motor, error) {
 	return resource.FromProvider[Motor](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Motor, error) {
+	return resource.FromResourceForAPI[Motor](res, API)
+}
+
 // NamesFromRobot is a helper for getting all motor names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/movementsensor/movementsensor.go
+++ b/components/movementsensor/movementsensor.go
@@ -206,6 +206,11 @@ func FromProvider(provider resource.Provider, name string) (MovementSensor, erro
 	return resource.FromProvider[MovementSensor](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (MovementSensor, error) {
+	return resource.FromResourceForAPI[MovementSensor](res, API)
+}
+
 // NamesFromRobot is a helper for getting all MovementSensor names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/posetracker/pose_tracker.go
+++ b/components/posetracker/pose_tracker.go
@@ -69,3 +69,8 @@ func FromDependencies(deps resource.Dependencies, name string) (PoseTracker, err
 func FromProvider(provider resource.Provider, name string) (PoseTracker, error) {
 	return resource.FromProvider[PoseTracker](provider, Named(name))
 }
+
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (PoseTracker, error) {
+	return resource.FromResourceForAPI[PoseTracker](res, API)
+}

--- a/components/powersensor/powersensor.go
+++ b/components/powersensor/powersensor.go
@@ -120,6 +120,11 @@ func FromProvider(provider resource.Provider, name string) (PowerSensor, error) 
 	return resource.FromProvider[PowerSensor](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (PowerSensor, error) {
+	return resource.FromResourceForAPI[PowerSensor](res, API)
+}
+
 // NamesFromRobot is a helper for getting all PowerSensor names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/sensor/sensor.go
+++ b/components/sensor/sensor.go
@@ -72,6 +72,12 @@ func FromProvider(provider resource.Provider, name string) (Sensor, error) {
 	return resource.FromProvider[Sensor](provider, Named(name))
 }
 
+// FromResource extracts a Sensor from a resource that may be a multi-API (composite) resource. Works
+// whether res is a plain sensor client or a composite that serves the sensor API alongside others.
+func FromResource(res resource.Resource) (Sensor, error) {
+	return resource.FromResourceForAPI[Sensor](res, API)
+}
+
 // NamesFromRobot is a helper for getting all sensor names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/servo/servo.go
+++ b/components/servo/servo.go
@@ -100,6 +100,11 @@ func FromProvider(provider resource.Provider, name string) (Servo, error) {
 	return resource.FromProvider[Servo](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Servo, error) {
+	return resource.FromResourceForAPI[Servo](res, API)
+}
+
 // NamesFromRobot is a helper for getting all servo names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/components/switch/switch.go
+++ b/components/switch/switch.go
@@ -106,6 +106,11 @@ func FromProvider(provider resource.Provider, name string) (Switch, error) {
 	return resource.FromProvider[Switch](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Switch, error) {
+	return resource.FromResourceForAPI[Switch](res, API)
+}
+
 // NamesFromRobot is a helper for getting all switch names from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/examples/customresources/demos/multiapimodules/.gitignore
+++ b/examples/customresources/demos/multiapimodules/.gitignore
@@ -1,0 +1,2 @@
+combomodule/combomodule
+combousermodule/combousermodule

--- a/examples/customresources/demos/multiapimodules/combomodule/combomodule.go
+++ b/examples/customresources/demos/multiapimodules/combomodule/combomodule.go
@@ -1,0 +1,21 @@
+// Package main is a module that serves the acme:demo:combodevice composite model. The single
+// model is advertised under all three of its APIs, so one instance shows up as one resource
+// reachable as a gizmo, a summation, and a sensor.
+package main
+
+import (
+	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/examples/customresources/apis/gizmoapi"
+	"go.viam.com/rdk/examples/customresources/apis/summationapi"
+	"go.viam.com/rdk/examples/customresources/models/combodevice"
+	"go.viam.com/rdk/module"
+	"go.viam.com/rdk/resource"
+)
+
+func main() {
+	module.ModularMain(
+		resource.APIModel{API: gizmoapi.API, Model: combodevice.Model},
+		resource.APIModel{API: summationapi.API, Model: combodevice.Model},
+		resource.APIModel{API: sensor.API, Model: combodevice.Model},
+	)
+}

--- a/examples/customresources/demos/multiapimodules/combomodule/run.sh
+++ b/examples/customresources/demos/multiapimodules/combomodule/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd `dirname $0`
+
+go build ./
+exec ./combomodule $@

--- a/examples/customresources/demos/multiapimodules/combousermodule/combousermodule.go
+++ b/examples/customresources/demos/multiapimodules/combousermodule/combousermodule.go
@@ -1,0 +1,15 @@
+// Package main is a module that serves the acme:demo:combouser model. It is deliberately a
+// separate module from the composite it depends on, so the dependency handle is a real composite
+// client rather than an in-process Go handle.
+package main
+
+import (
+	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/examples/customresources/models/combouser"
+	"go.viam.com/rdk/module"
+	"go.viam.com/rdk/resource"
+)
+
+func main() {
+	module.ModularMain(resource.APIModel{API: generic.API, Model: combouser.Model})
+}

--- a/examples/customresources/demos/multiapimodules/combousermodule/run.sh
+++ b/examples/customresources/demos/multiapimodules/combousermodule/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd `dirname $0`
+
+go build ./
+exec ./combousermodule $@

--- a/examples/customresources/demos/multiapimodules/module.json
+++ b/examples/customresources/demos/multiapimodules/module.json
@@ -1,0 +1,34 @@
+{
+	"modules": [
+		{
+			"name": "ComboModule",
+			"executable_path": "combomodule/run.sh",
+			"log_level": "debug"
+		},
+		{
+			"name": "ComboUserModule",
+			"executable_path": "combousermodule/run.sh",
+			"log_level": "debug"
+		}
+	],
+	"components": [
+		{
+			"name": "combodev1",
+			"namespace": "acme",
+			"type": "gizmo",
+			"model": "acme:demo:combodevice"
+		},
+		{
+			"name": "user1",
+			"namespace": "rdk",
+			"type": "generic",
+			"model": "acme:demo:combouser",
+			"attributes": {
+				"combo": "combodev1"
+			}
+		}
+	],
+	"network": {
+		"bind_address": ":8080"
+	}
+}

--- a/examples/customresources/demos/multiapimodules/module.json
+++ b/examples/customresources/demos/multiapimodules/module.json
@@ -14,14 +14,12 @@
 	"components": [
 		{
 			"name": "combodev1",
-			"namespace": "acme",
-			"type": "gizmo",
+			"api": "acme:component:gizmo",
 			"model": "acme:demo:combodevice"
 		},
 		{
 			"name": "user1",
-			"namespace": "rdk",
-			"type": "generic",
+			"api": "rdk:component:generic",
 			"model": "acme:demo:combouser",
 			"attributes": {
 				"combo": "combodev1"

--- a/examples/customresources/demos/multiapimodules/moduletest/module_test.go
+++ b/examples/customresources/demos/multiapimodules/moduletest/module_test.go
@@ -1,0 +1,153 @@
+// Package main tests the multiapimodules demo: a composite (multi-API) model served by one module
+// and a consumer served by a second module that depends on every one of the composite's APIs.
+package main_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"go.viam.com/test"
+	goutils "go.viam.com/utils"
+	"go.viam.com/utils/rpc"
+
+	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/examples/customresources/apis/gizmoapi"
+	"go.viam.com/rdk/examples/customresources/apis/summationapi"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/robot"
+	"go.viam.com/rdk/robot/client"
+	"go.viam.com/rdk/testutils"
+	"go.viam.com/rdk/testutils/robottestutils"
+	"go.viam.com/rdk/utils"
+)
+
+func TestMultiAPIModules(t *testing.T) {
+	logger, observer := logging.NewObservedTestLogger(t)
+	var port int
+	success := false
+	for portTryNum := 0; portTryNum < 10; portTryNum++ {
+		cfgFilename, portLocal, err := modifyCfg(t,
+			utils.ResolveFile("examples/customresources/demos/multiapimodules/module.json"), logger)
+		test.That(t, err, test.ShouldBeNil)
+		port = portLocal
+
+		server := robottestutils.ServerAsSeparateProcess(t, cfgFilename, logger)
+		err = server.Start(context.Background())
+		test.That(t, err, test.ShouldBeNil)
+
+		if robottestutils.WaitForServing(observer, port) {
+			success = true
+			defer func() { test.That(t, server.Stop(), test.ShouldBeNil) }()
+			break
+		}
+		server.Stop()
+	}
+	test.That(t, success, test.ShouldBeTrue)
+
+	rc, err := connect(port, logger, rpc.WithForceDirectGRPC())
+	test.That(t, err, test.ShouldBeNil)
+	defer func() { test.That(t, rc.Close(context.Background()), test.ShouldBeNil) }()
+
+	const comboName = "combodev1"
+
+	// The composite is reachable under each of its three APIs, and a single handle exposes all three.
+	t.Run("composite reachable under every API", func(t *testing.T) {
+		gizRes, err := rc.ResourceByName(gizmoapi.Named(comboName))
+		test.That(t, err, test.ShouldBeNil)
+
+		giz, err := resource.AsType[gizmoapi.Gizmo](gizRes)
+		test.That(t, err, test.ShouldBeNil)
+		two, err := giz.DoTwo(context.Background(), true)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, two, test.ShouldEqual, "combo saw arg1=true")
+
+		sum, err := resource.AsType[summationapi.Summation](gizRes)
+		test.That(t, err, test.ShouldBeNil)
+		total, err := sum.Sum(context.Background(), []float64{1, 2, 3, 4})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, total, test.ShouldEqual, 10)
+
+		sen, err := resource.AsType[sensor.Sensor](gizRes)
+		test.That(t, err, test.ShouldBeNil)
+		readings, err := sen.Readings(context.Background(), nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, readings["reading"], test.ShouldEqual, 42)
+	})
+
+	// The consumer, in a separate module, depends on the composite and drives all three of its APIs.
+	t.Run("consumer drives all three APIs of the dependency", func(t *testing.T) {
+		userRes, err := rc.ResourceByName(generic.Named("user1"))
+		test.That(t, err, test.ShouldBeNil)
+		out, err := userRes.DoCommand(context.Background(), map[string]interface{}{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, out["gizmo_dotwo"], test.ShouldEqual, "combo saw arg1=true")
+		test.That(t, out["sum"], test.ShouldEqual, 10)
+		readings, ok := out["readings"].(map[string]interface{})
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, readings["reading"], test.ShouldEqual, 42)
+	})
+}
+
+func connect(port int, logger logging.Logger, dialOpts ...rpc.DialOption) (robot.Robot, error) {
+	connectCtx, cancelConn := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancelConn()
+	for {
+		dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Second*2)
+		rc, err := client.New(dialCtx, fmt.Sprintf("localhost:%d", port), logger,
+			client.WithDialOptions(dialOpts...),
+			client.WithDisableSessions(),
+		)
+		dialCancel()
+		if !isRetryableConnErr(err) {
+			return rc, err
+		}
+		select {
+		case <-connectCtx.Done():
+			return nil, connectCtx.Err()
+		default:
+		}
+	}
+}
+
+func isRetryableConnErr(err error) bool {
+	return err != nil && errors.Is(err, context.DeadlineExceeded)
+}
+
+func modifyCfg(t *testing.T, cfgIn string, logger logging.Logger) (string, int, error) {
+	comboModPath := testutils.BuildTempModule(t, "examples/customresources/demos/multiapimodules/combomodule")
+	userModPath := testutils.BuildTempModule(t, "examples/customresources/demos/multiapimodules/combousermodule")
+
+	port, err := goutils.TryReserveRandomPort()
+	if err != nil {
+		return "", 0, err
+	}
+
+	cfg, err := config.Read(context.Background(), cfgIn, logger, nil)
+	if err != nil {
+		return "", 0, err
+	}
+	cfg.Network.BindAddress = fmt.Sprintf("localhost:%d", port)
+	cfg.Modules[0].ExePath = comboModPath
+	cfg.Modules[1].ExePath = userModPath
+	output, err := json.Marshal(cfg)
+	if err != nil {
+		return "", 0, err
+	}
+	file, err := os.CreateTemp(t.TempDir(), "viam-test-config-*")
+	if err != nil {
+		return "", 0, err
+	}
+	cfgFilename := file.Name()
+	if _, err = file.Write(output); err != nil {
+		return "", 0, err
+	}
+	return cfgFilename, port, file.Close()
+}

--- a/examples/customresources/demos/multiapimodules/moduletest/module_test.go
+++ b/examples/customresources/demos/multiapimodules/moduletest/module_test.go
@@ -94,6 +94,38 @@ func TestMultiAPIModules(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		test.That(t, readings["reading"], test.ShouldEqual, 42)
 	})
+
+	// An api-less name resolves to the one composite, and every API is reachable off that handle.
+	t.Run("api-less SimpleName resolves the composite", func(t *testing.T) {
+		res, err := rc.ResourceByName(resource.SimpleName(comboName))
+		test.That(t, err, test.ShouldBeNil)
+
+		giz, err := resource.AsType[gizmoapi.Gizmo](res)
+		test.That(t, err, test.ShouldBeNil)
+		two, err := giz.DoTwo(context.Background(), true)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, two, test.ShouldEqual, "combo saw arg1=true")
+
+		sen, err := resource.AsType[sensor.Sensor](res)
+		test.That(t, err, test.ShouldBeNil)
+		readings, err := sen.Readings(context.Background(), nil)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, readings["reading"], test.ShouldEqual, 42)
+	})
+
+	// Every lookup of the composite — by any API, or api-less — returns the one cached object rather
+	// than re-dialing per API.
+	t.Run("lookups share one cached composite", func(t *testing.T) {
+		viaGizmo, err := rc.ResourceByName(gizmoapi.Named(comboName))
+		test.That(t, err, test.ShouldBeNil)
+		viaSensor, err := rc.ResourceByName(sensor.Named(comboName))
+		test.That(t, err, test.ShouldBeNil)
+		viaBare, err := rc.ResourceByName(resource.SimpleName(comboName))
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, viaGizmo == viaSensor, test.ShouldBeTrue)
+		test.That(t, viaGizmo == viaBare, test.ShouldBeTrue)
+	})
 }
 
 func connect(port int, logger logging.Logger, dialOpts ...rpc.DialOption) (robot.Robot, error) {

--- a/examples/customresources/models/combodevice/combodevice.go
+++ b/examples/customresources/models/combodevice/combodevice.go
@@ -1,0 +1,98 @@
+// Package combodevice implements a single model that serves three co-equal APIs at once — a
+// custom component (acme:component:gizmo), a custom service (acme:service:summation), and a
+// builtin component (rdk:component:sensor). It is registered with resource.RegisterMultiAPI, so
+// one instance is one resource reachable under every one of those APIs.
+package combodevice
+
+import (
+	"context"
+	"fmt"
+
+	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/examples/customresources/apis/gizmoapi"
+	"go.viam.com/rdk/examples/customresources/apis/summationapi"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+)
+
+// Model is the full model definition of the composite device.
+var Model = resource.NewModel("acme", "demo", "combodevice")
+
+func init() {
+	// RegisterMultiAPI registers the single constructor under every listed API and records the set,
+	// marking this model as a composite. The first API (gizmo) is the canonical one used when a
+	// config entry omits its `api` field. Panics on fewer than two APIs.
+	resource.RegisterMultiAPI(
+		[]resource.API{gizmoapi.API, summationapi.API, sensor.API},
+		Model,
+		resource.Registration[resource.Resource, resource.NoNativeConfig]{
+			Constructor: newComboDevice,
+		},
+	)
+}
+
+// comboDevice is one object that implements all three API interfaces: gizmoapi.Gizmo,
+// summationapi.Summation, and sensor.Sensor.
+type comboDevice struct {
+	resource.Named
+	resource.TriviallyReconfigurable
+	resource.TriviallyCloseable
+	logger logging.Logger
+}
+
+func newComboDevice(
+	_ context.Context, _ resource.Dependencies, conf resource.Config, logger logging.Logger,
+) (resource.Resource, error) {
+	return &comboDevice{Named: conf.ResourceName().AsNamed(), logger: logger}, nil
+}
+
+// --- gizmoapi.Gizmo ---
+
+func (c *comboDevice) DoOne(_ context.Context, arg1 string) (bool, error) {
+	return arg1 == "combo", nil
+}
+
+func (c *comboDevice) DoOneClientStream(_ context.Context, arg1 []string) (bool, error) {
+	ret := len(arg1) > 0
+	for _, arg := range arg1 {
+		ret = ret && arg == "combo"
+	}
+	return ret, nil
+}
+
+func (c *comboDevice) DoOneServerStream(_ context.Context, arg1 string) ([]bool, error) {
+	return []bool{arg1 == "combo", false, true}, nil
+}
+
+func (c *comboDevice) DoOneBiDiStream(_ context.Context, arg1 []string) ([]bool, error) {
+	var rets []bool
+	for _, arg := range arg1 {
+		rets = append(rets, arg == "combo")
+	}
+	return rets, nil
+}
+
+func (c *comboDevice) DoTwo(_ context.Context, arg1 bool) (string, error) {
+	return fmt.Sprintf("combo saw arg1=%t", arg1), nil
+}
+
+// --- summationapi.Summation ---
+
+func (c *comboDevice) Sum(_ context.Context, nums []float64) (float64, error) {
+	var total float64
+	for _, n := range nums {
+		total += n
+	}
+	return total, nil
+}
+
+// --- sensor.Sensor ---
+
+func (c *comboDevice) Readings(_ context.Context, _ map[string]interface{}) (map[string]interface{}, error) {
+	return map[string]interface{}{"reading": 42}, nil
+}
+
+// DoCommand satisfies resource.Resource (and gizmoapi.Gizmo's embedded DoCommand).
+func (c *comboDevice) DoCommand(_ context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return cmd, nil
+}

--- a/examples/customresources/models/combouser/combouser.go
+++ b/examples/customresources/models/combouser/combouser.go
@@ -1,0 +1,107 @@
+// Package combouser implements a generic component that depends on a single composite
+// (multi-API) resource and consumes every one of its APIs. Because combouser lives in a
+// different module than the composite it depends on, the dependency handle it receives is a
+// real composite client assembled over gRPC — exercising the composite path end to end rather
+// than an in-process Go handle.
+package combouser
+
+import (
+	"context"
+
+	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/examples/customresources/apis/gizmoapi"
+	"go.viam.com/rdk/examples/customresources/apis/summationapi"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+)
+
+// Model is the full model definition of the consumer.
+var Model = resource.NewModel("acme", "demo", "combouser")
+
+// Config points at the composite resource this consumer depends on.
+type Config struct {
+	Combo string `json:"combo"`
+}
+
+// Validate ensures `combo` is set and declares it as a dependency by its bare name. The bare name
+// resolves to the one composite resource regardless of which of its APIs we later pull off it.
+func (cfg *Config) Validate(path string) ([]string, []string, error) {
+	if cfg.Combo == "" {
+		return nil, nil, resource.NewConfigValidationFieldRequiredError(path, "combo")
+	}
+	return []string{cfg.Combo}, nil, nil
+}
+
+func init() {
+	resource.RegisterComponent(generic.API, Model, resource.Registration[resource.Resource, *Config]{
+		Constructor: newComboUser,
+	})
+}
+
+type comboUser struct {
+	resource.Named
+	resource.TriviallyCloseable
+
+	gizmo gizmoapi.Gizmo
+	sum   summationapi.Summation
+	sen   sensor.Sensor
+}
+
+func newComboUser(
+	ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger,
+) (resource.Resource, error) {
+	u := &comboUser{Named: conf.ResourceName().AsNamed()}
+	if err := u.Reconfigure(ctx, deps, conf); err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
+// Reconfigure pulls a typed handle for each of the composite's APIs out of the single dependency.
+// All three lookups target the same bare name; each FromProvider selects the right interface off
+// the composite handle.
+func (u *comboUser) Reconfigure(_ context.Context, deps resource.Dependencies, conf resource.Config) error {
+	cfg, err := resource.NativeConfig[*Config](conf)
+	if err != nil {
+		return err
+	}
+
+	gizmo, err := resource.FromProvider[gizmoapi.Gizmo](deps, gizmoapi.Named(cfg.Combo))
+	if err != nil {
+		return err
+	}
+	sum, err := resource.FromProvider[summationapi.Summation](deps, summationapi.Named(cfg.Combo))
+	if err != nil {
+		return err
+	}
+	sen, err := resource.FromProvider[sensor.Sensor](deps, sensor.Named(cfg.Combo))
+	if err != nil {
+		return err
+	}
+
+	u.gizmo, u.sum, u.sen = gizmo, sum, sen
+	return nil
+}
+
+// DoCommand exercises all three of the composite's APIs through the one dependency and returns
+// what each reported, proving a single composite handle serves every API.
+func (u *comboUser) DoCommand(ctx context.Context, _ map[string]interface{}) (map[string]interface{}, error) {
+	two, err := u.gizmo.DoTwo(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	total, err := u.sum.Sum(ctx, []float64{1, 2, 3, 4})
+	if err != nil {
+		return nil, err
+	}
+	readings, err := u.sen.Readings(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{
+		"gizmo_dotwo": two,
+		"sum":         total,
+		"readings":    readings,
+	}, nil
+}

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -577,6 +577,30 @@ func (mgr *Manager) addResource(ctx context.Context, conf resource.Config, deps 
 	defer mod.resourcesMu.Unlock()
 	mod.resources[conf.ResourceName()] = &addedResource{conf, deps}
 
+	// A composite (multi-API) model: the module constructs one instance and serves it on each of its
+	// APIs (see module.Module.AddResource). Build a per-API client for every API in the set, all over
+	// the same shared connection, and return one composite so the server routes each API to the one
+	// module instance. Single-API resources take the plain path below.
+	if apis := resource.APIsForModel(conf.Model); len(apis) > 1 {
+		base := conf.ResourceName()
+		byAPI := make(map[resource.API]resource.Resource, len(apis))
+		for _, api := range apis {
+			subName := resource.Name{API: api, Remote: base.Remote, Name: base.Name}
+			mgr.rMap.Store(subName, mod)
+			apiInfo, ok := resource.LookupGenericAPIRegistration(api)
+			if !ok || apiInfo.RPCClient == nil {
+				byAPI[api] = rdkgrpc.NewForeignResource(subName, &mod.sharedConn)
+				continue
+			}
+			client, err := apiInfo.RPCClient(ctx, &mod.sharedConn, "", subName, mgr.logger)
+			if err != nil {
+				return nil, err
+			}
+			byAPI[api] = client
+		}
+		return resource.NewMultiAPIResource(resource.Name{API: apis[0], Remote: base.Remote, Name: base.Name}, apis, byAPI), nil
+	}
+
 	apiInfo, ok := resource.LookupGenericAPIRegistration(conf.API)
 	if !ok || apiInfo.RPCClient == nil {
 		mod.logger.CWarnw(ctx, "No built-in grpc client for modular resource", "resource", conf.ResourceName())

--- a/module/modmanager/module.go
+++ b/module/modmanager/module.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -464,6 +465,24 @@ func (m *module) registerResourceModels(mgr *Manager) {
 		default:
 			m.logger.Errorw("Invalid module type", "API type", api.API.Type)
 		}
+	}
+
+	// A model advertised by this module under more than one API is a composite (multi-API) model.
+	// Record its API set (sorted for a deterministic canonical API) so viam-server treats one config
+	// entry as a single instance reachable/advertised under each of its APIs, and can resolve an
+	// `api`-less config from the model. The per-API constructors above are the module proxies.
+	apisByModel := map[resource.Model][]resource.API{}
+	for api, models := range m.handles {
+		for _, model := range models {
+			apisByModel[model] = append(apisByModel[model], api.API)
+		}
+	}
+	for model, apis := range apisByModel {
+		if len(apis) < 2 {
+			continue
+		}
+		sort.Slice(apis, func(i, j int) bool { return apis[i].String() < apis[j].String() })
+		resource.RegisterMultiAPISet(model, apis)
 	}
 }
 

--- a/module/modmanager/multiapi_module_test.go
+++ b/module/modmanager/multiapi_module_test.go
@@ -1,0 +1,66 @@
+package modmanager
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/logging"
+	modmanageroptions "go.viam.com/rdk/module/modmanager/options"
+	"go.viam.com/rdk/resource"
+	rtestutils "go.viam.com/rdk/testutils"
+)
+
+// TestMultiAPIModule verifies the modular path of composable APIs: a module advertises one model
+// under two APIs (sensor + generic), and viam-server serves it as one instance reachable under both
+// — the module constructs it once (module.Module.AddResource) and the manager returns one composite
+// whose per-API sub-clients both route to that instance.
+func TestMultiAPIModule(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+
+	parentAddr := setupSocketWithRobot(t)
+	modPath := rtestutils.BuildTempModule(t, "module/testmodule")
+
+	mgr := setupModManager(t, ctx, parentAddr, logger, modmanageroptions.Options{UntrustedEnv: false})
+	err := mgr.Add(ctx, config.Module{Name: "test-module", ExePath: modPath, Type: config.ModuleTypeLocal})
+	test.That(t, err, test.ShouldBeNil)
+
+	multiModel := resource.NewModel("rdk", "test", "multi")
+
+	// The module advertised the model under two APIs, so viam-server recorded it as multi-API and a
+	// config may omit `api` (resolved to the canonical, first-sorted API).
+	apis := resource.APIsForModel(multiModel)
+	test.That(t, apis, test.ShouldContain, sensor.API)
+	test.That(t, apis, test.ShouldContain, generic.API)
+
+	cfg := resource.Config{Name: "combo", API: sensor.API, Model: multiModel}
+	_, _, err = cfg.Validate("test", resource.APITypeComponentName)
+	test.That(t, err, test.ShouldBeNil)
+
+	res, err := mgr.AddResource(ctx, cfg, nil)
+	test.That(t, err, test.ShouldBeNil)
+
+	// One composite object, usable under both APIs — each sub-client routes to the one module instance.
+	s, err := sensor.FromResource(res)
+	test.That(t, err, test.ShouldBeNil)
+	readings, err := s.Readings(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, readings["reading"], test.ShouldEqual, 42)
+
+	g, err := generic.FromResource(res)
+	test.That(t, err, test.ShouldBeNil)
+	resp, err := g.DoCommand(ctx, map[string]interface{}{})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, resp["did"], test.ShouldEqual, "it")
+
+	// The resource is modular under both of its API names.
+	test.That(t, mgr.IsModularResource(sensor.Named("combo")), test.ShouldBeTrue)
+	test.That(t, mgr.IsModularResource(generic.Named("combo")), test.ShouldBeTrue)
+
+	test.That(t, mgr.Close(ctx), test.ShouldBeNil)
+}

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -135,6 +135,42 @@ func TestAddModelFromRegistry(t *testing.T) {
 	}
 }
 
+func TestAddModelFromRegistryCompositeGuard(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewTestLogger(t)
+
+	ctor := func(context.Context, resource.Dependencies, resource.Config, logging.Logger) (resource.Resource, error) {
+		return nil, nil
+	}
+	reg := resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: ctor}
+
+	// A model registered under two APIs WITHOUT RegisterMultiAPI is incidental reuse; the module
+	// guard must reject advertising it under the second API.
+	incidental := resource.NewModel("acme", "test", "incidental")
+	resource.Register(gizmoapi.API, incidental, reg)
+	resource.Register(summationapi.API, incidental, reg)
+	defer resource.Deregister(gizmoapi.API, incidental)
+	defer resource.Deregister(summationapi.API, incidental)
+
+	m1, err := module.NewModule(ctx, filepath.Join(t.TempDir(), "guard1.sock"), logger)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, m1.AddModelFromRegistry(ctx, gizmoapi.API, incidental), test.ShouldBeNil)
+	err = m1.AddModelFromRegistry(ctx, summationapi.API, incidental)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "without RegisterMultiAPI")
+
+	// A model declared via RegisterMultiAPI may be advertised under each of its APIs.
+	declared := resource.NewModel("acme", "test", "declared")
+	resource.RegisterMultiAPI([]resource.API{gizmoapi.API, summationapi.API}, declared, reg)
+	defer resource.Deregister(gizmoapi.API, declared)
+	defer resource.Deregister(summationapi.API, declared)
+
+	m2, err := module.NewModule(ctx, filepath.Join(t.TempDir(), "guard2.sock"), logger)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, m2.AddModelFromRegistry(ctx, gizmoapi.API, declared), test.ShouldBeNil)
+	test.That(t, m2.AddModelFromRegistry(ctx, summationapi.API, declared), test.ShouldBeNil)
+}
+
 func TestModuleFunctions(t *testing.T) {
 	ctx := context.Background()
 	logger := logging.NewTestLogger(t)

--- a/module/resources.go
+++ b/module/resources.go
@@ -280,8 +280,26 @@ func (m *Module) AddModelFromRegistry(ctx context.Context, api resource.API, mod
 	}
 
 	m.registerMu.Lock()
+	defer m.registerMu.Unlock()
+	// A model advertised under more than one API must be a declared composite (via
+	// resource.RegisterMultiAPI), not an incidental reuse of one model string across APIs. Reject the
+	// latter so viam-server's inference — "a model under >=2 APIs is a composite" — is sound. Builtins
+	// that reuse a model across APIs (fake, gpio) register through the core registry rather than a
+	// module, so they are unaffected by this module-side guard.
+	for existingAPI, models := range m.handlers {
+		if existingAPI.API == api {
+			continue
+		}
+		for _, existing := range models {
+			if existing == model && len(resource.APIsForModel(model)) == 0 {
+				return fmt.Errorf(
+					"model %q is registered under multiple APIs (%s and %s) without RegisterMultiAPI; "+
+						"use resource.RegisterMultiAPI to declare a composite (multi-API) model",
+					model, existingAPI.API, api)
+			}
+		}
+	}
 	m.handlers[rpcAPI] = append(m.handlers[rpcAPI], model)
-	m.registerMu.Unlock()
 	return nil
 }
 

--- a/module/resources.go
+++ b/module/resources.go
@@ -362,6 +362,25 @@ func (m *Module) addResource(
 		return multierr.Combine(err, res.Close(ctx))
 	}
 
+	// Construct-once for composite (multi-API) models: the module builds one instance but serves it
+	// on each of its APIs, so register the same res in every other API's collection under that API's
+	// name. Each of the module's per-API gRPC services then resolves the one instance.
+	if apis := resource.APIsForModel(conf.Model); len(apis) > 1 {
+		base := conf.ResourceName()
+		for _, api := range apis {
+			if api == conf.API {
+				continue
+			}
+			other, ok := m.collections[api]
+			if !ok {
+				return fmt.Errorf("module cannot service api: %s", api)
+			}
+			if err := other.Add(resource.Name{API: api, Remote: base.Remote, Name: base.Name}, res); err != nil {
+				return multierr.Combine(err, res.Close(ctx))
+			}
+		}
+	}
+
 	m.resLoggers[res] = resLogger
 	// add the video stream resources upon creation
 	if p, ok := res.(rtppassthrough.Source); ok {

--- a/module/resources.go
+++ b/module/resources.go
@@ -309,6 +309,15 @@ func (m *Module) getDependenciesForConstruction(ctx context.Context, depStrings 
 			return nil, err
 		}
 		deps[depName] = clientRes
+
+		// A composite (multi-API) dependency is one object serving several APIs. Key it under each of
+		// its API names so a typed accessor for any of them (e.g. sensor.FromProvider) resolves it,
+		// matching how the client caches a composite under every one of its API names.
+		if mar, ok := clientRes.(resource.MultiAPIResource); ok {
+			for _, api := range mar.APIs() {
+				deps[resource.Name{API: api, Remote: depName.Remote, Name: depName.Name}] = clientRes
+			}
+		}
 	}
 
 	// let modules access RobotFrameSystem (name $framesystem) without needing entire RobotClient

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -32,6 +32,7 @@ var (
 	testSlowModel            = resource.NewModel("rdk", "test", "slow")
 	testFSDependentModel     = resource.NewModel("rdk", "test", "fsdep")
 	testSensorDependentModel = resource.NewModel("rdk", "test", "sensordep")
+	testMultiAPIModel        = resource.NewModel("rdk", "test", "multi")
 	myMod                    *module.Module
 )
 
@@ -104,6 +105,19 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 		resource.Registration[resource.Resource, *sensorDepConfig]{Constructor: newSensorDependent})
 	err = myMod.AddModelFromRegistry(ctx, sensor.API, testSensorDependentModel)
 	if err != nil {
+		return err
+	}
+
+	// A composite (multi-API) model: one instance serves both the sensor API (Readings) and the
+	// generic API (DoCommand). Advertised under both APIs.
+	resource.RegisterMultiAPI(
+		[]resource.API{sensor.API, generic.API},
+		testMultiAPIModel,
+		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newMultiAPI})
+	if err = myMod.AddModelFromRegistry(ctx, sensor.API, testMultiAPIModel); err != nil {
+		return err
+	}
+	if err = myMod.AddModelFromRegistry(ctx, generic.API, testMultiAPIModel); err != nil {
 		return err
 	}
 
@@ -529,4 +543,27 @@ func (sd *sensorDependent) Readings(ctx context.Context, _ map[string]interface{
 // DoCommand returns the number of times validate has been called on this module.
 func (sd *sensorDependent) DoCommand(ctx context.Context, _ map[string]interface{}) (map[string]interface{}, error) {
 	return map[string]interface{}{"validate_calls": sensorValidateCalls}, nil
+}
+
+// multiAPIThing is a composite resource that serves both the sensor API (via Readings) and the
+// generic API (via DoCommand) from a single instance.
+type multiAPIThing struct {
+	resource.Named
+	resource.TriviallyCloseable
+}
+
+func newMultiAPI(
+	_ context.Context, _ resource.Dependencies, conf resource.Config, _ logging.Logger,
+) (resource.Resource, error) {
+	return &multiAPIThing{Named: conf.ResourceName().AsNamed()}, nil
+}
+
+// Readings implements the sensor API.
+func (m *multiAPIThing) Readings(_ context.Context, _ map[string]interface{}) (map[string]interface{}, error) {
+	return map[string]interface{}{"reading": 42}, nil
+}
+
+// DoCommand implements the generic API.
+func (m *multiAPIThing) DoCommand(_ context.Context, _ map[string]interface{}) (map[string]interface{}, error) {
+	return map[string]interface{}{"did": "it"}, nil
 }

--- a/resource/config.go
+++ b/resource/config.go
@@ -272,6 +272,16 @@ func (conf *Config) Validate(path, defaultAPIType string) ([]string, []string, e
 // stored (JSON/Proto/Database) and will fix them up to the builtin values they
 // are intended for.
 func (conf *Config) AdjustPartialNames(defaultAPIType string) {
+	// A composite (multi-API) resource may omit `api` entirely; resolve its canonical API from the
+	// model's registered set. The node is later cached under every API in the set (see
+	// resource.RegisterMultiAPI / apisForNode), so any one of them serves as the config's API. This
+	// runs before the default-filling below so an omitted api is not mistaken for a partial rdk api.
+	if conf.API == (API{}) {
+		if apis := APIsForModel(conf.Model); len(apis) > 0 {
+			conf.API = apis[0]
+		}
+	}
+
 	if conf.API.Type.Namespace == "" {
 		conf.API.Type.Namespace = APINamespaceRDK
 	}

--- a/resource/multiapi.go
+++ b/resource/multiapi.go
@@ -31,6 +31,18 @@ func FromResourceForAPI[T Resource](res Resource, api API) (T, error) {
 	return AsType[T](subresourceForAPI(res, api))
 }
 
+// APIsOf returns the set of APIs a resource handle serves. For a composite (multi-API) resource it
+// returns every API it was registered under, in a stable order; for an ordinary resource it returns
+// the single API of its Name. It lets a consumer discover a handle's capabilities without a
+// MultiAPIResource type assertion or trial-and-error AsType, and is the runtime counterpart to
+// APIsForModel (which answers the same question from a model, before construction).
+func APIsOf(res Resource) []API {
+	if mar, ok := res.(MultiAPIResource); ok {
+		return mar.APIs()
+	}
+	return []API{res.Name().API}
+}
+
 // compositeResource is the default MultiAPIResource: one identity holding a typed sub-resource per
 // API. The client builds one of these for a multi-API resource by dialing each advertised API's
 // RPCClient; on the robot/in-process side the sub-resources may all be the same underlying object.

--- a/resource/multiapi.go
+++ b/resource/multiapi.go
@@ -1,0 +1,111 @@
+package resource
+
+import (
+	"context"
+
+	"go.uber.org/multierr"
+)
+
+// MultiAPIResource is a resource that serves more than one API from a single identity — a
+// "composite". On the client side, ResourceByName and the dependencies map return one composite
+// object for a multi-API resource; consumers get a typed handle for any of its APIs via that API
+// package's FromResource helper (which calls FromResourceForAPI), so custom/module APIs work the
+// same way builtin ones do — no closed set of embedded clients required.
+type MultiAPIResource interface {
+	Resource
+
+	// ResourceForAPI returns the sub-resource that serves the given API, and whether this composite
+	// serves it. The returned sub-resource is the concrete typed client/instance for that API.
+	ResourceForAPI(api API) (Resource, bool)
+
+	// APIs returns the set of APIs this composite serves, in a stable order.
+	APIs() []API
+}
+
+// FromResourceForAPI returns a typed handle for api from res. If res is a composite
+// (MultiAPIResource) that serves api, its sub-resource for that API is used; otherwise res itself
+// is asserted. This is the general, open-world access path: each API package wraps it in a
+// FromResource helper (e.g. arm.FromResource), so the "does this satisfy T" knowledge lives in the
+// API's own package rather than in a central superclient.
+func FromResourceForAPI[T Resource](res Resource, api API) (T, error) {
+	return AsType[T](subresourceForAPI(res, api))
+}
+
+// compositeResource is the default MultiAPIResource: one identity holding a typed sub-resource per
+// API. The client builds one of these for a multi-API resource by dialing each advertised API's
+// RPCClient; on the robot/in-process side the sub-resources may all be the same underlying object.
+type compositeResource struct {
+	name  Name
+	apis  []API // declared order, for deterministic DoCommand routing and APIs()
+	byAPI map[API]Resource
+}
+
+// NewMultiAPIResource assembles a composite from a name and a per-API set of sub-resources. apis
+// gives the stable order (first entry is the canonical/DoCommand-preferred API). Every api in apis
+// must have an entry in byAPI.
+func NewMultiAPIResource(name Name, apis []API, byAPI map[API]Resource) MultiAPIResource {
+	ordered := append([]API(nil), apis...)
+	return &compositeResource{name: name, apis: ordered, byAPI: byAPI}
+}
+
+func (c *compositeResource) Name() Name { return c.name }
+
+func (c *compositeResource) APIs() []API { return c.apis }
+
+func (c *compositeResource) ResourceForAPI(api API) (Resource, bool) {
+	sub, ok := c.byAPI[api]
+	return sub, ok
+}
+
+// DoCommand routes a bare command on the composite to the first sub-resource whose DoCommand is not
+// the unimplemented default. On the server the composite's APIs all resolve to one instance with one
+// DoCommand method, so every route converges; the choice only needs to be deterministic. Accessing a
+// specific API via FromResource sidesteps this entirely.
+func (c *compositeResource) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	var lastErr error
+	for _, api := range c.apis {
+		sub, ok := c.byAPI[api]
+		if !ok {
+			continue
+		}
+		res, err := sub.DoCommand(ctx, cmd)
+		if err == ErrDoUnimplemented {
+			lastErr = err
+			continue
+		}
+		return res, err
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, ErrDoUnimplemented
+}
+
+// Status routes to the canonical (first-declared) sub-resource. As with DoCommand, all APIs of a
+// composite resolve to one instance on the server, so any route reports the same status.
+func (c *compositeResource) Status(ctx context.Context) (map[string]interface{}, error) {
+	for _, api := range c.apis {
+		if sub, ok := c.byAPI[api]; ok {
+			return sub.Status(ctx)
+		}
+	}
+	return map[string]interface{}{}, nil
+}
+
+// Close closes each distinct sub-resource once. Sub-resources may share an underlying object, so a
+// resource is closed at most once even when several APIs map to it.
+func (c *compositeResource) Close(ctx context.Context) error {
+	seen := make(map[Resource]bool, len(c.byAPI))
+	var errs error
+	for _, api := range c.apis {
+		sub, ok := c.byAPI[api]
+		if !ok || seen[sub] {
+			continue
+		}
+		seen[sub] = true
+		if err := sub.Close(ctx); err != nil {
+			errs = multierr.Combine(errs, err)
+		}
+	}
+	return errs
+}

--- a/resource/multiapi_test.go
+++ b/resource/multiapi_test.go
@@ -21,6 +21,12 @@ type testAPITwo interface {
 	Two() string
 }
 
+// testAPIThree is served by neither sub-resource, for negative extraction tests.
+type testAPIThree interface {
+	Resource
+	Three() string
+}
+
 var (
 	apiOne = APINamespace("multiapi").WithComponentType("one")
 	apiTwo = APINamespace("multiapi").WithComponentType("two")
@@ -83,10 +89,8 @@ func TestCompositeFromResourceForAPI(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotTwo.Two(), test.ShouldEqual, "two")
 
-	// Asking the composite for an API it does not serve fails cleanly (falls back to asserting the
-	// composite itself, which is not a testAPIOne beyond what it delegates).
-	apiThree := APINamespace("multiapi").WithComponentType("three")
-	_, err = FromResourceForAPI[testAPIOne](composite, apiThree)
+	// Extracting a type that no sub-resource implements fails cleanly.
+	_, err = FromResourceForAPI[testAPIThree](composite, apiOne)
 	test.That(t, err, test.ShouldNotBeNil)
 
 	// APIs() reports the served set in declared order.

--- a/resource/multiapi_test.go
+++ b/resource/multiapi_test.go
@@ -1,0 +1,240 @@
+package resource
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/logging"
+)
+
+// Two ad-hoc co-equal APIs with distinct typed methods, used to exercise multi-API composition
+// without any gRPC plumbing.
+type testAPIOne interface {
+	Resource
+	One() string
+}
+
+type testAPITwo interface {
+	Resource
+	Two() string
+}
+
+var (
+	apiOne = APINamespace("multiapi").WithComponentType("one")
+	apiTwo = APINamespace("multiapi").WithComponentType("two")
+)
+
+// oneImpl implements only testAPIOne. Used as a client-side per-API sub-resource.
+type oneImpl struct {
+	Named
+	TriviallyReconfigurable
+	TriviallyCloseable
+	closed *bool
+}
+
+func (o *oneImpl) One() string { return "one" }
+
+func (o *oneImpl) Close(ctx context.Context) error {
+	if o.closed != nil {
+		*o.closed = true
+	}
+	return nil
+}
+
+// twoImpl implements only testAPITwo, and gives a real DoCommand so DoCommand routing can be tested.
+type twoImpl struct {
+	Named
+	TriviallyReconfigurable
+	TriviallyCloseable
+	closed *bool
+}
+
+func (t *twoImpl) Two() string { return "two" }
+
+func (t *twoImpl) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return map[string]interface{}{"served_by": "two"}, nil
+}
+
+func (t *twoImpl) Close(ctx context.Context) error {
+	if t.closed != nil {
+		*t.closed = true
+	}
+	return nil
+}
+
+func TestCompositeFromResourceForAPI(t *testing.T) {
+	name := NewName(apiOne, "dev")
+	one := &oneImpl{Named: name.AsNamed()}
+	two := &twoImpl{Named: NewName(apiTwo, "dev").AsNamed()}
+
+	composite := NewMultiAPIResource(name, []API{apiOne, apiTwo}, map[API]Resource{
+		apiOne: one,
+		apiTwo: two,
+	})
+
+	// The general open-world path: extract each API's typed handle off the one object.
+	gotOne, err := FromResourceForAPI[testAPIOne](composite, apiOne)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, gotOne.One(), test.ShouldEqual, "one")
+
+	gotTwo, err := FromResourceForAPI[testAPITwo](composite, apiTwo)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, gotTwo.Two(), test.ShouldEqual, "two")
+
+	// Asking the composite for an API it does not serve fails cleanly (falls back to asserting the
+	// composite itself, which is not a testAPIOne beyond what it delegates).
+	apiThree := APINamespace("multiapi").WithComponentType("three")
+	_, err = FromResourceForAPI[testAPIOne](composite, apiThree)
+	test.That(t, err, test.ShouldNotBeNil)
+
+	// APIs() reports the served set in declared order.
+	test.That(t, composite.APIs(), test.ShouldResemble, []API{apiOne, apiTwo})
+}
+
+func TestFromResourceForAPIPassThrough(t *testing.T) {
+	// For an ordinary (non-composite) resource, FromResourceForAPI is just AsType.
+	name := NewName(apiOne, "plain")
+	one := &oneImpl{Named: name.AsNamed()}
+	got, err := FromResourceForAPI[testAPIOne](one, apiOne)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, got.One(), test.ShouldEqual, "one")
+}
+
+func TestAccessorsUnwrapComposite(t *testing.T) {
+	// The typed accessors (FromDependencies / FromProvider) transparently unwrap a composite to the
+	// sub-resource for the requested API — so an existing arm.FromProvider(m, "dev") keeps working
+	// when "dev" is a multi-API resource. This is the back-compat guarantee of the one-object design.
+	nameOne := NewName(apiOne, "dev")
+	nameTwo := NewName(apiTwo, "dev")
+	one := &oneImpl{Named: nameOne.AsNamed()}
+	two := &twoImpl{Named: nameTwo.AsNamed()}
+	composite := NewMultiAPIResource(nameOne, []API{apiOne, apiTwo}, map[API]Resource{
+		apiOne: one, apiTwo: two,
+	})
+
+	// The client caches the one composite under each of its API names.
+	deps := Dependencies{nameOne: composite, nameTwo: composite}
+
+	gotOne, err := FromDependencies[testAPIOne](deps, nameOne)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, gotOne.One(), test.ShouldEqual, "one")
+
+	gotTwo, err := FromDependencies[testAPITwo](deps, nameTwo)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, gotTwo.Two(), test.ShouldEqual, "two")
+
+	// FromProvider (used by X.FromRobot) unwraps the same way.
+	gotOne2, err := FromProvider[testAPIOne](deps, nameOne)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, gotOne2.One(), test.ShouldEqual, "one")
+}
+
+func TestCompositeDoCommandRouting(t *testing.T) {
+	name := NewName(apiOne, "dev")
+	// oneImpl's DoCommand is the unimplemented default (from Named); twoImpl implements it.
+	one := &oneImpl{Named: name.AsNamed()}
+	two := &twoImpl{Named: NewName(apiTwo, "dev").AsNamed()}
+	composite := NewMultiAPIResource(name, []API{apiOne, apiTwo}, map[API]Resource{
+		apiOne: one, apiTwo: two,
+	})
+
+	// A bare DoCommand skips the unimplemented sub and routes to the one that implements it.
+	resp, err := composite.DoCommand(context.Background(), map[string]interface{}{})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, resp["served_by"], test.ShouldEqual, "two")
+}
+
+func TestCompositeCloseClosesEachOnce(t *testing.T) {
+	name := NewName(apiOne, "dev")
+	var oneClosed, twoClosed bool
+	one := &oneImpl{Named: name.AsNamed(), closed: &oneClosed}
+	two := &twoImpl{Named: NewName(apiTwo, "dev").AsNamed(), closed: &twoClosed}
+	composite := NewMultiAPIResource(name, []API{apiOne, apiTwo}, map[API]Resource{
+		apiOne: one, apiTwo: two,
+	})
+
+	test.That(t, composite.Close(context.Background()), test.ShouldBeNil)
+	test.That(t, oneClosed, test.ShouldBeTrue)
+	test.That(t, twoClosed, test.ShouldBeTrue)
+}
+
+func TestRegisterMultiAPI(t *testing.T) {
+	model := DefaultModelFamily.WithModel("multiapi_regmodel")
+	ctor := func(context.Context, Dependencies, Config, logging.Logger) (Resource, error) { return nil, nil }
+
+	RegisterMultiAPI([]API{apiOne, apiTwo}, model, Registration[Resource, NoNativeConfig]{Constructor: ctor})
+	defer func() {
+		Deregister(apiOne, model)
+		Deregister(apiTwo, model)
+		registryMu.Lock()
+		delete(multiAPIByModel, model)
+		registryMu.Unlock()
+	}()
+
+	// Registered under each API, and the set is discoverable from the model alone.
+	_, okOne := LookupRegistration(apiOne, model)
+	_, okTwo := LookupRegistration(apiTwo, model)
+	test.That(t, okOne, test.ShouldBeTrue)
+	test.That(t, okTwo, test.ShouldBeTrue)
+	test.That(t, APIsForModel(model), test.ShouldResemble, []API{apiOne, apiTwo})
+	// A single-API model has no recorded set.
+	test.That(t, APIsForModel(DefaultModelFamily.WithModel("nonexistent")), test.ShouldBeNil)
+}
+
+func TestMultiAPIGraphPeerRouting(t *testing.T) {
+	// A node whose model serves {apiOne, apiTwo} is cached under BOTH, resolving to one node.
+	logger := logging.NewTestLogger(t)
+	model := DefaultModelFamily.WithModel("multiapi_graphmodel")
+	registryMu.Lock()
+	multiAPIByModel[model] = []API{apiOne, apiTwo}
+	registryMu.Unlock()
+	defer func() {
+		registryMu.Lock()
+		delete(multiAPIByModel, model)
+		registryMu.Unlock()
+	}()
+
+	g := NewGraph(logger)
+	node := NewUnconfiguredGraphNode(Config{API: apiOne, Name: "dev", Model: model}, nil)
+	test.That(t, g.AddNode(NewName(apiOne, "dev"), node), test.ShouldBeNil)
+
+	gotOne, err := g.FindBySimpleNameAndAPI("dev", apiOne)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, gotOne, test.ShouldEqual, node)
+	gotTwo, err := g.FindBySimpleNameAndAPI("dev", apiTwo)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, gotTwo, test.ShouldEqual, node)
+
+	// Advertised under both APIs.
+	names := g.SimpleNamesWhere(func(Name, *GraphNode) bool { return true })
+	test.That(t, names, test.ShouldContain, NewName(apiOne, "dev"))
+	test.That(t, names, test.ShouldContain, NewName(apiTwo, "dev"))
+
+	// Removal tears down every peer entry.
+	g.remove(NewName(apiOne, "dev"))
+	_, err = g.FindBySimpleNameAndAPI("dev", apiOne)
+	test.That(t, err, test.ShouldNotBeNil)
+	_, err = g.FindBySimpleNameAndAPI("dev", apiTwo)
+	test.That(t, err, test.ShouldNotBeNil)
+}
+
+func TestConfigOmitsAPIForMultiAPIModel(t *testing.T) {
+	// A composite resource's config may omit `api`; AdjustPartialNames resolves the canonical API
+	// from the model's registered set.
+	model := DefaultModelFamily.WithModel("multiapi_cfgmodel")
+	registryMu.Lock()
+	multiAPIByModel[model] = []API{apiOne, apiTwo}
+	registryMu.Unlock()
+	defer func() {
+		registryMu.Lock()
+		delete(multiAPIByModel, model)
+		registryMu.Unlock()
+	}()
+
+	conf := Config{Name: "dev", Model: model} // no API
+	conf.AdjustPartialNames("")
+	test.That(t, conf.API, test.ShouldResemble, apiOne)
+	test.That(t, conf.ResourceName(), test.ShouldResemble, NewName(apiOne, "dev"))
+}

--- a/resource/multiapi_test.go
+++ b/resource/multiapi_test.go
@@ -165,6 +165,17 @@ func TestCompositeCloseClosesEachOnce(t *testing.T) {
 	test.That(t, twoClosed, test.ShouldBeTrue)
 }
 
+func TestAPIsOf(t *testing.T) {
+	nameOne := NewName(apiOne, "dev")
+	one := &oneImpl{Named: nameOne.AsNamed()}
+	two := &twoImpl{Named: NewName(apiTwo, "dev").AsNamed()}
+	composite := NewMultiAPIResource(nameOne, []API{apiOne, apiTwo}, map[API]Resource{apiOne: one, apiTwo: two})
+
+	// A composite reports every API it serves; an ordinary resource reports its single API.
+	test.That(t, APIsOf(composite), test.ShouldResemble, []API{apiOne, apiTwo})
+	test.That(t, APIsOf(one), test.ShouldResemble, []API{apiOne})
+}
+
 func TestRegisterMultiAPI(t *testing.T) {
 	model := DefaultModelFamily.WithModel("multiapi_regmodel")
 	ctor := func(context.Context, Dependencies, Config, logging.Logger) (Resource, error) { return nil, nil }

--- a/resource/multiapi_test.go
+++ b/resource/multiapi_test.go
@@ -188,6 +188,27 @@ func TestRegisterMultiAPI(t *testing.T) {
 	test.That(t, APIsForModel(DefaultModelFamily.WithModel("nonexistent")), test.ShouldBeNil)
 }
 
+func TestRegisterMultiAPISingleAPI(t *testing.T) {
+	// RegisterMultiAPI may serve as the uniform registration entry point: with a single API it
+	// registers the model like RegisterComponent/RegisterService and records no composite set.
+	model := DefaultModelFamily.WithModel("multiapi_single")
+	ctor := func(context.Context, Dependencies, Config, logging.Logger) (Resource, error) { return nil, nil }
+
+	RegisterMultiAPI([]API{apiOne}, model, Registration[Resource, NoNativeConfig]{Constructor: ctor})
+	defer Deregister(apiOne, model)
+
+	_, ok := LookupRegistration(apiOne, model)
+	test.That(t, ok, test.ShouldBeTrue)
+	// One API is not a composite, so nothing is recorded and the model resolves as single-API.
+	test.That(t, APIsForModel(model), test.ShouldBeNil)
+
+	// No APIs is a programmer error.
+	test.That(t, func() {
+		RegisterMultiAPI([]API{}, DefaultModelFamily.WithModel("multiapi_none"),
+			Registration[Resource, NoNativeConfig]{Constructor: ctor})
+	}, test.ShouldPanic)
+}
+
 func TestMultiAPIGraphPeerRouting(t *testing.T) {
 	// A node whose model serves {apiOne, apiTwo} is cached under BOTH, resolving to one node.
 	logger := logging.NewTestLogger(t)

--- a/resource/multiapi_test.go
+++ b/resource/multiapi_test.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"go.viam.com/test"
@@ -241,4 +242,29 @@ func TestConfigOmitsAPIForMultiAPIModel(t *testing.T) {
 	conf.AdjustPartialNames("")
 	test.That(t, conf.API, test.ShouldResemble, apiOne)
 	test.That(t, conf.ResourceName(), test.ShouldResemble, NewName(apiOne, "dev"))
+}
+
+func TestConfigJSONRoundTripOmitsAPI(t *testing.T) {
+	// A composite resource's config, parsed from JSON with no "api" field, resolves its API from the
+	// model's registered set through the normal Validate path (as config.Read would).
+	model := DefaultModelFamily.WithModel("multiapi_jsonmodel")
+	registryMu.Lock()
+	multiAPIByModel[model] = []API{apiOne, apiTwo}
+	registryMu.Unlock()
+	defer func() {
+		registryMu.Lock()
+		delete(multiAPIByModel, model)
+		registryMu.Unlock()
+	}()
+
+	var conf Config
+	err := json.Unmarshal([]byte(`{"name": "dev", "model": "rdk:builtin:multiapi_jsonmodel"}`), &conf)
+	test.That(t, err, test.ShouldBeNil)
+	// No api in the JSON.
+	test.That(t, conf.API, test.ShouldResemble, API{})
+
+	_, _, err = conf.Validate("test", "component")
+	test.That(t, err, test.ShouldBeNil)
+	// Resolved to the canonical (first) API of the set.
+	test.That(t, conf.API, test.ShouldResemble, apiOne)
 }

--- a/resource/multiapi_test.go
+++ b/resource/multiapi_test.go
@@ -225,6 +225,39 @@ func TestMultiAPIGraphPeerRouting(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 }
 
+func TestResolveDependencyOnComposite(t *testing.T) {
+	// A resource can depend on a composite by its bare name. The bare name matches every one of the
+	// composite's API names, which all back one node — that must resolve as a single dependency
+	// rather than being reported as a conflict between distinct names.
+	logger := logging.NewTestLogger(t)
+	model := DefaultModelFamily.WithModel("multiapi_depmodel")
+	registryMu.Lock()
+	multiAPIByModel[model] = []API{apiOne, apiTwo}
+	registryMu.Unlock()
+	defer func() {
+		registryMu.Lock()
+		delete(multiAPIByModel, model)
+		registryMu.Unlock()
+	}()
+
+	g := NewGraph(logger)
+
+	// The composite node, advertised under both apiOne and apiTwo.
+	composite := NewUnconfiguredGraphNode(Config{API: apiOne, Name: "dev", Model: model}, nil)
+	test.That(t, g.AddNode(NewName(apiOne, "dev"), composite), test.ShouldBeNil)
+
+	// A consumer that depends on the composite by its bare name.
+	consumerName := NewName(apiOne, "consumer")
+	consumer := NewUnconfiguredGraphNode(Config{API: apiOne, Name: "consumer"}, []string{"dev"})
+	test.That(t, g.AddNode(consumerName, consumer), test.ShouldBeNil)
+
+	// Resolution succeeds (one composite, not a conflict) and the edge points at the composite's
+	// canonical stored name.
+	test.That(t, g.ResolveDependencies(logger), test.ShouldBeNil)
+	test.That(t, consumer.UnresolvedDependencies(), test.ShouldBeEmpty)
+	test.That(t, g.GetAllParentsOf(consumerName), test.ShouldContain, NewName(apiOne, "dev"))
+}
+
 func TestConfigOmitsAPIForMultiAPIModel(t *testing.T) {
 	// A composite resource's config may omit `api`; AdjustPartialNames resolves the canonical API
 	// from the model's registered set.

--- a/resource/name.go
+++ b/resource/name.go
@@ -15,6 +15,16 @@ type Name struct {
 	Name   string
 }
 
+// SimpleName constructs a Name identified by its simple name alone, with no API — the same
+// "name without an API" that FindBySimpleName resolves. Passed to a robot's ResourceByName it
+// resolves to the single resource of that name, which for a multi-API (composite) resource is the
+// one instance serving every API it enumerates. Any remote prefix in name is parsed as it is by
+// NewName. Relies on machine-wide resource name uniqueness so a simple name identifies exactly one
+// resource. (The bare "Named" identifier is taken by the embeddable Named interface.)
+func SimpleName(name string) Name {
+	return NewName(API{}, name)
+}
+
 // NewName creates a new resource Name.
 func NewName(api API, name string) Name {
 	r := strings.Split(name, ":")

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -102,6 +102,7 @@ func FromDependencies[T Resource](resources Dependencies, name Name) (T, error) 
 	if err != nil {
 		return zero, DependencyNotFoundError(name)
 	}
+	res = subresourceForAPI(res, name.API)
 	typedRes, ok := res.(T)
 	if !ok {
 		return zero, DependencyTypeError[T](name, res)
@@ -116,11 +117,24 @@ func FromProvider[T Resource](provider Provider, name Name) (T, error) {
 	if err != nil {
 		return zero, err
 	}
+	res = subresourceForAPI(res, name.API)
 	typedRes, ok := res.(T)
 	if !ok {
 		return zero, DependencyTypeError[T](name, res)
 	}
 	return typedRes, nil
+}
+
+// subresourceForAPI unwraps a composite (multi-API) resource to the sub-resource serving api, so a
+// typed accessor for one of a composite's APIs resolves to that API's client. A non-composite (or a
+// composite that does not serve api) is returned unchanged.
+func subresourceForAPI(res Resource, api API) Resource {
+	if mar, ok := res.(MultiAPIResource); ok {
+		if sub, ok := mar.ResourceForAPI(api); ok {
+			return sub
+		}
+	}
+	return res
 }
 
 // GetResource implements Provider for Dependencies by looking up a resource by name.

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -323,14 +323,25 @@ func (s selfNamed) Status(ctx context.Context) (map[string]interface{}, error) {
 	return map[string]interface{}{}, nil
 }
 
-// AsType attempts to get a more specific interface from the resource.
+// AsType attempts to get a more specific interface from the resource. If from is a composite
+// (multi-API) resource that does not itself satisfy T, its sub-resources are tried and the one
+// satisfying T is returned — so a per-API server getter resolves the right sub-resource of a
+// composite without knowing which API it is looking for.
 func AsType[T Resource](from Resource) (T, error) {
-	res, ok := from.(T)
-	if !ok {
-		var zero T
-		return zero, TypeError[T](from)
+	if res, ok := from.(T); ok {
+		return res, nil
 	}
-	return res, nil
+	if mar, ok := from.(MultiAPIResource); ok {
+		for _, api := range mar.APIs() {
+			if sub, found := mar.ResourceForAPI(api); found {
+				if res, ok := sub.(T); ok {
+					return res, nil
+				}
+			}
+		}
+	}
+	var zero T
+	return zero, TypeError[T](from)
 }
 
 type closeOnlyResource struct {

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -447,16 +447,51 @@ func seq2First[K, V any](seq iter.Seq2[K, V]) (K, V, bool) {
 	return resK, resV, ok
 }
 
+// candidate is a (name, node) pairing considered by [Graph.SimpleNamesWhere] when applying
+// machine-wide name-uniqueness resolution.
+type candidate struct {
+	name Name
+	node *GraphNode
+}
+
+// candidatesAreOneComposite reports whether several candidates that share a simple name are one
+// composite (multi-API) resource rather than a genuine collision between distinct resources. They
+// are one composite when they all back the same graph node (a local composite advertised under
+// several APIs) or all come from a single remote (which enforces its own name uniqueness, so one
+// remote advertising a bare name under several APIs is a composite whose per-API names arrive as
+// distinct proxy nodes locally).
+func candidatesAreOneComposite(cands []candidate) bool {
+	if len(cands) < 2 {
+		return true
+	}
+	allSameNode := true
+	for _, c := range cands[1:] {
+		if c.node != cands[0].node {
+			allSameNode = false
+			break
+		}
+	}
+	if allSameNode {
+		return true
+	}
+	remote := cands[0].name.Remote
+	if remote == "" {
+		return false
+	}
+	for _, c := range cands[1:] {
+		if c.name.Remote != remote {
+			return false
+		}
+	}
+	return true
+}
+
 // SimpleNamesWhere returns a list of resource names with any configured remote
 // prefix applied. Names are only included in the return if filter returns true.
 func (g *Graph) SimpleNamesWhere(filter func(Name, *GraphNode) bool) []Name {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
-	type candidate struct {
-		name Name
-		node *GraphNode
-	}
 	var result []Name
 	emit := func(c candidate) {
 		if filter(c.name, c.node) {
@@ -490,10 +525,21 @@ func (g *Graph) SimpleNamesWhere(filter func(Name, *GraphNode) bool) []Name {
 	}
 
 	for _, cands := range byName {
-		chosen := cands[0]
 		if len(cands) > 1 {
-			// A local resource wins over remotes claiming the same name. If there is not
-			// exactly one local claimant (e.g. remote resources collide), the name is hidden.
+			// Several candidates sharing a simple name are one composite (multi-API) resource — not a
+			// collision — when they either all back the same graph node (a local composite advertised
+			// under each of its APIs) or all come from a single remote (a remote enforces its own name
+			// uniqueness, so one remote advertising a bare name under several APIs is a composite; its
+			// per-API names arrive as distinct proxy nodes locally). Advertise every such entry.
+			if candidatesAreOneComposite(cands) {
+				for _, c := range cands {
+					emit(c)
+				}
+				continue
+			}
+
+			// Genuine collision between distinct resources: a local resource wins over remotes claiming
+			// the same name. If there is not exactly one local claimant, the name is hidden.
 			var localCands []candidate
 			for _, c := range cands {
 				if c.name.Remote == "" {
@@ -503,9 +549,10 @@ func (g *Graph) SimpleNamesWhere(filter func(Name, *GraphNode) bool) []Name {
 			if len(localCands) != 1 {
 				continue
 			}
-			chosen = localCands[0]
+			emit(localCands[0])
+			continue
 		}
-		emit(chosen)
+		emit(cands[0])
 	}
 	return result
 }
@@ -524,7 +571,11 @@ func (g *Graph) CollidingNames() []Name {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
-	byName := make(map[string][]Name)
+	type entry struct {
+		name Name
+		node *GraphNode
+	}
+	byName := make(map[string][]entry)
 	for k, v := range g.nodes.simpleNameCache {
 		if v.local == nil {
 			continue
@@ -538,13 +589,22 @@ func (g *Graph) CollidingNames() []Name {
 		if !(k.api.IsComponent() || k.api.IsService()) {
 			continue
 		}
-		byName[k.name] = append(byName[k.name], Name{API: k.api, Name: k.name})
+		byName[k.name] = append(byName[k.name], entry{Name{API: k.api, Name: k.name}, v.local})
 	}
 
 	var colliding []Name
-	for _, names := range byName {
-		if len(names) > 1 {
-			colliding = append(colliding, names...)
+	for _, entries := range byName {
+		// A composite (multi-API) resource is one node advertised under several APIs, so several
+		// entries share its simple name while backing the same node — that is not a collision. Only
+		// two or more distinct nodes sharing a simple name collide.
+		distinct := make(map[*GraphNode]bool)
+		for _, e := range entries {
+			distinct[e.node] = true
+		}
+		if len(distinct) > 1 {
+			for _, e := range entries {
+				colliding = append(colliding, e.name)
+			}
 		}
 	}
 	return colliding

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -94,19 +94,34 @@ func (s graphStorage) Set(name Name, node *GraphNode) {
 	s.setSimpleNameCache(name, node)
 }
 
-func (s graphStorage) setSimpleNameCache(name Name, node *GraphNode) {
-	simpleName := simpleNameKey{node.prefix + name.Name, name.API}
-	val := s.simpleNameCache[simpleName]
-	if val == nil {
-		val = &simpleNameVal{
-			remote: map[string]*GraphNode{},
+// apisForNode returns the full set of co-equal APIs the node's resource serves (see
+// resource.RegisterMultiAPI), or just name.API for an ordinary single-API resource. A composite
+// (multi-API) node is cached under every one of its APIs so the one instance is routable and
+// advertisable as each of them.
+func apisForNode(name Name, node *GraphNode) []API {
+	if node != nil {
+		if apis := APIsForModel(node.config.Model); len(apis) > 0 {
+			return apis
 		}
-		s.simpleNameCache[simpleName] = val
 	}
-	if name.Remote == "" {
-		val.local = node
-	} else {
-		val.remote[name.Remote] = node
+	return []API{name.API}
+}
+
+func (s graphStorage) setSimpleNameCache(name Name, node *GraphNode) {
+	for _, api := range apisForNode(name, node) {
+		simpleName := simpleNameKey{node.prefix + name.Name, api}
+		val := s.simpleNameCache[simpleName]
+		if val == nil {
+			val = &simpleNameVal{
+				remote: map[string]*GraphNode{},
+			}
+			s.simpleNameCache[simpleName] = val
+		}
+		if name.Remote == "" {
+			val.local = node
+		} else {
+			val.remote[name.Remote] = node
+		}
 	}
 }
 
@@ -114,14 +129,15 @@ func (s graphStorage) UpdateSimpleName(name Name, prevPrefix string, node *Graph
 	if prevPrefix == node.prefix {
 		return
 	}
-	prevSimpleName := simpleNameKey{prevPrefix + name.Name, name.API}
-
-	prevVal := s.simpleNameCache[prevSimpleName]
-	if prevVal != nil {
-		if name.Remote == "" {
-			prevVal.local = nil
-		} else {
-			delete(prevVal.remote, name.Remote)
+	for _, api := range apisForNode(name, node) {
+		prevSimpleName := simpleNameKey{prevPrefix + name.Name, api}
+		prevVal := s.simpleNameCache[prevSimpleName]
+		if prevVal != nil {
+			if name.Remote == "" {
+				prevVal.local = nil
+			} else {
+				delete(prevVal.remote, name.Remote)
+			}
 		}
 	}
 
@@ -134,16 +150,18 @@ func (s graphStorage) Delete(name Name) {
 	if node == nil {
 		return
 	}
-	simpleName := simpleNameKey{node.prefix + name.Name, name.API}
-	existing := s.simpleNameCache[simpleName]
-	if existing == nil {
-		return
+	for _, api := range apisForNode(name, node) {
+		simpleName := simpleNameKey{node.prefix + name.Name, api}
+		existing := s.simpleNameCache[simpleName]
+		if existing == nil {
+			continue
+		}
+		if name.Remote == "" {
+			existing.local = nil
+		} else {
+			delete(existing.remote, name.Remote)
+		}
 	}
-	if name.Remote == "" {
-		existing.local = nil
-		return
-	}
-	delete(existing.remote, name.Remote)
 }
 
 func (s graphStorage) Copy() graphStorage {

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -677,6 +677,38 @@ func (g *Graph) namesMatchingSimpleName(name string) []Name {
 	return result
 }
 
+// resolveCompositeName resolves a set of names that share a bare name to the single graph node
+// backing them. A composite (multi-API) resource is cached under each of its APIs, so a bare name
+// can match several API names that all back one node; that is one resource, not a conflict. It
+// returns the node's canonical name (the key it is stored under) and true when every name maps to
+// the same node, and false for a genuine conflict between distinct nodes. g.mu must be held.
+func (g *Graph) resolveCompositeName(names []Name) (Name, bool) {
+	var node *GraphNode
+	var canonical Name
+	var haveCanonical bool
+	for _, n := range names {
+		found, err := g.nodes.FindBySimpleNameAndAPI(n.Name, n.API)
+		if err != nil || found == nil {
+			return Name{}, false
+		}
+		if node == nil {
+			node = found
+		} else if found != node {
+			return Name{}, false
+		}
+		// Exactly one of the API names is the actual key the node is stored under; that is the
+		// canonical name a dependency edge should point at.
+		if _, ok := g.nodes.Get(n); ok {
+			canonical = n
+			haveCanonical = true
+		}
+	}
+	if node == nil || !haveCanonical {
+		return Name{}, false
+	}
+	return canonical, true
+}
+
 // GetAllChildrenOf returns all direct children of a node.
 func (g *Graph) GetAllChildrenOf(node Name) []Name {
 	g.mu.RLock()
@@ -1030,6 +1062,24 @@ func (g *Graph) ResolveDependencies(logger logging.Logger) error {
 				if err != nil {
 					var multiErr *MultipleMatchingNamesError
 					if errors.As(err, &multiErr) {
+						// A composite (multi-API) resource is advertised under several API names that
+						// share one bare name but back a single graph node. That is one resource, not a
+						// conflict — resolve it to the node's canonical name. Only distinct nodes sharing
+						// a bare name are a genuine conflict.
+						if canonical, ok := g.resolveCompositeName(multiErr.Matches); ok {
+							if canonical.String() == nodeName.String() {
+								allErrs = multierr.Combine(allErrs,
+									errors.Errorf("node cannot depend on itself: %q", nodeName))
+								logger.Errorw("node cannot depend on itself", "name", nodeName)
+								return Name{}, false
+							}
+							logger.Debugw(
+								"composite dependency resolved for resource",
+								"name", nodeName,
+								"dependency", canonical,
+							)
+							return canonical, true
+						}
 						allErrs = multierr.Combine(
 							allErrs,
 							errors.Errorf("conflicting names for resource %q: %v", nodeName, NamesToStrings(multiErr.Matches)))

--- a/resource/resource_registry.go
+++ b/resource/resource_registry.go
@@ -201,6 +201,10 @@ var (
 	registry                      = map[APIModel]Registration[Resource, ConfigValidator]{}
 	apiRegistry                   = map[API]APIRegistration[Resource]{}
 	associatedConfigRegistrations = []AssociatedConfigRegistration[AssociatedConfig]{}
+	// multiAPIByModel records the set of co-equal APIs a model serves, for models registered via
+	// RegisterMultiAPI. Keyed by Model so config resolution can find a resource's API set from its
+	// model alone (a composite resource's config may omit `api`). See RegisterMultiAPI.
+	multiAPIByModel = map[Model][]API{}
 )
 
 // DefaultServices returns all servies that will be constructed by default if not
@@ -369,6 +373,36 @@ func LookupRegistration(api API, model Model) (Registration[Resource, ConfigVali
 		return registration, true
 	}
 	return Registration[Resource, ConfigValidator]{}, false
+}
+
+// RegisterMultiAPI registers one model that serves a set of co-equal APIs (a "composite" resource).
+// The APIs form a set with no primary: one instance of the model is reachable, routed, and advertised
+// under any of them, and the model's Go type must implement each API's interface (routing casts to the
+// requested one via AsType at call time). The single constructor in reg is registered under every API
+// in the set, and the set is recorded so config resolution can expand the model (with or without an
+// `api` field) into its full identity. Declare at init time. Panics if fewer than two APIs are given
+// (use RegisterComponent/RegisterService for a single API).
+func RegisterMultiAPI[ResourceT Resource, ConfigT ConfigValidator](
+	apis []API, model Model, reg Registration[ResourceT, ConfigT],
+) {
+	if len(apis) < 2 {
+		panic(errors.Errorf("RegisterMultiAPI needs at least two APIs for model %q, got %d", model, len(apis)))
+	}
+	for _, api := range apis {
+		Register(api, model, reg)
+	}
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	multiAPIByModel[model] = append([]API(nil), apis...)
+}
+
+// APIsForModel returns the set of co-equal APIs a composite model serves, or nil for an ordinary
+// single-API model. Config resolution uses this to expand a model into its API set when the config
+// omits `api`. The returned slice is shared and must not be mutated.
+func APIsForModel(model Model) []API {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	return multiAPIByModel[model]
 }
 
 // RegisterAPI register a ResourceAPI to its corresponding resource api.

--- a/resource/resource_registry.go
+++ b/resource/resource_registry.go
@@ -391,6 +391,17 @@ func RegisterMultiAPI[ResourceT Resource, ConfigT ConfigValidator](
 	for _, api := range apis {
 		Register(api, model, reg)
 	}
+	RegisterMultiAPISet(model, apis)
+}
+
+// RegisterMultiAPISet records the set of co-equal APIs a model serves, without registering
+// constructors (which are registered separately). Used when a model's per-API constructors already
+// exist — e.g. modular resources, whose constructors are the module proxies registered from the
+// module's handler map. A set of fewer than two APIs is ignored.
+func RegisterMultiAPISet(model Model, apis []API) {
+	if len(apis) < 2 {
+		return
+	}
 	registryMu.Lock()
 	defer registryMu.Unlock()
 	multiAPIByModel[model] = append([]API(nil), apis...)

--- a/resource/resource_registry.go
+++ b/resource/resource_registry.go
@@ -380,17 +380,21 @@ func LookupRegistration(api API, model Model) (Registration[Resource, ConfigVali
 // under any of them, and the model's Go type must implement each API's interface (routing casts to the
 // requested one via AsType at call time). The single constructor in reg is registered under every API
 // in the set, and the set is recorded so config resolution can expand the model (with or without an
-// `api` field) into its full identity. Declare at init time. Panics if fewer than two APIs are given
-// (use RegisterComponent/RegisterService for a single API).
+// `api` field) into its full identity. With a single API it behaves like RegisterComponent/
+// RegisterService and records no multi-API set, so it can serve as one uniform registration entry
+// point that a model adopts whether it serves one API or several. Declare at init time. Panics only
+// if no APIs are given.
 func RegisterMultiAPI[ResourceT Resource, ConfigT ConfigValidator](
 	apis []API, model Model, reg Registration[ResourceT, ConfigT],
 ) {
-	if len(apis) < 2 {
-		panic(errors.Errorf("RegisterMultiAPI needs at least two APIs for model %q, got %d", model, len(apis)))
+	if len(apis) == 0 {
+		panic(errors.Errorf("RegisterMultiAPI needs at least one API for model %q", model))
 	}
 	for _, api := range apis {
 		Register(api, model, reg)
 	}
+	// Only two or more APIs make a composite; RegisterMultiAPISet ignores a single-API set, so a
+	// one-API registration is recorded exactly like a plain single-API model.
 	RegisterMultiAPISet(model, apis)
 }
 

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -873,6 +874,27 @@ func (rc *RobotClient) ResourceByName(name resource.Name) (resource.Resource, er
 }
 
 func (rc *RobotClient) createClient(name resource.Name) (resource.Resource, error) {
+	// A multi-API (composite) resource is advertised as several resource names that share a bare
+	// name but differ by API. Assemble one composite object holding a sub-client per API, so
+	// ResourceByName / the dependencies map hand back a single handle. Callers reach a specific API
+	// off it via that API package's FromResource / FromProvider helper. (Relies on machine-wide name
+	// uniqueness so a shared bare name is guaranteed to be one instance.)
+	if apis := rc.apisSharingName(name); len(apis) > 1 {
+		byAPI := make(map[resource.API]resource.Resource, len(apis))
+		for _, api := range apis {
+			sub, err := rc.createSingleClient(resource.NewName(api, name.Name).PrependRemote(name.Remote))
+			if err != nil {
+				return nil, err
+			}
+			byAPI[api] = sub
+		}
+		return resource.NewMultiAPIResource(resource.NewName(apis[0], name.Name).PrependRemote(name.Remote), apis, byAPI), nil
+	}
+	return rc.createSingleClient(name)
+}
+
+// createSingleClient builds the typed client for exactly one (api, name).
+func (rc *RobotClient) createSingleClient(name resource.Name) (resource.Resource, error) {
 	apiInfo, ok := resource.LookupGenericAPIRegistration(name.API)
 	if !ok || apiInfo.RPCClient == nil {
 		return grpc.NewForeignResource(name, rc.getClientConn()), nil
@@ -890,6 +912,21 @@ func (rc *RobotClient) resourcesCallCtx(ctx context.Context) (context.Context, c
 		return ctx, func() {}
 	}
 	return contextutils.ContextWithTimeoutIfNoDeadline(ctx, rc.resourcesTimeout)
+}
+
+// apisSharingName returns, sorted, every API advertised under name's bare name and remote. A single
+// element means an ordinary single-API resource; more than one means a composite. rc.mu must be held.
+func (rc *RobotClient) apisSharingName(name resource.Name) []resource.API {
+	var apis []resource.API
+	seen := make(map[resource.API]bool)
+	for _, known := range rc.resourceNames {
+		if known.Name == name.Name && known.Remote == name.Remote && !seen[known.API] {
+			seen[known.API] = true
+			apis = append(apis, known.API)
+		}
+	}
+	sort.Slice(apis, func(i, j int) bool { return apis[i].String() < apis[j].String() })
+	return apis
 }
 
 func (rc *RobotClient) resources(ctx context.Context) ([]resource.Name, []resource.RPCAPI, error) {

--- a/robot/client/client.go
+++ b/robot/client/client.go
@@ -672,16 +672,22 @@ func (rc *RobotClient) updateResourceClients(ctx context.Context) error {
 		activeResources[name] = true
 	}
 
+	// A composite (multi-API) resource is cached under each of its API names, so close each distinct
+	// client only once even when several names map to it.
+	closed := make(map[resource.Resource]bool)
 	for resourceName, client := range rc.resourceClients {
 		// check if no longer an active resource
-		if !activeResources[resourceName] {
+		if activeResources[resourceName] {
+			continue
+		}
+		if !closed[client] {
+			closed[client] = true
 			rc.logger.Infow("Removing resource from remote client", "resourceName", resourceName.String())
 			if err := client.Close(ctx); err != nil {
 				rc.Logger().CError(ctx, err)
-				continue
 			}
-			delete(rc.resourceClients, resourceName)
 		}
+		delete(rc.resourceClients, resourceName)
 	}
 
 	return nil
@@ -846,6 +852,14 @@ func (rc *RobotClient) ResourceByName(name resource.Name) (resource.Resource, er
 	if val, ok := rc.remoteNameMap[name]; ok {
 		name = val
 	}
+	// An API-less name (from resource.SimpleName) identifies a resource by its simple name alone;
+	// resolve it to a concrete (api, name) advertised under that bare name so the rest of the lookup
+	// — cache, known-name check, and composite assembly — proceeds unchanged.
+	if name.API == (resource.API{}) {
+		if resolved, ok := rc.resolveBareName(name); ok {
+			name = resolved
+		}
+	}
 	if client, ok := rc.resourceClients[name]; ok {
 		rc.mu.RUnlock()
 		return client, nil
@@ -854,6 +868,12 @@ func (rc *RobotClient) ResourceByName(name resource.Name) (resource.Resource, er
 
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
+	// Re-resolve under the write lock in case the resource list changed after the read lock.
+	if name.API == (resource.API{}) {
+		if resolved, ok := rc.resolveBareName(name); ok {
+			name = resolved
+		}
+	}
 	// another check, this one with a stricter lock
 	if client, ok := rc.resourceClients[name]; ok {
 		return client, nil
@@ -866,11 +886,36 @@ func (rc *RobotClient) ResourceByName(name resource.Name) (resource.Resource, er
 			if err != nil {
 				return nil, err
 			}
-			rc.resourceClients[name] = resourceClient
+			rc.cacheResourceClient(name, resourceClient)
 			return resourceClient, nil
 		}
 	}
 	return nil, resource.NewNotFoundError(name)
+}
+
+// cacheResourceClient stores a freshly built client in the cache. A composite (multi-API) resource
+// is one object; cache it under every one of its API names so a lookup by any API — or the api-less
+// bare name, which resolves to one of them — returns the one handle and its sub-clients instead of
+// re-dialing per API. rc.mu must be held.
+func (rc *RobotClient) cacheResourceClient(name resource.Name, client resource.Resource) {
+	rc.resourceClients[name] = client
+	if mar, ok := client.(resource.MultiAPIResource); ok {
+		for _, api := range mar.APIs() {
+			rc.resourceClients[resource.NewName(api, name.Name).PrependRemote(name.Remote)] = client
+		}
+	}
+}
+
+// resolveBareName maps an API-less name to a concrete (api, name) for one of the APIs advertised
+// under its bare name — a representative the composite path in createClient then expands into the
+// full multi-API handle. Returns false when no resource is advertised under that bare name. rc.mu
+// must be held.
+func (rc *RobotClient) resolveBareName(name resource.Name) (resource.Name, bool) {
+	apis := rc.apisSharingName(name)
+	if len(apis) == 0 {
+		return resource.Name{}, false
+	}
+	return resource.NewName(apis[0], name.Name).PrependRemote(name.Remote), true
 }
 
 func (rc *RobotClient) createClient(name resource.Name) (resource.Resource, error) {

--- a/robot/framesystem/framesystem.go
+++ b/robot/framesystem/framesystem.go
@@ -210,7 +210,13 @@ func (svc *frameSystemService) BuiltInReconfigure(ctx context.Context, deps reso
 
 	components := make(map[string]resource.Resource)
 	for name, r := range deps {
-		if _, present := components[name.Name]; present {
+		if existing, present := components[name.Name]; present {
+			// A composite resource that serves multiple APIs (resource.RegisterMultiAPI) appears in
+			// deps once per API but is a single instance, so it is not a real duplicate. Only two
+			// *distinct* instances sharing a bare name is an error.
+			if existing == r {
+				continue
+			}
 			return DuplicateResourceNameError(name.Name)
 		}
 		components[name.Name] = r

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -226,7 +226,54 @@ func (r *localRobot) FindBySimpleNameAndAPI(name string, api resource.API) (reso
 // FindBySimpleNameAndAPI. ResourceByName is only called internally for some dependency
 // calculation and session code.
 func (r *localRobot) ResourceByName(name resource.Name) (resource.Resource, error) {
+	// An API-less name (from resource.SimpleName) identifies a resource by its bare name; resolve it
+	// to the resource of that name — a single composite handle for a multi-API model — so
+	// resource.AsType and resource.APIsOf work the same in-process as over a client.
+	if name.API == (resource.API{}) {
+		return r.resourceBySimpleName(name.Name)
+	}
 	return r.FindBySimpleNameAndAPI(name.Name, name.API)
+}
+
+// resourceBySimpleName resolves an API-less name to its resource. For a multi-API (composite) model
+// it returns one composite handle serving every API; for a single-API resource it returns that
+// resource directly. Only this api-less path wraps a composite — an api-specific lookup still returns
+// the raw instance, so in-process capability detection and typed handlers are unaffected.
+func (r *localRobot) resourceBySimpleName(name string) (resource.Resource, error) {
+	seen := make(map[resource.API]bool)
+	var apis []resource.API
+	for _, match := range r.manager.resources.FindAllBySimpleName(name) {
+		if !seen[match.API] {
+			seen[match.API] = true
+			apis = append(apis, match.API)
+		}
+	}
+	switch len(apis) {
+	case 0:
+		return nil, resource.NewNotFoundError(resource.SimpleName(name))
+	case 1:
+		return r.FindBySimpleNameAndAPI(name, apis[0])
+	}
+	sort.Slice(apis, func(i, j int) bool { return apis[i].String() < apis[j].String() })
+
+	canonical, err := r.FindBySimpleNameAndAPI(name, apis[0])
+	if err != nil {
+		return nil, err
+	}
+	// A modular composite is already a composite handle; return it as-is. A builtin composite is one
+	// raw instance serving every API, so wrap it under each API for uniform APIs()/AsType/APIsOf.
+	if _, ok := canonical.(resource.MultiAPIResource); ok {
+		return canonical, nil
+	}
+	byAPI := make(map[resource.API]resource.Resource, len(apis))
+	for _, api := range apis {
+		res, err := r.FindBySimpleNameAndAPI(name, api)
+		if err != nil {
+			return nil, err
+		}
+		byAPI[api] = res
+	}
+	return resource.NewMultiAPIResource(resource.NewName(apis[0], name), apis, byAPI), nil
 }
 
 // RemoteNames returns the names of all known remote robots.

--- a/robot/impl/multiapi_integration_test.go
+++ b/robot/impl/multiapi_integration_test.go
@@ -1,0 +1,91 @@
+package robotimpl
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+)
+
+// multiAPIModel is a builtin model that serves two co-equal APIs from one instance: the sensor API
+// (Readings) and the generic API (DoCommand). It is registered via resource.RegisterMultiAPI.
+var multiAPIModel = resource.DefaultModelFamily.WithModel("multiapi_integration")
+
+type multiAPIThing struct {
+	resource.Named
+	resource.TriviallyReconfigurable
+	resource.TriviallyCloseable
+}
+
+func (m *multiAPIThing) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+	return map[string]interface{}{"reading": 42}, nil
+}
+
+func (m *multiAPIThing) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return map[string]interface{}{"did": "it"}, nil
+}
+
+// TestMultiAPIResourceEndToEnd verifies, through a real local robot, that one model serving a set of
+// co-equal APIs is a single instance reachable and advertised under each of its APIs — configured
+// with NO `api` field (resolved from the model).
+func TestMultiAPIResourceEndToEnd(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	ctx := context.Background()
+
+	resource.RegisterMultiAPI(
+		[]resource.API{sensor.API, generic.API},
+		multiAPIModel,
+		resource.Registration[resource.Resource, resource.NoNativeConfig]{
+			Constructor: func(_ context.Context, _ resource.Dependencies, conf resource.Config, _ logging.Logger,
+			) (resource.Resource, error) {
+				return &multiAPIThing{Named: conf.ResourceName().AsNamed()}, nil
+			},
+		},
+	)
+	defer func() {
+		resource.Deregister(sensor.API, multiAPIModel)
+		resource.Deregister(generic.API, multiAPIModel)
+	}()
+
+	// A composite config entry: name + model, NO api. Ensure runs the same validation/partial-name
+	// resolution the production config path (config.Read) does, which fills the API from the model.
+	cfg := &config.Config{
+		Components: []resource.Config{
+			{Name: "combo", Model: multiAPIModel},
+		},
+	}
+	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
+	r := setupLocalRobot(t, ctx, cfg, logger)
+
+	// Advertised under BOTH APIs.
+	names := r.ResourceNames()
+	test.That(t, names, test.ShouldContain, sensor.Named("combo"))
+	test.That(t, names, test.ShouldContain, generic.Named("combo"))
+
+	// Reachable and usable under the sensor API.
+	s, err := sensor.FromProvider(r, "combo")
+	test.That(t, err, test.ShouldBeNil)
+	readings, err := s.Readings(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, readings["reading"], test.ShouldEqual, 42)
+
+	// Reachable under the generic API — the SAME instance.
+	g, err := generic.FromProvider(r, "combo")
+	test.That(t, err, test.ShouldBeNil)
+	resp, err := g.DoCommand(ctx, map[string]interface{}{})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, resp["did"], test.ShouldEqual, "it")
+
+	// Both API lookups resolve to one underlying instance.
+	viaSensor, err := r.ResourceByName(sensor.Named("combo"))
+	test.That(t, err, test.ShouldBeNil)
+	viaGeneric, err := r.ResourceByName(generic.Named("combo"))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, viaSensor, test.ShouldEqual, viaGeneric)
+}

--- a/robot/impl/multiapi_integration_test.go
+++ b/robot/impl/multiapi_integration_test.go
@@ -108,6 +108,18 @@ func TestMultiAPIResourceEndToEnd(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, viaSensor, test.ShouldEqual, viaGeneric)
 
+	// (gaps 2/3) An api-less SimpleName lookup resolves in-process to one composite handle serving
+	// every API — AsType extracts each capability, and APIsOf reports the full set off that handle.
+	viaSimple, err := r.ResourceByName(resource.SimpleName("combo"))
+	test.That(t, err, test.ShouldBeNil)
+	sen, err := resource.AsType[sensor.Sensor](viaSimple)
+	test.That(t, err, test.ShouldBeNil)
+	simpleReadings, err := sen.Readings(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, simpleReadings["reading"], test.ShouldEqual, 42)
+	test.That(t, resource.APIsOf(viaSimple), test.ShouldContain, sensor.API)
+	test.That(t, resource.APIsOf(viaSimple), test.ShouldContain, generic.API)
+
 	// (item 5) Removing the resource (reconfigure to empty) tears it down under both APIs and closes
 	// the single instance exactly once.
 	empty := &config.Config{}

--- a/robot/impl/multiapi_integration_test.go
+++ b/robot/impl/multiapi_integration_test.go
@@ -2,6 +2,7 @@ package robotimpl
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"go.viam.com/test"
@@ -17,10 +18,13 @@ import (
 // (Readings) and the generic API (DoCommand). It is registered via resource.RegisterMultiAPI.
 var multiAPIModel = resource.DefaultModelFamily.WithModel("multiapi_integration")
 
+// multiAPICloseCount counts Close calls on instances of multiAPIThing, to verify a composite
+// instance is closed exactly once even though it is reachable under multiple APIs.
+var multiAPICloseCount atomic.Int64
+
 type multiAPIThing struct {
 	resource.Named
 	resource.TriviallyReconfigurable
-	resource.TriviallyCloseable
 }
 
 func (m *multiAPIThing) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
@@ -31,12 +35,19 @@ func (m *multiAPIThing) DoCommand(ctx context.Context, cmd map[string]interface{
 	return map[string]interface{}{"did": "it"}, nil
 }
 
+func (m *multiAPIThing) Close(ctx context.Context) error {
+	multiAPICloseCount.Add(1)
+	return nil
+}
+
 // TestMultiAPIResourceEndToEnd verifies, through a real local robot, that one model serving a set of
 // co-equal APIs is a single instance reachable and advertised under each of its APIs — configured
-// with NO `api` field (resolved from the model).
+// with NO `api` field (resolved from the model) — and that it advertises both APIs, and is closed
+// exactly once when removed.
 func TestMultiAPIResourceEndToEnd(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 	ctx := context.Background()
+	multiAPICloseCount.Store(0)
 
 	resource.RegisterMultiAPI(
 		[]resource.API{sensor.API, generic.API},
@@ -63,10 +74,18 @@ func TestMultiAPIResourceEndToEnd(t *testing.T) {
 	test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
 	r := setupLocalRobot(t, ctx, cfg, logger)
 
-	// Advertised under BOTH APIs.
+	// Advertised under BOTH APIs in ResourceNames.
 	names := r.ResourceNames()
 	test.That(t, names, test.ShouldContain, sensor.Named("combo"))
 	test.That(t, names, test.ShouldContain, generic.Named("combo"))
+
+	// (item 2) Advertised under both APIs in ResourceRPCAPIs (what a connecting client discovers).
+	var advertised []resource.API
+	for _, rpcAPI := range r.ResourceRPCAPIs() {
+		advertised = append(advertised, rpcAPI.API)
+	}
+	test.That(t, advertised, test.ShouldContain, sensor.API)
+	test.That(t, advertised, test.ShouldContain, generic.API)
 
 	// Reachable and usable under the sensor API.
 	s, err := sensor.FromProvider(r, "combo")
@@ -88,4 +107,15 @@ func TestMultiAPIResourceEndToEnd(t *testing.T) {
 	viaGeneric, err := r.ResourceByName(generic.Named("combo"))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, viaSensor, test.ShouldEqual, viaGeneric)
+
+	// (item 5) Removing the resource (reconfigure to empty) tears it down under both APIs and closes
+	// the single instance exactly once.
+	empty := &config.Config{}
+	test.That(t, empty.Ensure(false, logger), test.ShouldBeNil)
+	r.Reconfigure(ctx, empty)
+
+	namesAfter := r.ResourceNames()
+	test.That(t, namesAfter, test.ShouldNotContain, sensor.Named("combo"))
+	test.That(t, namesAfter, test.ShouldNotContain, generic.Named("combo"))
+	test.That(t, multiAPICloseCount.Load(), test.ShouldEqual, 1)
 }

--- a/robot/impl/multiapi_remote_test.go
+++ b/robot/impl/multiapi_remote_test.go
@@ -1,0 +1,76 @@
+package robotimpl
+
+import (
+	"context"
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/components/generic"
+	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/config"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/testutils/robottestutils"
+)
+
+var remoteMultiAPIModel = resource.DefaultModelFamily.WithModel("multiapi_remote")
+
+// TestMultiAPIResourceOverRemote verifies that a composite (multi-API) resource on a remote robot is
+// reachable through the main robot under each of its APIs (with the remote prefix). A remote
+// advertises one such resource as two names sharing a bare name; the main robot surfaces both and
+// each routes to the one instance on the remote.
+func TestMultiAPIResourceOverRemote(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	ctx := context.Background()
+
+	resource.RegisterMultiAPI(
+		[]resource.API{sensor.API, generic.API},
+		remoteMultiAPIModel,
+		resource.Registration[resource.Resource, resource.NoNativeConfig]{
+			Constructor: func(_ context.Context, _ resource.Dependencies, conf resource.Config, _ logging.Logger,
+			) (resource.Resource, error) {
+				return &multiAPIThing{Named: conf.ResourceName().AsNamed()}, nil
+			},
+		},
+	)
+	defer func() {
+		resource.Deregister(sensor.API, remoteMultiAPIModel)
+		resource.Deregister(generic.API, remoteMultiAPIModel)
+	}()
+
+	// Remote robot serving the composite resource (api-less config).
+	remoteCfg := &config.Config{
+		Components: []resource.Config{{Name: "combo", Model: remoteMultiAPIModel}},
+	}
+	test.That(t, remoteCfg.Ensure(false, logger), test.ShouldBeNil)
+	remote := setupLocalRobot(t, ctx, remoteCfg, logger.Sublogger("remote"))
+
+	options, _, addr := robottestutils.CreateBaseOptionsAndListener(t)
+	test.That(t, remote.StartWeb(ctx, options), test.ShouldBeNil)
+
+	// Main robot connecting to the remote.
+	mainCfg := &config.Config{
+		Remotes: []config.Remote{{Name: "rem", Address: addr}},
+	}
+	main := setupLocalRobot(t, ctx, mainCfg, logger.Sublogger("main"))
+
+	// The composite surfaces under both APIs with the remote prefix.
+	names := main.ResourceNames()
+	test.That(t, names, test.ShouldContain, sensor.Named("rem:combo"))
+	test.That(t, names, test.ShouldContain, generic.Named("rem:combo"))
+
+	// Usable under the sensor API through the remote.
+	s, err := sensor.FromProvider(main, "rem:combo")
+	test.That(t, err, test.ShouldBeNil)
+	readings, err := s.Readings(ctx, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, readings["reading"], test.ShouldEqual, 42)
+
+	// And under the generic API — routing to the one instance on the remote.
+	g, err := generic.FromProvider(main, "rem:combo")
+	test.That(t, err, test.ShouldBeNil)
+	resp, err := g.DoCommand(ctx, map[string]interface{}{})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, resp["did"], test.ShouldEqual, "it")
+}

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -560,17 +560,26 @@ func (manager *resourceManager) ResourceRPCAPIs() []resource.RPCAPI {
 		if k.ContainsRemoteNames() {
 			continue
 		}
-		if types[k.API] != nil {
-			continue
-		}
 
-		st, ok := resourceAPIs[k.API]
-		if !ok {
-			continue
+		// Advertise every co-equal API a composite resource serves (resource.RegisterMultiAPI), or
+		// just its own API for an ordinary single-API resource.
+		apis := []resource.API{k.API}
+		if node, ok := manager.resources.Node(k); ok {
+			if served := resource.APIsForModel(node.Config().Model); len(served) > 0 {
+				apis = served
+			}
 		}
-
-		if st.ReflectRPCServiceDesc != nil {
-			types[k.API] = st.ReflectRPCServiceDesc
+		for _, api := range apis {
+			if types[api] != nil {
+				continue
+			}
+			st, ok := resourceAPIs[api]
+			if !ok {
+				continue
+			}
+			if st.ReflectRPCServiceDesc != nil {
+				types[api] = st.ReflectRPCServiceDesc
+			}
 		}
 	}
 	typesList := make([]resource.RPCAPI, 0, len(types))

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -895,7 +895,7 @@ func (svc *webService) foreignServiceHandler(srv interface{}, stream googlegrpc.
 
 	// We expect each message to contain a "name" argument which will allow us to route
 	// the message towards the correct destination.
-	resource, fqName, err := robot.ResourceFromProtoMessage(svc.r, firstMsg, subType.API)
+	res, fqName, err := robot.ResourceFromProtoMessage(svc.r, firstMsg, subType.API)
 	if err != nil {
 		svc.logger.Errorw("unable to route foreign message", "error", err)
 		return err
@@ -911,9 +911,18 @@ func (svc *webService) foreignServiceHandler(srv interface{}, stream googlegrpc.
 		firstMsg.SetFieldByName("name", fqName.PopRemote().ShortName())
 	}
 
-	foreignRes, ok := resource.(*grpc.ForeignResource)
+	// A composite (multi-API) resource serves this custom API through a per-API foreign sub-resource.
+	// Unwrap to that sub-resource so the call routes to the API's foreign client rather than failing
+	// the assertion below.
+	if mar, ok := res.(resource.MultiAPIResource); ok {
+		if sub, ok := mar.ResourceForAPI(subType.API); ok {
+			res = sub
+		}
+	}
+
+	foreignRes, ok := res.(*grpc.ForeignResource)
 	if !ok {
-		svc.logger.Errorf("expected resource to be a foreign RPC resource but was %T", foreignRes)
+		svc.logger.Errorf("expected resource to be a foreign RPC resource but was %T", res)
 		return grpc.UnimplementedError
 	}
 

--- a/services/baseremotecontrol/base_remote_control.go
+++ b/services/baseremotecontrol/base_remote_control.go
@@ -38,6 +38,11 @@ func FromProvider(provider resource.Provider, name string) (Service, error) {
 	return resource.FromProvider[Service](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Service, error) {
+	return resource.FromResourceForAPI[Service](res, API)
+}
+
 func init() {
 	resource.RegisterAPI(API, resource.APIRegistration[Service]{})
 	data.RegisterCollector(data.MethodMetadata{

--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -144,18 +144,26 @@ func (ac *AssociatedConfig) Link(conf *resource.Config) {
 	if len(ac.CaptureMethods) == 0 {
 		return
 	}
-
-	// infer name from first index in CaptureMethods
-	name := ac.CaptureMethods[0].Name
-	captureMethodCopies := make([]DataCaptureConfig, 0, len(ac.CaptureMethods))
-	for _, method := range ac.CaptureMethods {
-		methodCopy := method
-		captureMethodCopies = append(captureMethodCopies, methodCopy)
-	}
 	if conf.AssociatedAttributes == nil {
 		conf.AssociatedAttributes = make(map[resource.Name]resource.AssociatedConfig)
 	}
-	conf.AssociatedAttributes[name] = &AssociatedConfig{CaptureMethods: captureMethodCopies}
+
+	// Group capture methods by their target resource name, which includes the API. For an ordinary
+	// single-API resource every method shares one name, so this is a single group (unchanged
+	// behavior). For a resource serving multiple APIs (resource.RegisterMultiAPI), methods can target
+	// different APIs of the same bare name (e.g. arm/x EndPosition and camera/x ReadImage); each
+	// (api, name) bucket is filed separately and resolves to the one underlying instance.
+	order := make([]resource.Name, 0)
+	byName := make(map[resource.Name][]DataCaptureConfig)
+	for _, method := range ac.CaptureMethods {
+		if _, ok := byName[method.Name]; !ok {
+			order = append(order, method.Name)
+		}
+		byName[method.Name] = append(byName[method.Name], method)
+	}
+	for _, name := range order {
+		conf.AssociatedAttributes[name] = &AssociatedConfig{CaptureMethods: byName[name]}
+	}
 }
 
 // DataCaptureConfig is used to initialize a collector for a component or remote.

--- a/services/datamanager/data_manager.go
+++ b/services/datamanager/data_manager.go
@@ -91,6 +91,11 @@ func FromProvider(provider resource.Provider, name string) (Service, error) {
 	return resource.FromProvider[Service](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Service, error) {
+	return resource.FromResourceForAPI[Service](res, API)
+}
+
 // NamesFromRobot is a helper for getting all data manager services from the given Robot.
 func NamesFromRobot(r robot.Robot) []string {
 	return robot.NamesByAPI(r, API)

--- a/services/datamanager/data_manager_test.go
+++ b/services/datamanager/data_manager_test.go
@@ -6,6 +6,8 @@ import (
 	"go.viam.com/test"
 
 	"go.viam.com/rdk/components/arm"
+	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/resource"
 )
 
 func TestDataCaptureConfig(t *testing.T) {
@@ -173,4 +175,49 @@ func TestDataCaptureConfig(t *testing.T) {
 			test.That(t, tc.b.Equals(tc.a), test.ShouldEqual, tc.equal)
 		})
 	}
+}
+
+// TestLinkGroupsByAPI verifies that Link files capture methods under their own (api, name) key, so a
+// resource serving multiple APIs (resource.RegisterMultiAPI) can capture methods from each of its
+// APIs. Single-API resources (all methods share one name) collapse to one group as before.
+func TestLinkGroupsByAPI(t *testing.T) {
+	armName := arm.Named("combo")
+	sensorName := sensor.Named("combo")
+
+	ac := &AssociatedConfig{
+		CaptureMethods: []DataCaptureConfig{
+			{Name: armName, Method: "EndPosition"},
+			{Name: sensorName, Method: "Readings"},
+			{Name: armName, Method: "JointPositions"},
+		},
+	}
+	conf := &resource.Config{Name: "combo", API: arm.API}
+	ac.Link(conf)
+
+	// Each API gets its own bucket, resolving to the one instance.
+	test.That(t, len(conf.AssociatedAttributes), test.ShouldEqual, 2)
+	armAttrs, ok := conf.AssociatedAttributes[armName].(*AssociatedConfig)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, len(armAttrs.CaptureMethods), test.ShouldEqual, 2)
+	sensorAttrs, ok := conf.AssociatedAttributes[sensorName].(*AssociatedConfig)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, len(sensorAttrs.CaptureMethods), test.ShouldEqual, 1)
+	test.That(t, sensorAttrs.CaptureMethods[0].Method, test.ShouldEqual, "Readings")
+}
+
+// TestLinkSingleAPIUnchanged verifies the single-API case is one group (unchanged behavior).
+func TestLinkSingleAPIUnchanged(t *testing.T) {
+	armName := arm.Named("myarm")
+	ac := &AssociatedConfig{
+		CaptureMethods: []DataCaptureConfig{
+			{Name: armName, Method: "EndPosition"},
+			{Name: armName, Method: "JointPositions"},
+		},
+	}
+	conf := &resource.Config{Name: "myarm", API: arm.API}
+	ac.Link(conf)
+	test.That(t, len(conf.AssociatedAttributes), test.ShouldEqual, 1)
+	attrs, ok := conf.AssociatedAttributes[armName].(*AssociatedConfig)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, len(attrs.CaptureMethods), test.ShouldEqual, 2)
 }

--- a/services/discovery/discovery.go
+++ b/services/discovery/discovery.go
@@ -62,6 +62,11 @@ func FromProvider(provider resource.Provider, name string) (Service, error) {
 	return resource.FromProvider[Service](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Service, error) {
+	return resource.FromResourceForAPI[Service](res, API)
+}
+
 // Service describes the functions that are available to the service.
 //
 // For more information, see the [Discovery service docs].

--- a/services/mlmodel/mlmodel.go
+++ b/services/mlmodel/mlmodel.go
@@ -388,3 +388,8 @@ func FromDependencies(deps resource.Dependencies, name string) (Service, error) 
 func FromProvider(provider resource.Provider, name string) (Service, error) {
 	return resource.FromProvider[Service](provider, Named(name))
 }
+
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Service, error) {
+	return resource.FromResourceForAPI[Service](res, API)
+}

--- a/services/motion/motion.go
+++ b/services/motion/motion.go
@@ -450,6 +450,11 @@ func FromProvider(provider resource.Provider, name string) (Service, error) {
 	return resource.FromProvider[Service](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Service, error) {
+	return resource.FromResourceForAPI[Service](res, API)
+}
+
 // ToProto converts a PlanWithStatus to a *pb.PlanWithStatus.
 func (pws PlanWithStatus) ToProto() *pb.PlanWithStatus {
 	statusHistory := []*pb.PlanStatus{}

--- a/services/navigation/navigation.go
+++ b/services/navigation/navigation.go
@@ -233,6 +233,11 @@ func FromProvider(provider resource.Provider, name string) (Service, error) {
 	return resource.FromProvider[Service](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Service, error) {
+	return resource.FromResourceForAPI[Service](res, API)
+}
+
 func mapTypeToProtobuf(mapType MapType) servicepb.MapType {
 	switch mapType {
 	case NoMap:

--- a/services/slam/slam.go
+++ b/services/slam/slam.go
@@ -135,6 +135,11 @@ func FromProvider(provider resource.Provider, name string) (Service, error) {
 	return resource.FromProvider[Service](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Service, error) {
+	return resource.FromResourceForAPI[Service](res, API)
+}
+
 // Service describes the functions that are available to the service.
 //
 // The Go SDK implements helper functions that concatenate streaming

--- a/services/video/video.go
+++ b/services/video/video.go
@@ -70,3 +70,8 @@ func FromDependencies(deps resource.Dependencies, name string) (Service, error) 
 func FromProvider(provider resource.Provider, name string) (Service, error) {
 	return resource.FromProvider[Service](provider, Named(name))
 }
+
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Service, error) {
+	return resource.FromResourceForAPI[Service](res, API)
+}

--- a/services/vision/vision.go
+++ b/services/vision/vision.go
@@ -247,6 +247,11 @@ func FromProvider(provider resource.Provider, name string) (Service, error) {
 	return resource.FromProvider[Service](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Service, error) {
+	return resource.FromResourceForAPI[Service](res, API)
+}
+
 // Properties returns various information regarding the current vision service,
 // specifically, which vision tasks are supported by the resource.
 type Properties struct {

--- a/services/worldstatestore/world_state_store.go
+++ b/services/worldstatestore/world_state_store.go
@@ -64,6 +64,11 @@ func FromProvider(provider resource.Provider, name string) (Service, error) {
 	return resource.FromProvider[Service](provider, Named(name))
 }
 
+// FromResource extracts this API from a resource that may be a multi-API (composite) resource.
+func FromResource(res resource.Resource) (Service, error) {
+	return resource.FromResourceForAPI[Service](res, API)
+}
+
 // Service describes the functions that are available to the service.
 //
 // For more information, see the [WorldStateStore service docs].


### PR DESCRIPTION
Let a single model serve a set of co-equal APIs (a "composite" resource): one configured instance is reachable, routed, and advertised under any of its APIs, with no Protobuf changes and no breaking change to existing single-API resources.

- resource_registry.go: RegisterMultiAPI([]API, model, reg) registers one constructor under every API in the set and records the set; APIsForModel reads it (the model->API-set index that lets config omit `api`).
- resource_graph.go: apisForNode caches a resource's one node under every API its model serves (peers in simpleNameCache), so FindBySimpleNameAndAPI resolves the one instance under each API and SimpleNamesWhere advertises all.
- config.go: an omitted `api` is resolved to the model's canonical API, so a composite config is just name + model.
- multiapi.go: MultiAPIResource + generic FromResourceForAPI (the open-world access path each API package wraps as X.FromResource) + a composite impl.
- resource.go: FromProvider/FromDependencies transparently unwrap a composite to the requested API's sub-resource, so existing X.FromRobot keeps working.
- robot/client/client.go: createClient assembles one composite of per-API sub-clients for a multi-API resource; single-API resources unchanged.
- resource_manager.go: ResourceRPCAPIs advertises every co-equal API.
- framesystem.go: dedup peers (one instance under N APIs is not a dup name).
- arm/sensor: example FromResource helpers.

Tested: resource/multiapi_test.go (composite, accessors, DoCommand routing, registry, graph peer routing, config api-omission) and robot/impl/multiapi_integration_test.go (end-to-end through a real local robot: a model serving sensor+generic, configured with no api, reachable under both APIs and resolving to one instance).