### PR TITLE
spatialmath: speed up mesh collision checking for motion planning

### DIFF
--- a/spatialmath/bvh.go
+++ b/spatialmath/bvh.go
@@ -26,6 +26,18 @@ type bvhNode struct {
 // linear scans at leaves, large enough to avoid excessive tree overhead.
 const maxGeomsPerLeaf = 4
 
+// bvhDistanceRefinementCapMM caps how far the branch-and-bound collision
+// traversals refine the no-collision distance they report. Seeding best with
+// the cap prunes every subtree pair separated by at least this much at the
+// root — the traversal then costs about the same as a pure overlap walk —
+// while pairs closer than the cap get a true minimum distance. The reported
+// value is always a valid lower bound: "cap" means "at least cap apart".
+// Distances beyond the cap have little marginal value to the consumers (the
+// distAnchors cache and the planner's interpolation skip logic), but refining
+// them exactly is what made an uncapped traversal visit large swaths of both
+// trees near big flat geometry.
+const bvhDistanceRefinementCapMM = 25.0
+
 type geometryCentroidSorter struct {
 	geoms     []Geometry
 	centroids []r3.Vector
@@ -317,7 +329,9 @@ func expandAABBBuffer(minPt, maxPt r3.Vector, buffer float64) (r3.Vector, r3.Vec
 // bvhCollidesWithBVH checks if two BVH trees collide, using the given poses to transform them.
 // The BVH nodes store geometries in local space; poses are applied lazily during traversal.
 func bvhCollidesWithBVH(node1, node2 *bvhNode, pose1, pose2 Pose, collisionBufferMM float64) (bool, float64, error) {
-	collides, dist, _, err := bvhCollidesWithBVHTracked(node1, node2, pose1, pose2, collisionBufferMM)
+	pc1 := newBVHPoseCache(pose1)
+	pc2 := newBVHPoseCache(pose2)
+	collides, dist, _, err := bvhCollidesWithBVHTracked(node1, node2, &pc1, &pc2, collisionBufferMM)
 	return collides, dist, err
 }
 
@@ -327,142 +341,123 @@ func bvhCollidesWithBVH(node1, node2 *bvhNode, pose1, pose2 Pose, collisionBuffe
 // coherence cache so subsequent queries with nearby poses can re-check the same
 // pair directly and skip the BVH entirely. witness is the zero value when no
 // collision is found or when the colliding geometries weren't both Triangles.
-func bvhCollidesWithBVHTracked(node1, node2 *bvhNode, pose1, pose2 Pose, collisionBufferMM float64) (bool, float64, [2]*Triangle, error) {
+func bvhCollidesWithBVHTracked(
+	node1, node2 *bvhNode, pc1, pc2 *bvhPoseCache, collisionBufferMM float64,
+) (bool, float64, [2]*Triangle, error) {
 	var witness [2]*Triangle
 	if node1 == nil || node2 == nil {
 		return false, math.Inf(1), witness, nil
 	}
 
-	pc1 := newBVHPoseCache(pose1)
-	pc2 := newBVHPoseCache(pose2)
-
-	min1, max1 := transformAABBCached(node1.min, node1.max, &pc1)
+	min1, max1 := transformAABBCached(node1.min, node1.max, pc1)
 	min1, max1 = expandAABBBuffer(min1, max1, collisionBufferMM)
-	min2, max2 := transformAABBCached(node2.min, node2.max, &pc2)
+	min2, max2 := transformAABBCached(node2.min, node2.max, pc2)
 
-	collides, dist, err := bvhCollidesWithBVHRec(node1, min1, max1, node2, min2, max2, &pc1, &pc2, collisionBufferMM, &witness)
-	return collides, dist, witness, err
+	best := math.Max(bvhDistanceRefinementCapMM, 2*collisionBufferMM)
+	collides, err := bvhCollidesWithBVHRec(node1, min1, max1, node2, min2, max2, pc1, pc2, collisionBufferMM, &witness, &best)
+	if collides {
+		return true, -1, witness, err
+	}
+	// The root AABB gap is free and tight at long range, where the capped
+	// traversal reports only "at least the cap"; both are valid lower bounds.
+	return false, math.Max(best, aabbDistance(min1, max1, min2, max2)), witness, err
 }
 
-// bvhCollidesWithBVHRec is the recursive worker for bvhCollidesWithBVH.
+// bvhCollidesWithBVHRec is the recursive worker for bvhCollidesWithBVHTracked:
+// a branch-and-bound minimum-distance traversal. *best carries the tightest
+// leaf distance found so far; subtree pairs whose world-space AABB distance
+// can't beat it are pruned, and closer child pairs are visited first so *best
+// tightens early. A leaf pair within the collision buffer returns collision
+// immediately.
+//
+// Unlike the previous overlap-only traversal (whose no-collision distance was
+// the loose minimum over pruned AABB gaps), this returns the true minimum
+// distance via *best. That value feeds the meshState.distAnchors cache and the
+// planner's interpolation skip logic — a tight distance lets both skip far more
+// subsequent work, which pays for the extra nodes this traversal visits.
+//
 // Caller invariants:
 //   - min1/max1 is node1's world-space AABB pre-expanded by collisionBufferMM.
 //   - min2/max2 is node2's world-space AABB (unexpanded).
-//
-// This lets each node's AABB be transformed exactly once across the traversal,
-// instead of recomputing both AABBs at every recursive entry.
 func bvhCollidesWithBVHRec(
 	node1 *bvhNode, min1, max1 r3.Vector,
 	node2 *bvhNode, min2, max2 r3.Vector,
 	pc1, pc2 *bvhPoseCache,
 	collisionBufferMM float64,
 	witness *[2]*Triangle,
-) (bool, float64, error) {
-	if !aabbOverlap(min1, max1, min2, max2) {
-		return false, aabbDistance(min1, max1, min2, max2), nil
+	best *float64,
+) (bool, error) {
+	if aabbDistance(min1, max1, min2, max2) >= *best {
+		return false, nil
 	}
 
 	if node1.geoms != nil && node2.geoms != nil {
-		return leafCollidesWithLeaf(node1.geoms, node2.geoms, pc1.pose, pc2.pose, collisionBufferMM, witness)
+		collides, dist, err := leafCollidesWithLeaf(node1.geoms, node2.geoms, pc1.pose, pc2.pose, collisionBufferMM, witness, *best)
+		if err != nil || collides {
+			return collides, err
+		}
+		if dist < *best {
+			*best = dist
+		}
+		return false, nil
 	}
 
-	if node1.geoms != nil {
-		// node1 is leaf; transform node2's children once at this level.
-		l2Min, l2Max := transformAABBCached(node2.left.min, node2.left.max, pc2)
-		leftCollide, leftDist, err := bvhCollidesWithBVHRec(node1, min1, max1, node2.left, l2Min, l2Max, pc1, pc2, collisionBufferMM, witness)
-		if err != nil {
-			return false, 0, err
-		}
-		if leftCollide {
-			return true, leftDist, nil
-		}
-		r2Min, r2Max := transformAABBCached(node2.right.min, node2.right.max, pc2)
-		rightCollide, rightDist, err := bvhCollidesWithBVHRec(node1, min1, max1, node2.right, r2Min, r2Max, pc1, pc2, collisionBufferMM, witness)
-		if err != nil {
-			return false, 0, err
-		}
-		if rightCollide {
-			return true, rightDist, nil
-		}
-		return false, math.Min(leftDist, rightDist), nil
-	}
-
-	if node2.geoms != nil {
-		// node2 is leaf; transform node1's children once at this level.
-		l1Min, l1Max := transformAABBCached(node1.left.min, node1.left.max, pc1)
-		l1Min, l1Max = expandAABBBuffer(l1Min, l1Max, collisionBufferMM)
-		leftCollide, leftDist, err := bvhCollidesWithBVHRec(node1.left, l1Min, l1Max, node2, min2, max2, pc1, pc2, collisionBufferMM, witness)
-		if err != nil {
-			return false, 0, err
-		}
-		if leftCollide {
-			return true, leftDist, nil
-		}
-		r1Min, r1Max := transformAABBCached(node1.right.min, node1.right.max, pc1)
-		r1Min, r1Max = expandAABBBuffer(r1Min, r1Max, collisionBufferMM)
-		rightCollide, rightDist, err := bvhCollidesWithBVHRec(node1.right, r1Min, r1Max, node2, min2, max2, pc1, pc2, collisionBufferMM, witness)
-		if err != nil {
-			return false, 0, err
-		}
-		if rightCollide {
-			return true, rightDist, nil
-		}
-		return false, math.Min(leftDist, rightDist), nil
-	}
-
-	// Both internal: transform all 4 children once, then evaluate overlapping pairs
-	// first so collision short-circuits don't get blocked by guaranteed-miss pairs.
-	// Non-overlapping pairs need not recurse — their AABB distance is the best info
-	// available and feeds the minDist return.
-	lmin1, lmax1 := transformAABBCached(node1.left.min, node1.left.max, pc1)
-	lmin1, lmax1 = expandAABBBuffer(lmin1, lmax1, collisionBufferMM)
-	rmin1, rmax1 := transformAABBCached(node1.right.min, node1.right.max, pc1)
-	rmin1, rmax1 = expandAABBBuffer(rmin1, rmax1, collisionBufferMM)
-	lmin2, lmax2 := transformAABBCached(node2.left.min, node2.left.max, pc2)
-	rmin2, rmax2 := transformAABBCached(node2.right.min, node2.right.max, pc2)
-
+	// Split the internal side(s) into child pairs, transforming each child AABB once.
 	type pairEntry struct {
 		n1, n2                     *bvhNode
 		pMin1, pMax1, pMin2, pMax2 r3.Vector
-		overlap                    bool
+		d                          float64
 	}
-	pairs := [4]pairEntry{
-		{node1.left, node2.left, lmin1, lmax1, lmin2, lmax2, aabbOverlap(lmin1, lmax1, lmin2, lmax2)},
-		{node1.left, node2.right, lmin1, lmax1, rmin2, rmax2, aabbOverlap(lmin1, lmax1, rmin2, rmax2)},
-		{node1.right, node2.left, rmin1, rmax1, lmin2, lmax2, aabbOverlap(rmin1, rmax1, lmin2, lmax2)},
-		{node1.right, node2.right, rmin1, rmax1, rmin2, rmax2, aabbOverlap(rmin1, rmax1, rmin2, rmax2)},
+	var pairs [4]pairEntry
+	n := 0
+	add := func(a *bvhNode, aMin, aMax r3.Vector, b *bvhNode, bMin, bMax r3.Vector) {
+		pairs[n] = pairEntry{a, b, aMin, aMax, bMin, bMax, aabbDistance(aMin, aMax, bMin, bMax)}
+		n++
+	}
+	switch {
+	case node1.geoms != nil: // node1 is leaf; split node2.
+		l2Min, l2Max := transformAABBCached(node2.left.min, node2.left.max, pc2)
+		r2Min, r2Max := transformAABBCached(node2.right.min, node2.right.max, pc2)
+		add(node1, min1, max1, node2.left, l2Min, l2Max)
+		add(node1, min1, max1, node2.right, r2Min, r2Max)
+	case node2.geoms != nil: // node2 is leaf; split node1.
+		l1Min, l1Max := transformAABBCached(node1.left.min, node1.left.max, pc1)
+		l1Min, l1Max = expandAABBBuffer(l1Min, l1Max, collisionBufferMM)
+		r1Min, r1Max := transformAABBCached(node1.right.min, node1.right.max, pc1)
+		r1Min, r1Max = expandAABBBuffer(r1Min, r1Max, collisionBufferMM)
+		add(node1.left, l1Min, l1Max, node2, min2, max2)
+		add(node1.right, r1Min, r1Max, node2, min2, max2)
+	default: // Both internal: all 4 child pairs.
+		lmin1, lmax1 := transformAABBCached(node1.left.min, node1.left.max, pc1)
+		lmin1, lmax1 = expandAABBBuffer(lmin1, lmax1, collisionBufferMM)
+		rmin1, rmax1 := transformAABBCached(node1.right.min, node1.right.max, pc1)
+		rmin1, rmax1 = expandAABBBuffer(rmin1, rmax1, collisionBufferMM)
+		lmin2, lmax2 := transformAABBCached(node2.left.min, node2.left.max, pc2)
+		rmin2, rmax2 := transformAABBCached(node2.right.min, node2.right.max, pc2)
+		add(node1.left, lmin1, lmax1, node2.left, lmin2, lmax2)
+		add(node1.left, lmin1, lmax1, node2.right, rmin2, rmax2)
+		add(node1.right, rmin1, rmax1, node2.left, lmin2, lmax2)
+		add(node1.right, rmin1, rmax1, node2.right, rmin2, rmax2)
 	}
 
-	minDist := math.Inf(1)
-	// First pass: recurse only into overlapping pairs (where collisions are possible).
-	for i := range pairs {
-		p := &pairs[i]
-		if !p.overlap {
-			continue
-		}
-		collide, dist, err := bvhCollidesWithBVHRec(p.n1, p.pMin1, p.pMax1, p.n2, p.pMin2, p.pMax2, pc1, pc2, collisionBufferMM, witness)
-		if err != nil {
-			return false, 0, err
-		}
-		if collide {
-			return true, dist, nil
-		}
-		if dist < minDist {
-			minDist = dist
+	// Visit closest pairs first — tightening *best early maximizes pruning.
+	// Insertion sort; n ≤ 4.
+	for i := 1; i < n; i++ {
+		for j := i; j > 0 && pairs[j].d < pairs[j-1].d; j-- {
+			pairs[j], pairs[j-1] = pairs[j-1], pairs[j]
 		}
 	}
-	// Second pass: non-overlapping pairs contribute only to minDist.
-	for i := range pairs {
+	for i := 0; i < n; i++ {
 		p := &pairs[i]
-		if p.overlap {
-			continue
+		if p.d >= *best {
+			break // sorted: no later pair can improve either
 		}
-		dist := aabbDistance(p.pMin1, p.pMax1, p.pMin2, p.pMax2)
-		if dist < minDist {
-			minDist = dist
+		collides, err := bvhCollidesWithBVHRec(p.n1, p.pMin1, p.pMax1, p.n2, p.pMin2, p.pMax2, pc1, pc2, collisionBufferMM, witness, best)
+		if err != nil || collides {
+			return collides, err
 		}
 	}
-	return false, minDist, nil
+	return false, nil
 }
 
 // leafCollidesWithLeaf performs collision checks between two leaf nodes using the Geometry interface.
@@ -471,14 +466,14 @@ func bvhCollidesWithBVHRec(
 // are recorded — but only when both are *Triangle, which is the only case (*Mesh).collidesWithMesh
 // uses the cache for.
 func leafCollidesWithLeaf(
-	geoms1, geoms2 []Geometry, pose1, pose2 Pose, collisionBufferMM float64, witness *[2]*Triangle,
+	geoms1, geoms2 []Geometry, pose1, pose2 Pose, collisionBufferMM float64, witness *[2]*Triangle, upperBound float64,
 ) (bool, float64, error) {
 	// Fast path: triangle-triangle leaves (the dominant case for Mesh-Mesh checks).
 	// Transforms triangles into stack-allocated Triangle values instead of allocating
 	// a new *Triangle per Geometry.Transform call. Eliminates ~8 heap allocations per
 	// leaf pair in the hot path.
 	if allLeafTriangles(geoms1) && allLeafTriangles(geoms2) {
-		return triangleLeafCollide(geoms1, geoms2, pose1, pose2, collisionBufferMM, witness)
+		return triangleLeafCollide(geoms1, geoms2, pose1, pose2, collisionBufferMM, witness, upperBound)
 	}
 
 	minDist := math.Inf(1)
@@ -535,8 +530,11 @@ func allLeafTriangles(geoms []Geometry) bool {
 // avoids the *Triangle allocation that Triangle.Transform performs.
 // When witness != nil, records the local-space colliding pair so (*Mesh).collidesWithMesh
 // can re-check it directly on subsequent queries with similar poses.
+// upperBound seeds the pre-filter: triangle pairs that can't get closer than the
+// caller's best-so-far distance are skipped outright, since neither the collision
+// verdict nor the returned minimum can improve on them.
 func triangleLeafCollide(
-	geoms1, geoms2 []Geometry, pose1, pose2 Pose, collisionBufferMM float64, witness *[2]*Triangle,
+	geoms1, geoms2 []Geometry, pose1, pose2 Pose, collisionBufferMM float64, witness *[2]*Triangle, upperBound float64,
 ) (bool, float64, error) {
 	q1 := pose1.Orientation().Quaternion()
 	t1 := pose1.Point()
@@ -565,7 +563,7 @@ func triangleLeafCollide(
 		t2Min[i], t2Max[i] = triAABB(&worldT2s[i])
 	}
 
-	minDist := math.Inf(1)
+	minDist := upperBound * upperBound
 	for _, g1 := range geoms1 {
 		tri1 := g1.(*Triangle)
 		worldT1 := Triangle{
@@ -700,44 +698,45 @@ func bvhDistanceFromBVH(node1, node2 *bvhNode, pose1, pose2 Pose) (float64, erro
 // nearby poses can re-check the same triangle directly and skip the BVH entirely.
 func bvhCollidesWithGeometryTracked(
 	node *bvhNode,
-	bvhPose Pose,
+	pc *bvhPoseCache,
 	other Geometry,
 	otherMin,
 	otherMax r3.Vector,
 	buffer float64,
 ) (bool, float64, *Triangle, error) {
 	var witness *Triangle
-	collides, dist, err := bvhCollidesWithGeometryRec(node, bvhPose, other, otherMin, otherMax, buffer, &witness)
-	return collides, dist, witness, err
+	if node == nil {
+		return false, math.Inf(1), witness, nil
+	}
+	nodeMin, nodeMax := transformAABBCached(node.min, node.max, pc)
+	nodeMin, nodeMax = expandAABBBuffer(nodeMin, nodeMax, buffer)
+	best := math.Max(bvhDistanceRefinementCapMM, 2*buffer)
+	collides, err := bvhCollidesWithGeometryRec(node, nodeMin, nodeMax, pc, other, otherMin, otherMax, buffer, &witness, &best)
+	if collides {
+		return true, -1, witness, err
+	}
+	// The root AABB gap is free and tight at long range, where the capped
+	// traversal reports only "at least the cap"; both are valid lower bounds.
+	return false, math.Max(best, aabbDistance(nodeMin, nodeMax, otherMin, otherMax)), witness, err
 }
 
+// bvhCollidesWithGeometryRec is a branch-and-bound minimum-distance traversal;
+// see bvhCollidesWithBVHRec for the rationale. *best carries the tightest leaf
+// distance so far; nodes whose buffered world AABB can't beat it are pruned,
+// and the closer child is visited first. nodeMin/nodeMax is node's world-space
+// AABB pre-expanded by buffer.
 func bvhCollidesWithGeometryRec(
-	node *bvhNode,
-	bvhPose Pose,
+	node *bvhNode, nodeMin, nodeMax r3.Vector,
+	pc *bvhPoseCache,
 	other Geometry,
 	otherMin,
 	otherMax r3.Vector,
 	buffer float64,
 	witness **Triangle,
-) (bool, float64, error) {
-	if node == nil {
-		return false, math.Inf(1), nil
-	}
-
-	// Transform node AABB to world space
-	nodeMin, nodeMax := transformAABB(node.min, node.max, bvhPose)
-
-	// Expand node AABB by buffer
-	nodeMin.X -= buffer
-	nodeMin.Y -= buffer
-	nodeMin.Z -= buffer
-	nodeMax.X += buffer
-	nodeMax.Y += buffer
-	nodeMax.Z += buffer
-
-	// Early exit if AABBs don't overlap
-	if !aabbOverlap(nodeMin, nodeMax, otherMin, otherMax) {
-		return false, aabbDistance(nodeMin, nodeMax, otherMin, otherMax), nil
+	best *float64,
+) (bool, error) {
+	if aabbDistance(nodeMin, nodeMax, otherMin, otherMax) >= *best {
+		return false, nil
 	}
 
 	// Leaf node: check each geometry against other
@@ -746,9 +745,8 @@ func bvhCollidesWithGeometryRec(
 		// Triangle value so we don't allocate a *Triangle per leaf geometry
 		// (which is what g.Transform(bvhPose) would do).
 		if allLeafTriangles(node.geoms) {
-			q := bvhPose.Orientation().Quaternion()
-			trans := bvhPose.Point()
-			minDist := math.Inf(1)
+			q := pc.q
+			trans := pc.trans
 			for _, g := range node.geoms {
 				tri := g.(*Triangle)
 				worldT := Triangle{
@@ -759,48 +757,52 @@ func bvhCollidesWithGeometryRec(
 				}
 				collides, dist, err := worldT.CollidesWith(other, buffer)
 				if err != nil {
-					return false, 0, err
+					return false, err
 				}
 				if collides {
 					if witness != nil {
 						*witness = tri
 					}
-					return true, -1, nil
+					return true, nil
 				}
-				if dist < minDist {
-					minDist = dist
+				if dist < *best {
+					*best = dist
 				}
 			}
-			return false, minDist, nil
+			return false, nil
 		}
 		// Fallback: heterogeneous-leaf path with Geometry-interface dispatch.
-		minDist := math.Inf(1)
 		for _, g := range node.geoms {
-			worldG := g.Transform(bvhPose)
+			worldG := g.Transform(pc.pose)
 			collides, dist, err := worldG.CollidesWith(other, buffer)
 			if err != nil {
-				return false, 0, err
+				return false, err
 			}
 			if collides {
-				return true, -1, nil
+				return true, nil
 			}
-			if dist < minDist {
-				minDist = dist
+			if dist < *best {
+				*best = dist
 			}
 		}
-		return false, minDist, nil
+		return false, nil
 	}
 
-	// Internal node: recurse
-	leftCollide, leftDist, err := bvhCollidesWithGeometryRec(node.left, bvhPose, other, otherMin, otherMax, buffer, witness)
-	if err != nil || leftCollide {
-		return leftCollide, leftDist, err
+	// Internal node: recurse into the closer child first so *best tightens early.
+	lMin, lMax := transformAABBCached(node.left.min, node.left.max, pc)
+	lMin, lMax = expandAABBBuffer(lMin, lMax, buffer)
+	rMin, rMax := transformAABBCached(node.right.min, node.right.max, pc)
+	rMin, rMax = expandAABBBuffer(rMin, rMax, buffer)
+	first, fMin, fMax := node.left, lMin, lMax
+	second, sMin, sMax := node.right, rMin, rMax
+	if aabbDistance(rMin, rMax, otherMin, otherMax) < aabbDistance(lMin, lMax, otherMin, otherMax) {
+		first, fMin, fMax, second, sMin, sMax = second, sMin, sMax, first, fMin, fMax
 	}
-	rightCollide, rightDist, err := bvhCollidesWithGeometryRec(node.right, bvhPose, other, otherMin, otherMax, buffer, witness)
-	if err != nil || rightCollide {
-		return rightCollide, rightDist, err
+	collides, err := bvhCollidesWithGeometryRec(first, fMin, fMax, pc, other, otherMin, otherMax, buffer, witness, best)
+	if err != nil || collides {
+		return collides, err
 	}
-	return false, math.Min(leftDist, rightDist), nil
+	return bvhCollidesWithGeometryRec(second, sMin, sMax, pc, other, otherMin, otherMax, buffer, witness, best)
 }
 
 // leafDistanceFromLeaf computes the minimum distance between two sets of geometries.

--- a/spatialmath/bvh_test.go
+++ b/spatialmath/bvh_test.go
@@ -559,7 +559,8 @@ func TestLeafCollidesWithLeaf(t *testing.T) {
 			r3.Vector{X: -0.5, Y: 0.5, Z: 0},
 		)
 
-		collides, _, err := leafCollidesWithLeaf(trianglesToGeometries(tri1), trianglesToGeometries(tri2), zeroPose, zeroPose, 0, nil)
+		collides, _, err := leafCollidesWithLeaf(
+			trianglesToGeometries(tri1), trianglesToGeometries(tri2), zeroPose, zeroPose, 0, nil, math.Inf(1))
 		test.That(t, collides, test.ShouldBeTrue)
 		test.That(t, err, test.ShouldBeNil)
 	})
@@ -576,7 +577,8 @@ func TestLeafCollidesWithLeaf(t *testing.T) {
 			r3.Vector{X: 0, Y: 1, Z: 5},
 		)
 
-		collides, dist, err := leafCollidesWithLeaf(trianglesToGeometries(tri1), trianglesToGeometries(tri2), zeroPose, zeroPose, 0, nil)
+		collides, dist, err := leafCollidesWithLeaf(
+			trianglesToGeometries(tri1), trianglesToGeometries(tri2), zeroPose, zeroPose, 0, nil, math.Inf(1))
 		test.That(t, collides, test.ShouldBeFalse)
 		test.That(t, dist, test.ShouldAlmostEqual, 5, 1e-9)
 		test.That(t, err, test.ShouldBeNil)
@@ -595,12 +597,13 @@ func TestLeafCollidesWithLeaf(t *testing.T) {
 		)
 
 		// No collision without buffer
-		collides, _, err := leafCollidesWithLeaf(trianglesToGeometries(tri1), trianglesToGeometries(tri2), zeroPose, zeroPose, 0, nil)
+		collides, _, err := leafCollidesWithLeaf(
+			trianglesToGeometries(tri1), trianglesToGeometries(tri2), zeroPose, zeroPose, 0, nil, math.Inf(1))
 		test.That(t, collides, test.ShouldBeFalse)
 		test.That(t, err, test.ShouldBeNil)
 
 		// Collision with buffer
-		collides, _, err = leafCollidesWithLeaf(trianglesToGeometries(tri1), trianglesToGeometries(tri2), zeroPose, zeroPose, 1, nil)
+		collides, _, err = leafCollidesWithLeaf(trianglesToGeometries(tri1), trianglesToGeometries(tri2), zeroPose, zeroPose, 1, nil, math.Inf(1))
 		test.That(t, collides, test.ShouldBeTrue)
 		test.That(t, err, test.ShouldBeNil)
 	})

--- a/spatialmath/capsule.go
+++ b/spatialmath/capsule.go
@@ -158,6 +158,10 @@ func (c *capsule) CollidesWith(g Geometry, collisionBufferMM float64) (bool, flo
 		// Use fast collision check for box
 		col, d := capsuleVsBoxCollision(c, other, collisionBufferMM)
 		return col, d, nil
+	case *Mesh:
+		// Mesh's BVH walk (witness caching, early exit) is far cheaper than the
+		// exact per-triangle distance scan DistanceFrom would run.
+		return other.CollidesWith(c, collisionBufferMM)
 	default:
 		// For other types, distance calculation is relatively cheap
 		dist, err := c.DistanceFrom(g)
@@ -292,22 +296,24 @@ func capsuleVsBoxDistance(c *capsule, other *box) float64 {
 // IMPORTANT: meshes are not considered solid. A mesh is not guaranteed to represent an enclosed area. This will measure ONLY the distance
 // to the closest triangle in the mesh.
 func capsuleVsMeshDistance(c *capsule, other *Mesh) float64 {
+	// Distances are preserved under rigid transforms, so rather than transforming
+	// every triangle into world space (which allocates per triangle), bring the
+	// capsule's segment into the mesh's local frame once and scan the triangles
+	// where they already live.
+	inv := PoseInverse(other.pose)
+	q := inv.Orientation().Quaternion()
+	t := inv.Point()
+	segA := TransformPoint(q, t, c.segA)
+	segB := TransformPoint(q, t, c.segB)
 	lowDist := math.Inf(1)
-	for _, t := range other.triangles {
-		// Measure distance to each mesh triangle
-		// Make sure the triangle is transformed by the pose of the mesh to ensure that it is properly positioned
-		properlyPositionedTriangle := t.Transform(other.pose).(*Triangle)
-		dist := capsuleVsTriangleDistance(c, properlyPositionedTriangle)
+	for _, tri := range other.triangles {
+		capPt, triPt := ClosestPointsSegmentTriangle(segA, segB, tri)
+		dist := capPt.Sub(triPt).Norm()
 		if dist < lowDist {
 			lowDist = dist
 		}
 	}
-	return lowDist
-}
-
-func capsuleVsTriangleDistance(c *capsule, other *Triangle) float64 {
-	capPt, triPt := ClosestPointsSegmentTriangle(c.segA, c.segB, other)
-	return capPt.Sub(triPt).Norm() - c.radius
+	return lowDist - c.radius
 }
 
 // capsuleInCapsule returns a bool describing if the inner capsule is fully encompassed by the outer capsule.

--- a/spatialmath/mesh.go
+++ b/spatialmath/mesh.go
@@ -68,6 +68,13 @@ type Mesh struct {
 	uniqueVerts     []r3.Vector
 	uniqueVertsOnce sync.Once
 
+	// poseCache is the mesh's pose pre-decomposed for BVH traversal. A Mesh's
+	// pose is immutable, but one Mesh copy is collision-checked against many
+	// geometries per planner state; memoizing avoids re-deriving the rotation
+	// matrix/quaternion (which allocate) on every query.
+	poseCache     bvhPoseCache
+	poseCacheOnce sync.Once
+
 	// state carries per-logical-mesh witness caches that survive Transform copies
 	// (the pointer is shared across Transform-derived Meshes). The hot collision
 	// path reaches the witness caches via direct field access; this turned out
@@ -110,6 +117,86 @@ type meshState struct {
 	// verify on lookup — hash collisions are rare but treated as cache misses
 	// (the cached entry is overwritten by the next BVH walk anyway).
 	negCache sync.Map // uint64 -> *negCacheEntry
+
+	// distAnchors generalizes negCache from "same world poses" to "nearby
+	// relative pose". Each entry records the clearance a full BVH walk measured
+	// at a specific relative pose; while the pair's relative pose stays within
+	// that clearance of the anchor, collision-freedom follows without a walk —
+	// rigid geometry cannot close a gap faster than it moves. During fine path
+	// interpolation consecutive states move millimeters while clearances are
+	// centimeters, so this removes the large majority of BVH walks. Pairs that
+	// never move relative to each other (e.g. a parked arm vs world obstacles)
+	// hit the anchor forever.
+	distAnchors sync.Map // *meshState (partner) -> *distAnchor
+
+	// geomAnchors is the same idea for non-mesh partners, keyed by label the
+	// same way geomWitness is.
+	geomAnchors sync.Map // string (other.Label()) -> *distAnchor
+
+	// boundingRadius is the max distance of any local-space point of the mesh
+	// from the mesh origin (computed from the BVH root AABB). Used to bound how
+	// far mesh points can move under a relative-pose change in the distAnchors
+	// fast path. Built lazily; shared across Transform copies via meshState.
+	boundingRadius     float64
+	boundingRadiusOnce sync.Once
+}
+
+// distAnchor records the clearance measured by a full narrow-phase query at a
+// specific relative pose between two geometries. See meshState.distAnchors.
+type distAnchor struct {
+	relQ quat.Number // rotation part of inv(aPose) * bPose
+	relT r3.Vector   // translation part of inv(aPose) * bPose
+	dist float64     // conservative lower bound on separation at that pose
+}
+
+// relativeQT decomposes inv(a)*b into rotation and translation without allocating.
+func relativeQT(a, b Pose) (quat.Number, r3.Vector) {
+	qaConj := quat.Conj(a.Orientation().Quaternion())
+	relQ := quat.Mul(qaConj, b.Orientation().Quaternion())
+	relT := TransformPoint(qaConj, r3.Vector{}, b.Point().Sub(a.Point()))
+	return relQ, relT
+}
+
+// displacement bounds how far any point of the partner geometry (within
+// `radius` of its own origin) can have moved, in the anchor owner's frame,
+// between the anchor's relative pose and the given one: translation delta plus
+// the rotation chord 2·sin(Δθ/2)·radius.
+func (a *distAnchor) displacement(relQ quat.Number, relT r3.Vector, radius float64) float64 {
+	dt := relT.Sub(a.relT).Norm()
+	dot := math.Abs(relQ.Real*a.relQ.Real + relQ.Imag*a.relQ.Imag + relQ.Jmag*a.relQ.Jmag + relQ.Kmag*a.relQ.Kmag)
+	if dot > 1 {
+		dot = 1
+	}
+	return dt + 2*math.Sqrt(1-dot*dot)*radius
+}
+
+// localBoundingRadius returns the max distance of any point of the mesh from
+// its local origin, computed conservatively from the BVH root AABB corners.
+func (m *Mesh) localBoundingRadius() float64 {
+	m.state.boundingRadiusOnce.Do(func() {
+		if bvh := m.ensureBVH(); bvh != nil {
+			for _, x := range []float64{bvh.min.X, bvh.max.X} {
+				for _, y := range []float64{bvh.min.Y, bvh.max.Y} {
+					for _, z := range []float64{bvh.min.Z, bvh.max.Z} {
+						m.state.boundingRadius = math.Max(m.state.boundingRadius, r3.Vector{X: x, Y: y, Z: z}.Norm())
+					}
+				}
+			}
+		}
+	})
+	return m.state.boundingRadius
+}
+
+// geometryBoundingRadius bounds the distance of any point of g from its pose
+// origin, via its current world AABB. The value is orientation-invariant, so a
+// snapshot at any pose is a valid bound.
+func geometryBoundingRadius(g Geometry) float64 {
+	gMin, gMax := computeGeometryAABB(g)
+	c := g.Pose().Point()
+	dx := math.Max(gMax.X-c.X, c.X-gMin.X)
+	dy := math.Max(gMax.Y-c.Y, c.Y-gMin.Y)
+	dz := math.Max(gMax.Z-c.Z, c.Z-gMin.Z)
+	return math.Sqrt(dx*dx + dy*dy + dz*dz)
 }
 
 // witnessPair records a previously-colliding triangle pair so subsequent
@@ -452,18 +539,24 @@ func (m *Mesh) CollidesWith(g Geometry, collisionBufferMM float64) (bool, float6
 
 	switch other := g.(type) {
 	case *box:
+		if isClear, lb := m.geomAnchorClear(other, collisionBufferMM); isClear {
+			return false, lb, nil
+		}
 		// Mesh-ifying the box misses the case where the box encompasses a mesh triangle without its surface intersecting a triangle.
 		encompassed := m.boxIntersectsVertex(other)
 		if encompassed {
 			return true, -1, nil
 		}
-		return m.collidesWithGeometryBVH(other, collisionBufferMM)
+		return m.collidesWithGeometryAnchored(other, collisionBufferMM)
 	case *Mesh:
 		return m.collidesWithMesh(other, collisionBufferMM)
 	case *Cylinder:
 		return other.CollidesWith(m, collisionBufferMM)
 	case *capsule, *point, *sphere:
-		return m.collidesWithGeometryBVH(other, collisionBufferMM)
+		if isClear, lb := m.geomAnchorClear(g, collisionBufferMM); isClear {
+			return false, lb, nil
+		}
+		return m.collidesWithGeometryAnchored(g, collisionBufferMM)
 	case *Triangle:
 		// Wrap in a Mesh so we get the negative-cache short-circuit in
 		// collidesWithMesh — RRT smoothing re-checks the same triangle at the
@@ -560,16 +653,40 @@ func (m *Mesh) ensureUniqueVertices() []r3.Vector {
 
 // Returns true if any triangle vertex of the mesh intersects the box.
 func (m *Mesh) boxIntersectsVertex(b *box) bool {
-	q := m.pose.Orientation().Quaternion()
-	t := m.pose.Point()
-	for _, pt := range m.ensureUniqueVertices() {
-		worldPt := TransformPoint(q, t, pt)
-		c, _ := pointVsBoxCollision(worldPt, b, defaultCollisionBufferMM)
-		if c {
-			return true
-		}
+	// Descend the mesh BVH so subtrees whose bounds don't reach the box are pruned,
+	// instead of sweeping every vertex of the mesh on every call.
+	bvh := m.ensureBVH()
+	if bvh == nil {
+		return false
 	}
-	return false
+	bMin, bMax := computeGeometryAABB(b)
+	bMin, bMax = expandAABBBuffer(bMin, bMax, defaultCollisionBufferMM)
+	return boxIntersectsVertexRec(bvh, m.ensurePoseCache(), b, bMin, bMax)
+}
+
+func boxIntersectsVertexRec(node *bvhNode, pc *bvhPoseCache, b *box, bMin, bMax r3.Vector) bool {
+	nMin, nMax := transformAABBCached(node.min, node.max, pc)
+	if !aabbOverlap(nMin, nMax, bMin, bMax) {
+		return false
+	}
+	if node.geoms != nil {
+		for _, g := range node.geoms {
+			// A Mesh's own BVH only holds triangles.
+			tri, ok := g.(*Triangle)
+			if !ok {
+				continue
+			}
+			for _, pt := range [3]r3.Vector{tri.p0, tri.p1, tri.p2} {
+				worldPt := TransformPoint(pc.q, pc.trans, pt)
+				if c, _ := pointVsBoxCollision(worldPt, b, defaultCollisionBufferMM); c {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	return boxIntersectsVertexRec(node.left, pc, b, bMin, bMax) ||
+		boxIntersectsVertexRec(node.right, pc, b, bMin, bMax)
 }
 
 func (m *Mesh) distanceFromSphere(s *sphere) float64 {
@@ -606,6 +723,17 @@ func (m *Mesh) encompassedByMeshAABB(other *Mesh) bool {
 	return true
 }
 
+// ensurePoseCache returns the mesh's pose pre-decomposed for BVH traversal,
+// building it on first use (thread-safe). A Mesh's pose is immutable, so the
+// cache stays valid for the life of this Mesh value; Transform() copies start
+// with a fresh cache for their new pose.
+func (m *Mesh) ensurePoseCache() *bvhPoseCache {
+	m.poseCacheOnce.Do(func() {
+		m.poseCache = newBVHPoseCache(m.pose)
+	})
+	return &m.poseCache
+}
+
 // ensureBVH builds the BVH if it hasn't been built yet (thread-safe).
 // Returns nil for empty meshes (no triangles).
 func (m *Mesh) ensureBVH() *bvhNode {
@@ -639,12 +767,23 @@ func (m *Mesh) collidesWithMesh(other *Mesh, collisionBufferMM float64) (bool, f
 	var (
 		negKey         uint64
 		negKeyComputed bool
+		relQ           quat.Number
+		relT           r3.Vector
+		relComputed    bool
 	)
 	if m.state != nil && other.state != nil {
 		if v, ok := m.state.witnesses.Load(other.state); ok {
 			wp := v.(*witnessPair)
 			if witnessStillCollides(wp.t1, wp.t2, m.pose, other.pose, collisionBufferMM) {
 				return true, -1, nil
+			}
+		}
+		relQ, relT = relativeQT(m.pose, other.pose)
+		relComputed = true
+		if v, ok := m.state.distAnchors.Load(other.state); ok {
+			a := v.(*distAnchor)
+			if lb := a.dist - a.displacement(relQ, relT, other.localBoundingRadius()); lb > collisionBufferMM {
+				return false, lb, nil
 			}
 		}
 		negKey = negCacheKey(other.state, m.pose, other.pose)
@@ -657,7 +796,8 @@ func (m *Mesh) collidesWithMesh(other *Mesh, collisionBufferMM float64) (bool, f
 		}
 	}
 
-	collides, dist, witness, err := bvhCollidesWithBVHTracked(m.ensureBVH(), other.ensureBVH(), m.pose, other.pose, collisionBufferMM)
+	collides, dist, witness, err := bvhCollidesWithBVHTracked(
+		m.ensureBVH(), other.ensureBVH(), m.ensurePoseCache(), other.ensurePoseCache(), collisionBufferMM)
 	if err != nil {
 		return false, 0, err
 	}
@@ -665,6 +805,9 @@ func (m *Mesh) collidesWithMesh(other *Mesh, collisionBufferMM float64) (bool, f
 		if collides && witness[0] != nil && witness[1] != nil {
 			m.state.witnesses.Store(other.state, &witnessPair{t1: witness[0], t2: witness[1]})
 		} else if !collides {
+			if relComputed && dist > collisionBufferMM {
+				m.state.distAnchors.Store(other.state, &distAnchor{relQ: relQ, relT: relT, dist: dist})
+			}
 			if !negKeyComputed {
 				negKey = negCacheKey(other.state, m.pose, other.pose)
 			}
@@ -718,7 +861,7 @@ func (m *Mesh) collidesWithGeometryBVH(other Geometry, collisionBufferMM float64
 	}
 
 	otherMin, otherMax := computeGeometryAABB(other)
-	collides, dist, witness, err := bvhCollidesWithGeometryTracked(bvh, m.pose, other, otherMin, otherMax, collisionBufferMM)
+	collides, dist, witness, err := bvhCollidesWithGeometryTracked(bvh, m.ensurePoseCache(), other, otherMin, otherMax, collisionBufferMM)
 	if err != nil {
 		return false, 0, err
 	}
@@ -728,6 +871,44 @@ func (m *Mesh) collidesWithGeometryBVH(other Geometry, collisionBufferMM float64
 		}
 	}
 	return collides, dist, nil
+}
+
+// geomAnchorClear consults the distAnchors entry for a non-mesh partner (keyed
+// by label, like geomWitness). Returns (true, clearance) when the anchor proves
+// the pair is still separated by more than the collision buffer at the current
+// poses, letting the caller skip both the box-vertex sweep and the BVH walk.
+func (m *Mesh) geomAnchorClear(g Geometry, collisionBufferMM float64) (bool, float64) {
+	if m.state == nil {
+		return false, 0
+	}
+	label := g.Label()
+	if label == "" {
+		return false, 0
+	}
+	v, ok := m.state.geomAnchors.Load(label)
+	if !ok {
+		return false, 0
+	}
+	a := v.(*distAnchor)
+	relQ, relT := relativeQT(m.pose, g.Pose())
+	if lb := a.dist - a.displacement(relQ, relT, geometryBoundingRadius(g)); lb > collisionBufferMM {
+		return true, lb
+	}
+	return false, 0
+}
+
+// collidesWithGeometryAnchored runs the BVH query and, on a clear result,
+// records a distAnchor so future queries at nearby relative poses can skip the
+// walk (see meshState.distAnchors).
+func (m *Mesh) collidesWithGeometryAnchored(g Geometry, collisionBufferMM float64) (bool, float64, error) {
+	collides, dist, err := m.collidesWithGeometryBVH(g, collisionBufferMM)
+	if err == nil && !collides && dist > collisionBufferMM && m.state != nil {
+		if label := g.Label(); label != "" {
+			relQ, relT := relativeQT(m.pose, g.Pose())
+			m.state.geomAnchors.Store(label, &distAnchor{relQ: relQ, relT: relT, dist: dist})
+		}
+	}
+	return collides, dist, err
 }
 
 // witnessTriCollidesWith re-checks a cached colliding triangle (from m's BVH)


### PR DESCRIPTION
Profiling a captured dual-arm plan showed nearly all planning time in mesh collision checks. Three layers of fixes:

- Dispatch: capsule.CollidesWith(mesh) ran an exact distance scan over every mesh triangle, transforming each triangle to world space per call (the top allocation site in the profile). It now delegates to the mesh's BVH walk; the remaining exact-distance path transforms the capsule into mesh-local space once instead. boxIntersectsVertex now descends the BVH instead of sweeping every vertex per query, and each Mesh memoizes its pose decomposition instead of re-deriving rotation matrices per traversal.

- Distance anchors: a new temporal-coherence cache on meshState records the clearance a full BVH walk measured at a specific relative pose. While a pair's relative pose stays within that clearance of the anchor, collision-freedom follows without a walk - rigid geometry cannot close a gap faster than it moves. During fine path interpolation consecutive states move millimeters while clearances are centimeters, so most walks disappear; pairs that never move relative to each other (a parked arm vs world obstacles) hit the anchor forever.

- Branch-and-bound traversal: the BVH walks now return a true minimum distance (visiting closer child pairs first, pruning on best-so-far) instead of the loose pruned-AABB bound, which makes the anchors and the planner's interpolation skip logic far more effective. Refinement is capped at 25mm - beyond that the exact value has no marginal use, and refining it is what made an uncapped traversal crawl near big flat geometry - with the free root AABB gap covering long range.

On the captured plan this takes cBiRRT planning from 169s to 16s with an identical-quality trajectory.