### PR TITLE
motionplan: distance-field and sphere-cover collision constraint evaluation

### DIFF
--- a/motionplan/collision.go
+++ b/motionplan/collision.go
@@ -191,6 +191,17 @@ func checkCollisionsHinted(
 	timeChecks := logger.GetLevel() <= logging.DEBUG
 	var pairCounter atomic.Uint64
 	checkOnePair := func(xName, yName string, xGeometry, yGeometry spatialmath.Geometry) (bool, error) {
+		// Bounding-sphere broadphase: most pairs in the moving-vs-static
+		// product are nowhere near each other, and even the cached narrow
+		// phase costs three orders of magnitude more than this gap test.
+		if cx, rx, okx := spatialmath.BoundingSphere(xGeometry); okx {
+			if cy, ry, oky := spatialmath.BoundingSphere(yGeometry); oky {
+				if gap := cx.Sub(cy).Norm() - rx - ry; gap > collisionBufferMM {
+					minDistance = min(minDistance, gap)
+					return false, nil
+				}
+			}
+		}
 		var start time.Time
 		timeThis := timeChecks && pairCounter.Add(1)&15 == 0
 		if timeThis {

--- a/motionplan/collision_cache.go
+++ b/motionplan/collision_cache.go
@@ -35,9 +35,6 @@ type CollisionCache struct {
 	// for an interpolated edge. Key is the canonical {hashA, hashB} pair —
 	// uint64 fits inside sync.Map's interface{} slot without allocation.
 	edgeResults sync.Map // edgeResultKey -> edgeResultValue
-
-	// sdfs caches voxel distance fields per static geometry set (see SDFFor).
-	sdfs sync.Map // uint64 -> *spatialmath.VoxelSDF
 }
 
 // NewCollisionCache constructs an empty cache. Safe for concurrent use.
@@ -86,34 +83,86 @@ func (c *CollisionCache) StoreEdgeResult(hashA, hashB uint64, isClear bool) {
 	c.edgeResults.Store(edgeResultKey{a: hashA, b: hashB}, edgeResultValue{isClear: isClear})
 }
 
+// sdfRegistry caches voxel distance fields process-wide. A field depends only
+// on the static scene (keyed by the shape-aware staticSetHash), never on the
+// plan, and costs ~35-70ms plus a multi-MB grid allocation to build - caching
+// it per plan made every replan of an otherwise-trivial scene pay that in
+// full. Small LRU: each field can be tens of MB, and a scene whose obstacles
+// move between plans mints a new key every time.
+type sdfRegistry struct {
+	mu      sync.Mutex
+	tick    uint64
+	entries map[uint64]*sdfRegistryEntry
+}
+
+type sdfRegistryEntry struct {
+	sdf      *spatialmath.VoxelSDF // nil records a scene the SDF cannot represent
+	lastUsed uint64
+}
+
+const sdfRegistryCap = 8
+
+var globalSDFRegistry = sdfRegistry{entries: map[uint64]*sdfRegistryEntry{}}
+
+func (r *sdfRegistry) lookup(key uint64) (*spatialmath.VoxelSDF, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e, ok := r.entries[key]
+	if !ok {
+		return nil, false
+	}
+	r.tick++
+	e.lastUsed = r.tick
+	return e.sdf, true
+}
+
+func (r *sdfRegistry) insert(key uint64, sdf *spatialmath.VoxelSDF) *spatialmath.VoxelSDF {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if e, ok := r.entries[key]; ok {
+		// Another plan built the same field concurrently; keep the incumbent.
+		return e.sdf
+	}
+	r.tick++
+	r.entries[key] = &sdfRegistryEntry{sdf: sdf, lastUsed: r.tick}
+	for len(r.entries) > sdfRegistryCap {
+		var oldestKey uint64
+		oldest := uint64(math.MaxUint64)
+		for k, e := range r.entries {
+			if e.lastUsed < oldest {
+				oldest, oldestKey = e.lastUsed, k
+			}
+		}
+		delete(r.entries, oldestKey)
+	}
+	return sdf
+}
+
 // SDFFor returns the voxel distance field for the given static geometry set,
-// building it on first request. Keyed by a hash of the geometries' labels and
-// poses so all PlanSegmentContexts of a plan (which share their static scene)
-// share one field. sdfResolutionMM balances build time (~70ms for a dual-arm
-// scene at 10mm) against the conservative margin subtracted from every query
-// (half the voxel diagonal, ~8.7mm at 10mm).
+// building it on first request anywhere in the process and sharing it across
+// plans of the same scene. sdfResolutionMM balances build time (~70ms for a
+// dual-arm scene at 10mm) against the conservative margin subtracted from
+// every query (half the voxel diagonal, ~8.7mm at 10mm).
 func (c *CollisionCache) SDFFor(static []spatialmath.Geometry) *spatialmath.VoxelSDF {
 	if c == nil || len(static) == 0 {
 		return nil
 	}
 	key := staticSetHash(static)
-	if v, ok := c.sdfs.Load(key); ok {
-		return v.(*spatialmath.VoxelSDF)
+	if sdf, ok := globalSDFRegistry.lookup(key); ok {
+		return sdf
 	}
-	sdf := spatialmath.NewVoxelSDF(static, sdfResolutionMM)
-	if sdf == nil {
-		return nil
-	}
-	actual, _ := c.sdfs.LoadOrStore(key, sdf)
-	return actual.(*spatialmath.VoxelSDF)
+	return globalSDFRegistry.insert(key, spatialmath.NewVoxelSDF(static, sdfResolutionMM))
 }
 
 const sdfResolutionMM = 10.0
 
-// staticSetHash fingerprints a static geometry set by label and pose. The
-// per-geometry hashes are combined commutatively because callers assemble the
-// set from map iteration - the same scene must hash identically regardless of
-// geometry order, or every segment context would rebuild the field.
+// staticSetHash fingerprints a static geometry set by label, pose, and shape
+// (via Geometry.Hash, which folds in type-specific dimensions - process-wide
+// sharing must not serve a stale field to a same-named, same-posed geometry
+// whose size changed). The per-geometry hashes are combined commutatively
+// because callers assemble the set from map iteration - the same scene must
+// hash identically regardless of geometry order, or every caller would
+// rebuild the field.
 func staticSetHash(geoms []spatialmath.Geometry) uint64 {
 	const fnvPrime = 0x100000001b3
 	total := uint64(len(geoms))
@@ -131,6 +180,7 @@ func staticSetHash(geoms []spatialmath.Geometry) uint64 {
 		for _, f := range [7]float64{pt.X, pt.Y, pt.Z, q.Real, q.Imag, q.Jmag, q.Kmag} {
 			mix(math.Float64bits(f))
 		}
+		mix(uint64(g.Hash()))
 		total += h
 	}
 	return total

--- a/motionplan/collision_cache.go
+++ b/motionplan/collision_cache.go
@@ -1,8 +1,11 @@
 package motionplan
 
 import (
+	"math"
 	"sync"
 	"sync/atomic"
+
+	"go.viam.com/rdk/spatialmath"
 )
 
 // CollisionCache holds planner-level temporal-coherence state for collision
@@ -32,6 +35,9 @@ type CollisionCache struct {
 	// for an interpolated edge. Key is the canonical {hashA, hashB} pair —
 	// uint64 fits inside sync.Map's interface{} slot without allocation.
 	edgeResults sync.Map // edgeResultKey -> edgeResultValue
+
+	// sdfs caches voxel distance fields per static geometry set (see SDFFor).
+	sdfs sync.Map // uint64 -> *spatialmath.VoxelSDF
 }
 
 // NewCollisionCache constructs an empty cache. Safe for concurrent use.
@@ -78,4 +84,54 @@ func (c *CollisionCache) StoreEdgeResult(hashA, hashB uint64, isClear bool) {
 		hashA, hashB = hashB, hashA
 	}
 	c.edgeResults.Store(edgeResultKey{a: hashA, b: hashB}, edgeResultValue{isClear: isClear})
+}
+
+// SDFFor returns the voxel distance field for the given static geometry set,
+// building it on first request. Keyed by a hash of the geometries' labels and
+// poses so all PlanSegmentContexts of a plan (which share their static scene)
+// share one field. sdfResolutionMM balances build time (~70ms for a dual-arm
+// scene at 10mm) against the conservative margin subtracted from every query
+// (half the voxel diagonal, ~8.7mm at 10mm).
+func (c *CollisionCache) SDFFor(static []spatialmath.Geometry) *spatialmath.VoxelSDF {
+	if c == nil || len(static) == 0 {
+		return nil
+	}
+	key := staticSetHash(static)
+	if v, ok := c.sdfs.Load(key); ok {
+		return v.(*spatialmath.VoxelSDF)
+	}
+	sdf := spatialmath.NewVoxelSDF(static, sdfResolutionMM)
+	if sdf == nil {
+		return nil
+	}
+	actual, _ := c.sdfs.LoadOrStore(key, sdf)
+	return actual.(*spatialmath.VoxelSDF)
+}
+
+const sdfResolutionMM = 10.0
+
+// staticSetHash fingerprints a static geometry set by label and pose. The
+// per-geometry hashes are combined commutatively because callers assemble the
+// set from map iteration - the same scene must hash identically regardless of
+// geometry order, or every segment context would rebuild the field.
+func staticSetHash(geoms []spatialmath.Geometry) uint64 {
+	const fnvPrime = 0x100000001b3
+	total := uint64(len(geoms))
+	for _, g := range geoms {
+		h := uint64(0xcbf29ce484222325)
+		mix := func(v uint64) {
+			h ^= v
+			h *= fnvPrime
+		}
+		for _, ch := range g.Label() {
+			mix(uint64(ch))
+		}
+		pt := g.Pose().Point()
+		q := g.Pose().Orientation().Quaternion()
+		for _, f := range [7]float64{pt.X, pt.Y, pt.Z, q.Real, q.Imag, q.Jmag, q.Kmag} {
+			mix(math.Float64bits(f))
+		}
+		total += h
+	}
+	return total
 }

--- a/motionplan/collision_cache_test.go
+++ b/motionplan/collision_cache_test.go
@@ -1,0 +1,59 @@
+package motionplan
+
+import (
+	"testing"
+
+	"github.com/golang/geo/r3"
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/spatialmath"
+)
+
+func testStaticScene(t *testing.T, dims r3.Vector) []spatialmath.Geometry {
+	t.Helper()
+	box, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{X: 100}), dims, "wall")
+	test.That(t, err, test.ShouldBeNil)
+	sphere, err := spatialmath.NewSphere(spatialmath.NewPoseFromPoint(r3.Vector{Y: 200}), 30, "ball")
+	test.That(t, err, test.ShouldBeNil)
+	return []spatialmath.Geometry{box, sphere}
+}
+
+func TestSDFRegistrySharing(t *testing.T) {
+	sceneA := testStaticScene(t, r3.Vector{X: 50, Y: 400, Z: 400})
+
+	c1 := NewCollisionCache()
+	sdf1 := c1.SDFFor(sceneA)
+	test.That(t, sdf1, test.ShouldNotBeNil)
+
+	// A different plan's cache, same scene in reversed order: same field.
+	c2 := NewCollisionCache()
+	sdf2 := c2.SDFFor([]spatialmath.Geometry{sceneA[1], sceneA[0]})
+	test.That(t, sdf2, test.ShouldEqual, sdf1)
+
+	// Same labels and poses but a resized geometry must not reuse the field.
+	sceneB := testStaticScene(t, r3.Vector{X: 50, Y: 400, Z: 800})
+	sdf3 := NewCollisionCache().SDFFor(sceneB)
+	test.That(t, sdf3, test.ShouldNotBeNil)
+	test.That(t, sdf3, test.ShouldNotEqual, sdf1)
+}
+
+func TestSDFRegistryEviction(t *testing.T) {
+	r := sdfRegistry{entries: map[uint64]*sdfRegistryEntry{}}
+	scene := testStaticScene(t, r3.Vector{X: 50, Y: 400, Z: 400})
+	sdf := spatialmath.NewVoxelSDF(scene, sdfResolutionMM)
+	test.That(t, sdf, test.ShouldNotBeNil)
+
+	for key := uint64(0); key < sdfRegistryCap+3; key++ {
+		r.insert(key, sdf)
+		if key > 0 {
+			// Keep key 0 warm so eviction drops the stale middle keys instead.
+			_, ok := r.lookup(0)
+			test.That(t, ok, test.ShouldBeTrue)
+		}
+	}
+	test.That(t, len(r.entries), test.ShouldEqual, sdfRegistryCap)
+	_, ok := r.lookup(0)
+	test.That(t, ok, test.ShouldBeTrue)
+	_, ok = r.lookup(1)
+	test.That(t, ok, test.ShouldBeFalse)
+}

--- a/motionplan/constraint.go
+++ b/motionplan/constraint.go
@@ -92,6 +92,45 @@ func (oc *OrientationConstraint) Distance(from, to, now spatialmath.Orientation)
 	return min(a, b)
 }
 
+// OrientationConstraintEval evaluates one OrientationConstraint against fixed
+// start and goal orientations. The endpoints never change during a plan, but
+// Distance re-derives their orientation-vector forms on every call -
+// precomputing them leaves one conversion (the current orientation) per check.
+type OrientationConstraintEval struct {
+	oc           OrientationConstraint
+	from, to     spatialmath.Orientation
+	fromOV, toOV *spatialmath.OrientationVectorDegrees
+}
+
+// NewOrientationConstraintEval precomputes the fixed endpoint conversions.
+func NewOrientationConstraintEval(oc OrientationConstraint, from, to spatialmath.Orientation) *OrientationConstraintEval {
+	return &OrientationConstraintEval{
+		oc: oc, from: from, to: to,
+		fromOV: from.OrientationVectorDegrees(), toOV: to.OrientationVectorDegrees(),
+	}
+}
+
+// Distance is OrientationConstraint.Distance with the endpoint conversions amortized.
+func (e *OrientationConstraintEval) Distance(now spatialmath.Orientation) float64 {
+	n := now.OrientationVectorDegrees()
+	if between(e.fromOV.OX, e.toOV.OX, n.OX) &&
+		between(e.fromOV.OY, e.toOV.OY, n.OY) &&
+		between(e.fromOV.OZ, e.toOV.OZ, n.OZ) &&
+		between(e.fromOV.Theta, e.toOV.Theta, n.Theta) {
+		return 0
+	}
+	return min(OrientDist(e.from, now), OrientDist(e.to, now))
+}
+
+// Score mirrors OrientationConstraint.Score.
+func (e *OrientationConstraintEval) Score(now spatialmath.Orientation) float64 {
+	d := e.Distance(now)
+	if d <= 0 {
+		return 0
+	}
+	return max(0, d-e.oc.OrientationToleranceDegs)
+}
+
 // CollisionSpecificationAllowedFrameCollisions is used to define frames that are allowed to collide.
 type CollisionSpecificationAllowedFrameCollisions struct {
 	Frame1, Frame2 string

--- a/motionplan/constraint_checker.go
+++ b/motionplan/constraint_checker.go
@@ -7,7 +7,6 @@ import (
 	"sync/atomic"
 
 	"github.com/pkg/errors"
-	"go.viam.com/utils/trace"
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/referenceframe"
@@ -169,13 +168,24 @@ func (c *ConstraintChecker) addTopoConstraints(
 		fromPoses[f] = x.(*referenceframe.PoseInFrame)
 	}
 
+	// Precompute per-frame orientation-constraint evaluators: the endpoint
+	// orientation-vector conversions are the expensive part of the check and
+	// the endpoints are fixed for the plan's lifetime.
+	orientationEvals := map[string][]*OrientationConstraintEval{}
+	for frame, toPIF := range toPoses {
+		fromPIF := fromPoses[frame]
+		if fromPIF.Parent() != toPIF.Parent() {
+			return fmt.Errorf("in topo constraint, from and to are in different frames %s != %s", fromPIF.Parent(), toPIF.Parent())
+		}
+		for _, oc := range constraints.OrientationConstraint {
+			orientationEvals[frame] = append(orientationEvals[frame],
+				NewOrientationConstraintEval(oc, fromPIF.Pose().Orientation(), toPIF.Pose().Orientation()))
+		}
+	}
+
 	c.topoConstraint = func(state *StateFS) error {
 		for frame, toPIF := range toPoses {
 			fromPIF := fromPoses[frame]
-
-			if fromPIF.Parent() != toPIF.Parent() {
-				return fmt.Errorf("in topo constraint, from and to are in different frames %s != %s", fromPIF.Parent(), toPIF.Parent())
-			}
 
 			currPosePIF, err := state.FS.Transform(state.Configuration, referenceframe.NewZeroPoseInFrame(frame), toPIF.Parent())
 			if err != nil {
@@ -200,8 +210,8 @@ func (c *ConstraintChecker) addTopoConstraints(
 				}
 			}
 
-			for _, oc := range constraints.OrientationConstraint {
-				err := checkOrientationConstraint(frame, oc, from, to, currPose)
+			for _, eval := range orientationEvals[frame] {
+				err := checkOrientationConstraintEval(frame, eval, currPose)
 				if err != nil {
 					return err
 				}
@@ -265,19 +275,29 @@ func checkPseudoLinearConstraint(frame string, plinConstraint PseudolinearConstr
 	return nil
 }
 
-func checkOrientationConstraint(frame string, c OrientationConstraint, from, to, currPose spatialmath.Pose) error {
-	dist := c.Distance(from.Orientation(), to.Orientation(), currPose.Orientation())
-	if dist > c.OrientationToleranceDegs {
-		return orientationError(frame, from.Orientation(), to.Orientation(), currPose.Orientation(), dist, c.OrientationToleranceDegs)
+func checkOrientationConstraintEval(frame string, e *OrientationConstraintEval, currPose spatialmath.Pose) error {
+	dist := e.Distance(currPose.Orientation())
+	if dist > e.oc.OrientationToleranceDegs {
+		return orientationError(frame, e.from, e.to, currPose.Orientation(), dist, e.oc.OrientationToleranceDegs)
 	}
 	return nil
 }
 
 // CheckStateFSConstraints will check a given input against all FS state constraints.
 // first is closest obstacle, negative if in collision
+// Deliberately no tracing span here: this runs hundreds of thousands of times
+// per plan, and per-call span creation plus exporter wakeups measurably
+// dominated planning time once the checks themselves became cheap.
 func (c *ConstraintChecker) CheckStateFSConstraints(ctx context.Context, state *StateFS) (float64, error) {
-	_, span := trace.StartSpan(ctx, "CheckStateFSConstraints")
-	defer span.End()
+	// Topological constraints (orientation/linear) cost a single FK pass —
+	// orders of magnitude cheaper than the collision sweeps below — so check
+	// them first: constrained planners generate many candidate states that fail
+	// only the topological check, and those shouldn't pay for collision work.
+	if c.topoConstraint != nil {
+		if err := c.topoConstraint(state); err != nil {
+			return math.Inf(1), err
+		}
+	}
 
 	closest := math.Inf(1)
 
@@ -299,13 +319,18 @@ func (c *ConstraintChecker) CheckStateFSConstraints(ctx context.Context, state *
 		}
 	}
 
-	if c.topoConstraint != nil {
-		err := c.topoConstraint(state)
-		if err != nil {
-			return closest, err
-		}
-	}
 	return closest, nil
+}
+
+// CheckStateFSTopoOnly evaluates only the topological (orientation/linear)
+// constraints for a state — the cheap, single-FK subset of
+// CheckStateFSConstraints. For callers that skip collision checks under a
+// clearance bound but must still verify topological validity per state.
+func (c *ConstraintChecker) CheckStateFSTopoOnly(state *StateFS) error {
+	if c.topoConstraint == nil {
+		return nil
+	}
+	return c.topoConstraint(state)
 }
 
 // InterpolateSegmentFS is a helper function which produces a list of intermediate inputs, between the start and end
@@ -355,9 +380,6 @@ func (c *ConstraintChecker) CheckStateConstraintsAcrossSegmentFS(
 	resolution float64,
 	checkFinal bool,
 ) (*SegmentFS, error) {
-	ctx, span := trace.StartSpan(ctx, "CheckStateConstraintsAcrossSegmentFS")
-	defer span.End()
-
 	interpolatedConfigurations, err := InterpolateSegmentFS(ci, resolution)
 	if err != nil {
 		return nil, err
@@ -382,8 +404,24 @@ func (c *ConstraintChecker) CheckStateConstraintsAcrossSegmentFS(
 		}
 		lastGood = interpC.Configuration
 
+		// The clearance at this state proves the next canSkip states cannot
+		// collide (the robot can't cross a gap faster than it moves), so the
+		// expensive collision constraints may be skipped for them. Topological
+		// constraints (orientation/linear) carry no such guarantee but are
+		// cheap - a single FK pass per state - so evaluate just those on the
+		// skipped states instead of disabling skipping altogether.
 		canSkip := int(min(100, math.Floor(closestObstacle/resolution)))
-		if canSkip > 0 && c.topoConstraint == nil {
+		if canSkip > 0 && c.topoConstraint != nil {
+			for j := i + 1; j <= i+canSkip && j < end; j++ {
+				topoC := &StateFS{FS: ci.FS, Configuration: interpolatedConfigurations[j]}
+				if err := c.topoConstraint(topoC); err != nil {
+					return &SegmentFS{StartConfiguration: ci.StartConfiguration, EndConfiguration: lastGood, FS: ci.FS}, err
+				}
+				// Collision-free by the clearance bound and topo-checked: valid.
+				lastGood = topoC.Configuration
+			}
+		}
+		if canSkip > 0 {
 			i += canSkip
 		}
 	}
@@ -416,6 +454,11 @@ func CreateAllCollisionConstraints(
 		selfHint = &cache.selfPairHint
 	}
 
+	// Precompute local-frame sphere covers for the moving frames once; the
+	// three constraint closures share the table (and, per state, the world
+	// covers computed from it) so most states never materialize geometry.
+	coverTable := buildFrameCoverTable(fs, movingFrameNames)
+
 	if len(worldGeometries) > 0 {
 		obstacleConstraintFS, err := NewCollisionConstraintFS(
 			fs,
@@ -427,6 +470,7 @@ func CreateAllCollisionConstraints(
 			false,
 			obstacleHint,
 			cache,
+			coverTable,
 			logger,
 		)
 		if err != nil {
@@ -446,6 +490,7 @@ func CreateAllCollisionConstraints(
 			false,
 			robotHint,
 			cache,
+			coverTable,
 			logger,
 		)
 		if err != nil {
@@ -465,6 +510,7 @@ func CreateAllCollisionConstraints(
 			true,
 			selfHint,
 			cache,
+			coverTable,
 			logger,
 		)
 		if err != nil {
@@ -491,9 +537,9 @@ func NewCollisionConstraintFS(
 	isSelfCollision bool,
 	pairHint *atomic.Pointer[[2]string],
 	cache *CollisionCache,
+	coverTable *frameCoverTable,
 	logger logging.Logger,
 ) (CollisionConstraintFunc, error) {
-	_ = cache // reserved for future planner-level caches (edge memoization lives elsewhere on the same struct)
 	ignoreCollisions, err := computeInitialCollisionsToIgnore(fs, moving, static,
 		collisionSpecifications, collisionBufferMM, logger)
 	if err != nil {
@@ -502,8 +548,144 @@ func NewCollisionConstraintFS(
 
 	allowed := makeAllowedCollisionsLookup(ignoreCollisions)
 
+	// Distance-field fast path for the moving-vs-static product: a voxel SDF
+	// over the static set answers "this moving geometry is at least D away
+	// from everything static" from a handful of array lookups against the
+	// geometry's conservative sphere cover. Only clear verdicts are used -
+	// anything near, uncovered, or colliding falls through to the exact
+	// checker, so allowed-collision pairs and near-contact distances keep
+	// their exact semantics. The field is built once per static scene and
+	// shared across all segment contexts through the plan cache.
+	var sdf *spatialmath.VoxelSDF
+	if !isSelfCollision {
+		sdf = cache.SDFFor(static)
+	}
+	sdfClearThreshold := math.Max(2.0, 2*collisionBufferMM)
+
+	// finish shares the tail of every path: convert a found collision into
+	// the constraint-violated error.
+	finish := func(collisions []Collision, minDist float64, err error) (float64, error) {
+		if err != nil {
+			return minDist, err
+		}
+		if len(collisions) != 0 {
+			return minDist, fmt.Errorf(
+				"violation between %s and %s geometries",
+				collisions[0].name1,
+				collisions[0].name2,
+			)
+		}
+		return minDist, nil
+	}
+
+	// checkStaticViaCovers evaluates the moving-vs-static constraint from the
+	// state's sphere covers and the distance field, materializing geometry
+	// only for the frames the sphere phase cannot clear.
+	checkStaticViaCovers := func(state *StateFS, cs *stateCoverSet) (float64, error) {
+		sdfMin := math.Inf(1)
+		needFrames := map[string]bool{}
+		for f := range coverTable.materialize {
+			needFrames[f] = true
+		}
+		for i := range cs.geoms {
+			cg := &cs.geoms[i]
+			lb := math.Inf(1)
+			for _, sb := range cg.world {
+				if v := sdf.PointClearance(sb.Center) - sb.R; v < lb {
+					lb = v
+				}
+			}
+			if lb > sdfClearThreshold {
+				sdfMin = math.Min(sdfMin, lb)
+			} else {
+				needFrames[cg.frameName] = true
+			}
+		}
+		if len(needFrames) == 0 {
+			return sdfMin, nil
+		}
+		geoms, err := materializedSubset(state, fs, needFrames)
+		if err != nil {
+			return 0, err
+		}
+		collisions, minDist, err := checkCollisionsHinted(
+			geoms, static, allowed, collisionBufferMM, false, pairHint, logger)
+		return finish(collisions, math.Min(minDist, sdfMin), err)
+	}
+
+	// checkSelfViaCovers evaluates self-collision pairwise from the covers'
+	// enclosing spheres; only frames belonging to a near pair (or without
+	// covers) are materialized and checked exactly.
+	checkSelfViaCovers := func(state *StateFS, cs *stateCoverSet) (float64, error) {
+		selfMin := math.Inf(1)
+		near := map[string]bool{}
+		for f := range coverTable.materialize {
+			near[f] = true
+		}
+		// Uncovered frames must pair against everything; materialize them
+		// first so their bounding spheres can prune covered partners.
+		var uncoveredBounds []spatialmath.SphereBound
+		if len(near) > 0 {
+			geoms, err := materializedSubset(state, fs, near)
+			if err != nil {
+				return 0, err
+			}
+			for _, g := range geoms {
+				if c, r, ok := spatialmath.BoundingSphere(g); ok {
+					uncoveredBounds = append(uncoveredBounds, spatialmath.SphereBound{Center: c, R: r})
+				} else {
+					// No cheap bound: everything is potentially near it.
+					for i := range cs.geoms {
+						near[cs.geoms[i].frameName] = true
+					}
+					uncoveredBounds = nil
+					break
+				}
+			}
+		}
+		for i := range cs.geoms {
+			a := &cs.geoms[i]
+			for j := i + 1; j < len(cs.geoms); j++ {
+				b := &cs.geoms[j]
+				gap := a.bound.Center.Sub(b.bound.Center).Norm() - a.bound.R - b.bound.R
+				if gap > sdfClearThreshold {
+					selfMin = math.Min(selfMin, gap)
+					continue
+				}
+				near[a.frameName] = true
+				near[b.frameName] = true
+			}
+			for _, ub := range uncoveredBounds {
+				if a.bound.Center.Sub(ub.Center).Norm()-a.bound.R-ub.R <= sdfClearThreshold {
+					near[a.frameName] = true
+				}
+			}
+		}
+		if len(near) == 0 {
+			return selfMin, nil
+		}
+		geoms, err := materializedSubset(state, fs, near)
+		if err != nil {
+			return 0, err
+		}
+		collisions, minDist, err := checkCollisionsHinted(
+			geoms, geoms, allowed, collisionBufferMM, false, pairHint, logger)
+		return finish(collisions, math.Min(minDist, selfMin), err)
+	}
+
 	// create constraint from reference collision graph
 	constraint := func(state *StateFS) (float64, error) {
+		if coverTable != nil {
+			if cs := coverSetFor(state, fs, coverTable); !cs.failed {
+				if isSelfCollision {
+					return checkSelfViaCovers(state, cs)
+				}
+				if sdf != nil {
+					return checkStaticViaCovers(state, cs)
+				}
+			}
+		}
+
 		// state.movingGeometries is shared across the three collision constraints
 		// (obstacle / robot-vs-robot / self-collision); whichever runs first for
 		// this state populates it, the others hit the cache. Safe because all
@@ -521,6 +703,34 @@ func NewCollisionConstraintFS(
 			internalGeoms = append(internalGeoms, geosInFrame.Geometries()...)
 		}
 
+		sdfMin := math.Inf(1)
+		if sdf != nil {
+			// Keep only the geometries the SDF cannot clear for the exact pass.
+			needExact := internalGeoms[:0:0]
+			for _, g := range internalGeoms {
+				cover := spatialmath.SphereCover(g)
+				if cover == nil {
+					needExact = append(needExact, g)
+					continue
+				}
+				lb := math.Inf(1)
+				for _, sb := range cover {
+					if v := sdf.PointClearance(sb.Center) - sb.R; v < lb {
+						lb = v
+					}
+				}
+				if lb > sdfClearThreshold {
+					sdfMin = math.Min(sdfMin, lb)
+				} else {
+					needExact = append(needExact, g)
+				}
+			}
+			if len(needExact) == 0 {
+				return sdfMin, nil
+			}
+			internalGeoms = needExact
+		}
+
 		// For self-collision, compare moving geometries against themselves
 		staticToCheck := static
 		if isSelfCollision {
@@ -529,6 +739,7 @@ func NewCollisionConstraintFS(
 
 		collisions, minDist, err := checkCollisionsHinted(
 			internalGeoms, staticToCheck, allowed, collisionBufferMM, false, pairHint, logger)
+		minDist = math.Min(minDist, sdfMin)
 		if err != nil {
 			return minDist, err
 		}

--- a/motionplan/cover_state.go
+++ b/motionplan/cover_state.go
@@ -1,0 +1,202 @@
+package motionplan
+
+import (
+	"math"
+
+	"github.com/golang/geo/r3"
+
+	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/spatialmath"
+)
+
+// The cover table lets the collision constraints evaluate most states without
+// materializing any world-space geometry objects. For every moving frame with
+// configuration-independent local geometry (zero degrees of freedom - the
+// normal case for the link frames of a flattened arm model), it precomputes
+// each geometry's conservative sphere cover in the frame's parent
+// coordinates. A state check then needs only memoized FK for the parent
+// frames plus point transforms of the cover centers; full geometry objects
+// are built only for the few frames the sphere phase cannot clear.
+
+// geomCover is one geometry's precomputed local-frame cover.
+type geomCover struct {
+	label string
+	// cover spheres in the owning frame's parent coordinates.
+	local []spatialmath.SphereBound
+	// bound encloses the whole cover: one sphere for pair-level broadphase.
+	bound spatialmath.SphereBound
+}
+
+// frameCoverEntry is the cover data for one moving frame.
+type frameCoverEntry struct {
+	frameName  string
+	parentName string
+	geoms      []geomCover
+}
+
+// frameCoverTable is the per-checker precomputation. materialize lists moving
+// frames whose geometry could not be covered (input-dependent geometry or
+// unsupported types); they are always evaluated exactly.
+type frameCoverTable struct {
+	entries     []frameCoverEntry
+	materialize map[string]bool
+}
+
+// buildFrameCoverTable precomputes covers for the moving frames. Returns nil
+// when nothing could be covered (callers then keep the materialize-everything
+// path).
+func buildFrameCoverTable(fs *referenceframe.FrameSystem, movingFrameNames map[string]bool) *frameCoverTable {
+	t := &frameCoverTable{materialize: map[string]bool{}}
+	for name := range movingFrameNames {
+		frame := fs.Frame(name)
+		if frame == nil {
+			continue
+		}
+		parent, err := fs.Parent(frame)
+		if err != nil || len(frame.DoF()) != 0 {
+			// Input-dependent geometry (or no parent): always exact.
+			t.materialize[name] = true
+			continue
+		}
+		gif, err := frame.Geometries([]referenceframe.Input{})
+		if err != nil || gif == nil || len(gif.Geometries()) == 0 {
+			if err != nil {
+				t.materialize[name] = true
+			}
+			continue
+		}
+		entry := frameCoverEntry{frameName: name, parentName: parent.Name()}
+		covered := true
+		for _, g := range gif.Geometries() {
+			cover := spatialmath.SphereCover(g)
+			if len(cover) == 0 {
+				covered = false
+				break
+			}
+			entry.geoms = append(entry.geoms, geomCover{
+				label: g.Label(),
+				local: cover,
+				bound: enclosingSphere(cover),
+			})
+		}
+		if !covered {
+			t.materialize[name] = true
+			continue
+		}
+		t.entries = append(t.entries, entry)
+	}
+	if len(t.entries) == 0 {
+		return nil
+	}
+	return t
+}
+
+// enclosingSphere returns one sphere containing every sphere of the cover.
+func enclosingSphere(cover []spatialmath.SphereBound) spatialmath.SphereBound {
+	minPt := r3.Vector{X: math.Inf(1), Y: math.Inf(1), Z: math.Inf(1)}
+	maxPt := r3.Vector{X: math.Inf(-1), Y: math.Inf(-1), Z: math.Inf(-1)}
+	for _, sb := range cover {
+		minPt.X = math.Min(minPt.X, sb.Center.X-sb.R)
+		minPt.Y = math.Min(minPt.Y, sb.Center.Y-sb.R)
+		minPt.Z = math.Min(minPt.Z, sb.Center.Z-sb.R)
+		maxPt.X = math.Max(maxPt.X, sb.Center.X+sb.R)
+		maxPt.Y = math.Max(maxPt.Y, sb.Center.Y+sb.R)
+		maxPt.Z = math.Max(maxPt.Z, sb.Center.Z+sb.R)
+	}
+	c := minPt.Add(maxPt).Mul(0.5)
+	return spatialmath.SphereBound{Center: c, R: maxPt.Sub(c).Norm()}
+}
+
+// coveredWorldGeom is one geometry's cover transformed into world coordinates
+// for a specific state.
+type coveredWorldGeom struct {
+	frameName string
+	label     string
+	world     []spatialmath.SphereBound
+	bound     spatialmath.SphereBound
+}
+
+// stateCoverSet is the per-state evaluation of a frameCoverTable, shared by
+// the three collision constraints of a checker via StateFS.
+type stateCoverSet struct {
+	geoms []coveredWorldGeom
+	// failed is set when FK failed; callers must use the exact path.
+	failed bool
+}
+
+// coverSetFor evaluates (and caches on the state) the world-space covers.
+func coverSetFor(state *StateFS, fs *referenceframe.FrameSystem, table *frameCoverTable) *stateCoverSet {
+	if state.coverSet != nil {
+		return state.coverSet.(*stateCoverSet)
+	}
+	cs := &stateCoverSet{}
+	fk := fs.NewFrameToWorld(state.Configuration)
+	for i := range table.entries {
+		e := &table.entries[i]
+		q, tr, err := fk.PoseQT(e.parentName)
+		if err != nil {
+			cs.failed = true
+			break
+		}
+		for gi := range e.geoms {
+			gc := &e.geoms[gi]
+			world := make([]spatialmath.SphereBound, len(gc.local))
+			for si, sb := range gc.local {
+				world[si] = spatialmath.SphereBound{Center: spatialmath.TransformPoint(q, tr, sb.Center), R: sb.R}
+			}
+			cs.geoms = append(cs.geoms, coveredWorldGeom{
+				frameName: e.frameName,
+				label:     gc.label,
+				world:     world,
+				bound: spatialmath.SphereBound{
+					Center: spatialmath.TransformPoint(q, tr, gc.bound.Center),
+					R:      gc.bound.R,
+				},
+			})
+		}
+	}
+	state.coverSet = cs
+	return cs
+}
+
+// materializedSubset returns the world-posed geometries of the requested
+// frames, materializing them on demand and caching per state so the three
+// constraints share the work.
+func materializedSubset(
+	state *StateFS, fs *referenceframe.FrameSystem, frames map[string]bool,
+) ([]spatialmath.Geometry, error) {
+	if len(frames) == 0 {
+		return nil, nil
+	}
+	if state.partialGeoms == nil {
+		state.partialGeoms = map[string]*referenceframe.GeometriesInFrame{}
+	}
+	missing := map[string]bool{}
+	for f := range frames {
+		if _, ok := state.partialGeoms[f]; !ok {
+			missing[f] = true
+		}
+	}
+	if len(missing) > 0 {
+		got, err := referenceframe.FrameSystemGeometriesForFrames(fs, state.Configuration, missing)
+		if err != nil {
+			return nil, err
+		}
+		for f, gif := range got {
+			state.partialGeoms[f] = gif
+		}
+		// Frames that produced no geometries still count as materialized.
+		for f := range missing {
+			if _, ok := state.partialGeoms[f]; !ok {
+				state.partialGeoms[f] = referenceframe.NewGeometriesInFrame(referenceframe.World, nil)
+			}
+		}
+	}
+	var out []spatialmath.Geometry
+	for f := range frames {
+		if gif := state.partialGeoms[f]; gif != nil {
+			out = append(out, gif.Geometries()...)
+		}
+	}
+	return out, nil
+}

--- a/motionplan/metrics.go
+++ b/motionplan/metrics.go
@@ -49,6 +49,14 @@ type StateFS struct {
 	geometries       map[string]*referenceframe.GeometriesInFrame
 	movingGeometries map[string]*referenceframe.GeometriesInFrame
 	poses            referenceframe.FrameSystemPoses
+
+	// coverSet caches the state's world-space sphere covers (see
+	// cover_state.go); partialGeoms caches per-frame materialized geometries
+	// for the exact-check fallback. Both are shared across the checker's
+	// three collision constraints. coverSet is `any` to keep this file free
+	// of the cover machinery's internals.
+	coverSet     any
+	partialGeoms map[string]*referenceframe.GeometriesInFrame
 }
 
 // Geometries get Geometries and cache
@@ -91,6 +99,30 @@ func OrientDist(o1, o2 spatial.Orientation) float64 {
 // WeightedSquaredNormDistance is a distance function between two poses to be used for gradient descent.
 func WeightedSquaredNormDistance(start, end spatial.Pose) float64 {
 	return WeightedSquaredNormDistanceWithOptions(start, end, 1.0, orientationDistanceScaling)
+}
+
+// WeightedSquaredNormDistanceWithTolerance is WeightedSquaredNormDistanceWithOptions
+// with a free orientation band: rotation within toleranceRads of the target
+// contributes nothing, and only the excess beyond the band is penalized. Used
+// when solving for intermediate keypoints whose orientation only needs to stay
+// within a constraint band (or does not matter at all).
+func WeightedSquaredNormDistanceWithTolerance(start, end spatial.Pose, cartesianScale, orientScale, toleranceRads float64) float64 {
+	orientDelta := 0.0
+	if orientScale > 0 && toleranceRads < math.Pi {
+		theta := spatial.QuatToR3AA(spatial.QuatBetween(
+			start.Orientation(),
+			end.Orientation(),
+		)).Norm()
+		theta = math.Max(0, theta-toleranceRads) * orientScale
+		orientDelta = theta * theta
+	}
+
+	ptDelta := 0.0
+	if cartesianScale > 0 {
+		ptDelta = end.Point().Mul(cartesianScale).Sub(start.Point().Mul(cartesianScale)).Norm2()
+	}
+
+	return ptDelta + orientDelta
 }
 
 // WeightedSquaredNormDistanceWithOptions is a distance function between two poses to be used for gradient descent.

--- a/spatialmath/bvh.go
+++ b/spatialmath/bvh.go
@@ -137,6 +137,24 @@ func computeGeometryAABB(g Geometry) (r3.Vector, r3.Vector) {
 	case *point:
 		pt := geom.position
 		return pt, pt
+	case *Cylinder:
+		// Conservative: the cylinder's bounding capsule (axis segment padded
+		// by radius on every axis), at most radius of slack along the axis.
+		center := geom.pose.Point()
+		q := geom.pose.Orientation().Quaternion()
+		half := TransformPoint(q, r3.Vector{}, r3.Vector{Z: geom.height / 2})
+		segA, segB := center.Sub(half), center.Add(half)
+		lo := r3.Vector{
+			X: math.Min(segA.X, segB.X) - geom.radius,
+			Y: math.Min(segA.Y, segB.Y) - geom.radius,
+			Z: math.Min(segA.Z, segB.Z) - geom.radius,
+		}
+		hi := r3.Vector{
+			X: math.Max(segA.X, segB.X) + geom.radius,
+			Y: math.Max(segA.Y, segB.Y) + geom.radius,
+			Z: math.Max(segA.Z, segB.Z) + geom.radius,
+		}
+		return lo, hi
 	case *Mesh:
 		// BVH stores bounds in local space. We must transform to world space via the mesh pose.
 		// Previously this returned bvh.min/max directly (local space), which caused collision

--- a/spatialmath/sdf_test.go
+++ b/spatialmath/sdf_test.go
@@ -19,7 +19,11 @@ func TestVoxelSDFConservative(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	tri := NewTriangle(r3.Vector{X: 0, Y: 200, Z: -50}, r3.Vector{X: 50, Y: 250, Z: 60}, r3.Vector{X: -60, Y: 220, Z: 40})
 	mesh := NewMesh(NewZeroPose(), []*Triangle{tri}, "m")
-	geoms := []Geometry{b, s, c, mesh}
+	// Tilted cylinder: regression for the whitelisted-but-unbuildable case
+	// (computeGeometryAABB used to panic on cylinders).
+	cyl, err := NewCylinder(NewPose(r3.Vector{X: 150, Y: 150, Z: -50}, &OrientationVectorDegrees{OX: 1, OZ: 1, Theta: 20}), 35, 120, "cyl")
+	test.That(t, err, test.ShouldBeNil)
+	geoms := []Geometry{b, s, c, mesh, cyl}
 
 	sdf := NewVoxelSDF(geoms, 10)
 	test.That(t, sdf, test.ShouldNotBeNil)


### PR DESCRIPTION
Part 3 of 4 of a motion-planning performance series, following #6375 and #6376 (both merged — this branch is rebased directly on main).

Note: the first commit here (`spatialmath: computeGeometryAABB panicked on cylinders`) is the fix for @JosephBorodach's review catch on #6375 — that PR merged minutes before the fix landed on its branch, so it rides here instead. It's a hard dependency: the SDF whitelists `*Cylinder`, so without it any cylinder-containing scene panics at field build.

## What

Rebuilds the collision-constraint hot path so most states are checked without materializing world-space geometry:

- Each constraint checker precomputes local-frame sphere covers for its zero-DoF moving frames (`cover_state.go`). Per state, memoized FK (#6376) transforms only the cover centers. Moving-vs-static constraints clear covered geometries against a voxel distance field (#6375), built once per static scene and shared **process-wide** in a small LRU registry keyed by an order-independent, shape-aware scene fingerprint (per-plan caching made every replan pay the ~35–70ms build + multi-MB allocation, which showed up as large relative regressions on trivial scenes in the motion benchmarks); self-collision clears pairs by enclosing-sphere gaps. Full geometry objects are built lazily, per frame, only for whatever the sphere phase cannot clear — and shared across the three constraints of a checker.
- A bounding-sphere broadphase rejects far pairs before narrow-phase work in the exact fallback.
- Topological constraints run before collision constraints (one FK pass vs. full collision sweeps), and no longer disable clearance-based state skipping in segment sweeps; skipped states still get the cheap topological check. Orientation-constraint endpoint conversions are precomputed once per plan.
- Per-state tracing spans are removed from paths called hundreds of thousands of times per plan. Once checks became cheap, span creation and exporter wakeups dominated wall time (one profile: 18s of scheduler wakeups vs. 5s of planning). Coarse per-phase spans remain; the per-pair slow-check timer is sampled 1/16 and logs at debug only. **Reviewer note:** this deliberately trades away per-state prod telemetry — flagging for an explicit maintainer call.
- `NewCollisionConstraintFS` gains a cover-table parameter; no callers exist outside `motionplan`.

## Safety

All fast paths are conservative: near-contact states, uncovered geometry types, allowed-collision pairs, and scenes the SDF can't represent keep exact semantics. Existing motionplan suites pass unchanged.

## Impact

With #6378 on top, a captured production scene goes ~170s → ~2.5s warm; this PR is where the per-check cost collapses.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyqhmqkxS9B8bGjdUhTtAs