### PR TITLE
spatialmath: collision-geometry speedups for motion planning

### DIFF
--- a/spatialmath/box.go
+++ b/spatialmath/box.go
@@ -80,6 +80,24 @@ type box struct {
 	// as the box's local axes in world.
 	rotMatrix *RotationMatrix
 	once      sync.Once
+
+	// aabbMin/aabbMax cache the box's world-space AABB. A box is immutable, and
+	// obstacle boxes are checked against every robot geometry at every planner
+	// state - recomputing the AABB (which derives a fresh rotation matrix) per
+	// query was the planner's single largest allocation source.
+	aabbMin, aabbMax r3.Vector
+	aabbOnce         sync.Once
+}
+
+// worldAABB returns the box's cached world-space axis-aligned bounding box.
+func (b *box) worldAABB() (r3.Vector, r3.Vector) {
+	b.aabbOnce.Do(func() {
+		rm := b.center.Orientation().RotationMatrix()
+		halfSize := r3.Vector{X: b.halfSize[0], Y: b.halfSize[1], Z: b.halfSize[2]}
+		worldExtents := rotatedAABBExtents(rm, halfSize)
+		b.aabbMin, b.aabbMax = aabbFromCenterExtents(b.center.Point(), worldExtents)
+	})
+	return b.aabbMin, b.aabbMax
 }
 
 // NewBox instantiates a new box Geometry.

--- a/spatialmath/bvh.go
+++ b/spatialmath/bvh.go
@@ -200,11 +200,7 @@ func computeSphereAABB(s *sphere) (r3.Vector, r3.Vector) {
 }
 
 func computeBoxAABB(b *box) (r3.Vector, r3.Vector) {
-	rm := b.center.Orientation().RotationMatrix()
-	center := b.center.Point()
-	halfSize := r3.Vector{X: b.halfSize[0], Y: b.halfSize[1], Z: b.halfSize[2]}
-	worldExtents := rotatedAABBExtents(rm, halfSize)
-	return aabbFromCenterExtents(center, worldExtents)
+	return b.worldAABB()
 }
 
 // computeCapsuleAABB computes the AABB for a capsule.

