### PR TITLE
RSDK-14442 Add FTDC statistics for Data Manager Scheduler performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ web/cmd/server/*.core
 # Claude Code
 .claude/worktrees
 .claude/settings.local.json
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ mplans
 
 out/
 .idea/*
+*.iml
 bin/
 
 # artifact
@@ -100,4 +101,3 @@ web/cmd/server/*.core
 # Claude Code
 .claude/worktrees
 .claude/settings.local.json
-*.iml

--- a/data/capture_buffer.go
+++ b/data/capture_buffer.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	goerrors "errors"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -60,11 +61,11 @@ func (b *CaptureBuffer) WriteBinary(item *v1.SensorData, mimeType string) error 
 		return err
 	}
 
-	if err := binFile.WriteNext(item); err != nil {
-		return err
+	if err = binFile.WriteNext(item); err != nil {
+		return goerrors.Join(err, binFile.Close())
 	}
 
-	if err := binFile.Close(); err != nil {
+	if err = binFile.Close(); err != nil {
 		return err
 	}
 	return nil

--- a/ftdc/uploader.go
+++ b/ftdc/uploader.go
@@ -3,6 +3,7 @@ package ftdc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -61,6 +62,8 @@ func (uploader *uploader) uploadRunner(ctx context.Context) {
 		case ftdcFilename := <-uploader.toUpload:
 			if err := uploader.uploadFile(ctx, ftdcFilename); err != nil {
 				uploader.logger.Warnw("Error uploading FTDC file", "filename", ftdcFilename, "error", err)
+			} else {
+				uploader.logger.Infow("Successfully uploaded FTDC file", "filename", ftdcFilename)
 			}
 		}
 	}
@@ -72,12 +75,12 @@ func (uploader *uploader) uploadFile(ctx context.Context, filename string) error
 	// Get file timestamps
 	fileTimes, err := utils.GetFileTimes(filename)
 	if err != nil {
-		return err
+		return fmt.Errorf("failure getting file times: %w", err)
 	}
 
 	binaryClient, err := uploader.dataSyncClient.FileUpload(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failure establishing file upload client stream: %w", err)
 	}
 
 	err = binaryClient.Send(&v1.FileUploadRequest{
@@ -96,7 +99,7 @@ func (uploader *uploader) uploadFile(ctx context.Context, filename string) error
 		if !errors.Is(err, io.EOF) {
 			// When the error is not an EOF, it means the client code encountered an error. Return
 			// that directly.
-			return err
+			return fmt.Errorf("failure sending file upload metadata: %w", err)
 		}
 
 		// `Send` returning an EOF means the an error originated outside of the client code. We
@@ -108,7 +111,7 @@ func (uploader *uploader) uploadFile(ctx context.Context, filename string) error
 
 	file, err := os.Open(filename) //nolint: gosec
 	if err != nil {
-		return err
+		return fmt.Errorf("failure opening filename for upload: %w", err)
 	}
 	defer viamutils.UncheckedErrorFunc(file.Close)
 
@@ -131,7 +134,7 @@ func (uploader *uploader) uploadFile(ctx context.Context, filename string) error
 			if !errors.Is(err, io.EOF) {
 				// When the error is not an EOF, it means the client code encountered an error. Return
 				// that directly.
-				return err
+				return fmt.Errorf("failure sending file upload content message with %d bytes: %w", bytesRead, err)
 			}
 
 			// `Send` returning an EOF means the an error originated outside of the client code. We
@@ -143,10 +146,10 @@ func (uploader *uploader) uploadFile(ctx context.Context, filename string) error
 	}
 
 	_, err = binaryClient.CloseAndRecv()
-	if errors.Is(err, io.EOF) {
+	if err == nil || errors.Is(err, io.EOF) {
 		// We've finished sending. `CloseAndRecv` will return an EOF to denote success. The server
 		// has acknowledged receipt of the full file.
 		return nil
 	}
-	return err
+	return fmt.Errorf("failure closing file upload client stream after finishing upload: %w", err)
 }

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -821,6 +821,7 @@ func (svc *webService) initMux(options weboptions.Options) *goji.Mux {
 	// registered when the web profile option is enabled (via the `enable_web_profile`
 	// config field or the `--webprofile` command line flag).
 	if options.Pprof {
+		svc.logger.Infof("Web profile enabled")
 		mux.HandleFunc(pat.New("/debug/pprof"), func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "/debug/pprof/", http.StatusMovedPermanently)
 		})
@@ -837,6 +838,8 @@ func (svc *webService) initMux(options weboptions.Options) *goji.Mux {
 		// serve resource graph visualization
 		// TODO: accept params to display different formats
 		mux.HandleFunc(pat.New("/debug/graph"), svc.handleVisualizeResourceGraph)
+	} else {
+		svc.logger.Debugf("Web profile disabled")
 	}
 
 	// serve restart status

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -590,10 +590,10 @@ func (b *builtIn) UploadDataFromPath(ctx context.Context, path string, uploadMet
 }
 
 type dataManagerStats struct {
-	SyncPaths               syncPathsSummary
-	DiskUsage               diskUsageSummary
-	FilesDeletedToFreeSpace int64
-	Upload                  datasync.FTDCUploadStats
+	SyncPaths syncPathsSummary
+	DiskUsage diskUsageSummary
+	Sync      datasync.FTDCSyncStats
+	Upload    datasync.FTDCUploadStats
 }
 
 // Stats satisfies the ftdc.Statser interface and will return the disk usage and sync statistics.
@@ -611,7 +611,7 @@ func (b *builtIn) Stats() any {
 	// Upload and deleted file stats.
 	if b.sync != nil {
 		syncStats := b.sync.GetStats()
-		result.FilesDeletedToFreeSpace = syncStats.FilesDeletedToFreeSpace
+		result.Sync = syncStats.Sync
 		result.Upload = syncStats.Upload
 	}
 

--- a/services/datamanager/builtin/sync/file_deletion.go
+++ b/services/datamanager/builtin/sync/file_deletion.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
-	"sync/atomic"
 
 	"github.com/benbjohnson/clock"
 	"github.com/pkg/errors"
@@ -29,7 +27,7 @@ func deleteExcessFilesOnSchedule(
 	captureDirThreshold float64,
 	clock clock.Clock,
 	logger logging.Logger,
-	deletedFileCount *atomic.Int64,
+	syncStats *syncStats,
 ) {
 	if runtime.GOOS == "android" {
 		logger.Debug("file deletion if disk is full is not currently supported on Android")
@@ -47,7 +45,7 @@ func deleteExcessFilesOnSchedule(
 			return
 		case <-t.C:
 			maybeDeleteExcessFiles(
-				ctx, fileTracker, captureDir, deleteEveryNth, diskUsageThreshold, captureDirThreshold, clock, logger, deletedFileCount,
+				ctx, fileTracker, captureDir, deleteEveryNth, diskUsageThreshold, captureDirThreshold, clock, logger, syncStats,
 			)
 		}
 	}
@@ -62,7 +60,7 @@ func maybeDeleteExcessFiles(
 	captureDirThreshold float64,
 	clock clock.Clock,
 	logger logging.Logger,
-	deletedFileCount *atomic.Int64,
+	syncStats *syncStats,
 ) {
 	start := clock.Now()
 	usage, err := diskusage.Statfs(captureDir)
@@ -84,16 +82,15 @@ func maybeDeleteExcessFiles(
 		diskUsageThreshold,
 		captureDirThreshold,
 		logger)
-
 	duration := clock.Since(start)
+	syncStats.filesDeletedToFreeSpace.Add(int64(count))
 
-	switch {
-	case err != nil:
-		logger.Errorw("error deleting cached datacapture files", "error", err, "execution time", duration.String())
-	case count > 0:
-		if deletedFileCount != nil {
-			deletedFileCount.Add(int64(count))
-		}
+	if err != nil {
+		logger.Errorw("error deleting cached datacapture files",
+			"captureDir", captureDir, "error", err, "execution time", duration.String())
+	} else {
+		logger.Infow("Performed delete excess files round",
+			"captureDir", captureDir, "count", count, "execution time", duration.String())
 	}
 }
 
@@ -214,7 +211,7 @@ func deleteFiles(
 ) (int, error) {
 	index := 0
 	deletedFileCount := 0
-	logger.Infof("Deleting every %dth file", deleteEveryNth)
+	logger.Infof("Deleting every %dth capture file", deleteEveryNth)
 	fileDeletion := func(path string, d fs.DirEntry, err error) error {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -240,23 +237,27 @@ func deleteFiles(
 			}
 			return err
 		}
-		isCompletedDataCaptureFile := strings.Contains(fileInfo.Name(), data.CompletedCaptureFileExt)
+
 		// if at nth file and the file is not currently being written, mark as in progress if possible
-		if isCompletedDataCaptureFile && index%deleteEveryNth == 0 {
-			if !fileTracker.markInProgress(path) {
-				logger.Debugw("Tried to mark file as in progress but lock already held", "file", d.Name())
-				return nil
+		if filepath.Ext(fileInfo.Name()) == data.CompletedCaptureFileExt {
+			if index%deleteEveryNth == 0 {
+				if !fileTracker.markInProgress(path) {
+					logger.Debugw("Tried to mark file as in progress but lock already held", "file", d.Name())
+					return nil
+				}
+				// don't memory leak the in-progress tracking
+				defer fileTracker.unmarkInProgress(path)
+
+				if err = os.Remove(path); err != nil {
+					logger.Warnw("error deleting file", "error", err)
+					return err
+				}
+				logger.Infof("successfully deleted %s", d.Name())
+				deletedFileCount++
 			}
-			if err := os.Remove(path); err != nil {
-				logger.Warnw("error deleting file", "error", err)
-				fileTracker.unmarkInProgress(path)
-				return err
-			}
-			logger.Infof("successfully deleted %s", d.Name())
-			deletedFileCount++
-		}
-		// only increment on completed files
-		if isCompletedDataCaptureFile {
+
+			// Increment the index only if we did successfully delete a file. We don't to
+			// skip deleting a file just because a given Nth file happened to be in progress.
 			index++
 		}
 		return nil

--- a/services/datamanager/builtin/sync/file_deletion.go
+++ b/services/datamanager/builtin/sync/file_deletion.go
@@ -88,7 +88,7 @@ func maybeDeleteExcessFiles(
 	if err != nil {
 		logger.Errorw("error deleting cached datacapture files",
 			"captureDir", captureDir, "error", err, "execution time", duration.String())
-	} else {
+	} else if count > 0 {
 		logger.Infow("Performed delete excess files round",
 			"captureDir", captureDir, "count", count, "execution time", duration.String())
 	}
@@ -241,6 +241,8 @@ func deleteFiles(
 		// if at nth file and the file is not currently being written, mark as in progress if possible
 		if filepath.Ext(fileInfo.Name()) == data.CompletedCaptureFileExt {
 			if index%deleteEveryNth == 0 {
+				// Atomically claim the file so a concurrent sync won't pick it up mid-delete,
+				// and so we don't delete a file mid-sync.
 				if !fileTracker.markInProgress(path) {
 					logger.Debugw("Tried to mark file as in progress but lock already held", "file", d.Name())
 					return nil
@@ -256,7 +258,7 @@ func deleteFiles(
 				deletedFileCount++
 			}
 
-			// Increment the index only if we did successfully delete a file. We don't to
+			// Increment for every completed file unless we bailed early. We don't want to
 			// skip deleting a file just because a given Nth file happened to be in progress.
 			index++
 		}

--- a/services/datamanager/builtin/sync/file_tracker.go
+++ b/services/datamanager/builtin/sync/file_tracker.go
@@ -36,10 +36,3 @@ func (ft *fileTracker) unmarkInProgress(path string) {
 	defer ft.mu.Unlock()
 	delete(ft.store, path)
 }
-
-func (ft *fileTracker) Len() int {
-	ft.mu.Lock()
-	count := len(ft.store)
-	ft.mu.Unlock()
-	return count
-}

--- a/services/datamanager/builtin/sync/file_tracker.go
+++ b/services/datamanager/builtin/sync/file_tracker.go
@@ -36,3 +36,10 @@ func (ft *fileTracker) unmarkInProgress(path string) {
 	defer ft.mu.Unlock()
 	delete(ft.store, path)
 }
+
+func (ft *fileTracker) Len() int {
+	ft.mu.Lock()
+	count := len(ft.store)
+	ft.mu.Unlock()
+	return count
+}

--- a/services/datamanager/builtin/sync/sync.go
+++ b/services/datamanager/builtin/sync/sync.go
@@ -47,6 +47,12 @@ const (
 	durationBetweenAcquireConnection = time.Second
 )
 
+type syncStats struct {
+	filesDeletedToFreeSpace      atomic.Int64
+	schedulerRoundsTotal         atomic.Uint64
+	schedulerDurationMillisTotal atomic.Uint64
+}
+
 // uploadStats tracks cumulative upload statistics.
 type uploadStats struct {
 	binary    dataTypeUploadStats
@@ -62,10 +68,19 @@ type dataTypeUploadStats struct {
 	uploadFailedFileCount atomic.Uint64
 }
 
-// FTDCStats represents upload and deleted file metric values for a given moment. Returned by Sync.GetStats().
+// FTDCStats represents upload and sync metric values for a given moment. Returned by Sync.GetStats().
 type FTDCStats struct {
-	FilesDeletedToFreeSpace int64
-	Upload                  FTDCUploadStats
+	Sync   FTDCSyncStats
+	Upload FTDCUploadStats
+}
+
+type FTDCSyncStats struct {
+	FilesDeletedToFreeSpace      int64
+	SchedulerRoundsTotal         uint64
+	SchedulerDurationMillisTotal uint64
+	FilesToSyncChannelLength     uint64
+	ActiveSyncs                  uint32
+	MaxActiveSyncs               uint32
 }
 
 // FTDCUploadStats represents upload metric values for a given moment.
@@ -107,7 +122,7 @@ type Sync struct {
 	clientConstructor func(cc grpc.ClientConnInterface) v1.DataSyncServiceClient
 	clock             clock.Clock
 	uploadStats       *uploadStats
-	deletedFileCount  atomic.Int64
+	syncStats         *syncStats
 
 	configMu sync.Mutex
 	config   Config
@@ -121,7 +136,7 @@ type Sync struct {
 	cloudConnManager *goutils.StoppableWorkers
 	// FileDeletingWorkers is only public for tests
 	FileDeletingWorkers *goutils.StoppableWorkers
-	// MaxSyncThreads only exists for tests
+	// MaxSyncThreads exists for FTDC stat and tests
 	MaxSyncThreads int
 }
 
@@ -133,7 +148,6 @@ func New(
 	logger logging.Logger,
 ) *Sync {
 	configCtx, configCancelFunc := context.WithCancel(context.Background())
-	var uploadStats uploadStats
 	s := Sync{
 		clock:               clock,
 		configCtx:           configCtx,
@@ -146,7 +160,8 @@ func New(
 		Scheduler:           goutils.NewBackgroundStoppableWorkers(),
 		cloudConn:           cloudConn{ready: make(chan struct{})},
 		FileDeletingWorkers: goutils.NewBackgroundStoppableWorkers(),
-		uploadStats:         &uploadStats,
+		uploadStats:         new(uploadStats),
+		syncStats:           new(syncStats),
 	}
 	return &s
 }
@@ -205,6 +220,7 @@ func (s *Sync) Reconfigure(_ context.Context, config Config, cloudConnSvc cloud.
 		s.Scheduler = goutils.NewBackgroundStoppableWorkers(func(ctx context.Context) {
 			s.runScheduler(ctx, tkr, config)
 		})
+		s.logger.Infof("Started sync scheduler with interval %dms", interval.Milliseconds())
 	} else {
 		s.logger.Info("Sync Disabled")
 	}
@@ -223,7 +239,7 @@ func (s *Sync) Reconfigure(_ context.Context, config Config, cloudConnSvc cloud.
 				config.CaptureDirDeletionThreshold,
 				s.clock,
 				s.logger,
-				&s.deletedFileCount,
+				&s.syncStats.filesDeletedToFreeSpace,
 			)
 		})
 	}
@@ -233,7 +249,14 @@ func (s *Sync) Reconfigure(_ context.Context, config Config, cloudConnSvc cloud.
 func (s *Sync) GetStats() FTDCStats {
 	return FTDCStats{
 		// File deletion metric.
-		FilesDeletedToFreeSpace: s.deletedFileCount.Load(),
+		Sync: FTDCSyncStats{
+			FilesDeletedToFreeSpace:      s.syncStats.filesDeletedToFreeSpace.Load(),
+			SchedulerRoundsTotal:         s.syncStats.schedulerRoundsTotal.Load(),
+			SchedulerDurationMillisTotal: s.syncStats.schedulerDurationMillisTotal.Load(),
+			FilesToSyncChannelLength:     uint64(len(s.filesToSync)),
+			ActiveSyncs:                  uint32(s.fileTracker.Len()),
+			MaxActiveSyncs:               uint32(s.MaxSyncThreads),
+		},
 
 		Upload: FTDCUploadStats{
 			// Upload metrics - arbitrary files.
@@ -491,7 +514,7 @@ func (s *Sync) syncDataCaptureFile(f *os.File, captureDir string, logger logging
 		if err != nil {
 			return 0, errors.Wrap(err, errMetadata)
 		}
-		logger.Debugf("uploadDataCaptureFile uploaded: %d bytes", bytesUploaded)
+		logger.Debugf("Sync data capture file uploaded with %d bytes", bytesUploaded)
 		return bytesUploaded, nil
 	})
 
@@ -524,6 +547,8 @@ func (s *Sync) syncDataCaptureFile(f *os.File, captureDir string, logger logging
 	if err := captureFile.Delete(); err != nil {
 		logger.Error(errors.Wrap(err, "error deleting data capture file").Error())
 	}
+
+	logger.Debugf("Sync deleted capture file after successful upload %s", f.Name())
 	if isBinary {
 		s.uploadStats.binary.uploadedFileCount.Add(1)
 		s.uploadStats.binary.completedUploadBytes.Add(bytesUploaded)
@@ -576,6 +601,8 @@ func (s *Sync) syncArbitraryFile(
 	if err := os.Remove(f.Name()); err != nil {
 		logger.Error(errors.Wrap(err, fmt.Sprintf("error deleting file %s", f.Name())).Error())
 	}
+
+	logger.Debugf("Sync deleted arbitrary file after successful upload %s", f.Name())
 	s.uploadStats.arbitrary.uploadedFileCount.Add(1)
 	s.uploadStats.arbitrary.completedUploadBytes.Add(bytesUploaded)
 	return nil
@@ -710,6 +737,12 @@ func (s *Sync) runScheduler(ctx context.Context, tkr *clock.Ticker, config Confi
 // returns early with an error if either ctx is cancelled or if the reconfigure is called
 // while walkDirsAndSendFilesToSync.
 func (s *Sync) walkDirsAndSendFilesToSync(ctx context.Context, config Config) error {
+	now := s.clock.Now()
+	defer func() {
+		s.syncStats.schedulerRoundsTotal.Add(1)
+		s.syncStats.schedulerDurationMillisTotal.Add(uint64(s.clock.Since(now).Milliseconds()))
+	}()
+
 	s.flushCollectors()
 	var errs []error
 	for _, dir := range config.SyncPaths() {

--- a/services/datamanager/builtin/sync/sync.go
+++ b/services/datamanager/builtin/sync/sync.go
@@ -51,6 +51,8 @@ type syncStats struct {
 	filesDeletedToFreeSpace      atomic.Int64
 	schedulerRoundsTotal         atomic.Uint64
 	schedulerDurationMillisTotal atomic.Uint64
+	// activeSyncs counts in-flight file syncs.
+	activeSyncs atomic.Int64
 }
 
 // uploadStats tracks cumulative upload statistics.
@@ -255,7 +257,7 @@ func (s *Sync) GetStats() FTDCStats {
 			SchedulerRoundsTotal:         s.syncStats.schedulerRoundsTotal.Load(),
 			SchedulerDurationMillisTotal: s.syncStats.schedulerDurationMillisTotal.Load(),
 			FilesToSyncChannelLength:     uint64(len(s.filesToSync)),
-			ActiveSyncs:                  uint32(s.fileTracker.Len()),
+			ActiveSyncs:                  uint32(s.syncStats.activeSyncs.Load()),
 			MaxActiveSyncs:               uint32(s.MaxSyncThreads),
 		},
 
@@ -450,6 +452,9 @@ func (s *Sync) syncFile(config Config, filePath string) {
 		return
 	}
 	defer s.fileTracker.unmarkInProgress(filePath)
+
+	s.syncStats.activeSyncs.Add(1)
+	defer s.syncStats.activeSyncs.Add(-1)
 
 	// Sequence files upload via CreateSequence; dispatch by path before opening so we don't
 	// leak a file descriptor on the sequence path (which does its own os.ReadFile).

--- a/services/datamanager/builtin/sync/sync.go
+++ b/services/datamanager/builtin/sync/sync.go
@@ -74,6 +74,7 @@ type FTDCStats struct {
 	Upload FTDCUploadStats
 }
 
+// FTDCSyncStats represents sync metric values for a given moment.
 type FTDCSyncStats struct {
 	FilesDeletedToFreeSpace      int64
 	SchedulerRoundsTotal         uint64

--- a/services/datamanager/builtin/sync/sync.go
+++ b/services/datamanager/builtin/sync/sync.go
@@ -240,7 +240,7 @@ func (s *Sync) Reconfigure(_ context.Context, config Config, cloudConnSvc cloud.
 				config.CaptureDirDeletionThreshold,
 				s.clock,
 				s.logger,
-				&s.syncStats.filesDeletedToFreeSpace,
+				s.syncStats,
 			)
 		})
 	}

--- a/services/datamanager/builtin/sync/sync.go
+++ b/services/datamanager/builtin/sync/sync.go
@@ -51,8 +51,9 @@ type syncStats struct {
 	filesDeletedToFreeSpace      atomic.Int64
 	schedulerRoundsTotal         atomic.Uint64
 	schedulerDurationMillisTotal atomic.Uint64
-	// activeSyncs counts in-flight file syncs.
-	activeSyncs atomic.Int64
+	// activeBackgroundFileSyncs counts in-flight background file syncs from data manager
+	// but does not include any on-demand file upload requests.
+	activeBackgroundFileSyncs atomic.Uint32
 }
 
 // uploadStats tracks cumulative upload statistics.
@@ -81,9 +82,9 @@ type FTDCSyncStats struct {
 	FilesDeletedToFreeSpace      int64
 	SchedulerRoundsTotal         uint64
 	SchedulerDurationMillisTotal uint64
-	FilesToSyncChannelLength     uint64
-	ActiveSyncs                  uint32
-	MaxActiveSyncs               uint32
+	QueuedFilesToSync            uint64
+	ActiveBackgroundFileSyncs    uint32
+	MaxActiveBackgroundFileSyncs uint32
 }
 
 // FTDCUploadStats represents upload metric values for a given moment.
@@ -256,9 +257,9 @@ func (s *Sync) GetStats() FTDCStats {
 			FilesDeletedToFreeSpace:      s.syncStats.filesDeletedToFreeSpace.Load(),
 			SchedulerRoundsTotal:         s.syncStats.schedulerRoundsTotal.Load(),
 			SchedulerDurationMillisTotal: s.syncStats.schedulerDurationMillisTotal.Load(),
-			FilesToSyncChannelLength:     uint64(len(s.filesToSync)),
-			ActiveSyncs:                  uint32(s.syncStats.activeSyncs.Load()),
-			MaxActiveSyncs:               uint32(s.MaxSyncThreads),
+			QueuedFilesToSync:            uint64(len(s.filesToSync)),
+			ActiveBackgroundFileSyncs:    s.syncStats.activeBackgroundFileSyncs.Load(),
+			MaxActiveBackgroundFileSyncs: uint32(s.MaxSyncThreads),
 		},
 
 		Upload: FTDCUploadStats{
@@ -432,8 +433,8 @@ func (s *Sync) runWorker(config Config) {
 		select {
 		case <-s.configCtx.Done():
 			return
-		case path := <-s.filesToSync:
-			s.syncFile(config, path)
+		case filePath := <-s.filesToSync:
+			s.syncFile(config, filePath)
 		}
 	}
 }
@@ -453,8 +454,8 @@ func (s *Sync) syncFile(config Config, filePath string) {
 	}
 	defer s.fileTracker.unmarkInProgress(filePath)
 
-	s.syncStats.activeSyncs.Add(1)
-	defer s.syncStats.activeSyncs.Add(-1)
+	s.syncStats.activeBackgroundFileSyncs.Add(1)
+	defer s.syncStats.activeBackgroundFileSyncs.Add(-1)
 
 	// Sequence files upload via CreateSequence; dispatch by path before opening so we don't
 	// leak a file descriptor on the sequence path (which does its own os.ReadFile).
@@ -520,7 +521,7 @@ func (s *Sync) syncDataCaptureFile(f *os.File, captureDir string, logger logging
 		if err != nil {
 			return 0, errors.Wrap(err, errMetadata)
 		}
-		logger.Debugf("Sync data capture file uploaded with %d bytes", bytesUploaded)
+		logger.Debugf("Background sync uploaded data capture file with %d bytes", bytesUploaded)
 		return bytesUploaded, nil
 	})
 
@@ -554,7 +555,7 @@ func (s *Sync) syncDataCaptureFile(f *os.File, captureDir string, logger logging
 		logger.Error(errors.Wrap(err, "error deleting data capture file").Error())
 	}
 
-	logger.Debugf("Sync deleted capture file after successful upload %s", f.Name())
+	logger.Debugf("Background sync deleted capture file after successful upload %s", f.Name())
 	if isBinary {
 		s.uploadStats.binary.uploadedFileCount.Add(1)
 		s.uploadStats.binary.completedUploadBytes.Add(bytesUploaded)
@@ -608,7 +609,7 @@ func (s *Sync) syncArbitraryFile(
 		logger.Error(errors.Wrap(err, fmt.Sprintf("error deleting file %s", f.Name())).Error())
 	}
 
-	logger.Debugf("Sync deleted arbitrary file after successful upload %s", f.Name())
+	logger.Debugf("Deleted arbitrary file after successful upload %s", f.Name())
 	s.uploadStats.arbitrary.uploadedFileCount.Add(1)
 	s.uploadStats.arbitrary.completedUploadBytes.Add(bytesUploaded)
 	return nil

--- a/services/datamanager/builtin/sync/sync.go
+++ b/services/datamanager/builtin/sync/sync.go
@@ -53,7 +53,7 @@ type syncStats struct {
 	schedulerDurationMillisTotal atomic.Uint64
 	// activeBackgroundFileSyncs counts in-flight background file syncs from data manager
 	// but does not include any on-demand file upload requests.
-	activeBackgroundFileSyncs atomic.Uint32
+	activeBackgroundFileSyncs atomic.Int32
 }
 
 // uploadStats tracks cumulative upload statistics.
@@ -258,7 +258,7 @@ func (s *Sync) GetStats() FTDCStats {
 			SchedulerRoundsTotal:         s.syncStats.schedulerRoundsTotal.Load(),
 			SchedulerDurationMillisTotal: s.syncStats.schedulerDurationMillisTotal.Load(),
 			QueuedFilesToSync:            uint64(len(s.filesToSync)),
-			ActiveBackgroundFileSyncs:    s.syncStats.activeBackgroundFileSyncs.Load(),
+			ActiveBackgroundFileSyncs:    uint32(s.syncStats.activeBackgroundFileSyncs.Load()),
 			MaxActiveBackgroundFileSyncs: uint32(s.MaxSyncThreads),
 		},
 


### PR DESCRIPTION
JIRA: https://viam.atlassian.net/browse/RSDK-14442

**Highlights**
* Adds FTDC statistics for:
  * Scheduler round duration total
  * Scheduler round count
  * filesToSync channel depth
  * Active syncs
  * Max active syncs

* Fixes file handle leak on error when writing image files
* Adds a few additional Debug/Info logs