### PR TITLE
RSDK-14419: add SetJointLimits for patching a kinematics document

### DIFF
--- a/referenceframe/limits.go
+++ b/referenceframe/limits.go
@@ -1,0 +1,165 @@
+package referenceframe
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"slices"
+)
+
+// ErrURDFLimitsUnsupported is returned when limits are set on a URDF-backed kinematics document.
+var ErrURDFLimitsUnsupported = fmt.Errorf(
+	"cannot set joint limits on a URDF document; see RSDK-14232")
+
+// JointLimits is a partial update to one joint's limits. A nil field leaves that limit as it is,
+// so a caller who knows only how fast a joint may move can say that without restating where it
+// may go.
+//
+// Values are in the units the kinematics document uses, not the internal ones: degrees and
+// degrees per second for revolute joints, millimeters and millimeters per second for prismatic.
+// A module reading speeds out of its own config is already holding degrees, which is why this
+// takes them.
+//
+// Every value must be finite, the speeds must not be negative, and a joint's min must not end up
+// above its max. Leaving a field out is how you say a joint is unbounded on that axis.
+type JointLimits struct {
+	Min             *float64
+	Max             *float64
+	MaxVelocity     *float64
+	MaxAcceleration *float64
+}
+
+// validate rejects values that would produce a document nobody can act on. The caller is usually
+// passing numbers straight out of a user's resource config, so this is the last place to catch a
+// typo before it becomes a limit the motion service plans against.
+func (jl JointLimits) validate(id string) error {
+	for _, field := range []struct {
+		name  string
+		value *float64
+	}{
+		{"min", jl.Min},
+		{"max", jl.Max},
+		{"max_velocity", jl.MaxVelocity},
+		{"max_acceleration", jl.MaxAcceleration},
+	} {
+		if field.value == nil {
+			continue
+		}
+		// Infinity would mean two different things depending on the field, dropping out of the
+		// document for the speeds and failing to marshal at all for the positions, so neither is
+		// allowed. Leave a field out to say a joint is unbounded.
+		if math.IsNaN(*field.value) || math.IsInf(*field.value, 0) {
+			return fmt.Errorf("joint %q: %s must be a finite number, got %v", id, field.name, *field.value)
+		}
+	}
+
+	if jl.MaxVelocity != nil && *jl.MaxVelocity < 0 {
+		return fmt.Errorf("joint %q: max_velocity cannot be negative, got %v", id, *jl.MaxVelocity)
+	}
+	if jl.MaxAcceleration != nil && *jl.MaxAcceleration < 0 {
+		return fmt.Errorf("joint %q: max_acceleration cannot be negative, got %v", id, *jl.MaxAcceleration)
+	}
+
+	return nil
+}
+
+// SetJointLimits applies the given limits to the named joints and returns the result, with
+// OriginalFile re-marshalled so that the new limits reach whoever asks the machine for its
+// kinematics.
+//
+// Re-marshalling is the point of this function. KinematicModelToProtobuf does not serialize a
+// model, it replays cfg.OriginalFile.Bytes, so limits written onto the in-memory frames alone
+// would never leave the module process. This is the Go equivalent of what the UR module does by
+// hand in to_sva_json.
+//
+// cfg is not modified by this call. Model.ModelConfig hands out the live pointer rather than a
+// copy, so a caller passing it straight in would otherwise find its own model rewritten
+// underneath it. The result is not a deep copy though: it shares the Links slice, and each
+// joint's Geometry and Mimic, with cfg. Treat those as read-only through either handle.
+//
+// Re-marshalling also normalizes the document's key casing, because the axis and geometry types
+// carry no JSON tags: an axis authored as {"x":0,"y":0,"z":1} comes back as {"X":0,"Y":0,"Z":1}.
+// Go reads either, since encoding/json matches field names case-insensitively, but a consumer
+// parsing case-sensitively sees a different shape than the module author wrote.
+//
+// It returns an error for a URDF-backed document. Go could convert one to SVA, but the C++ and
+// Python SDKs hold kinematics as opaque bytes and cannot, and a helper that quietly does more in
+// one language than the others is worse than one that refuses everywhere. Declaring limits in a
+// URDF is RSDK-14232.
+func SetJointLimits(cfg *ModelConfigJSON, limits map[string]JointLimits) (*ModelConfigJSON, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("cannot set joint limits on a nil model config")
+	}
+	if cfg.OriginalFile != nil && cfg.OriginalFile.Extension == "urdf" {
+		return nil, ErrURDFLimitsUnsupported
+	}
+	if cfg.KinParamType == "DH" {
+		return nil, fmt.Errorf(
+			"cannot set joint limits on model %q: DH kinematics describe joints as parameters rather "+
+				"than as joints with limits", cfg.Name)
+	}
+
+	// Joints is the only field we write, so it is the only one that needs its own copy. Clearing
+	// OriginalFile matters more than it looks: marshaling with it still set would nest the old
+	// document inside the new one, and parsing that back would restore the pre-patch bytes.
+	out := *cfg
+	out.Joints = slices.Clone(cfg.Joints)
+	out.OriginalFile = nil
+
+	for id, limit := range limits {
+		if err := limit.validate(id); err != nil {
+			return nil, err
+		}
+
+		idx := slices.IndexFunc(out.Joints, func(j JointConfig) bool { return j.ID == id })
+		if idx < 0 {
+			return nil, fmt.Errorf("no joint %q in kinematics for model %q", id, cfg.Name)
+		}
+
+		joint := &out.Joints[idx]
+
+		// A mimic joint takes its limits from whatever drives it, and parsing rejects one that
+		// declares its own. Without this check we would emit a document that no consumer can
+		// read back, which is a worse failure than refusing here.
+		if joint.Mimic != nil {
+			return nil, fmt.Errorf("%w: joint %q", ErrMimicWithLimits, id)
+		}
+
+		if limit.Min != nil {
+			joint.Min = *limit.Min
+		}
+		if limit.Max != nil {
+			joint.Max = *limit.Max
+		}
+		if limit.MaxVelocity != nil {
+			joint.MaxVelocity = limitPtr(limit.MaxVelocity, nil)
+		}
+		if limit.MaxAcceleration != nil {
+			joint.MaxAcceleration = limitPtr(limit.MaxAcceleration, nil)
+		}
+
+		// Min and Max move independently so that a caller can pin a joint without restating the
+		// other side, which means the pair can be left crossed. A joint with an empty range is
+		// not something a planner can work with, and randomFrameInputs would hand back positions
+		// outside both bounds rather than fail.
+		if joint.Min > joint.Max {
+			return nil, fmt.Errorf("joint %q: min %v is greater than max %v after applying limits",
+				id, joint.Min, joint.Max)
+		}
+	}
+
+	raw, err := json.Marshal(&out)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling patched kinematics for model %q: %w", cfg.Name, err)
+	}
+
+	// These bytes are the whole product: they are what GetKinematics sends and what every
+	// consumer reads. Parsing them here turns any way of emitting a broken document into an
+	// error the module author sees, rather than one the far end of the connection discovers.
+	if _, err := UnmarshalModelJSON(raw, cfg.Name); err != nil {
+		return nil, fmt.Errorf("patched kinematics for model %q no longer parses: %w", cfg.Name, err)
+	}
+	out.OriginalFile = &ModelFile{Bytes: raw, Extension: "json"}
+
+	return &out, nil
+}

