### PR TITLE
spatialmath: export CentroidOfPoints for []r3.Vector

### DIFF
--- a/spatialmath/mesh_decimation.go
+++ b/spatialmath/mesh_decimation.go
@@ -113,7 +113,7 @@ func conservativeHullDecimateTriangles(triangles []*Triangle, targetTriangles in
 	}
 
 	// Strict containment: if sampled hull misses extremes, scale it outward just enough to contain all vertices.
-	hullCenter := centroidOfPoints(hullPoints)
+	hullCenter := CentroidOfPoints(hullPoints)
 	scale := requiredHullScale(vertices, faces, hullCenter)
 	if scale > 1.0 {
 		hullTris = scaleTrianglesAboutPoint(hullTris, hullCenter, scale*(1.0+1e-9))
@@ -297,7 +297,7 @@ func selectSupportVertices(vertices []r3.Vector, maxPoints int) []r3.Vector {
 	for len(selected) < maxPoints {
 		if len(selected) < 4 {
 			// Not enough for a hull yet — add farthest from centroid.
-			center := centroidOfPoints(selected)
+			center := CentroidOfPoints(selected)
 			bestDist := -1.0
 			bestVert := r3.Vector{}
 			for _, v := range vertices {
@@ -439,7 +439,7 @@ func quickHull3D(points []r3.Vector, eps float64) ([]quickHullFace, []r3.Vector,
 		return nil, nil, errors.New("points are nearly coplanar")
 	}
 
-	interior := centroidOfPoints([]r3.Vector{points[i0], points[i1], points[i2], points[i3]})
+	interior := CentroidOfPoints([]r3.Vector{points[i0], points[i1], points[i2], points[i3]})
 	faces := []quickHullFace{
 		newQuickHullFace(points, i0, i1, i2, interior),
 		newQuickHullFace(points, i0, i3, i1, interior),
@@ -669,17 +669,6 @@ func hullFacesToTriangles(faces []quickHullFace, points []r3.Vector) []*Triangle
 		tris = append(tris, NewTriangle(points[face.a], points[face.b], points[face.c]))
 	}
 	return tris
-}
-
-func centroidOfPoints(points []r3.Vector) r3.Vector {
-	if len(points) == 0 {
-		return r3.Vector{}
-	}
-	acc := r3.Vector{}
-	for _, p := range points {
-		acc = acc.Add(p)
-	}
-	return acc.Mul(1.0 / float64(len(points)))
 }
 
 func requiredHullScale(original []r3.Vector, faces []quickHullFace, center r3.Vector) float64 {

--- a/spatialmath/r3vector.go
+++ b/spatialmath/r3vector.go
@@ -11,6 +11,18 @@ func R3VectorAlmostEqual(a, b r3.Vector, epsilon float64) bool {
 	return math.Abs(a.X-b.X) < epsilon && math.Abs(a.Y-b.Y) < epsilon && math.Abs(a.Z-b.Z) < epsilon
 }
 
+// CentroidOfPoints returns the arithmetic mean of the given points. Returns the zero vector when points is empty.
+func CentroidOfPoints(points []r3.Vector) r3.Vector {
+	if len(points) == 0 {
+		return r3.Vector{}
+	}
+	acc := r3.Vector{}
+	for _, p := range points {
+		acc = acc.Add(p)
+	}
+	return acc.Mul(1.0 / float64(len(points)))
+}
+
 // AxisConfig represents the configuration format representing an axis.
 type AxisConfig r3.Vector
 

--- a/spatialmath/r3vector_test.go
+++ b/spatialmath/r3vector_test.go
@@ -12,6 +12,17 @@ func TestR3VectorAlmostEqual(t *testing.T) {
 	test.That(t, R3VectorAlmostEqual(r3.Vector{1, 2, 3}, r3.Vector{1.001, 2.001, 3.001}, 1e-2), test.ShouldBeTrue)
 }
 
+func TestCentroidOfPoints(t *testing.T) {
+	test.That(t, CentroidOfPoints(nil), test.ShouldResemble, r3.Vector{})
+	test.That(t, CentroidOfPoints([]r3.Vector{}), test.ShouldResemble, r3.Vector{})
+	test.That(t, CentroidOfPoints([]r3.Vector{{1, 2, 3}}), test.ShouldResemble, r3.Vector{1, 2, 3})
+	test.That(t,
+		CentroidOfPoints([]r3.Vector{{0, 0, 0}, {2, 4, 6}, {4, 8, 12}}),
+		test.ShouldResemble,
+		r3.Vector{2, 4, 6},
+	)
+}
+
 func TestAxisSerialization(t *testing.T) {
 	tc := NewAxisConfig(R4AA{Theta: 1, RX: 1})
 	newTc := NewAxisConfig(tc.ParseConfig())


### PR DESCRIPTION
Export spatialmath.CentroidOfPoints([]r3.Vector) r3.Vector

Fills a symmetry gap next to the existing `pointcloud.CloudCentroid` and `(*Triangle).Centroid()`.

This logic is already duplicated in the sanding module and I just duplicated it in another module
   
No behavior change