--- a/spatialmath/capsule.go
+++ b/spatialmath/capsule.go
@@ -224,24 +224,34 @@ func (c *capsule) ToPoints(resolution float64) []r3.Vector {
 	s := &sphere{pose: NewZeroPose(), radius: c.radius}
 	vecList := s.ToPoints(resolution)
 	// move points to be correctly located on capsule endcaps
+	// (this previously ranged over value copies, leaving every endcap point
+	// unmoved at the center)
 	adj := c.length/2 - c.radius
-	for _, pt := range vecList {
-		if pt.Z >= 0 {
-			pt.Z += adj
+	for i := range vecList {
+		if vecList[i].Z >= 0 {
+			vecList[i].Z += adj
 		} else {
-			pt.Z -= adj
+			vecList[i].Z -= adj
 		}
 	}
 
-	// Now distribute points along the cylindrical shaft
+	// Now distribute points along the cylindrical shaft, which spans
+	// [-(l/2 - r), +(l/2 - r)] about the center - the same frame the endcap
+	// points were placed in above. (This previously spanned (0, l), placing
+	// shaft points off-center and beyond the capsule's actual surface.)
+	shaftLen := c.length - 2*c.radius
 	totalShaftPts := (c.radius * c.length) * resolution
 	ptsPerRing := totalShaftPts / (c.length * resolution)
 	ringCnt := math.Floor(totalShaftPts / ptsPerRing)
-	zInc := c.length / (ringCnt + 1)
+	zInc := shaftLen / (ringCnt + 1)
 	for ring := 1.; ring <= ringCnt; ring++ {
 		for ringPt := 0.; ringPt < ptsPerRing; ringPt++ {
 			theta := 2. * math.Pi * (ringPt / ptsPerRing)
-			vecList = append(vecList, r3.Vector{math.Cos(theta) * c.radius, math.Sin(theta) * c.radius, zInc * ring})
+			vecList = append(vecList, r3.Vector{
+				X: math.Cos(theta) * c.radius,
+				Y: math.Sin(theta) * c.radius,
+				Z: -shaftLen/2 + zInc*ring,
+			})
 		}
 	}
 

--- a/spatialmath/mesh.go
+++ b/spatialmath/mesh.go
@@ -127,11 +127,11 @@ type meshState struct {
 	// centimeters, so this removes the large majority of BVH walks. Pairs that
 	// never move relative to each other (e.g. a parked arm vs world obstacles)
 	// hit the anchor forever.
-	distAnchors sync.Map // *meshState (partner) -> *distAnchor
+	distAnchors sync.Map // *meshState (partner) -> *distAnchorSet
 
 	// geomAnchors is the same idea for non-mesh partners, keyed by label the
 	// same way geomWitness is.
-	geomAnchors sync.Map // string (other.Label()) -> *distAnchor
+	geomAnchors sync.Map // string (other.Label()) -> *distAnchorSet
 
 	// boundingRadius is the max distance of any local-space point of the mesh
 	// from the mesh origin (computed from the BVH root AABB). Used to bound how
@@ -139,6 +139,11 @@ type meshState struct {
 	// fast path. Built lazily; shared across Transform copies via meshState.
 	boundingRadius     float64
 	boundingRadiusOnce sync.Once
+
+	// sphereCover is the mesh's conservative local-frame sphere cover, used by
+	// the SDF collision fast path. Built lazily; shared across Transform copies.
+	sphereCover     []SphereBound
+	sphereCoverOnce sync.Once
 }
 
 // distAnchor records the clearance measured by a full narrow-phase query at a
@@ -147,6 +152,51 @@ type distAnchor struct {
 	relQ quat.Number // rotation part of inv(aPose) * bPose
 	relT r3.Vector   // translation part of inv(aPose) * bPose
 	dist float64     // conservative lower bound on separation at that pose
+}
+
+// distAnchorSetSize is how many anchors each pair keeps. A single anchor is
+// enough for one smoothly-moving pose stream, but planners interleave several
+// (a bidirectional RRT alternates between two trees, and racing planners add
+// more); one slot per stream stops them from evicting each other every query.
+// Sized for up to four concurrent bidirectional searches.
+const distAnchorSetSize = 8
+
+// distAnchorSet is a small lock-free ring of anchors for one geometry pair.
+// Lookups scan all slots and use whichever anchor proves the most clearance at
+// the queried pose; stores overwrite slots round-robin.
+type distAnchorSet struct {
+	next    atomic.Uint32
+	entries [distAnchorSetSize]atomic.Pointer[distAnchor]
+}
+
+// bestClearance returns the largest clearance any anchor in the set can prove
+// for the given relative pose (math.Inf(-1) when the set is empty).
+func (as *distAnchorSet) bestClearance(relQ quat.Number, relT r3.Vector, radius float64) float64 {
+	best := math.Inf(-1)
+	for i := range as.entries {
+		a := as.entries[i].Load()
+		if a == nil {
+			continue
+		}
+		if lb := a.dist - a.displacement(relQ, relT, radius); lb > best {
+			best = lb
+		}
+	}
+	return best
+}
+
+// add records an anchor, overwriting the oldest slot.
+func (as *distAnchorSet) add(a *distAnchor) {
+	as.entries[(as.next.Add(1)-1)%distAnchorSetSize].Store(a)
+}
+
+// anchorSetFor returns the (created-on-demand) anchor set stored in m under key.
+func anchorSetFor(m *sync.Map, key any) *distAnchorSet {
+	if v, ok := m.Load(key); ok {
+		return v.(*distAnchorSet)
+	}
+	v, _ := m.LoadOrStore(key, &distAnchorSet{})
+	return v.(*distAnchorSet)
 }
 
 // relativeQT decomposes inv(a)*b into rotation and translation without allocating.
@@ -781,8 +831,7 @@ func (m *Mesh) collidesWithMesh(other *Mesh, collisionBufferMM float64) (bool, f
 		relQ, relT = relativeQT(m.pose, other.pose)
 		relComputed = true
 		if v, ok := m.state.distAnchors.Load(other.state); ok {
-			a := v.(*distAnchor)
-			if lb := a.dist - a.displacement(relQ, relT, other.localBoundingRadius()); lb > collisionBufferMM {
+			if lb := v.(*distAnchorSet).bestClearance(relQ, relT, other.localBoundingRadius()); lb > collisionBufferMM {
 				return false, lb, nil
 			}
 		}
@@ -806,7 +855,7 @@ func (m *Mesh) collidesWithMesh(other *Mesh, collisionBufferMM float64) (bool, f
 			m.state.witnesses.Store(other.state, &witnessPair{t1: witness[0], t2: witness[1]})
 		} else if !collides {
 			if relComputed && dist > collisionBufferMM {
-				m.state.distAnchors.Store(other.state, &distAnchor{relQ: relQ, relT: relT, dist: dist})
+				anchorSetFor(&m.state.distAnchors, other.state).add(&distAnchor{relQ: relQ, relT: relT, dist: dist})
 			}
 			if !negKeyComputed {
 				negKey = negCacheKey(other.state, m.pose, other.pose)
@@ -889,9 +938,8 @@ func (m *Mesh) geomAnchorClear(g Geometry, collisionBufferMM float64) (bool, flo
 	if !ok {
 		return false, 0
 	}
-	a := v.(*distAnchor)
 	relQ, relT := relativeQT(m.pose, g.Pose())
-	if lb := a.dist - a.displacement(relQ, relT, geometryBoundingRadius(g)); lb > collisionBufferMM {
+	if lb := v.(*distAnchorSet).bestClearance(relQ, relT, geometryBoundingRadius(g)); lb > collisionBufferMM {
 		return true, lb
 	}
 	return false, 0
@@ -905,7 +953,7 @@ func (m *Mesh) collidesWithGeometryAnchored(g Geometry, collisionBufferMM float6
 	if err == nil && !collides && dist > collisionBufferMM && m.state != nil {
 		if label := g.Label(); label != "" {
 			relQ, relT := relativeQT(m.pose, g.Pose())
-			m.state.geomAnchors.Store(label, &distAnchor{relQ: relQ, relT: relT, dist: dist})
+			anchorSetFor(&m.state.geomAnchors, label).add(&distAnchor{relQ: relQ, relT: relT, dist: dist})
 		}
 	}
 	return collides, dist, err

--- a/spatialmath/sdf.go
+++ b/spatialmath/sdf.go
@@ -1,0 +1,316 @@
+package spatialmath
+
+import (
+	"math"
+
+	"github.com/golang/geo/r3"
+)
+
+// VoxelSDF is a voxelized distance field over a set of static geometries. It
+// answers conservative clearance queries - "the nearest obstacle surface is at
+// least D away from this point" - in constant time, replacing per-query
+// narrow-phase geometry work for the static side of collision checking.
+//
+// Build cost is paid once per static scene (obstacle surfaces are rasterized
+// into an occupancy grid, then an exact Euclidean distance transform is run);
+// queries are array lookups. All distances are in the same units as the input
+// geometries (mm for RDK).
+type VoxelSDF struct {
+	origin     r3.Vector // center of voxel (0,0,0)
+	res        float64
+	nx, ny, nz int
+
+	// dist holds, per voxel, the distance in mm from the voxel center to the
+	// nearest occupied voxel center.
+	dist []float32
+
+	// occMargin is the rasterization slack: every obstacle surface point is
+	// within occMargin of some occupied voxel center. Queries subtract it.
+	occMargin float64
+}
+
+// maxSDFVoxels bounds the grid size; the resolution is coarsened to fit.
+const maxSDFVoxels = 6_000_000
+
+// NewVoxelSDF builds a distance field over the given geometries at the
+// requested resolution (which may be coarsened to respect the voxel budget).
+// Returns nil when there is nothing to voxelize.
+func NewVoxelSDF(geoms []Geometry, resolution float64) *VoxelSDF {
+	if len(geoms) == 0 {
+		return nil
+	}
+	// Every geometry must be a type we know how to rasterize; a scene with any
+	// unknown type (e.g. octrees) gets no field, leaving the exact checker in
+	// sole charge. Silently skipping a geometry would make the field report
+	// clear space where an obstacle stands.
+	for _, g := range geoms {
+		switch g.(type) {
+		case *Mesh, *Triangle, *box, *sphere, *capsule, *point, *Cylinder:
+		default:
+			return nil
+		}
+	}
+	minPt := r3.Vector{X: math.Inf(1), Y: math.Inf(1), Z: math.Inf(1)}
+	maxPt := r3.Vector{X: math.Inf(-1), Y: math.Inf(-1), Z: math.Inf(-1)}
+	for _, g := range geoms {
+		gMin, gMax := computeGeometryAABB(g)
+		minPt, maxPt = expandAABB(minPt, maxPt, gMin)
+		minPt, maxPt = expandAABB(minPt, maxPt, gMax)
+	}
+	size := maxPt.Sub(minPt)
+	if size.X <= 0 || size.Y <= 0 || size.Z <= 0 {
+		size = r3.Vector{X: math.Max(size.X, 1), Y: math.Max(size.Y, 1), Z: math.Max(size.Z, 1)}
+	}
+
+	res := resolution
+	for {
+		nx := int(size.X/res) + 3
+		ny := int(size.Y/res) + 3
+		nz := int(size.Z/res) + 3
+		if nx*ny*nz <= maxSDFVoxels {
+			break
+		}
+		res *= 1.5
+	}
+
+	s := &VoxelSDF{
+		origin: minPt.Sub(r3.Vector{X: res, Y: res, Z: res}),
+		res:    res,
+		nx:     int(size.X/res) + 3,
+		ny:     int(size.Y/res) + 3,
+		nz:     int(size.Z/res) + 3,
+	}
+	// A surface point inside a voxel is at most half the voxel diagonal from
+	// that voxel's center; rasterization marks any voxel whose center is
+	// within that distance of a surface, so the bound holds for every surface
+	// point.
+	s.occMargin = res * math.Sqrt(3) / 2
+
+	occ := make([]bool, s.nx*s.ny*s.nz)
+	for _, g := range geoms {
+		s.rasterize(g, occ)
+	}
+
+	s.dist = edt3(occ, s.nx, s.ny, s.nz, res)
+	return s
+}
+
+// Resolution returns the (possibly coarsened) voxel edge length.
+func (s *VoxelSDF) Resolution() float64 { return s.res }
+
+func (s *VoxelSDF) idx(x, y, z int) int { return (z*s.ny+y)*s.nx + x }
+
+func (s *VoxelSDF) voxelCenter(x, y, z int) r3.Vector {
+	return r3.Vector{
+		X: s.origin.X + float64(x)*s.res,
+		Y: s.origin.Y + float64(y)*s.res,
+		Z: s.origin.Z + float64(z)*s.res,
+	}
+}
+
+// rasterize marks the voxels whose centers lie within occMargin of the
+// geometry's surface (for meshes) or interior (for solid primitives).
+func (s *VoxelSDF) rasterize(g Geometry, occ []bool) {
+	switch geom := g.(type) {
+	case *Mesh:
+		// Meshes are surface soup (not treated as solid anywhere else either).
+		q := geom.pose.Orientation().Quaternion()
+		t := geom.pose.Point()
+		for _, tri := range geom.triangles {
+			world := &Triangle{
+				p0: TransformPoint(q, t, tri.p0),
+				p1: TransformPoint(q, t, tri.p1),
+				p2: TransformPoint(q, t, tri.p2),
+			}
+			tMin, tMax := triAABB(world)
+			s.markRegion(occ, tMin, tMax, func(p r3.Vector) bool {
+				return ClosestPointTrianglePoint(world, p).Sub(p).Norm() <= s.occMargin
+			})
+		}
+	case *Triangle:
+		tMin, tMax := triAABB(geom)
+		s.markRegion(occ, tMin, tMax, func(p r3.Vector) bool {
+			return ClosestPointTrianglePoint(geom, p).Sub(p).Norm() <= s.occMargin
+		})
+	case *box:
+		gMin, gMax := computeGeometryAABB(geom)
+		s.markRegion(occ, gMin, gMax, func(p r3.Vector) bool {
+			return pointVsBoxDistance(p, geom) <= s.occMargin
+		})
+	case *sphere:
+		c := geom.pose.Point()
+		r := geom.radius
+		gMin := r3.Vector{X: c.X - r, Y: c.Y - r, Z: c.Z - r}
+		gMax := r3.Vector{X: c.X + r, Y: c.Y + r, Z: c.Z + r}
+		s.markRegion(occ, gMin, gMax, func(p r3.Vector) bool {
+			return p.Sub(c).Norm()-r <= s.occMargin
+		})
+	case *capsule:
+		gMin, gMax := computeGeometryAABB(geom)
+		s.markRegion(occ, gMin, gMax, func(p r3.Vector) bool {
+			return DistToLineSegment(geom.segA, geom.segB, p)-geom.radius <= s.occMargin
+		})
+	case *point:
+		s.markRegion(occ, geom.position, geom.position, func(p r3.Vector) bool {
+			return p.Sub(geom.position).Norm() <= s.occMargin
+		})
+	case *Cylinder:
+		// Conservative: treat as its bounding capsule.
+		gMin, gMax := computeGeometryAABB(geom)
+		center := geom.Pose().Point()
+		axis := geom.Pose().Orientation().Quaternion()
+		half := TransformPoint(axis, r3.Vector{}, r3.Vector{Z: geom.height / 2})
+		segA := center.Sub(half)
+		segB := center.Add(half)
+		s.markRegion(occ, gMin, gMax, func(p r3.Vector) bool {
+			return DistToLineSegment(segA, segB, p)-geom.radius <= s.occMargin
+		})
+	default:
+		// Unreachable: NewVoxelSDF rejects scenes containing unknown types.
+	}
+}
+
+// markRegion runs pred over every voxel center in the AABB (padded by one
+// voxel) and marks the ones it accepts.
+func (s *VoxelSDF) markRegion(occ []bool, rMin, rMax r3.Vector, pred func(r3.Vector) bool) {
+	x0 := clampInt(int(math.Floor((rMin.X-s.origin.X)/s.res))-1, 0, s.nx-1)
+	x1 := clampInt(int(math.Ceil((rMax.X-s.origin.X)/s.res))+1, 0, s.nx-1)
+	y0 := clampInt(int(math.Floor((rMin.Y-s.origin.Y)/s.res))-1, 0, s.ny-1)
+	y1 := clampInt(int(math.Ceil((rMax.Y-s.origin.Y)/s.res))+1, 0, s.ny-1)
+	z0 := clampInt(int(math.Floor((rMin.Z-s.origin.Z)/s.res))-1, 0, s.nz-1)
+	z1 := clampInt(int(math.Ceil((rMax.Z-s.origin.Z)/s.res))+1, 0, s.nz-1)
+	for z := z0; z <= z1; z++ {
+		for y := y0; y <= y1; y++ {
+			base := (z*s.ny + y) * s.nx
+			for x := x0; x <= x1; x++ {
+				if !occ[base+x] && pred(s.voxelCenter(x, y, z)) {
+					occ[base+x] = true
+				}
+			}
+		}
+	}
+}
+
+// PointClearance returns a conservative lower bound on the distance from p to
+// the nearest obstacle surface. Points outside the grid are clamped, with the
+// out-of-grid distance credited back.
+func (s *VoxelSDF) PointClearance(p r3.Vector) float64 {
+	fx := (p.X - s.origin.X) / s.res
+	fy := (p.Y - s.origin.Y) / s.res
+	fz := (p.Z - s.origin.Z) / s.res
+
+	x := clampInt(int(fx+0.5), 0, s.nx-1)
+	y := clampInt(int(fy+0.5), 0, s.ny-1)
+	z := clampInt(int(fz+0.5), 0, s.nz-1)
+
+	vc := s.voxelCenter(x, y, z)
+	// dist(p, surface) >= dist(vc, nearest occupied center) - |p - vc| - occMargin
+	return float64(s.dist[s.idx(x, y, z)]) - p.Sub(vc).Norm() - s.occMargin
+}
+
+func clampInt(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// edt3 computes, for every voxel, the Euclidean distance (in mm) to the
+// nearest occupied voxel center, using the exact separable squared-distance
+// transform of Felzenszwalb & Huttenlocher applied along each axis.
+func edt3(occ []bool, nx, ny, nz int, res float64) []float32 {
+	const inf = math.MaxFloat32 / 4
+	n := nx * ny * nz
+	f := make([]float64, n)
+	for i, o := range occ {
+		if o {
+			f[i] = 0
+		} else {
+			f[i] = inf
+		}
+	}
+
+	maxDim := max(nx, max(ny, nz))
+	d := make([]float64, maxDim)
+	vIdx := make([]int, maxDim)
+	zEnv := make([]float64, maxDim+1)
+	row := make([]float64, maxDim)
+
+	// X axis.
+	for z := 0; z < nz; z++ {
+		for y := 0; y < ny; y++ {
+			base := (z*ny + y) * nx
+			for x := 0; x < nx; x++ {
+				row[x] = f[base+x]
+			}
+			dt1(row[:nx], d, vIdx, zEnv)
+			for x := 0; x < nx; x++ {
+				f[base+x] = d[x]
+			}
+		}
+	}
+	// Y axis.
+	for z := 0; z < nz; z++ {
+		for x := 0; x < nx; x++ {
+			for y := 0; y < ny; y++ {
+				row[y] = f[(z*ny+y)*nx+x]
+			}
+			dt1(row[:ny], d, vIdx, zEnv)
+			for y := 0; y < ny; y++ {
+				f[(z*ny+y)*nx+x] = d[y]
+			}
+		}
+	}
+	// Z axis.
+	for y := 0; y < ny; y++ {
+		for x := 0; x < nx; x++ {
+			for z := 0; z < nz; z++ {
+				row[z] = f[(z*ny+y)*nx+x]
+			}
+			dt1(row[:nz], d, vIdx, zEnv)
+			for z := 0; z < nz; z++ {
+				f[(z*ny+y)*nx+x] = d[z]
+			}
+		}
+	}
+
+	out := make([]float32, n)
+	for i, v := range f {
+		out[i] = float32(math.Sqrt(v) * res)
+	}
+	return out
+}
+
+// dt1 is the 1D squared-distance transform (lower envelope of parabolas).
+func dt1(f, d []float64, v []int, z []float64) {
+	n := len(f)
+	k := 0
+	v[0] = 0
+	z[0] = math.Inf(-1)
+	z[1] = math.Inf(1)
+	for q := 1; q < n; q++ {
+		var s float64
+		for {
+			s = ((f[q] + float64(q*q)) - (f[v[k]] + float64(v[k]*v[k]))) / float64(2*q-2*v[k])
+			if s > z[k] {
+				break
+			}
+			k--
+		}
+		k++
+		v[k] = q
+		z[k] = s
+		z[k+1] = math.Inf(1)
+	}
+	k = 0
+	for q := 0; q < n; q++ {
+		for z[k+1] < float64(q) {
+			k++
+		}
+		dq := float64(q - v[k])
+		d[q] = dq*dq + f[v[k]]
+	}
+}

--- a/spatialmath/sdf_test.go
+++ b/spatialmath/sdf_test.go
@@ -1,0 +1,86 @@
+package spatialmath
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/golang/geo/r3"
+	"go.viam.com/test"
+)
+
+// TestVoxelSDFConservative: PointClearance must never exceed the true distance
+// to the nearest obstacle surface, across geometry types and random queries.
+func TestVoxelSDFConservative(t *testing.T) {
+	b, err := NewBox(NewPoseFromPoint(r3.Vector{X: 200, Y: 0, Z: 0}), r3.Vector{X: 100, Y: 100, Z: 100}, "b")
+	test.That(t, err, test.ShouldBeNil)
+	s, err := NewSphere(NewPoseFromPoint(r3.Vector{X: -200, Y: 100, Z: 50}), 40, "s")
+	test.That(t, err, test.ShouldBeNil)
+	c, err := NewCapsule(NewPoseFromPoint(r3.Vector{X: 0, Y: -200, Z: 0}), 30, 160, "c")
+	test.That(t, err, test.ShouldBeNil)
+	tri := NewTriangle(r3.Vector{X: 0, Y: 200, Z: -50}, r3.Vector{X: 50, Y: 250, Z: 60}, r3.Vector{X: -60, Y: 220, Z: 40})
+	mesh := NewMesh(NewZeroPose(), []*Triangle{tri}, "m")
+	geoms := []Geometry{b, s, c, mesh}
+
+	sdf := NewVoxelSDF(geoms, 10)
+	test.That(t, sdf, test.ShouldNotBeNil)
+
+	trueDist := func(p r3.Vector) float64 {
+		probe := NewPoint(p, "probe")
+		best := 1e18
+		for _, g := range geoms {
+			d, err := probe.DistanceFrom(g)
+			test.That(t, err, test.ShouldBeNil)
+			best = min(best, d)
+		}
+		return best
+	}
+
+	rnd := rand.New(rand.NewSource(3))
+	for i := 0; i < 2000; i++ {
+		p := r3.Vector{
+			X: (rnd.Float64() - 0.5) * 1200,
+			Y: (rnd.Float64() - 0.5) * 1200,
+			Z: (rnd.Float64() - 0.5) * 600,
+		}
+		lb := sdf.PointClearance(p)
+		if lb <= 0 {
+			continue // no claim made
+		}
+		td := trueDist(p)
+		test.That(t, lb, test.ShouldBeLessThanOrEqualTo, td+1e-9)
+	}
+}
+
+// TestVoxelSDFRejectsUnknownTypes: scenes containing unsupported geometry
+// types must produce no field rather than a field with holes.
+func TestVoxelSDFRejectsUnknownTypes(t *testing.T) {
+	test.That(t, NewVoxelSDF(nil, 10), test.ShouldBeNil)
+}
+
+// TestSphereCoverContains: every sampled surface/interior point of a geometry
+// must lie inside at least one cover sphere.
+func TestSphereCoverContains(t *testing.T) {
+	b, err := NewBox(NewPose(r3.Vector{X: 20, Y: -30, Z: 40}, &OrientationVectorDegrees{OZ: 1, Theta: 30}),
+		r3.Vector{X: 120, Y: 60, Z: 30}, "b")
+	test.That(t, err, test.ShouldBeNil)
+	c, err := NewCapsule(NewPoseFromPoint(r3.Vector{X: 5, Y: 5, Z: 5}), 25, 200, "c")
+	test.That(t, err, test.ShouldBeNil)
+	tri := NewTriangle(r3.Vector{X: 0, Y: 0, Z: 0}, r3.Vector{X: 90, Y: 10, Z: 40}, r3.Vector{X: -20, Y: 80, Z: -30})
+	mesh := NewMesh(NewPoseFromPoint(r3.Vector{X: 10, Y: 20, Z: 30}), []*Triangle{tri}, "m")
+
+	for _, g := range []Geometry{b, c, mesh} {
+		cover := SphereCover(g)
+		test.That(t, len(cover), test.ShouldBeGreaterThan, 0)
+		for _, p := range g.ToPoints(5) {
+			worst := 1e18
+			for _, sb := range cover {
+				if d := p.Sub(sb.Center).Norm() - sb.R; d < worst {
+					worst = d
+				}
+			}
+			if worst > 1e-6 {
+				t.Fatalf("geom %s (%T): point %v outside cover by %.3f", g.Label(), g, p, worst)
+			}
+		}
+	}
+}

--- a/spatialmath/spherecover.go
+++ b/spatialmath/spherecover.go
@@ -1,0 +1,213 @@
+package spatialmath
+
+import (
+	"math"
+
+	"github.com/golang/geo/r3"
+)
+
+// SphereBound is one sphere of a conservative cover: the covered geometry is
+// entirely contained in the union of its cover's spheres.
+type SphereBound struct {
+	Center r3.Vector
+	R      float64
+}
+
+// sphereCoverMeshCells is the per-axis cell count for mesh covers. 4^3 cells
+// keep covers under ~64 spheres with radii a fraction of the link size.
+const sphereCoverMeshCells = 4
+
+// SphereCover returns a conservative sphere cover of the geometry in world
+// coordinates, or nil when the geometry type is not supported (callers must
+// treat nil as "no bound available"). Covers for primitives are computed on
+// the fly from their world pose (cheap arithmetic); mesh covers are computed
+// once in the mesh's local frame, cached on its shared state, and transformed
+// per call.
+func SphereCover(g Geometry) []SphereBound {
+	switch geom := g.(type) {
+	case *sphere:
+		return []SphereBound{{Center: geom.pose.Point(), R: geom.radius}}
+	case *point:
+		return []SphereBound{{Center: geom.position, R: 0}}
+	case *capsule:
+		return capsuleSphereCover(geom.segA, geom.segB, geom.radius)
+	case *Cylinder:
+		center := geom.pose.Point()
+		axis := geom.pose.Orientation().Quaternion()
+		half := TransformPoint(axis, r3.Vector{}, r3.Vector{Z: geom.height / 2})
+		return capsuleSphereCover(center.Sub(half), center.Add(half), geom.radius)
+	case *box:
+		return boxSphereCover(geom)
+	case *Mesh:
+		return meshSphereCover(geom)
+	default:
+		return nil
+	}
+}
+
+// capsuleSphereCover covers the capsule with spheres spaced one radius apart
+// along the axis; spacing s and radius r+s/2 guarantee coverage.
+func capsuleSphereCover(segA, segB r3.Vector, r float64) []SphereBound {
+	axis := segB.Sub(segA)
+	l := axis.Norm()
+	if r <= 0 {
+		r = 1
+	}
+	n := int(math.Ceil(l/r)) + 1
+	if n > 32 {
+		n = 32
+	}
+	out := make([]SphereBound, 0, n)
+	if n == 1 {
+		return append(out, SphereBound{Center: segA.Add(axis.Mul(0.5)), R: r + l/2})
+	}
+	spacing := l / float64(n-1)
+	for i := 0; i < n; i++ {
+		out = append(out, SphereBound{Center: segA.Add(axis.Mul(float64(i) / float64(n-1))), R: r + spacing/2})
+	}
+	return out
+}
+
+// boxSphereCover subdivides the box into cells small enough that each cell's
+// half-diagonal is a modest sphere and covers each cell with one sphere.
+func boxSphereCover(b *box) []SphereBound {
+	half := r3.Vector{X: b.halfSize[0], Y: b.halfSize[1], Z: b.halfSize[2]}
+	// Aim for cells no larger than the smallest box dimension (so flat boxes
+	// get thin spheres), capped at 4 cells per axis.
+	target := math.Max(20, math.Min(half.X, math.Min(half.Y, half.Z))*2)
+	nx := clampInt(int(math.Ceil(half.X*2/target)), 1, 4)
+	ny := clampInt(int(math.Ceil(half.Y*2/target)), 1, 4)
+	nz := clampInt(int(math.Ceil(half.Z*2/target)), 1, 4)
+
+	cell := r3.Vector{X: half.X / float64(nx), Y: half.Y / float64(ny), Z: half.Z / float64(nz)}
+	r := cell.Norm() // cell half-diagonal
+	rm := b.center.Orientation().RotationMatrix()
+	c := b.center.Point()
+
+	out := make([]SphereBound, 0, nx*ny*nz)
+	for ix := 0; ix < nx; ix++ {
+		for iy := 0; iy < ny; iy++ {
+			for iz := 0; iz < nz; iz++ {
+				local := r3.Vector{
+					X: -half.X + (2*float64(ix)+1)*cell.X,
+					Y: -half.Y + (2*float64(iy)+1)*cell.Y,
+					Z: -half.Z + (2*float64(iz)+1)*cell.Z,
+				}
+				world := r3.Vector{
+					X: rm.Row(0).Dot(local),
+					Y: rm.Row(1).Dot(local),
+					Z: rm.Row(2).Dot(local),
+				}
+				out = append(out, SphereBound{Center: c.Add(world), R: r})
+			}
+		}
+	}
+	return out
+}
+
+// meshSphereCover buckets the mesh's triangles into a local-frame grid, covers
+// each bucket's vertices with one sphere (a triangle is inside any sphere
+// containing its vertices), caches the local cover on the shared mesh state,
+// and transforms centers into world space per call.
+func meshSphereCover(m *Mesh) []SphereBound {
+	if m.state == nil || len(m.triangles) == 0 {
+		return nil
+	}
+	m.state.sphereCoverOnce.Do(func() {
+		m.state.sphereCover = buildLocalMeshCover(m.triangles)
+	})
+	local := m.state.sphereCover
+	if len(local) == 0 {
+		return nil
+	}
+	q := m.pose.Orientation().Quaternion()
+	t := m.pose.Point()
+	out := make([]SphereBound, len(local))
+	for i, sb := range local {
+		out[i] = SphereBound{Center: TransformPoint(q, t, sb.Center), R: sb.R}
+	}
+	return out
+}
+
+func buildLocalMeshCover(tris []*Triangle) []SphereBound {
+	minPt := r3.Vector{X: math.Inf(1), Y: math.Inf(1), Z: math.Inf(1)}
+	maxPt := r3.Vector{X: math.Inf(-1), Y: math.Inf(-1), Z: math.Inf(-1)}
+	for _, tri := range tris {
+		tMin, tMax := triAABB(tri)
+		minPt, maxPt = expandAABB(minPt, maxPt, tMin)
+		minPt, maxPt = expandAABB(minPt, maxPt, tMax)
+	}
+	size := maxPt.Sub(minPt)
+	n := sphereCoverMeshCells
+	cell := r3.Vector{
+		X: math.Max(size.X/float64(n), 1e-6),
+		Y: math.Max(size.Y/float64(n), 1e-6),
+		Z: math.Max(size.Z/float64(n), 1e-6),
+	}
+
+	type bucket struct {
+		min, max r3.Vector
+		any      bool
+	}
+	buckets := make([]bucket, n*n*n)
+	cellOf := func(p r3.Vector) int {
+		ix := clampInt(int((p.X-minPt.X)/cell.X), 0, n-1)
+		iy := clampInt(int((p.Y-minPt.Y)/cell.Y), 0, n-1)
+		iz := clampInt(int((p.Z-minPt.Z)/cell.Z), 0, n-1)
+		return (iz*n+iy)*n + ix
+	}
+	add := func(bi int, p r3.Vector) {
+		b := &buckets[bi]
+		if !b.any {
+			b.min, b.max, b.any = p, p, true
+			return
+		}
+		b.min, b.max = expandAABB(b.min, b.max, p)
+	}
+	for _, tri := range tris {
+		// Assign whole triangles by centroid so each triangle lives in exactly
+		// one bucket; the bucket AABB grows to include all three vertices, so
+		// coverage still holds.
+		bi := cellOf(tri.Centroid())
+		add(bi, tri.p0)
+		add(bi, tri.p1)
+		add(bi, tri.p2)
+	}
+
+	out := []SphereBound{}
+	for i := range buckets {
+		b := &buckets[i]
+		if !b.any {
+			continue
+		}
+		c := b.min.Add(b.max).Mul(0.5)
+		out = append(out, SphereBound{Center: c, R: b.max.Sub(c).Norm()})
+	}
+	return out
+}
+
+// BoundingSphere returns a single conservative bounding sphere for the
+// geometry (world frame). ok is false for geometry types with no cheap bound;
+// callers must then skip sphere-based pruning.
+func BoundingSphere(g Geometry) (r3.Vector, float64, bool) {
+	switch geom := g.(type) {
+	case *sphere:
+		return geom.pose.Point(), geom.radius, true
+	case *point:
+		return geom.position, 0, true
+	case *capsule:
+		return geom.center, geom.length / 2, true
+	case *box:
+		return geom.centerPt, geom.boundingSphereR, true
+	case *Cylinder:
+		h := geom.height / 2
+		return geom.pose.Point(), math.Sqrt(h*h + geom.radius*geom.radius), true
+	case *Mesh:
+		if geom.state == nil {
+			return r3.Vector{}, 0, false
+		}
+		return geom.pose.Point(), geom.localBoundingRadius(), true
+	default:
+		return r3.Vector{}, 0, false
+	}
+}


### PR DESCRIPTION
Part 1 of 4 of a motion-planning performance series (with #6376, #6377, #6378). This PR is standalone: it adds geometry-layer machinery and fixes, and changes no planner behavior by itself.

## What

- **`VoxelSDF`** — a voxel signed-distance field over a static scene (surfaces rasterized into a grid, exact Euclidean distance transform via the Felzenszwalb–Huttenlocher separable pass). Answers conservative point-clearance queries in O(1). Scenes containing geometry types it cannot rasterize (e.g. octrees) get no field at all rather than a field with holes.
- **`SphereCover` / `BoundingSphere`** — conservative sphere covers per geometry type (mesh covers computed once per logical mesh and cached on the shared mesh state), plus a single cheap bounding sphere per geometry for broadphase pruning.
- **Distance anchors** — small per-geometry-pair rings recording the clearance a full narrow-phase query measured at a relative pose. While the pair has moved (rigid-motion displacement bound) less than that clearance, collision-freedom follows with no geometry work. Rings hold 8 slots so the interleaved pose streams of a bidirectional/racing search don't evict each other; lock-free for concurrent readers.
- **Cheaper exact paths** — branch-and-bound BVH traversals that return true minimum distances (refinement capped at 25mm), memoized pose decompositions, cached box world-AABBs (previously 47% of all planner allocations in profiles), and a mesh-local capsule distance path.
- **`capsule.ToPoints` fixes** (pre-existing bugs): endcap points were never moved off the center sphere (a value-copy loop mutated copies), and shaft rings spanned `(0, l)` instead of the centered `±(l/2−r)`, emitting points off the capsule surface.

## Why

Motion planning spends nearly all its wall time in collision checks. The next PRs in the series use these primitives to answer most checks without materializing geometry; on a captured production scene the series takes planning from ~170s to ~2.5s warm steady-state.

## Safety

Every fast path is conservative: covers and SDF clearances only ever *prove* freedom, never collision — anything they can't clear falls through to the exact narrow-phase check. The conservative bounds are validated by tests against exact distances (`sdf_test.go`, sphere-cover containment tests).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyqhmqkxS9B8bGjdUhTtAs