--- a/referenceframe/limits_test.go
+++ b/referenceframe/limits_test.go
@@ -1,0 +1,263 @@
+package referenceframe
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/utils"
+)
+
+// twoJointModelJSON is a small SVA document with two revolute joints, so tests can check that
+// only the named joint moves.
+const twoJointModelJSON = `{
+  "name": "arm",
+  "kinematic_param_type": "SVA",
+  "links": [
+    {"id": "base", "parent": "world"},
+    {"id": "mid", "parent": "j1"},
+    {"id": "tcp", "parent": "j2"}
+  ],
+  "joints": [
+    {"id": "j1", "type": "revolute", "parent": "base", "axis": {"x": 0, "y": 0, "z": 1},
+     "min": -360, "max": 360},
+    {"id": "j2", "type": "revolute", "parent": "mid", "axis": {"x": 0, "y": 0, "z": 1},
+     "min": -180, "max": 180, "max_velocity": 90}
+  ]
+}`
+
+func parseTwoJointConfig(t *testing.T) *ModelConfigJSON {
+	t.Helper()
+	m, err := UnmarshalModelJSON([]byte(twoJointModelJSON), "")
+	test.That(t, err, test.ShouldBeNil)
+	return m.ModelConfig()
+}
+
+// The property the whole module boundary rests on: the limits have to be in the bytes, because
+// that is what KinematicModelToProtobuf sends. Asserting on the returned config's frames would
+// pass even if the document were never patched.
+func TestSetJointLimitsReachesTheBytes(t *testing.T) {
+	cfg := parseTwoJointConfig(t)
+
+	patched, err := SetJointLimits(cfg, map[string]JointLimits{
+		"j1": {MaxVelocity: ptr(180.0), MaxAcceleration: ptr(1145.0)},
+	})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, patched.OriginalFile, test.ShouldNotBeNil)
+	test.That(t, patched.OriginalFile.Extension, test.ShouldEqual, "json")
+
+	// re-parse the emitted document, the way viam-server does after GetKinematics
+	reparsed, err := UnmarshalModelJSON(patched.OriginalFile.Bytes, "")
+	test.That(t, err, test.ShouldBeNil)
+
+	limits := reparsed.DoF()
+	test.That(t, limits, test.ShouldHaveLength, 2)
+	test.That(t, *limits[0].MaxVelocity, test.ShouldAlmostEqual, math.Pi, defaultFloatPrecision)
+	test.That(t, *limits[0].MaxAcceleration, test.ShouldAlmostEqual, utils.DegToRad(1145), defaultFloatPrecision)
+
+	// and it survives the trip out to a client
+	resp := KinematicModelToProtobuf(reparsed)
+	rebuilt, err := KinematicModelFromProtobuf("arm", resp)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, limitsAlmostEqual(rebuilt.DoF(), reparsed.DoF(), defaultFloatPrecision), test.ShouldBeTrue)
+}
+
+// Marshaling without clearing OriginalFile first would nest the old document inside the new one,
+// and parsing that back would hand you the pre-patch bytes.
+func TestSetJointLimitsDoesNotNestTheOldDocument(t *testing.T) {
+	cfg := parseTwoJointConfig(t)
+
+	patched, err := SetJointLimits(cfg, map[string]JointLimits{"j1": {MaxVelocity: ptr(180.0)}})
+	test.That(t, err, test.ShouldBeNil)
+
+	var doc map[string]json.RawMessage
+	test.That(t, json.Unmarshal(patched.OriginalFile.Bytes, &doc), test.ShouldBeNil)
+	_, nested := doc["original_file"]
+	test.That(t, nested, test.ShouldBeFalse)
+}
+
+func TestSetJointLimitsIsAPartialUpdate(t *testing.T) {
+	cfg := parseTwoJointConfig(t)
+
+	patched, err := SetJointLimits(cfg, map[string]JointLimits{"j2": {MaxAcceleration: ptr(500.0)}})
+	test.That(t, err, test.ShouldBeNil)
+
+	j2 := patched.Joints[1]
+	test.That(t, j2.Min, test.ShouldEqual, -180.0)
+	test.That(t, j2.Max, test.ShouldEqual, 180.0)
+	test.That(t, *j2.MaxVelocity, test.ShouldEqual, 90.0) // was already set, untouched
+	test.That(t, *j2.MaxAcceleration, test.ShouldEqual, 500.0)
+
+	// the joint nobody named is untouched
+	test.That(t, patched.Joints[0].MaxVelocity, test.ShouldBeNil)
+
+	t.Run("position can be set through the same call", func(t *testing.T) {
+		locked, err := SetJointLimits(cfg, map[string]JointLimits{
+			"j1": {Min: ptr(-1.0), Max: ptr(1.0)},
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, locked.Joints[0].Min, test.ShouldEqual, -1.0)
+		test.That(t, locked.Joints[0].Max, test.ShouldEqual, 1.0)
+	})
+
+	t.Run("an explicit zero velocity is applied, not treated as unset", func(t *testing.T) {
+		frozen, err := SetJointLimits(cfg, map[string]JointLimits{"j1": {MaxVelocity: ptr(0.0)}})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, frozen.Joints[0].MaxVelocity, test.ShouldNotBeNil)
+		test.That(t, *frozen.Joints[0].MaxVelocity, test.ShouldEqual, 0.0)
+	})
+}
+
+// ModelConfig hands out the live pointer, so a caller passing it straight in must not find its
+// own model rewritten.
+func TestSetJointLimitsLeavesTheInputAlone(t *testing.T) {
+	m, err := UnmarshalModelJSON([]byte(twoJointModelJSON), "")
+	test.That(t, err, test.ShouldBeNil)
+	cfg := m.ModelConfig()
+	originalBytes := append([]byte(nil), cfg.OriginalFile.Bytes...)
+
+	_, err = SetJointLimits(cfg, map[string]JointLimits{
+		"j1": {Min: ptr(-1.0), Max: ptr(1.0), MaxVelocity: ptr(180.0)},
+	})
+	test.That(t, err, test.ShouldBeNil)
+
+	test.That(t, cfg.Joints[0].MaxVelocity, test.ShouldBeNil)
+	test.That(t, cfg.Joints[0].Min, test.ShouldEqual, -360.0)
+	test.That(t, cfg.OriginalFile.Bytes, test.ShouldResemble, originalBytes)
+
+	// and the model those came from still reports what it always did
+	test.That(t, m.DoF()[0].MaxVelocity, test.ShouldBeNil)
+	test.That(t, m.DoF()[0].Min, test.ShouldAlmostEqual, utils.DegToRad(-360), defaultFloatPrecision)
+}
+
+func TestSetJointLimitsErrors(t *testing.T) {
+	t.Run("nil config", func(t *testing.T) {
+		_, err := SetJointLimits(nil, map[string]JointLimits{"j1": {}})
+		test.That(t, err, test.ShouldNotBeNil)
+	})
+
+	t.Run("unknown joint", func(t *testing.T) {
+		cfg := parseTwoJointConfig(t)
+		_, err := SetJointLimits(cfg, map[string]JointLimits{"nope": {MaxVelocity: ptr(1.0)}})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, `no joint "nope"`)
+	})
+
+	// A mimic joint's limits come from whatever drives it, and parsing rejects one that declares
+	// its own. Emitting such a document would produce bytes no consumer can read, which is worse
+	// than refusing.
+	t.Run("mimic joint", func(t *testing.T) {
+		m, err := ParseModelJSONFile("testfiles/test_mimic_gripper.json", "")
+		test.That(t, err, test.ShouldBeNil)
+
+		cfg := m.ModelConfig()
+		var mimicID string
+		for _, joint := range cfg.Joints {
+			if joint.Mimic != nil {
+				mimicID = joint.ID
+				break
+			}
+		}
+		test.That(t, mimicID, test.ShouldNotBeBlank)
+
+		_, err = SetJointLimits(cfg, map[string]JointLimits{mimicID: {MaxVelocity: ptr(90.0)}})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, ErrMimicWithLimits.Error())
+
+		// the joints a mimic does not drive are still fair game
+		patched, err := SetJointLimits(cfg, map[string]JointLimits{"left_joint": {MaxVelocity: ptr(90.0)}})
+		test.That(t, err, test.ShouldBeNil)
+		_, err = UnmarshalModelJSON(patched.OriginalFile.Bytes, "")
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	// These come straight from a user's resource config in the documented use case, so a typo
+	// has to stop here rather than become a limit the motion service plans against.
+	t.Run("values that cannot describe a joint", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			limit JointLimits
+			want  string
+		}{
+			{"negative velocity", JointLimits{MaxVelocity: ptr(-50.0)}, "cannot be negative"},
+			{"negative acceleration", JointLimits{MaxAcceleration: ptr(-1.0)}, "cannot be negative"},
+			{"infinite velocity", JointLimits{MaxVelocity: ptr(math.Inf(1))}, "must be a finite number"},
+			{"infinite min", JointLimits{Min: ptr(math.Inf(-1))}, "must be a finite number"},
+			{"NaN acceleration", JointLimits{MaxAcceleration: ptr(math.NaN())}, "must be a finite number"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				cfg := parseTwoJointConfig(t)
+				_, err := SetJointLimits(cfg, map[string]JointLimits{"j1": tc.limit})
+				test.That(t, err, test.ShouldNotBeNil)
+				test.That(t, err.Error(), test.ShouldContainSubstring, tc.want)
+			})
+		}
+	})
+
+	// Min and Max move independently so a joint can be pinned without restating the other side,
+	// which means a partial update can leave them crossed.
+	t.Run("min above max", func(t *testing.T) {
+		cfg := parseTwoJointConfig(t)
+
+		// j1 runs -360 to 360, so raising min alone past 360 empties its range
+		_, err := SetJointLimits(cfg, map[string]JointLimits{"j1": {Min: ptr(400.0)}})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "greater than max")
+
+		// setting both is fine
+		patched, err := SetJointLimits(cfg, map[string]JointLimits{"j1": {Min: ptr(400.0), Max: ptr(450.0)}})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, patched.Joints[0].Min, test.ShouldEqual, 400.0)
+	})
+
+	t.Run("DH config", func(t *testing.T) {
+		m, err := ParseModelJSONFile("testfiles/ur5eDH.json", "")
+		test.That(t, err, test.ShouldBeNil)
+
+		_, err = SetJointLimits(m.ModelConfig(), map[string]JointLimits{"q_0": {MaxVelocity: ptr(90.0)}})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "DH kinematics")
+	})
+
+	// A URDF-backed arm ships a URDF for its meshes. Converting it to SVA to attach limits is
+	// something only the Go SDK could do, so the helper refuses everywhere instead.
+	t.Run("urdf backed config", func(t *testing.T) {
+		cfg := parseTwoJointConfig(t)
+		cfg.OriginalFile = &ModelFile{Bytes: []byte("<robot/>"), Extension: "urdf"}
+
+		_, err := SetJointLimits(cfg, map[string]JointLimits{"j1": {MaxVelocity: ptr(1.0)}})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "RSDK-14232")
+	})
+}
+
+// What a module actually does: take speeds out of its own config, put them on every joint, and
+// serve the result. Ends with the check a trajectory generator makes.
+func TestSetJointLimitsWholeArm(t *testing.T) {
+	cfg := parseTwoJointConfig(t)
+
+	const speedDegsPerSec, accelDegsPerSec2 = 180.0, 1145.0
+	limits := map[string]JointLimits{}
+	for _, joint := range cfg.Joints {
+		limits[joint.ID] = JointLimits{
+			MaxVelocity:     ptr(speedDegsPerSec),
+			MaxAcceleration: ptr(accelDegsPerSec2),
+		}
+	}
+
+	patched, err := SetJointLimits(cfg, limits)
+	test.That(t, err, test.ShouldBeNil)
+
+	served, err := UnmarshalModelJSON(patched.OriginalFile.Bytes, "")
+	test.That(t, err, test.ShouldBeNil)
+
+	vels, accs, ok := TrajectoryLimits(served.DoF())
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, vels, test.ShouldHaveLength, 2)
+	for i := range vels {
+		test.That(t, vels[i], test.ShouldAlmostEqual, utils.DegToRad(speedDegsPerSec), defaultFloatPrecision)
+		test.That(t, accs[i], test.ShouldAlmostEqual, utils.DegToRad(accelDegsPerSec2), defaultFloatPrecision)
+	}
+}


### PR DESCRIPTION
## Summary

Modules that know their own speed limits need a way to get them into the kinematics document they serve, because that document is what actually crosses the module boundary. `KinematicModelToProtobuf` does not serialize a model, it replays `cfg.OriginalFile.Bytes`, so limits written onto the in-memory frames alone never leave the module process.

```go
type JointLimits struct{ Min, Max, MaxVelocity, MaxAcceleration *float64 }

func SetJointLimits(cfg *ModelConfigJSON, limits map[string]JointLimits) (*ModelConfigJSON, error)
```

This is the Go equivalent of what the UR module does by hand in `to_sva_json`. Ticket 2 of [RSDK-14385](https://viam.atlassian.net/browse/RSDK-14385), on top of #6361 ([RSDK-14418](https://viam.atlassian.net/browse/RSDK-14418)) which added the fields this patches.

## Design notes

**Keyed by joint ID, not positional.** A slice indexed by DoF order is silently transposable — swap two joints on a six-axis arm and nothing errors, tests with similar limits still pass, and the hardware moves wrong.

**Every field is a pointer**, so a caller who knows only how fast a joint may move can say that without restating where it may go. Including `Min`/`Max` lets a module do a joint-locking patch through the same call rather than hand-rolling the re-marshal.

**Values are in document units** — degrees and deg/s for revolute, mm for prismatic — not internal radians. A module reading `speed_degs_per_sec` out of its own config is already holding degrees, and this edits a document.

**It refuses a URDF-backed document.** Go *could* convert one to SVA, and the meshes would survive as inline base64, but the C++ and Python SDKs hold kinematics as opaque bytes and would have to reimplement the URDF parser, the disk mesh loader, decimation, and PLY conversion to do the same. A helper that quietly does more in one language than the others is worse than one that refuses everywhere. Declaring limits in a URDF is RSDK-14232.

**The input config is left alone.** `Model.ModelConfig` hands out the live pointer rather than a copy, so a caller passing it straight in would otherwise find its own model rewritten underneath it.

**Clearing `OriginalFile` before marshaling is load-bearing, not tidiness.** Leaving it set nests the old document inside the new one under `original_file`, and parsing that back restores the pre-patch bytes — silently undoing the whole exercise. There is a test asserting the key is absent.

## Testing

Eight cases in `referenceframe/limits_test.go`. The two that matter most:

- **The limits are in the bytes.** Re-parses `patched.OriginalFile.Bytes` the way viam-server does after `GetKinematics`, then pushes it through `KinematicModelToProtobuf` out to a client. Asserting on the returned config's frames would pass even if the document were never patched, which is the bug this function exists to prevent.
- **Whole-arm flow**, the path a module will take: read a speed out of config, apply it to every joint, serve the result, and confirm `TrajectoryLimits` accepts it.

Plus partial updates, explicit-zero velocity, input immutability including the source `Model`, unknown joint IDs, and the URDF refusal.

`referenceframe` suite and `make lint-go` clean.

## Next

Ticket 3 wires this into ufactory xarm, which is what satisfies the scope's done-criteria of limits set in an arm's resource config arriving intact on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[RSDK-14385]: https://viam.atlassian.net/browse/RSDK-14385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RSDK-14418]: https://viam.atlassian.net/browse/RSDK-14418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