### PR TITLE
armplanning: retreat corridors, search racing, and a learning roadmap

### DIFF
--- a/motionplan/armplanning/api.go
+++ b/motionplan/armplanning/api.go
@@ -244,6 +244,10 @@ type PlanMeta struct {
 	// straight-line path with small nudges around obstacles, skipping CBIRRT.
 	GoalsNudgeSolved int
 
+	// GoalsRoadmapSolved is the number of waypoints solved through the lazy
+	// roadmap, skipping CBIRRT.
+	GoalsRoadmapSolved int
+
 	// SubgoalsPerGoal will have size of `GoalsProcessed`. If there are no linear/orientation
 	// constraints, we do not create any additional subgoals/waypoints. SubgoalsPerGoal in that case
 	// will be set to 1 for each goal index. Otherwise it will be sent to the number of internal

--- a/motionplan/armplanning/cBiRRT.go
+++ b/motionplan/armplanning/cBiRRT.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/rand"
 	"slices"
-	"sync/atomic"
 	"time"
 
 	"go.viam.com/utils/trace"
@@ -38,6 +38,16 @@ type cBiRRTMotionPlanner struct {
 	logger logging.Logger
 
 	fastGradDescent *ik.NloptIK
+
+	// rnd drives sampling. Defaults to the shared PlanContext rand; racing
+	// attempts (raceCBiRRT) each get their own stream so they explore
+	// different regions and can run concurrently.
+	rnd *rand.Rand
+
+	// maxIter caps rrtRunner's iterations when positive; raceCBiRRT uses short
+	// caps so failed attempts restart with a fresh RNG stream instead of
+	// grinding a bad trajectory to the 5000-iteration default.
+	maxIter int
 }
 
 // newCBiRRTMotionPlannerWithSeed creates a cBiRRTMotionPlanner object with a user specified random seed.
@@ -49,6 +59,7 @@ func newCBiRRTMotionPlanner(ctx context.Context, pc *PlanContext, psc *PlanSegme
 		pc:     pc,
 		psc:    psc,
 		logger: logger,
+		rnd:    pc.randseed,
 	}
 
 	var err error
@@ -103,6 +114,8 @@ func (mp *cBiRRTMotionPlanner) rrtRunner(
 	defer cancel()
 	startTime := time.Now()
 
+	corridorTops := mp.seedGoalRetreatCorridors(ctx, rrtMaps)
+
 	// initialize maps
 	// Pick a random (first in map) seed node to create the first interp node
 	var seed *referenceframe.LinearInputs
@@ -123,8 +136,12 @@ func (mp *cBiRRTMotionPlanner) rrtRunner(
 
 	target := newConfigurationNode(interpConfig)
 
+	iterCap := maxPlanIter
+	if mp.maxIter > 0 && mp.maxIter < iterCap {
+		iterCap = mp.maxIter
+	}
 	map1, map2 := rrtMaps.startMap, rrtMaps.goalMap
-	for i := 0; i < maxPlanIter; i++ {
+	for i := 0; i < iterCap; i++ {
 		mp.logger.CDebugf(ctx, "iteration: %d target: %v", i, logging.FloatArrayFormat{"", target.inputs.GetLinearizedInputs()})
 		if ctx.Err() != nil {
 			mp.logger.CDebugf(ctx, "CBiRRT timed out after %d iterations", i)
@@ -175,10 +192,18 @@ func (mp *cBiRRTMotionPlanner) rrtRunner(
 			return &rrtSolution{steps: path, maps: rrtMaps}, nil
 		}
 
-		// sample near map 1 and switch which map is which to keep adding to them even
-		target, err = mp.sample(map1reached, i)
-		if err != nil {
-			return &rrtSolution{maps: rrtMaps}, err
+		// Aim the early iterations at the goal corridors' open-space entrances:
+		// they are already wired into the goal tree, so each such iteration is
+		// a direct attempt to connect the start tree to a validated descent.
+		// After that, revisit them occasionally as the trees grow.
+		if len(corridorTops) > 0 && (i < 2*len(corridorTops) || i%8 == 0) {
+			target = newConfigurationNode(corridorTops[i%len(corridorTops)].inputs)
+		} else {
+			// sample near map 1 and switch which map is which to keep adding to them even
+			target, err = mp.sample(map1reached, i)
+			if err != nil {
+				return &rrtSolution{maps: rrtMaps}, err
+			}
 		}
 		map1, map2 = map2, map1
 	}
@@ -194,8 +219,6 @@ func (mp *cBiRRTMotionPlanner) constrainedExtend(
 	rrtMap map[*node]*node,
 	near, target *node,
 ) *node {
-	ctx, span := trace.StartSpan(ctx, "constrainedExtend")
-	defer span.End()
 	qstep := mp.getFrameSteps(defaultFrameStep, iterationNumber, false)
 
 	// Allow qstep to be doubled as a means to escape from configurations which gradient descend to their seed
@@ -289,57 +312,16 @@ func (mp *cBiRRTMotionPlanner) constrainNear(
 		return target
 	}
 
-	if len(mp.psc.pc.request.Constraints.OrientationConstraint) > 0 {
-		myFunc := func(metric *motionplan.StateFS) float64 {
-			score := 0.0
-			now, err := metric.Poses()
-			if err != nil {
-				panic(err)
-			}
-			for f, g := range mp.psc.goal {
-				s := mp.psc.startPoses[f]
-				n := now[f]
-				if g.Parent() != referenceframe.World ||
-					s.Parent() != referenceframe.World ||
-					n.Parent() != referenceframe.World {
-					panic(fmt.Errorf("mismatch frame %v %v %v", g.Parent(), s.Parent(), n.Parent()))
-				}
-
-				for _, c := range mp.psc.pc.request.Constraints.OrientationConstraint {
-					score += c.Score(
-						s.Pose().Orientation(),
-						g.Pose().Orientation(),
-						n.Pose().Orientation(),
-					)
-				}
-			}
-
-			return score
-		}
-
-		linearSeed := target.GetLinearizedInputs()
-		var totalAttempts atomic.Int32
-		solutions, _, err := ik.DoSolve(ctx, mp.fastGradDescent, &totalAttempts,
-			mp.psc.pc.LinearizeFSMetric(myFunc),
-			[][]float64{linearSeed}, [][]referenceframe.Limit{ik.ComputeAdjustLimits(linearSeed, mp.pc.lis.GetLimits(), .05)})
-		if err != nil {
-			mp.logger.Debugf("constrainNear fail (DoSolve): %v", err)
+	if metric := mp.psc.topoProjectionMetric(); metric != nil {
+		projected := mp.psc.projectToOrientationBand(ctx, mp.fastGradDescent, metric, target)
+		if projected == nil {
+			mp.logger.Debugf("constrainNear: orientation projection failed")
 			return nil
 		}
-
-		if len(solutions) == 0 {
-			return nil
-		}
-
 		if debugConstrainNear {
-			mp.logger.Infof("\t -> %v", logging.FloatArrayFormat{"", solutions[0]})
+			mp.logger.Infof("\t -> %v", logging.FloatArrayFormat{"", projected.GetLinearizedInputs()})
 		}
-
-		target, err = mp.psc.pc.lis.FloatsToInputs(solutions[0])
-		if err != nil {
-			mp.logger.Infof("constrainNear fail (FloatsToInputs): %v", err)
-			return nil
-		}
+		target = projected
 	}
 
 	failpos, err := mp.psc.Checker.CheckStateConstraintsAcrossSegmentFS(
@@ -442,7 +424,7 @@ func (mp *cBiRRTMotionPlanner) sample(rSeed *node, sampleNum int) (*node, error)
 	for name, inputs := range rSeed.inputs.Items() {
 		f := mp.pc.fs.Frame(name)
 		if f != nil && len(f.DoF()) > 0 {
-			q, err := referenceframe.RestrictedRandomFrameInputs(f, mp.pc.randseed, percent, inputs)
+			q, err := referenceframe.RestrictedRandomFrameInputs(f, mp.rnd, percent, inputs)
 			if err != nil {
 				return nil, err
 			}
@@ -450,4 +432,64 @@ func (mp *cBiRRTMotionPlanner) sample(rSeed *node, sampleNum int) (*node, error)
 		}
 	}
 	return newConfigurationNode(newInputs), nil
+}
+
+// seedGoalRetreatCorridors pre-populates the goal tree with a "descent
+// corridor" per goal root: a chain of validated configurations jogging the
+// end effector straight up into open space. The final approach to a goal is
+// usually the most cluttered part of a scene, and random bidirectional
+// sampling spends most of its iterations rediscovering how to descend into
+// it; a deterministic retreat chain lets the search connect to the corridor
+// high in open space instead, with the descent already validated.
+func (mp *cBiRRTMotionPlanner) seedGoalRetreatCorridors(ctx context.Context, rrtMaps *rrtMaps) []*node {
+	if len(mp.psc.goal) != 1 {
+		return nil
+	}
+	var frame string
+	for f := range mp.psc.goal {
+		frame = f
+	}
+
+	roots := []*node{}
+	isParent := map[*node]bool{}
+	childCount := 0
+	for n, parent := range rrtMaps.goalMap {
+		if parent == nil {
+			roots = append(roots, n)
+		} else {
+			childCount++
+			isParent[parent] = true
+		}
+	}
+	if childCount > 0 {
+		// Corridors were already seeded (racing attempts share pre-seeded
+		// maps); the corridor tops are the non-root leaves.
+		tops := []*node{}
+		for n, parent := range rrtMaps.goalMap {
+			if parent != nil && !isParent[n] {
+				tops = append(tops, n)
+			}
+		}
+		return tops
+	}
+
+	added := 0
+	tops := []*node{}
+	for _, root := range roots {
+		chain := retreatChain(ctx, mp.psc, mp.fastGradDescent, frame, root.inputs)
+		cur := root
+		for _, cfg := range chain[1:] {
+			n := &node{inputs: cfg}
+			rrtMaps.goalMap[n] = cur
+			cur = n
+			added++
+		}
+		if cur != root {
+			tops = append(tops, cur)
+		}
+	}
+	if added > 0 {
+		mp.logger.CDebugf(ctx, "seeded %d goal retreat corridor nodes across %d roots (%d corridor tops)", added, len(roots), len(tops))
+	}
+	return tops
 }

--- a/motionplan/armplanning/cBiRRT_test.go
+++ b/motionplan/armplanning/cBiRRT_test.go
@@ -110,7 +110,7 @@ func TestSimpleLinearMotion(t *testing.T) {
 	for i, step := range inputSteps {
 		inputSlice[i] = step.inputs
 	}
-	finalSteps, err := smoothPath(ctx, psc, inputSlice)
+	finalSteps, _, err := smoothPath(ctx, psc, inputSlice)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(finalSteps), test.ShouldBeLessThanOrEqualTo, unsmoothLen)
 	// Test that path has changed after smoothing was applied

--- a/motionplan/armplanning/cmd-plan/cmd-plan.go
+++ b/motionplan/armplanning/cmd-plan/cmd-plan.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"runtime/pprof"
 	"slices"
 	"sort"
@@ -48,6 +49,14 @@ func main() {
 }
 
 func realMain() error {
+	// The planner allocates heavily during search (per-state geometry
+	// materialization); the default GC target spends a quarter of planning
+	// CPU on mark work. A higher target trades memory headroom for planning
+	// speed. Overridable with the GOGC env var.
+	if os.Getenv("GOGC") == "" {
+		debug.SetGCPercent(300)
+	}
+
 	ctx := context.Background()
 	logger, reg := logging.NewLoggerWithRegistry("cmd-plan")
 
@@ -187,7 +196,7 @@ func realMain() error {
 		return fmt.Errorf("path and trajectory not the same %d vs %d", len(plan.Path()), len(plan.Trajectory()))
 	}
 
-	for *cpu != "" && time.Since(start) < (10*time.Second) {
+	for *cpu != "" && time.Since(start) < (45*time.Second) {
 		ss := time.Now()
 		_, _, err := armplanning.PlanMotion(ctx, mpLogger, req)
 		if err != nil {

--- a/motionplan/armplanning/context.go
+++ b/motionplan/armplanning/context.go
@@ -3,10 +3,12 @@ package armplanning
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"hash/fnv"
 	"math"
 	"math/rand"
 	"strings"
+	"sync/atomic"
 
 	"go.viam.com/utils/trace"
 
@@ -65,13 +67,31 @@ func NewPlanContext(ctx context.Context, logger logging.Logger, request *PlanReq
 	}
 
 	for _, fn := range pc.fs.FrameNames() {
-		f := pc.fs.Frame(fn)
-		if len(f.DoF()) > 0 {
+		if frameCanMove(pc.fs, pc.fs.Frame(fn)) {
 			pc.movableFrames = append(pc.movableFrames, fn)
 		}
 	}
 
 	return pc, nil
+}
+
+// frameCanMove reports whether a frame's world pose depends on the
+// configuration: the frame itself or any ancestor has DoF. A static frame
+// attached below a joint (e.g. a held object hanging off a gripper) moves with
+// it, and a collision involving it is recoverable by moving that joint - it
+// must not be misclassified as a fatal static-geometry collision.
+func frameCanMove(fs *referenceframe.FrameSystem, f referenceframe.Frame) bool {
+	for f != nil {
+		if len(f.DoF()) > 0 {
+			return true
+		}
+		parent, err := fs.Parent(f)
+		if err != nil {
+			return false
+		}
+		f = parent
+	}
+	return false
 }
 
 // GetLinearInputsSchema gets the LinearInputsSchema.
@@ -180,9 +200,6 @@ func NewPlanSegmentContext(ctx context.Context, pc *PlanContext, start *referenc
 func (psc *PlanSegmentContext) CheckPath(
 	ctx context.Context, start, end *referenceframe.LinearInputs, checkFinal bool, outPath *PathFeedback,
 ) error {
-	ctx, span := trace.StartSpan(ctx, "checkPath")
-	defer span.End()
-
 	// Edge-result memoization: RRT-Connect rewire and path smoothing re-check
 	// the same (start, end) edges constantly. Skip the full interpolated sweep
 	// when the cache has already verified this edge collision-free under the
@@ -212,13 +229,84 @@ func (psc *PlanSegmentContext) CheckPath(
 	}
 
 	if err != nil && outPath != nil {
-		*outPath = PathFeedback{
+		fb := PathFeedback{
 			IsObstacleCollision: strings.Contains(err.Error(), motionplan.ObstacleConstraintDescription) ||
 				strings.Contains(err.Error(), motionplan.RobotCollisionConstraintDescription),
-			LastGoodInputs: validSegment.EndConfiguration,
 		}
+		// validSegment is nil when the very first state of the segment fails.
+		if validSegment != nil {
+			fb.LastGoodInputs = validSegment.EndConfiguration
+		}
+		*outPath = fb
 	}
 	return err
+}
+
+// topoProjectionMetric returns a metric scoring how far a configuration's
+// orientations stray beyond the request's orientation-constraint band, used to
+// gradient-descend configurations back onto the constraint manifold. Returns
+// nil when the request carries no orientation constraints.
+func (psc *PlanSegmentContext) topoProjectionMetric() motionplan.StateFSMetric {
+	if psc.pc.request.Constraints == nil || len(psc.pc.request.Constraints.OrientationConstraint) == 0 {
+		return nil
+	}
+	// Precompute per-frame evaluators - the endpoint orientation conversions
+	// are fixed for the plan and this metric runs once per IK gradient sample.
+	evals := map[string][]*motionplan.OrientationConstraintEval{}
+	for f, g := range psc.goal {
+		s := psc.startPoses[f]
+		if g.Parent() != referenceframe.World || s.Parent() != referenceframe.World {
+			panic(fmt.Errorf("mismatch frame %v %v", g.Parent(), s.Parent()))
+		}
+		for _, c := range psc.pc.request.Constraints.OrientationConstraint {
+			evals[f] = append(evals[f],
+				motionplan.NewOrientationConstraintEval(c, s.Pose().Orientation(), g.Pose().Orientation()))
+		}
+	}
+
+	return func(state *motionplan.StateFS) float64 {
+		score := 0.0
+		for f := range psc.goal {
+			// Per-frame FK: this metric runs inside nlopt's gradient loop
+			// (thousands of evaluations per projection), and computing poses
+			// for every frame in the system was the dominant cost of the
+			// whole search.
+			dq, err := state.FS.TransformToDQ(state.Configuration, f, referenceframe.World)
+			if err != nil {
+				panic(err)
+			}
+			o := dq.Orientation()
+			for _, e := range evals[f] {
+				score += e.Score(o)
+			}
+		}
+		return score
+	}
+}
+
+// projectToOrientationBand gradient-descends cfg back onto the orientation
+// constraint manifold using the given solver and metric (from
+// topoProjectionMetric). Returns the projected configuration, or nil when the
+// descent fails.
+func (psc *PlanSegmentContext) projectToOrientationBand(
+	ctx context.Context,
+	solver *ik.NloptIK,
+	metric motionplan.StateFSMetric,
+	cfg *referenceframe.LinearInputs,
+) *referenceframe.LinearInputs {
+	linearSeed := cfg.GetLinearizedInputs()
+	var totalAttempts atomic.Int32
+	solutions, _, err := ik.DoSolve(ctx, solver, &totalAttempts,
+		psc.pc.LinearizeFSMetric(metric),
+		[][]float64{linearSeed}, [][]referenceframe.Limit{ik.ComputeAdjustLimits(linearSeed, psc.pc.lis.GetLimits(), .05)})
+	if err != nil || len(solutions) == 0 {
+		return nil
+	}
+	out, err := psc.pc.lis.FloatsToInputs(solutions[0])
+	if err != nil {
+		return nil
+	}
+	return out
 }
 
 // hashLinearInputs computes a deterministic FNV-1a hash over the float values

--- a/motionplan/armplanning/nearest_neighbor.go
+++ b/motionplan/armplanning/nearest_neighbor.go
@@ -16,11 +16,39 @@ func nodeConfigurationDistanceFunc(node1, node2 *node) float64 {
 	})
 }
 
+func nodeLinear(n *node) []float64 {
+	if n.linear == nil {
+		n.linear = n.inputs.GetLinearizedInputs()
+	}
+	return n.linear
+}
+
+// nearestNeighbor scans the tree for the node closest to seed. The scan runs
+// once per extend over trees that grow to thousands of nodes, so it compares
+// cached linearized-input slices directly instead of going through the
+// LinearInputs frame-map distance (which was the planner's hottest loop).
 func nearestNeighbor(seed *node, tree rrtMap, nodeDistanceFunc NodeDistanceMetric) *node {
+	sl := nodeLinear(seed)
 	bestDist := math.Inf(1)
 	var best *node
 	for k := range tree {
-		dist := nodeDistanceFunc(seed, k)
+		kl := nodeLinear(k)
+		if len(kl) != len(sl) {
+			// Mixed schemas: fall back to the full metric for this candidate.
+			if dist := nodeDistanceFunc(seed, k); dist < bestDist {
+				bestDist = dist
+				best = k
+			}
+			continue
+		}
+		dist := 0.0
+		for i, v := range sl {
+			d := v - kl[i]
+			dist += d * d
+			if dist >= bestDist {
+				break
+			}
+		}
 		if dist < bestDist {
 			bestDist = dist
 			best = k

--- a/motionplan/armplanning/nearest_neighbor.go
+++ b/motionplan/armplanning/nearest_neighbor.go
@@ -17,10 +17,13 @@ func nodeConfigurationDistanceFunc(node1, node2 *node) float64 {
 }
 
 func nodeLinear(n *node) []float64 {
-	if n.linear == nil {
-		n.linear = n.inputs.GetLinearizedInputs()
+	if p := n.linear.Load(); p != nil {
+		return *p
 	}
-	return n.linear
+	// Concurrent computes are fine: the value is deterministic.
+	l := n.inputs.GetLinearizedInputs()
+	n.linear.Store(&l)
+	return l
 }
 
 // nearestNeighbor scans the tree for the node closest to seed. The scan runs

--- a/motionplan/armplanning/nearest_neighbor.go
+++ b/motionplan/armplanning/nearest_neighbor.go
@@ -16,26 +16,17 @@ func nodeConfigurationDistanceFunc(node1, node2 *node) float64 {
 	})
 }
 
-func nodeLinear(n *node) []float64 {
-	if p := n.linear.Load(); p != nil {
-		return *p
-	}
-	// Concurrent computes are fine: the value is deterministic.
-	l := n.inputs.GetLinearizedInputs()
-	n.linear.Store(&l)
-	return l
-}
-
 // nearestNeighbor scans the tree for the node closest to seed. The scan runs
 // once per extend over trees that grow to thousands of nodes, so it compares
-// cached linearized-input slices directly instead of going through the
-// LinearInputs frame-map distance (which was the planner's hottest loop).
+// the linearized-input slices directly (a field read on LinearInputs) instead
+// of going through the frame-map distance metric (which was the planner's
+// hottest loop).
 func nearestNeighbor(seed *node, tree rrtMap, nodeDistanceFunc NodeDistanceMetric) *node {
-	sl := nodeLinear(seed)
+	sl := seed.inputs.GetLinearizedInputs()
 	bestDist := math.Inf(1)
 	var best *node
 	for k := range tree {
-		kl := nodeLinear(k)
+		kl := k.inputs.GetLinearizedInputs()
 		if len(kl) != len(sl) {
 			// Mixed schemas: fall back to the full metric for this candidate.
 			if dist := nodeDistanceFunc(seed, k); dist < bestDist {

--- a/motionplan/armplanning/node.go
+++ b/motionplan/armplanning/node.go
@@ -71,11 +71,6 @@ type node struct {
 	// cost of moving from seed to this inputs
 	cost float64
 
-	// linear caches inputs.GetLinearizedInputs() for the nearest-neighbor hot
-	// loop, which distance-compares a target against every tree node per
-	// extend. Populated lazily by nodeLinear; atomic because racing searches
-	// share nodes through their cloned tree maps.
-	linear atomic.Pointer[[]float64]
 	// checkPathError is nil when the straight-line path to this node meets all constraints.
 	checkPath bool
 

--- a/motionplan/armplanning/node.go
+++ b/motionplan/armplanning/node.go
@@ -240,12 +240,17 @@ func NewSolutionSolvingState(ctx context.Context, psc *PlanSegmentContext, logge
 	// Goal-adjacent configurations remembered by the roadmap (harvested from
 	// earlier successful plans) seed IK with each known-good joint family, so
 	// the family nearest the start is reliably among the ranked solutions
-	// rather than depending on nlopt's random draws.
-	for i, s := range roadmapGoalSeeds(psc, 4) {
-		si := s.GetLinearizedInputs()
-		sss.LinearSeeds = append(sss.LinearSeeds, si)
-		sss.SeedLimits = append(sss.SeedLimits, ik.ComputeAdjustLimits(si, sss.SeedLimits[0], .1))
-		sss.SeedDescriptions = append(sss.SeedDescriptions, fmt.Sprintf("roadmap goal-adjacent %d", i))
+	// rather than depending on nlopt's random draws. Only for far goals (same
+	// bar as smart seeds): family choice is irrelevant for near goals, and
+	// the per-call overhead multiplies across the subgoals of waypoint
+	// ladders.
+	if sss.goodCost > 1 {
+		for i, s := range roadmapGoalSeeds(psc, 4) {
+			si := s.GetLinearizedInputs()
+			sss.LinearSeeds = append(sss.LinearSeeds, si)
+			sss.SeedLimits = append(sss.SeedLimits, ik.ComputeAdjustLimits(si, sss.SeedLimits[0], .1))
+			sss.SeedDescriptions = append(sss.SeedDescriptions, fmt.Sprintf("roadmap goal-adjacent %d", i))
+		}
 	}
 
 	sss.moving, sss.nonmoving = sss.psc.motionChains.framesFilteredByMovingAndNonmoving()

--- a/motionplan/armplanning/node.go
+++ b/motionplan/armplanning/node.go
@@ -237,6 +237,17 @@ func NewSolutionSolvingState(ctx context.Context, psc *PlanSegmentContext, logge
 		sss.SeedDescriptions = append(sss.SeedDescriptions, "start · tight (5%)")
 	}
 
+	// Goal-adjacent configurations remembered by the roadmap (harvested from
+	// earlier successful plans) seed IK with each known-good joint family, so
+	// the family nearest the start is reliably among the ranked solutions
+	// rather than depending on nlopt's random draws.
+	for i, s := range roadmapGoalSeeds(psc, 4) {
+		si := s.GetLinearizedInputs()
+		sss.LinearSeeds = append(sss.LinearSeeds, si)
+		sss.SeedLimits = append(sss.SeedLimits, ik.ComputeAdjustLimits(si, sss.SeedLimits[0], .1))
+		sss.SeedDescriptions = append(sss.SeedDescriptions, fmt.Sprintf("roadmap goal-adjacent %d", i))
+	}
+
 	sss.moving, sss.nonmoving = sss.psc.motionChains.framesFilteredByMovingAndNonmoving()
 
 	if psc.pc.planMeta.CollectSolutionDiagnostics {

--- a/motionplan/armplanning/node.go
+++ b/motionplan/armplanning/node.go
@@ -73,8 +73,9 @@ type node struct {
 
 	// linear caches inputs.GetLinearizedInputs() for the nearest-neighbor hot
 	// loop, which distance-compares a target against every tree node per
-	// extend. Populated lazily by nodeLinear.
-	linear []float64
+	// extend. Populated lazily by nodeLinear; atomic because racing searches
+	// share nodes through their cloned tree maps.
+	linear atomic.Pointer[[]float64]
 	// checkPathError is nil when the straight-line path to this node meets all constraints.
 	checkPath bool
 

--- a/motionplan/armplanning/node.go
+++ b/motionplan/armplanning/node.go
@@ -70,6 +70,11 @@ type node struct {
 	inputs *referenceframe.LinearInputs
 	// cost of moving from seed to this inputs
 	cost float64
+
+	// linear caches inputs.GetLinearizedInputs() for the nearest-neighbor hot
+	// loop, which distance-compares a target against every tree node per
+	// extend. Populated lazily by nodeLinear.
+	linear []float64
 	// checkPathError is nil when the straight-line path to this node meets all constraints.
 	checkPath bool
 

--- a/motionplan/armplanning/nudge.go
+++ b/motionplan/armplanning/nudge.go
@@ -69,8 +69,12 @@ func tryNudgedStraightLine(
 		return nil
 	}
 
+	// Nudge exists for barely-blocked straight lines; if the several
+	// lowest-cost goal configurations all fail, more distant ones will not do
+	// better, and each attempt burns a full segment-check budget.
+	const maxNudgeGoals = 6
 	for gi, g := range goals {
-		if ctx.Err() != nil {
+		if gi >= maxNudgeGoals || ctx.Err() != nil {
 			return nil
 		}
 		budget := nudgeMaxSegmentChecks

--- a/motionplan/armplanning/plan_manager.go
+++ b/motionplan/armplanning/plan_manager.go
@@ -3,6 +3,7 @@ package armplanning
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"go.viam.com/utils/trace"
@@ -11,6 +12,7 @@ import (
 	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/rdk/utils"
 )
 
 // planManager is intended to be the single entry point to motion planners.
@@ -169,7 +171,7 @@ func (pm *planManager) planToDirectJoints(
 	if err != nil {
 		return nil, err
 	}
-	finalSteps.steps, err = smoothPath(ctx, psc, finalSteps.steps)
+	finalSteps.steps, _, err = smoothPath(ctx, psc, finalSteps.steps)
 	if err != nil {
 		return nil, err
 	}
@@ -204,6 +206,7 @@ func (pm *planManager) planSingleGoal(
 
 	if planSeed.steps != nil {
 		pm.logger.Debugf("found an ideal ik solution")
+		pm.harvestPlan(psc, append([]*referenceframe.LinearInputs{psc.start}, planSeed.steps...), pm.logger)
 		return planSeed.steps, nil
 	}
 
@@ -217,32 +220,50 @@ func (pm *planManager) planSingleGoal(
 	// straight-line path with small nudges off whatever it grazes — the common
 	// case for barely-blocked paths.
 	if nudged := tryNudgedStraightLine(ctx, psc, planSeed.maps.goalMap, pm.pc.randseed, pm.logger.Sublogger("nudge")); nudged != nil {
-		steps, err := smoothPath(ctx, psc, nudged)
+		steps, compact, err := smoothPath(ctx, psc, nudged)
 		if err == nil {
 			pm.logger.Debugf("solved with nudged straight line: %d -> %d waypoints", len(nudged), len(steps))
 			pm.pc.planMeta.GoalsNudgeSolved++
+			pm.harvestPlan(psc, compact, pm.logger)
 			return steps, nil
 		}
 		pm.logger.Debugf("nudged path failed to smooth, falling back to cbirrt: %v", err)
 	}
 
-	pathPlanner, err := newCBiRRTMotionPlanner(ctx, pm.pc, psc, pm.logger.Sublogger("cbirrt"))
+	// Roadmap: reusable configuration-space graph with per-scene lazily
+	// validated edges - including workspace bridge edges between joint
+	// families. First query in a scene pays edge validation; later queries in
+	// the same scene reuse the verdicts.
+	goalRoots := make([]*node, 0, len(planSeed.maps.goalMap))
+	for n, parent := range planSeed.maps.goalMap {
+		if parent == nil {
+			goalRoots = append(goalRoots, n)
+		}
+	}
+	if path := pm.tryRoadmap(ctx, psc, goalRoots, pm.logger.Sublogger("roadmap")); path != nil {
+		smoothed, compact, err := smoothPath(ctx, psc, path)
+		if err == nil {
+			pm.logger.Debugf("solved via roadmap: %d -> %d waypoints", len(path), len(smoothed))
+			pm.pc.planMeta.GoalsRoadmapSolved++
+			pm.harvestPlan(psc, compact, pm.logger)
+			return smoothed, nil
+		}
+		pm.logger.Debugf("roadmap path failed to smooth, falling back: %v", err)
+	}
+
+	rawSteps, err := pm.raceCBiRRT(ctx, psc, planSeed.maps)
 	if err != nil {
 		return nil, err
 	}
 
-	finalSteps, err := pathPlanner.rrtRunner(ctx, planSeed.maps)
-	if err != nil {
-		return nil, err
-	}
-
-	finalSteps.steps, err = smoothPath(ctx, psc, finalSteps.steps)
+	steps, compact, err := smoothPath(ctx, psc, rawSteps)
 	if err != nil {
 		return nil, err
 	}
 
 	pm.pc.planMeta.GoalsCBIRRTSolved++
-	return finalSteps.steps, nil
+	pm.harvestPlan(psc, compact, pm.logger)
+	return steps, nil
 }
 
 // generateWaypoints will return the list of atomic waypoints that correspond to a specific goal in a plan request.
@@ -381,4 +402,101 @@ func initRRTSolutions(ctx context.Context, psc *PlanSegmentContext, logger loggi
 	rrt.maps.startMap[&node{inputs: seed.inputs}] = nil
 
 	return rrt, nil
+}
+
+// cbirrtRaceAttempts is how many independently-seeded cBiRRT searches run
+// concurrently when the search phase is reached. Constrained searches have
+// heavy-tailed run-to-run variance (samples on one captured scene span 18s to
+// 139s under identical inputs); racing takes roughly the minimum of that
+// distribution and turns the tail into the exception instead of the ruin of a
+// plan. The searches share the plan's collision caches (concurrent-safe, and
+// one racer's discoveries speed up the others) but use private RNG streams
+// and tree maps.
+var cbirrtRaceAttempts = utils.GetenvInt("CBIRRT_RACE_ATTEMPTS", 4)
+
+// cloneRRTMaps gives one racing attempt its own tree maps. Nodes are shared
+// (they are never mutated after insertion); only the map structure - tree
+// membership and parentage - must be private per attempt.
+func cloneRRTMaps(maps *rrtMaps) *rrtMaps {
+	c := &rrtMaps{
+		startMap: make(rrtMap, len(maps.startMap)),
+		goalMap:  make(rrtMap, len(maps.goalMap)),
+		optNode:  maps.optNode,
+	}
+	for k, v := range maps.startMap {
+		c.startMap[k] = v
+	}
+	for k, v := range maps.goalMap {
+		c.goalMap[k] = v
+	}
+	return c
+}
+
+// raceCBiRRT runs cbirrtRaceAttempts independent cBiRRT searches concurrently
+// and returns the first solution found, cancelling the rest.
+func (pm *planManager) raceCBiRRT(
+	ctx context.Context,
+	psc *PlanSegmentContext,
+	maps *rrtMaps,
+) ([]*referenceframe.LinearInputs, error) {
+	attempts := max(1, cbirrtRaceAttempts)
+
+	raceCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	type raceResult struct {
+		steps   []*referenceframe.LinearInputs
+		err     error
+		attempt int
+	}
+	results := make(chan raceResult, attempts)
+
+	// Seed the goal retreat corridors once on the master maps; every attempt's
+	// clone inherits them, so restarts don't repeat the corridor IK.
+	if seeder, err := newCBiRRTMotionPlanner(raceCtx, pm.pc, psc, pm.logger.Sublogger("corridors")); err == nil {
+		seeder.seedGoalRetreatCorridors(raceCtx, maps)
+	}
+	// NOTE: pruning goal roots without corridors was tried here and reverted:
+	// corridor presence is not connectability, and on the captured hard scene
+	// it sometimes removed every root the search could actually reach,
+	// converting a solvable plan into a timeout. The corridor-aiming already
+	// biases racers toward corridor-bearing roots without excluding the rest.
+
+	for a := 0; a < attempts; a++ {
+		go func(a int) {
+			logger := pm.logger.Sublogger(fmt.Sprintf("cbirrt%d", a))
+			planner, err := newCBiRRTMotionPlanner(raceCtx, pm.pc, psc, logger)
+			if err != nil {
+				results <- raceResult{nil, err, a}
+				return
+			}
+			// Continuous searches (restart-chopping was tried and hurt: the
+			// trees are the asset, and successful searches historically need
+			// several hundred iterations). Diversity comes from the racers'
+			// distinct RNG streams.
+			//nolint:gosec
+			planner.rnd = rand.New(rand.NewSource(int64(pm.pc.planOpts.RandomSeed) + int64(a)*7919))
+			sol, err := planner.rrtRunner(raceCtx, cloneRRTMaps(maps))
+			if err != nil {
+				results <- raceResult{nil, err, a}
+				return
+			}
+			results <- raceResult{sol.steps, nil, a}
+		}(a)
+	}
+
+	var firstErr error
+	for i := 0; i < attempts; i++ {
+		r := <-results
+		if r.err == nil {
+			pm.logger.Debugf("cbirrt race: attempt %d finished first (%d raw nodes)", r.attempt, len(r.steps))
+			return r.steps, nil
+		}
+		// Context cancellation of the losers is expected once someone wins;
+		// remember only the first real failure.
+		if firstErr == nil {
+			firstErr = r.err
+		}
+	}
+	return nil, firstErr
 }

--- a/motionplan/armplanning/plan_manager.go
+++ b/motionplan/armplanning/plan_manager.go
@@ -385,6 +385,14 @@ func initRRTSolutions(ctx context.Context, psc *PlanSegmentContext, logger loggi
 		}
 	}
 
+	// Near-duplicate goal solutions (IK polishing the same joint family from
+	// several seeds) add no reachability but multiply the work of everything
+	// downstream - nudge target attempts, the roadmap's multi-goal A* edge
+	// validations, cBiRRT goal trees. goalNodes is cost-sorted, so keeping
+	// the first of each cluster keeps the best.
+	const goalRootDedupSq = 0.25 // squared L2 rad; IK near-dupes are far under, families far over
+	const maxGoalRoots = 16
+	kept := make([][]float64, 0, maxGoalRoots)
 	for _, solution := range goalNodes {
 		if solution.cost > reasonableCost {
 			// if it's this bad, we don't want for cbirrt or going straight
@@ -397,6 +405,21 @@ func initRRTSolutions(ctx context.Context, psc *PlanSegmentContext, logger loggi
 			rrt.steps = []*referenceframe.LinearInputs{solution.inputs}
 			return rrt, nil
 		}
+		if len(kept) >= maxGoalRoots {
+			break
+		}
+		flat := solution.inputs.GetLinearizedInputs()
+		dup := false
+		for _, k := range kept {
+			if flatL2Sq(k, flat) < goalRootDedupSq {
+				dup = true
+				break
+			}
+		}
+		if dup {
+			continue
+		}
+		kept = append(kept, flat)
 		rrt.maps.goalMap[&node{inputs: solution.inputs, cost: solution.cost}] = nil
 	}
 	rrt.maps.startMap[&node{inputs: seed.inputs}] = nil

--- a/motionplan/armplanning/planner_options.go
+++ b/motionplan/armplanning/planner_options.go
@@ -159,12 +159,25 @@ func NewPlannerOptionsFromExtra(extra map[string]interface{}) (*PlannerOptions, 
 
 // GetGoalMetric creates the distance metric for the solver using the configured options.
 func (p *PlannerOptions) GetGoalMetric(goals referenceframe.FrameSystemPoses) motionplan.StateFSMetric {
+	return p.GetGoalMetricWithOrientationSlack(goals, 0)
+}
+
+// GetGoalMetricWithOrientationSlack creates the goal distance metric with a
+// free orientation band of slackDegs around each goal orientation - any
+// orientation within the band scores as exact. Used when solving for
+// intermediate keypoints: their orientation only needs to satisfy the
+// request's constraints (or, with no constraints, doesn't matter at all), and
+// insisting on an exact orientation needlessly rejects reachable keypoints.
+func (p *PlannerOptions) GetGoalMetricWithOrientationSlack(
+	goals referenceframe.FrameSystemPoses, slackDegs float64,
+) motionplan.StateFSMetric {
 	cartesianScale := 1.0
 	orientScale := 100.0
 
 	if p.GoalMetricType == motionplan.PositionOnly {
 		orientScale = 0
 	}
+	slackRads := utils.DegToRad(slackDegs)
 
 	return func(state *motionplan.StateFS) float64 {
 		score := 0.
@@ -179,7 +192,7 @@ func (p *PlannerOptions) GetGoalMetric(goals referenceframe.FrameSystemPoses) mo
 				continue
 			}
 
-			score += motionplan.WeightedSquaredNormDistanceWithOptions(goal.Pose(), &dq, cartesianScale, orientScale)
+			score += motionplan.WeightedSquaredNormDistanceWithTolerance(goal.Pose(), &dq, cartesianScale, orientScale, slackRads)
 		}
 		return score
 	}

--- a/motionplan/armplanning/retreat.go
+++ b/motionplan/armplanning/retreat.go
@@ -1,0 +1,99 @@
+package armplanning
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/golang/geo/r3"
+
+	"go.viam.com/rdk/motionplan"
+	"go.viam.com/rdk/motionplan/ik"
+	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/spatialmath"
+)
+
+const (
+	// goalRetreatStepMM and goalRetreatCount shape the retreat corridors: the
+	// cumulative upward offsets of the validated chain grown from each goal
+	// root. See seedGoalRetreatCorridors.
+	goalRetreatStepMM = 75.0
+	goalRetreatCount  = 3
+)
+
+// midOrientationSlackDegs returns how much an intermediate keypoint's
+// orientation may deviate from its nominal target. With orientation
+// constraints, the constraint band (the keypoint must satisfy it anyway, and
+// the state check enforces that); with path-shape constraints, none; with no
+// constraints at all, unlimited - a stepping stone's orientation is irrelevant.
+func midOrientationSlackDegs(c *motionplan.Constraints) float64 {
+	if c == nil {
+		return 360
+	}
+	if len(c.LinearConstraint) > 0 || len(c.PseudolinearConstraint) > 0 {
+		return 0
+	}
+	if len(c.OrientationConstraint) == 0 {
+		return 360
+	}
+	slack := c.OrientationConstraint[0].OrientationToleranceDegs
+	for _, oc := range c.OrientationConstraint[1:] {
+		slack = min(slack, oc.OrientationToleranceDegs)
+	}
+	return max(0, slack)
+}
+
+// retreatChain jogs the end effector of `frame` straight up from `from` in
+// validated steps, returning the chain [from, step1, step2, ...] as far as it
+// gets (possibly just [from]). Each hop is produced by a short gradient
+// descent seeded at the previous configuration, then state- and path-checked.
+func retreatChain(
+	ctx context.Context,
+	psc *PlanSegmentContext,
+	solver *ik.NloptIK,
+	frame string,
+	from *referenceframe.LinearInputs,
+) []*referenceframe.LinearInputs {
+	chain := []*referenceframe.LinearInputs{from}
+	cur := from
+	for step := 0; step < goalRetreatCount; step++ {
+		if ctx.Err() != nil {
+			return chain
+		}
+		curDQ, err := psc.pc.fs.TransformToDQ(cur, frame, referenceframe.World)
+		if err != nil {
+			return chain
+		}
+		curPt := curDQ.Point()
+		target := spatialmath.NewPose(
+			r3.Vector{X: curPt.X, Y: curPt.Y, Z: curPt.Z + goalRetreatStepMM},
+			curDQ.Orientation())
+
+		metric := psc.pc.planOpts.GetGoalMetricWithOrientationSlack(referenceframe.FrameSystemPoses{
+			frame: referenceframe.NewPoseInFrame(referenceframe.World, target),
+		}, midOrientationSlackDegs(psc.pc.request.Constraints))
+		linearSeed := cur.GetLinearizedInputs()
+		var totalAttempts atomic.Int32
+		solutions, _, err := ik.DoSolve(ctx, solver, &totalAttempts,
+			psc.pc.LinearizeFSMetric(metric),
+			[][]float64{linearSeed},
+			[][]referenceframe.Limit{ik.ComputeAdjustLimits(linearSeed, psc.pc.lis.GetLimits(), .05)})
+		if err != nil || len(solutions) == 0 {
+			return chain
+		}
+		retreatCfg, err := psc.pc.lis.FloatsToInputs(solutions[0])
+		if err != nil {
+			return chain
+		}
+		if _, err := psc.Checker.CheckStateFSConstraints(ctx, &motionplan.StateFS{
+			FS: psc.pc.fs, Configuration: retreatCfg,
+		}); err != nil {
+			return chain
+		}
+		if err := psc.CheckPath(ctx, cur, retreatCfg, true, nil); err != nil {
+			return chain
+		}
+		chain = append(chain, retreatCfg)
+		cur = retreatCfg
+	}
+	return chain
+}

--- a/motionplan/armplanning/roadmap.go
+++ b/motionplan/armplanning/roadmap.go
@@ -1,0 +1,608 @@
+package armplanning
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"strings"
+	"sync"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/referenceframe"
+)
+
+// This file implements a lazy probabilistic roadmap: a reusable graph over the
+// moving chain's configuration space whose edge validity is discovered per
+// scene and remembered. The expensive part of planning - discovering how
+// configuration-space regions connect, including the joint-family
+// reconfigurations that random search spends most of its time on - is thereby
+// paid once per robot+scene instead of once per plan.
+//
+// Structure (nodes and candidate edges) contains no collision information at
+// all, so it is cached per (frame system, moving chain, goal frame) for the
+// life of the process. Edges are proposed two ways:
+//
+//   - joint-space k-nearest neighbors: short, ordinary motions;
+//   - workspace k-nearest neighbors: node pairs whose end effectors are close
+//     while their configurations are far - exactly the joint-family bridges a
+//     joint-space-only roadmap can never contain.
+//
+// Validity is evaluated on demand during the query's A* search via
+// PlanSegmentContext.CheckPath (inheriting the distance-field and cover fast
+// paths) and cached per scene fingerprint, including negative verdicts.
+
+const (
+	// roadmapNodes is the number of sampled configurations in the structure.
+	roadmapNodes = 600
+	// roadmapJointK is the joint-space nearest-neighbor edge count per node.
+	roadmapJointK = 10
+	// roadmapWorkspaceK is the workspace nearest-neighbor edge count per node.
+	roadmapWorkspaceK = 4
+	// roadmapQueryK is how many roadmap nodes the query's start and each goal
+	// configuration get candidate connections to.
+	roadmapQueryK = 15
+	// roadmapEdgeBudget caps edge validations per query; an exhausted budget
+	// fails the query and the planner falls back to search.
+	roadmapEdgeBudget = 500
+	// roadmapStructureSeed makes the sampled structure deterministic.
+	roadmapStructureSeed = 424242
+)
+
+// roadmapRegistry caches structures per key for the life of the process.
+var roadmapRegistry sync.Map // string -> *roadmap
+
+type roadmap struct {
+	frames []string // moving chain frames with DoF, sorted; defines flat layout
+	dims   []int    // DoF per frame
+
+	// mu guards flat and neighbors: queries hold it for read, harvesting
+	// appends under write.
+	mu   sync.RWMutex
+	flat [][]float64
+	// neighbors is the union of joint-space and workspace candidate edges.
+	neighbors [][]int
+
+	// sceneVerdicts caches per-scene edge validity: key -> bool.
+	sceneVerdicts sync.Map // roadmapVerdictKey -> bool
+
+	buildOnce sync.Once
+	buildErr  error
+}
+
+type roadmapVerdictKey struct {
+	scene uint64
+	a, b  int32 // canonical: a < b; query endpoints use negative ids
+}
+
+// roadmapKeyFor identifies a reusable structure.
+func roadmapKeyFor(psc *PlanSegmentContext, frames []string) string {
+	var sb strings.Builder
+	sb.WriteString(psc.pc.fs.Name())
+	for _, f := range frames {
+		sb.WriteByte('|')
+		sb.WriteString(f)
+	}
+	for f := range psc.goal {
+		sb.WriteByte('#')
+		sb.WriteString(f)
+	}
+	return sb.String()
+}
+
+// getRoadmap returns the (possibly freshly built) structure for this segment
+// context, or nil when the chain is unsuitable.
+func getRoadmap(psc *PlanSegmentContext, logger logging.Logger) *roadmap {
+	frames := movingFrameNamesWithDoF(psc)
+	if len(frames) == 0 || len(psc.goal) != 1 {
+		return nil
+	}
+	sort.Strings(frames)
+	key := roadmapKeyFor(psc, frames)
+	v, _ := roadmapRegistry.LoadOrStore(key, &roadmap{frames: frames})
+	rm := v.(*roadmap)
+	rm.buildOnce.Do(func() {
+		rm.buildErr = rm.build(psc, logger)
+	})
+	if rm.buildErr != nil {
+		return nil
+	}
+	return rm
+}
+
+// build samples the structure. No collision checking happens here.
+func (rm *roadmap) build(psc *PlanSegmentContext, logger logging.Logger) error {
+	fs := psc.pc.fs
+	totalDoF := 0
+	rm.dims = make([]int, len(rm.frames))
+	type frameLimits struct {
+		min, max []float64
+	}
+	limits := make([]frameLimits, len(rm.frames))
+	for i, name := range rm.frames {
+		f := fs.Frame(name)
+		if f == nil {
+			return fmt.Errorf("roadmap: missing frame %s", name)
+		}
+		dof := f.DoF()
+		rm.dims[i] = len(dof)
+		totalDoF += len(dof)
+		fl := frameLimits{min: make([]float64, len(dof)), max: make([]float64, len(dof))}
+		for j, l := range dof {
+			lo, hi := l.Min, l.Max
+			if math.IsInf(lo, -1) || lo < -999 {
+				lo = -999
+			}
+			if math.IsInf(hi, 1) || hi > 999 {
+				hi = 999
+			}
+			fl.min[j], fl.max[j] = lo, hi
+		}
+		limits[i] = fl
+	}
+	if totalDoF == 0 {
+		return fmt.Errorf("roadmap: chain has no degrees of freedom")
+	}
+
+	//nolint:gosec
+	rnd := rand.New(rand.NewSource(roadmapStructureSeed))
+	rm.flat = make([][]float64, roadmapNodes)
+	for n := 0; n < roadmapNodes; n++ {
+		cfg := make([]float64, 0, totalDoF)
+		for i := range rm.frames {
+			for j := 0; j < rm.dims[i]; j++ {
+				lo, hi := limits[i].min[j], limits[i].max[j]
+				cfg = append(cfg, lo+rnd.Float64()*(hi-lo))
+			}
+		}
+		rm.flat[n] = cfg
+	}
+
+	// Workspace positions for the bridge edges: end-effector pose of each
+	// node, other frames at the query start (constant offsets cancel in
+	// nearest-neighbor comparisons).
+	var goalFrame string
+	for f := range psc.goal {
+		goalFrame = f
+	}
+	positions := make([][3]float64, roadmapNodes)
+	for n := range rm.flat {
+		cfg := rm.compose(psc.start, rm.flat[n])
+		fk := fs.NewFrameToWorld(cfg)
+		_, pt, err := fk.PoseQT(goalFrame)
+		if err != nil {
+			return err
+		}
+		positions[n] = [3]float64{pt.X, pt.Y, pt.Z}
+	}
+
+	// Candidate edges: joint kNN plus workspace kNN.
+	rm.neighbors = make([][]int, roadmapNodes)
+	type distIdx struct {
+		d float64
+		i int
+	}
+	addEdge := func(a, b int) {
+		if a == b {
+			return
+		}
+		for _, e := range rm.neighbors[a] {
+			if e == b {
+				return
+			}
+		}
+		rm.neighbors[a] = append(rm.neighbors[a], b)
+		rm.neighbors[b] = append(rm.neighbors[b], a)
+	}
+	scratch := make([]distIdx, roadmapNodes)
+	for a := 0; a < roadmapNodes; a++ {
+		for b := 0; b < roadmapNodes; b++ {
+			scratch[b] = distIdx{flatL2Sq(rm.flat[a], rm.flat[b]), b}
+		}
+		sort.Slice(scratch, func(i, j int) bool { return scratch[i].d < scratch[j].d })
+		for i := 1; i <= roadmapJointK && i < len(scratch); i++ {
+			addEdge(a, scratch[i].i)
+		}
+		for b := 0; b < roadmapNodes; b++ {
+			dx := positions[a][0] - positions[b][0]
+			dy := positions[a][1] - positions[b][1]
+			dz := positions[a][2] - positions[b][2]
+			scratch[b] = distIdx{dx*dx + dy*dy + dz*dz, b}
+		}
+		sort.Slice(scratch, func(i, j int) bool { return scratch[i].d < scratch[j].d })
+		for i := 1; i <= roadmapWorkspaceK && i < len(scratch); i++ {
+			addEdge(a, scratch[i].i)
+		}
+	}
+
+	edgeCount := 0
+	for _, nb := range rm.neighbors {
+		edgeCount += len(nb)
+	}
+	logger.Debugf("roadmap built: %d nodes, %d DoF, %d edges", roadmapNodes, totalDoF, edgeCount/2)
+	return nil
+}
+
+// compose overlays a flat chain configuration onto the base configuration.
+func (rm *roadmap) compose(base *referenceframe.LinearInputs, flat []float64) *referenceframe.LinearInputs {
+	out := base.Copy()
+	idx := 0
+	for i, name := range rm.frames {
+		vals := make([]referenceframe.Input, rm.dims[i])
+		for j := range vals {
+			vals[j] = flat[idx]
+			idx++
+		}
+		out.Put(name, vals)
+	}
+	return out
+}
+
+// extract pulls the chain frames' values out of a full configuration.
+func (rm *roadmap) extract(cfg *referenceframe.LinearInputs) []float64 {
+	out := make([]float64, 0, 16)
+	for i, name := range rm.frames {
+		vals := cfg.Get(name)
+		if len(vals) != rm.dims[i] {
+			return nil
+		}
+		out = append(out, vals...)
+	}
+	return out
+}
+
+func flatL2Sq(a, b []float64) float64 {
+	t := 0.0
+	for i := range a {
+		d := a[i] - b[i]
+		t += d * d
+	}
+	return t
+}
+
+// tryRoadmap answers the query start -> any goal root through the roadmap
+// with lazily-validated edges. Returns the waypoint list (full
+// configurations, start included) or nil.
+func (pm *planManager) tryRoadmap(
+	ctx context.Context,
+	psc *PlanSegmentContext,
+	goalRoots []*node,
+	logger logging.Logger,
+) []*referenceframe.LinearInputs {
+	rm := getRoadmap(psc, logger)
+	if rm == nil || len(goalRoots) == 0 {
+		return nil
+	}
+	sceneKey := pm.roadmapSceneKey(psc, rm)
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+
+	startFlat := rm.extract(psc.start)
+	if startFlat == nil {
+		return nil
+	}
+	goals := make([][]float64, 0, len(goalRoots))
+	goalCfgs := make([]*referenceframe.LinearInputs, 0, len(goalRoots))
+	for _, g := range goalRoots {
+		if f := rm.extract(g.inputs); f != nil {
+			goals = append(goals, f)
+			goalCfgs = append(goalCfgs, g.inputs)
+		}
+	}
+	if len(goals) == 0 {
+		return nil
+	}
+
+	// Query graph ids: 0..N-1 roadmap, N = start, N+1+i = goal i.
+	n := len(rm.flat)
+	startID := n
+	goalID := func(i int) int { return n + 1 + i }
+	isGoal := func(id int) bool { return id > startID }
+
+	flatOf := func(id int) []float64 {
+		switch {
+		case id < n:
+			return rm.flat[id]
+		case id == startID:
+			return startFlat
+		default:
+			return goals[id-startID-1]
+		}
+	}
+	cfgOf := func(id int) *referenceframe.LinearInputs {
+		switch {
+		case id < n:
+			return rm.compose(psc.start, rm.flat[id])
+		case id == startID:
+			return psc.start
+		default:
+			return goalCfgs[id-startID-1]
+		}
+	}
+
+	// Candidate neighbors of the query endpoints.
+	queryNeighbors := func(flat []float64) []int {
+		type distIdx struct {
+			d float64
+			i int
+		}
+		best := make([]distIdx, 0, n)
+		for i := 0; i < n; i++ {
+			best = append(best, distIdx{flatL2Sq(flat, rm.flat[i]), i})
+		}
+		sort.Slice(best, func(i, j int) bool { return best[i].d < best[j].d })
+		out := make([]int, 0, roadmapQueryK)
+		for i := 0; i < roadmapQueryK && i < len(best); i++ {
+			out = append(out, best[i].i)
+		}
+		return out
+	}
+	startNbrs := queryNeighbors(startFlat)
+	goalNbrs := make(map[int][]int, len(goals)) // roadmap node -> goal ids it connects to
+	for gi, g := range goals {
+		for _, nb := range queryNeighbors(g) {
+			goalNbrs[nb] = append(goalNbrs[nb], goalID(gi))
+		}
+	}
+
+	neighborsOf := func(id int) []int {
+		switch {
+		case id == startID:
+			return startNbrs
+		case isGoal(id):
+			return nil // goals are terminal
+		default:
+			nbrs := rm.neighbors[id]
+			if extra, ok := goalNbrs[id]; ok {
+				out := make([]int, 0, len(nbrs)+len(extra)+1)
+				out = append(out, nbrs...)
+				out = append(out, extra...)
+				return out
+			}
+			return nbrs
+		}
+	}
+
+	heuristic := func(id int) float64 {
+		f := flatOf(id)
+		best := math.Inf(1)
+		for _, g := range goals {
+			best = math.Min(best, flatL2Sq(f, g))
+		}
+		return math.Sqrt(best)
+	}
+
+	budget := roadmapEdgeBudget
+	validated := 0
+	checkEdge := func(a, b int) bool {
+		ka, kb := int32(a), int32(b)
+		// Query endpoints get negative ids in the cache key so different
+		// queries never collide with structural edges.
+		if a >= n {
+			ka = -int32(a - n + 1)
+		}
+		if b >= n {
+			kb = -int32(b - n + 1)
+		}
+		if ka > kb {
+			ka, kb = kb, ka
+		}
+		key := roadmapVerdictKey{scene: sceneKey, a: ka, b: kb}
+		// Query-endpoint verdicts are only cacheable for the start/goals of
+		// this exact query; structural edges (both ids >= 0) cache globally.
+		cacheable := ka >= 0
+		if cacheable {
+			if v, ok := rm.sceneVerdicts.Load(key); ok {
+				return v.(bool)
+			}
+		}
+		if budget <= 0 {
+			return false
+		}
+		budget--
+		validated++
+		ok := psc.CheckPath(ctx, cfgOf(a), cfgOf(b), true, nil) == nil
+		if cacheable {
+			rm.sceneVerdicts.Store(key, ok)
+		}
+		return ok
+	}
+
+	// A* with lazy edge validation on expansion.
+	pq := &roadmapPQ{}
+	heap.Init(pq)
+	gScore := map[int]float64{startID: 0}
+	cameFrom := map[int]int{}
+	closed := map[int]bool{}
+	heap.Push(pq, roadmapQItem{startID, heuristic(startID)})
+
+	for pq.Len() > 0 && ctx.Err() == nil && budget > 0 {
+		cur := heap.Pop(pq).(roadmapQItem)
+		if closed[cur.id] {
+			continue
+		}
+		closed[cur.id] = true
+		if isGoal(cur.id) {
+			// Reconstruct.
+			ids := []int{cur.id}
+			for ids[len(ids)-1] != startID {
+				ids = append(ids, cameFrom[ids[len(ids)-1]])
+			}
+			path := make([]*referenceframe.LinearInputs, 0, len(ids))
+			for i := len(ids) - 1; i >= 0; i-- {
+				path = append(path, cfgOf(ids[i]))
+			}
+			logger.Debugf("roadmap connected: %d waypoints, %d edges validated", len(path), validated)
+			return path
+		}
+		for _, nb := range neighborsOf(cur.id) {
+			if closed[nb] {
+				continue
+			}
+			if !checkEdge(cur.id, nb) {
+				continue
+			}
+			tentative := gScore[cur.id] + math.Sqrt(flatL2Sq(flatOf(cur.id), flatOf(nb)))
+			if old, ok := gScore[nb]; ok && tentative >= old {
+				continue
+			}
+			gScore[nb] = tentative
+			cameFrom[nb] = cur.id
+			heap.Push(pq, roadmapQItem{nb, tentative + heuristic(nb)})
+		}
+	}
+	logger.Debugf("roadmap query failed: %d edges validated, budget left %d", validated, budget)
+	return nil
+}
+
+// roadmapSceneKey fingerprints everything edge validity depends on beyond the
+// structure: the obstacle set and the non-chain part of the configuration.
+func (pm *planManager) roadmapSceneKey(psc *PlanSegmentContext, rm *roadmap) uint64 {
+	const fnvPrime = 0x100000001b3
+	h := uint64(0xcbf29ce484222325)
+	mix := func(v uint64) {
+		h ^= v
+		h *= fnvPrime
+	}
+	inChain := map[string]bool{}
+	for _, f := range rm.frames {
+		inChain[f] = true
+	}
+	for name, vals := range psc.start.Items() {
+		if inChain[name] {
+			continue
+		}
+		for _, ch := range name {
+			mix(uint64(ch))
+		}
+		for _, v := range vals {
+			mix(math.Float64bits(v))
+		}
+	}
+	if pm.request.ObstaclesInWorldFrame != nil {
+		for _, g := range pm.request.ObstaclesInWorldFrame.Geometries() {
+			for _, ch := range g.Label() {
+				mix(uint64(ch))
+			}
+			pt := g.Pose().Point()
+			mix(math.Float64bits(pt.X))
+			mix(math.Float64bits(pt.Y))
+			mix(math.Float64bits(pt.Z))
+		}
+	}
+	return h
+}
+
+// roadmapQItem is one A* frontier entry.
+type roadmapQItem struct {
+	id int
+	f  float64
+}
+
+// roadmapPQ is a minimal min-heap on f-score for the A* frontier.
+type roadmapPQ []roadmapQItem
+
+func (pq roadmapPQ) Len() int           { return len(pq) }
+func (pq roadmapPQ) Less(i, j int) bool { return pq[i].f < pq[j].f }
+func (pq roadmapPQ) Swap(i, j int)      { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *roadmapPQ) Push(x any)        { *pq = append(*pq, x.(roadmapQItem)) }
+func (pq *roadmapPQ) Pop() any {
+	old := *pq
+	n := len(old)
+	x := old[n-1]
+	*pq = old[:n-1]
+	return x
+}
+
+// harvestKNN is how many candidate edges each harvested waypoint gets into
+// the existing structure (validity lazy, like any candidate edge).
+const harvestKNN = 6
+
+// harvest inserts a successful plan's waypoints into the roadmap: nodes are
+// permanent (they describe robot capability, not the scene), consecutive
+// edges are recorded as valid for the scene they were planned in, and each
+// node is candidate-linked to its nearest existing neighbors. Every solved
+// plan thereby teaches the roadmap a working corridor - including the
+// joint-family reconfigurations a fresh search pays hundreds of iterations to
+// rediscover.
+func (rm *roadmap) harvest(scene uint64, path []*referenceframe.LinearInputs, logger logging.Logger) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	type distIdx struct {
+		d float64
+		i int
+	}
+	prev := -1
+	added := 0
+	for _, cfg := range path {
+		flat := rm.extract(cfg)
+		if flat == nil {
+			prev = -1
+			continue
+		}
+		if prev >= 0 && flatL2Sq(rm.flat[prev], flat) < 1e-12 {
+			continue
+		}
+		// Reuse an existing node when the waypoint is (nearly) already there,
+		// so repeated plans don't grow the roadmap without bound.
+		id := -1
+		best := 1e-4 // squared; ~0.01 rad
+		for i, f := range rm.flat {
+			if d := flatL2Sq(f, flat); d < best {
+				best, id = d, i
+			}
+		}
+		if id < 0 {
+			id = len(rm.flat)
+			rm.flat = append(rm.flat, flat)
+			rm.neighbors = append(rm.neighbors, nil)
+			added++
+			// Candidate-link into the structure.
+			cands := make([]distIdx, 0, id)
+			for i := 0; i < id; i++ {
+				cands = append(cands, distIdx{flatL2Sq(rm.flat[i], flat), i})
+			}
+			sort.Slice(cands, func(i, j int) bool { return cands[i].d < cands[j].d })
+			for i := 0; i < harvestKNN && i < len(cands); i++ {
+				nb := cands[i].i
+				rm.neighbors[id] = append(rm.neighbors[id], nb)
+				rm.neighbors[nb] = append(rm.neighbors[nb], id)
+			}
+		}
+		if prev >= 0 && prev != id {
+			rm.neighbors[prev] = append(rm.neighbors[prev], id)
+			rm.neighbors[id] = append(rm.neighbors[id], prev)
+			a, b := int32(prev), int32(id)
+			if a > b {
+				a, b = b, a
+			}
+			// The hop was validated by the plan's full-resolution smoothing
+			// sweep for this scene.
+			rm.sceneVerdicts.Store(roadmapVerdictKey{scene: scene, a: a, b: b}, true)
+		}
+		prev = id
+	}
+	if added > 0 {
+		logger.Debugf("roadmap harvested %d nodes (total %d)", added, len(rm.flat))
+	}
+}
+
+// harvestPlan records a successful plan into the roadmap, if one exists for
+// this segment context.
+func (pm *planManager) harvestPlan(psc *PlanSegmentContext, steps []*referenceframe.LinearInputs, logger logging.Logger) {
+	rm := getRoadmap(psc, logger)
+	if rm == nil || len(steps) < 2 {
+		return
+	}
+	// Backstop against feedback loops: a plan that smoothed poorly would
+	// teach the roadmap a long, awkward corridor that makes every later
+	// query's raw path longer still.
+	if len(steps) > 48 {
+		logger.Debugf("skipping harvest of %d-waypoint path", len(steps))
+		return
+	}
+	rm.harvest(pm.roadmapSceneKey(psc, rm), steps, logger)
+}

--- a/motionplan/armplanning/roadmap.go
+++ b/motionplan/armplanning/roadmap.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/referenceframe"
@@ -57,13 +58,23 @@ var roadmapRegistry sync.Map // string -> *roadmap
 type roadmap struct {
 	frames []string // moving chain frames with DoF, sorted; defines flat layout
 	dims   []int    // DoF per frame
+	// goalFrame is the frame whose world position eePos records.
+	goalFrame string
 
-	// mu guards flat and neighbors: queries hold it for read, harvesting
-	// appends under write.
+	// mu guards flat, neighbors, and eePos: queries hold it for read,
+	// harvesting appends under write.
 	mu   sync.RWMutex
 	flat [][]float64
 	// neighbors is the union of joint-space and workspace candidate edges.
 	neighbors [][]int
+	// eePos is the goalFrame's world position per node (non-chain frames at
+	// the building query's start). Used to find goal-adjacent configurations
+	// for IK seeding; entries that failed FK hold +Inf.
+	eePos [][3]float64
+
+	// built flips true once build has completed successfully; lock-free
+	// readers (peekRoadmap) must check it before touching any other field.
+	built atomic.Bool
 
 	// sceneVerdicts caches per-scene edge validity: key -> bool.
 	sceneVerdicts sync.Map // roadmapVerdictKey -> bool
@@ -110,6 +121,92 @@ func getRoadmap(psc *PlanSegmentContext, logger logging.Logger) *roadmap {
 		return nil
 	}
 	return rm
+}
+
+// peekRoadmap returns the already-built structure for this segment context,
+// or nil. Unlike getRoadmap it never builds, so cheap callers (IK seeding)
+// don't pay the build cost for plans that may never need the roadmap.
+func peekRoadmap(psc *PlanSegmentContext) *roadmap {
+	frames := movingFrameNamesWithDoF(psc)
+	if len(frames) == 0 || len(psc.goal) != 1 {
+		return nil
+	}
+	sort.Strings(frames)
+	v, ok := roadmapRegistry.Load(roadmapKeyFor(psc, frames))
+	if !ok {
+		return nil
+	}
+	rm := v.(*roadmap)
+	if !rm.built.Load() {
+		return nil
+	}
+	return rm
+}
+
+// roadmapGoalSeeds returns up to maxSeeds roadmap configurations whose end
+// effector already sits near this goal's world position - in practice, goal
+// configurations harvested from earlier successful plans in this process.
+// They are fed to IK as seeds: nlopt's per-seed draws sometimes miss the
+// joint family closest to the start entirely, and every downstream strategy
+// then pays a reconfiguration detour to whatever family it did find. Seeding
+// with remembered goal-adjacent configurations makes the good family reliably
+// present, so the solution ranking (by cost from start) can prefer it.
+func roadmapGoalSeeds(psc *PlanSegmentContext, maxSeeds int) []*referenceframe.LinearInputs {
+	rm := peekRoadmap(psc)
+	if rm == nil {
+		return nil
+	}
+	var goalFrame string
+	goalPt := [3]float64{}
+	for f, p := range psc.goal {
+		goalFrame = f
+		pt := p.Pose().Point()
+		goalPt = [3]float64{pt.X, pt.Y, pt.Z}
+	}
+	if goalFrame != rm.goalFrame {
+		return nil
+	}
+	// Generous radius: harvested goal configurations match the goal almost
+	// exactly; uniform samples essentially never land this close. The seeds
+	// are advisory (IK still solves to the actual goal), so a near-miss from
+	// a slightly moved goal is still a useful seed.
+	const goalSeedRadiusMM = 100.0
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+	type cand struct {
+		d float64
+		i int
+	}
+	cands := make([]cand, 0, 8)
+	for i, p := range rm.eePos {
+		dx, dy, dz := p[0]-goalPt[0], p[1]-goalPt[1], p[2]-goalPt[2]
+		if d := dx*dx + dy*dy + dz*dz; d < goalSeedRadiusMM*goalSeedRadiusMM {
+			cands = append(cands, cand{d, i})
+		}
+	}
+	sort.Slice(cands, func(i, j int) bool { return cands[i].d < cands[j].d })
+	out := make([]*referenceframe.LinearInputs, 0, maxSeeds)
+	chosen := make([][]float64, 0, maxSeeds)
+	for _, c := range cands {
+		f := rm.flat[c.i]
+		// Keep only one representative per joint family.
+		distinct := true
+		for _, cf := range chosen {
+			if flatL2Sq(cf, f) < 1.0 {
+				distinct = false
+				break
+			}
+		}
+		if !distinct {
+			continue
+		}
+		chosen = append(chosen, f)
+		out = append(out, rm.compose(psc.start, f))
+		if len(out) >= maxSeeds {
+			break
+		}
+	}
+	return out
 }
 
 // build samples the structure. No collision checking happens here.
@@ -177,6 +274,8 @@ func (rm *roadmap) build(psc *PlanSegmentContext, logger logging.Logger) error {
 		}
 		positions[n] = [3]float64{pt.X, pt.Y, pt.Z}
 	}
+	rm.goalFrame = goalFrame
+	rm.eePos = positions
 
 	// Candidate edges: joint kNN plus workspace kNN.
 	rm.neighbors = make([][]int, roadmapNodes)
@@ -222,6 +321,7 @@ func (rm *roadmap) build(psc *PlanSegmentContext, logger logging.Logger) error {
 		edgeCount += len(nb)
 	}
 	logger.Debugf("roadmap built: %d nodes, %d DoF, %d edges", roadmapNodes, totalDoF, edgeCount/2)
+	rm.built.Store(true)
 	return nil
 }
 
@@ -274,6 +374,14 @@ func (pm *planManager) tryRoadmap(
 	rm := getRoadmap(psc, logger)
 	if rm == nil || len(goalRoots) == 0 {
 		return nil
+	}
+	// Every goal root costs roadmapQueryK candidate connections in the
+	// multi-goal A*; past the several cheapest, extra roots only burn edge
+	// budget.
+	const roadmapMaxGoals = 8
+	if len(goalRoots) > roadmapMaxGoals {
+		sort.Slice(goalRoots, func(i, j int) bool { return goalRoots[i].cost < goalRoots[j].cost })
+		goalRoots = goalRoots[:roadmapMaxGoals]
 	}
 	sceneKey := pm.roadmapSceneKey(psc, rm)
 	rm.mu.RLock()
@@ -527,7 +635,7 @@ const harvestKNN = 6
 // plan thereby teaches the roadmap a working corridor - including the
 // joint-family reconfigurations a fresh search pays hundreds of iterations to
 // rediscover.
-func (rm *roadmap) harvest(scene uint64, path []*referenceframe.LinearInputs, logger logging.Logger) {
+func (rm *roadmap) harvest(psc *PlanSegmentContext, scene uint64, path []*referenceframe.LinearInputs, logger logging.Logger) {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 
@@ -559,6 +667,11 @@ func (rm *roadmap) harvest(scene uint64, path []*referenceframe.LinearInputs, lo
 			id = len(rm.flat)
 			rm.flat = append(rm.flat, flat)
 			rm.neighbors = append(rm.neighbors, nil)
+			pos := [3]float64{math.Inf(1), math.Inf(1), math.Inf(1)}
+			if _, pt, err := psc.pc.fs.NewFrameToWorld(cfg).PoseQT(rm.goalFrame); err == nil {
+				pos = [3]float64{pt.X, pt.Y, pt.Z}
+			}
+			rm.eePos = append(rm.eePos, pos)
 			added++
 			// Candidate-link into the structure.
 			cands := make([]distIdx, 0, id)
@@ -604,5 +717,5 @@ func (pm *planManager) harvestPlan(psc *PlanSegmentContext, steps []*referencefr
 		logger.Debugf("skipping harvest of %d-waypoint path", len(steps))
 		return
 	}
-	rm.harvest(pm.roadmapSceneKey(psc, rm), steps, logger)
+	rm.harvest(psc, pm.roadmapSceneKey(psc, rm), steps, logger)
 }

--- a/motionplan/armplanning/smooth.go
+++ b/motionplan/armplanning/smooth.go
@@ -38,6 +38,77 @@ func simpleSmoothStep(ctx context.Context, psc *PlanSegmentContext, steps []*ref
 // uncapped pass over a long raw search path could cost more than the search.
 const smoothProbeBudget = 300
 
+// vertexPullStep shrinks detours that waypoint removal cannot: when deleting
+// an interior waypoint is blocked (the straight bypass clips an obstacle),
+// the waypoint can often still be pulled partway toward the midpoint of its
+// neighbors, tightening the arc around the obstacle. Without this, a path
+// routed through an arbitrary intermediate configuration (a roadmap sample, a
+// search tree node) keeps that configuration's full detour forever - which
+// also means harvesting locks the detour into every future replan. Every
+// accepted pull strictly lowers path cost, so a few rounds converge.
+func vertexPullStep(ctx context.Context, psc *PlanSegmentContext, steps []*referenceframe.LinearInputs,
+	budget *int,
+) []*referenceframe.LinearInputs {
+	if len(steps) < 3 {
+		return steps
+	}
+	segCost := func(a, b *referenceframe.LinearInputs) float64 {
+		return psc.pc.ConfigurationDistanceFunc(&motionplan.SegmentFS{StartConfiguration: a, EndConfiguration: b})
+	}
+	// Only paths carrying substantial detour are worth the CheckPath spend:
+	// a path near the direct start-goal cost has nothing to reclaim (and a
+	// converged, previously-pulled path re-entering smoothing skips straight
+	// through here on replans).
+	const vertexPullSlackFactor = 1.5
+	total := 0.0
+	for i := 1; i < len(steps); i++ {
+		total += segCost(steps[i-1], steps[i])
+	}
+	direct := segCost(steps[0], steps[len(steps)-1])
+	if total <= vertexPullSlackFactor*direct {
+		return steps
+	}
+	const pullRounds = 6
+	for r := 0; r < pullRounds; r++ {
+		improved := false
+		for i := 1; i+1 < len(steps); i++ {
+			prev, cur, next := steps[i-1], steps[i], steps[i+1]
+			mid, err := referenceframe.InterpolateFS(psc.pc.fs, prev, next, 0.5)
+			if err != nil {
+				return steps
+			}
+			curCost := segCost(prev, cur) + segCost(cur, next)
+			// Blend from cur toward the neighbors' midpoint, most aggressive
+			// first. The full midpoint itself is never a candidate: it lies on
+			// the straight prev-next line, which waypoint removal already
+			// proved blocked whenever this step matters.
+			for _, alpha := range []float64{0.75, 0.5, 0.25} {
+				cand, err := referenceframe.InterpolateFS(psc.pc.fs, cur, mid, alpha)
+				if err != nil {
+					return steps
+				}
+				if segCost(prev, cand)+segCost(cand, next) >= curCost-1e-9 {
+					continue
+				}
+				if *budget <= 0 {
+					return steps
+				}
+				*budget -= 2
+				if psc.CheckPath(ctx, prev, cand, false, nil) != nil || psc.CheckPath(ctx, cand, next, false, nil) != nil {
+					continue
+				}
+				steps[i] = cand
+				improved = true
+				break
+			}
+		}
+		if !improved {
+			break
+		}
+	}
+	return steps
+}
+
 // smoothPath will pick two points at random along the path and attempt to do a fast gradient descent directly between
 // them, which will cut off randomly-chosen points with odd joint angles into something that is a more intuitive motion.
 func smoothPathSimple(ctx context.Context, psc *PlanSegmentContext,
@@ -55,6 +126,10 @@ func smoothPathSimple(ctx context.Context, psc *PlanSegmentContext,
 	if len(steps) > 15 {
 		steps = simpleSmoothStep(ctx, psc, steps, 3, &budget)
 	}
+	steps = simpleSmoothStep(ctx, psc, steps, 1, &budget)
+	steps = vertexPullStep(ctx, psc, steps, &budget)
+	// Pulled vertices can straighten segments enough to make whole waypoints
+	// removable, so run one more removal pass.
 	steps = simpleSmoothStep(ctx, psc, steps, 1, &budget)
 
 	steps = tryOnlyMovingComponentsThatNeedToMove(ctx, psc, steps)

--- a/motionplan/armplanning/smooth.go
+++ b/motionplan/armplanning/smooth.go
@@ -2,6 +2,7 @@ package armplanning
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"time"
 
@@ -12,11 +13,14 @@ import (
 )
 
 func simpleSmoothStep(ctx context.Context, psc *PlanSegmentContext, steps []*referenceframe.LinearInputs, step int,
+	budget *int,
 ) []*referenceframe.LinearInputs {
-	ctx, span := trace.StartSpan(ctx, "simpleSmoothStep")
-	defer span.End()
 	// look at each triplet, see if we can remove the middle one
 	for i := step + 1; i < len(steps); i += step {
+		if *budget <= 0 {
+			return steps
+		}
+		*budget--
 		err := psc.CheckPath(ctx, steps[i-step-1], steps[i], false, nil)
 		if err != nil {
 			continue
@@ -28,6 +32,12 @@ func simpleSmoothStep(ctx context.Context, psc *PlanSegmentContext, steps []*ref
 	return steps
 }
 
+// smoothProbeBudget caps the total number of coarse shortcut probes one
+// smoothing invocation may spend. Smoothing has diminishing returns - the
+// close-obstacle sweep afterwards validates whatever shape remains - and an
+// uncapped pass over a long raw search path could cost more than the search.
+const smoothProbeBudget = 300
+
 // smoothPath will pick two points at random along the path and attempt to do a fast gradient descent directly between
 // them, which will cut off randomly-chosen points with odd joint angles into something that is a more intuitive motion.
 func smoothPathSimple(ctx context.Context, psc *PlanSegmentContext,
@@ -38,9 +48,14 @@ func smoothPathSimple(ctx context.Context, psc *PlanSegmentContext,
 	start := time.Now()
 
 	originalSize := len(steps)
-	steps = simpleSmoothStep(ctx, psc, steps, 10)
-	steps = simpleSmoothStep(ctx, psc, steps, 3)
-	steps = simpleSmoothStep(ctx, psc, steps, 1)
+	budget := smoothProbeBudget
+	if len(steps) > 40 {
+		steps = simpleSmoothStep(ctx, psc, steps, 10, &budget)
+	}
+	if len(steps) > 15 {
+		steps = simpleSmoothStep(ctx, psc, steps, 3, &budget)
+	}
+	steps = simpleSmoothStep(ctx, psc, steps, 1, &budget)
 
 	steps = tryOnlyMovingComponentsThatNeedToMove(ctx, psc, steps)
 
@@ -50,25 +65,29 @@ func smoothPathSimple(ctx context.Context, psc *PlanSegmentContext,
 	return steps
 }
 
+// smoothPath returns the final trajectory and, separately, the compact
+// smoothed path from before close-obstacle waypoint insertion. Harvesting
+// must use the compact form: the close waypoints are interpolation guards,
+// not corridor structure, and feeding them back into the roadmap makes every
+// replan's path longer than the last.
 func smoothPath(
 	ctx context.Context, psc *PlanSegmentContext, steps []*referenceframe.LinearInputs,
-) ([]*referenceframe.LinearInputs, error) {
+) (final, compact []*referenceframe.LinearInputs, err error) {
 	ctx, span := trace.StartSpan(ctx, "smoothPlan")
 	defer span.End()
-	var err error
-	steps = smoothPathSimple(ctx, psc, steps)
-	if !psc.pc.request.myTestOptions.doNotCloseObstacles {
-		steps, err = addCloseObstacleWaypoints(ctx, psc, steps)
-		if err != nil {
-			return nil, err
-		}
+
+	compact = smoothPathSimple(ctx, psc, steps)
+
+	if psc.pc.request.myTestOptions.doNotCloseObstacles {
+		return compact, compact, nil
 	}
-	return steps, nil
+	final, err = addCloseObstacleWaypoints(ctx, psc, compact)
+	return final, compact, err
 }
 
-// addCloseObstacleWaypoints interpolates between waypoints and adds new waypoints
-// where the path comes within twice the minimum distance of an obstacle.
-// This prevents the smoothed path from getting too close to obstacles during interpolation.
+// addCloseObstacleWaypoints interpolates every segment at full resolution and
+// inserts waypoints wherever the path comes close to an obstacle, preventing
+// later interpolation from cutting corners.
 func addCloseObstacleWaypoints(
 	ctx context.Context, psc *PlanSegmentContext, steps []*referenceframe.LinearInputs,
 ) ([]*referenceframe.LinearInputs, error) {
@@ -80,15 +99,14 @@ func addCloseObstacleWaypoints(
 	}
 
 	result := []*referenceframe.LinearInputs{steps[0]}
-
 	for i := 1; i < len(steps); i++ {
-		// Get waypoints that are close to obstacles in this segment
-		closeWaypoints, err := findCloseObstacleWaypoints(ctx, psc, steps[i-1], steps[i])
+		closeWaypoints, blocked, err := findCloseObstacleWaypoints(ctx, psc, steps[i-1], steps[i])
 		if err != nil {
 			return nil, err
 		}
-
-		// Add close waypoints before the current step
+		if blocked {
+			return nil, fmt.Errorf("smoothed path segment %d invalid at full resolution", i)
+		}
 		result = append(result, closeWaypoints...)
 		result = append(result, steps[i])
 	}
@@ -97,34 +115,37 @@ func addCloseObstacleWaypoints(
 		psc.pc.logger.Debugf("addCloseObstacleWaypoints: added %d waypoints (%d -> %d)",
 			len(result)-len(steps), len(steps), len(result))
 	}
-
 	return result, nil
 }
 
-// findCloseObstacleWaypoints interpolates between start and end configurations
-// and returns configurations where the robot has a local minimum distance to obstacles
-// less than twice the global min distance. Instead of adding every point within the threshold,
-// this finds contiguous "close zones" and adds only the point of closest approach
-// in each zone.
+// findCloseObstacleWaypoints interpolates between start and end at full
+// resolution, verifying every state, and reports configurations that come
+// within the close-obstacle threshold. blocked is true when any state violates
+// a constraint. States whose clearance proves the next several interpolation
+// steps cannot collide are skipped for collision purposes (their cheap
+// topological constraints are still verified individually).
 func findCloseObstacleWaypoints(
 	ctx context.Context,
 	psc *PlanSegmentContext,
 	start, end *referenceframe.LinearInputs,
-) ([]*referenceframe.LinearInputs, error) {
+) ([]*referenceframe.LinearInputs, bool, error) {
 	segment := &motionplan.SegmentFS{
 		StartConfiguration: start,
 		EndConfiguration:   end,
 		FS:                 psc.pc.fs,
 	}
 
-	interpolated, err := motionplan.InterpolateSegmentFS(segment, psc.pc.planOpts.Resolution)
+	resolution := psc.pc.planOpts.Resolution
+	interpolated, err := motionplan.InterpolateSegmentFS(segment, resolution)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	if len(interpolated) < 3 {
-		return nil, nil
+		return nil, false, nil
 	}
+
+	closeThreshold := max(.1, 10*psc.pc.planOpts.CollisionBufferMM)
 
 	var closeWaypoints []*referenceframe.LinearInputs
 
@@ -136,15 +157,32 @@ func findCloseObstacleWaypoints(
 
 		closestObstacle, err := psc.Checker.CheckStateFSConstraints(ctx, state)
 		if err != nil {
-			return nil, err
+			return nil, true, nil //nolint:nilerr // constraint violation is the blocked verdict, not an error
 		}
 
-		if closestObstacle < max(.1, 10*psc.pc.planOpts.CollisionBufferMM) {
+		if closestObstacle < closeThreshold {
 			closeWaypoints = append(closeWaypoints, interpolated[i])
+			continue
 		}
+
+		// Clearance-bound skipping (same argument as the segment checker's):
+		// nothing can collide within the next canSkip steps, and no state in
+		// them can be within the close threshold either. Topological
+		// constraints carry no such bound but are cheap; verify them per
+		// skipped state.
+		canSkip := int(min(100, (closestObstacle-closeThreshold)/resolution))
+		for j := i + 1; j <= i+canSkip && j < len(interpolated)-1; j++ {
+			if err := psc.Checker.CheckStateFSTopoOnly(&motionplan.StateFS{
+				FS:            psc.pc.fs,
+				Configuration: interpolated[j],
+			}); err != nil {
+				return nil, true, nil //nolint:nilerr // constraint violation is the blocked verdict, not an error
+			}
+		}
+		i += canSkip
 	}
 
-	return closeWaypoints, nil
+	return closeWaypoints, false, nil
 }
 
 func tryOnlyMovingComponentsThatNeedToMove(ctx context.Context, psc *PlanSegmentContext,
@@ -158,6 +196,7 @@ func tryOnlyMovingComponentsThatNeedToMove(ctx context.Context, psc *PlanSegment
 
 		updated := curr.Copy()
 
+		changed := false
 		for component, currInputs := range curr.Items() {
 			if slices.Contains(moving, component) {
 				continue
@@ -168,8 +207,17 @@ func tryOnlyMovingComponentsThatNeedToMove(ctx context.Context, psc *PlanSegment
 			}
 
 			prevInputs := prev.Get(component)
+			if referenceframe.InputsL2Distance(prevInputs, currInputs) == 0 {
+				continue
+			}
 
 			updated.Put(component, prevInputs)
+			changed = true
+		}
+		// Nothing to pin down (the non-moving components already hold still):
+		// skip the full path check entirely.
+		if !changed {
+			continue
 		}
 
 		err := psc.CheckPath(ctx, prev, updated, false, nil)

--- a/motionplan/armplanning/smooth_test.go
+++ b/motionplan/armplanning/smooth_test.go
@@ -57,7 +57,7 @@ func TestSmoothPlans1(t *testing.T) {
 		inputSlice[i] = n.inputs
 	}
 
-	nodes, err := smoothPath(ctx, psc, inputSlice)
+	nodes, _, err := smoothPath(ctx, psc, inputSlice)
 	test.That(t, err, test.ShouldBeNil)
 
 	for idx, n := range nodes {
@@ -94,7 +94,7 @@ func BenchmarkSmoothPlans1(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		nodes, err := smoothPath(ctx, psc, inputSlice)
+		nodes, _, err := smoothPath(ctx, psc, inputSlice)
 		test.That(b, err, test.ShouldBeNil)
 		test.That(b, len(nodes), test.ShouldEqual, 5)
 	}

--- a/motionplan/armplanning/wallhop_test.go
+++ b/motionplan/armplanning/wallhop_test.go
@@ -1,0 +1,59 @@
+package armplanning
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/golang/geo/r3"
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/rdk/utils"
+)
+
+// TestWallHopWithoutSearch: the straight path to a same-joint-family goal is
+// blocked by a wall large enough that the nudge cannot skirt it; the cheap
+// ladder (roadmap et al.) must solve it without falling back to a cBiRRT
+// search.
+func TestWallHopWithoutSearch(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	model, err := referenceframe.ParseModelJSONFile(utils.ResolveFile("components/arm/kinematics/xarm6.json"), "arm")
+	test.That(t, err, test.ShouldBeNil)
+	fs := referenceframe.NewEmptyFrameSystem("")
+	test.That(t, fs.AddFrame(model, fs.World()), test.ShouldBeNil)
+
+	startJoints := []float64{0, 0.5, -1.0, 0, 0.5, 0}
+	goalJoints := []float64{math.Pi / 2, 0.5, -1.0, 0, 0.5, 0}
+	midJoints := []float64{math.Pi / 4, 0.5, -1.0, 0, 0.5, 0}
+
+	midPose, err := model.Transform(midJoints)
+	test.That(t, err, test.ShouldBeNil)
+	goalPose, err := model.Transform(goalJoints)
+	test.That(t, err, test.ShouldBeNil)
+
+	// A wall across the sweep, wide and deep enough that lateral nudges can't
+	// get around it; the only way over is a real up-and-over keypoint hop.
+	wallCenter := midPose.Point()
+	wallCenter.Z -= 100
+	obstacle, err := spatialmath.NewBox(
+		spatialmath.NewPoseFromPoint(wallCenter), r3.Vector{X: 350, Y: 350, Z: 500}, "bigwall")
+	test.That(t, err, test.ShouldBeNil)
+
+	plan, meta, err := PlanMotion(context.Background(), logger, &PlanRequest{
+		FrameSystem: fs,
+		Goals: []*PlanState{
+			{poses: referenceframe.FrameSystemPoses{"arm": referenceframe.NewPoseInFrame(referenceframe.World, goalPose)}},
+		},
+		StartState:            &PlanState{structuredConfiguration: referenceframe.FrameSystemInputs{"arm": startJoints}},
+		ObstaclesInWorldFrame: referenceframe.NewGeometriesInFrame(referenceframe.World, []spatialmath.Geometry{obstacle}),
+		PlannerOptions:        NewBasicPlannerOptions(),
+	})
+	test.That(t, err, test.ShouldBeNil)
+	t.Logf("nudge=%d roadmap=%d cbirrt=%d traj=%d",
+		meta.GoalsNudgeSolved, meta.GoalsRoadmapSolved, meta.GoalsCBIRRTSolved, len(plan.Trajectory()))
+	// The point of the scene: no random search should be needed.
+	test.That(t, meta.GoalsCBIRRTSolved, test.ShouldEqual, 0)
+}

--- a/motionplan/collision.go
+++ b/motionplan/collision.go
@@ -191,6 +191,17 @@ func checkCollisionsHinted(
 	timeChecks := logger.GetLevel() <= logging.DEBUG
 	var pairCounter atomic.Uint64
 	checkOnePair := func(xName, yName string, xGeometry, yGeometry spatialmath.Geometry) (bool, error) {
+		// Bounding-sphere broadphase: most pairs in the moving-vs-static
+		// product are nowhere near each other, and even the cached narrow
+		// phase costs three orders of magnitude more than this gap test.
+		if cx, rx, okx := spatialmath.BoundingSphere(xGeometry); okx {
+			if cy, ry, oky := spatialmath.BoundingSphere(yGeometry); oky {
+				if gap := cx.Sub(cy).Norm() - rx - ry; gap > collisionBufferMM {
+					minDistance = min(minDistance, gap)
+					return false, nil
+				}
+			}
+		}
 		var start time.Time
 		timeThis := timeChecks && pairCounter.Add(1)&15 == 0
 		if timeThis {

--- a/motionplan/collision_cache.go
+++ b/motionplan/collision_cache.go
@@ -35,9 +35,6 @@ type CollisionCache struct {
 	// for an interpolated edge. Key is the canonical {hashA, hashB} pair —
 	// uint64 fits inside sync.Map's interface{} slot without allocation.
 	edgeResults sync.Map // edgeResultKey -> edgeResultValue
-
-	// sdfs caches voxel distance fields per static geometry set (see SDFFor).
-	sdfs sync.Map // uint64 -> *spatialmath.VoxelSDF
 }
 
 // NewCollisionCache constructs an empty cache. Safe for concurrent use.
@@ -86,34 +83,86 @@ func (c *CollisionCache) StoreEdgeResult(hashA, hashB uint64, isClear bool) {
 	c.edgeResults.Store(edgeResultKey{a: hashA, b: hashB}, edgeResultValue{isClear: isClear})
 }
 
+// sdfRegistry caches voxel distance fields process-wide. A field depends only
+// on the static scene (keyed by the shape-aware staticSetHash), never on the
+// plan, and costs ~35-70ms plus a multi-MB grid allocation to build - caching
+// it per plan made every replan of an otherwise-trivial scene pay that in
+// full. Small LRU: each field can be tens of MB, and a scene whose obstacles
+// move between plans mints a new key every time.
+type sdfRegistry struct {
+	mu      sync.Mutex
+	tick    uint64
+	entries map[uint64]*sdfRegistryEntry
+}
+
+type sdfRegistryEntry struct {
+	sdf      *spatialmath.VoxelSDF // nil records a scene the SDF cannot represent
+	lastUsed uint64
+}
+
+const sdfRegistryCap = 8
+
+var globalSDFRegistry = sdfRegistry{entries: map[uint64]*sdfRegistryEntry{}}
+
+func (r *sdfRegistry) lookup(key uint64) (*spatialmath.VoxelSDF, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e, ok := r.entries[key]
+	if !ok {
+		return nil, false
+	}
+	r.tick++
+	e.lastUsed = r.tick
+	return e.sdf, true
+}
+
+func (r *sdfRegistry) insert(key uint64, sdf *spatialmath.VoxelSDF) *spatialmath.VoxelSDF {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if e, ok := r.entries[key]; ok {
+		// Another plan built the same field concurrently; keep the incumbent.
+		return e.sdf
+	}
+	r.tick++
+	r.entries[key] = &sdfRegistryEntry{sdf: sdf, lastUsed: r.tick}
+	for len(r.entries) > sdfRegistryCap {
+		var oldestKey uint64
+		oldest := uint64(math.MaxUint64)
+		for k, e := range r.entries {
+			if e.lastUsed < oldest {
+				oldest, oldestKey = e.lastUsed, k
+			}
+		}
+		delete(r.entries, oldestKey)
+	}
+	return sdf
+}
+
 // SDFFor returns the voxel distance field for the given static geometry set,
-// building it on first request. Keyed by a hash of the geometries' labels and
-// poses so all PlanSegmentContexts of a plan (which share their static scene)
-// share one field. sdfResolutionMM balances build time (~70ms for a dual-arm
-// scene at 10mm) against the conservative margin subtracted from every query
-// (half the voxel diagonal, ~8.7mm at 10mm).
+// building it on first request anywhere in the process and sharing it across
+// plans of the same scene. sdfResolutionMM balances build time (~70ms for a
+// dual-arm scene at 10mm) against the conservative margin subtracted from
+// every query (half the voxel diagonal, ~8.7mm at 10mm).
 func (c *CollisionCache) SDFFor(static []spatialmath.Geometry) *spatialmath.VoxelSDF {
 	if c == nil || len(static) == 0 {
 		return nil
 	}
 	key := staticSetHash(static)
-	if v, ok := c.sdfs.Load(key); ok {
-		return v.(*spatialmath.VoxelSDF)
+	if sdf, ok := globalSDFRegistry.lookup(key); ok {
+		return sdf
 	}
-	sdf := spatialmath.NewVoxelSDF(static, sdfResolutionMM)
-	if sdf == nil {
-		return nil
-	}
-	actual, _ := c.sdfs.LoadOrStore(key, sdf)
-	return actual.(*spatialmath.VoxelSDF)
+	return globalSDFRegistry.insert(key, spatialmath.NewVoxelSDF(static, sdfResolutionMM))
 }
 
 const sdfResolutionMM = 10.0
 
-// staticSetHash fingerprints a static geometry set by label and pose. The
-// per-geometry hashes are combined commutatively because callers assemble the
-// set from map iteration - the same scene must hash identically regardless of
-// geometry order, or every segment context would rebuild the field.
+// staticSetHash fingerprints a static geometry set by label, pose, and shape
+// (via Geometry.Hash, which folds in type-specific dimensions - process-wide
+// sharing must not serve a stale field to a same-named, same-posed geometry
+// whose size changed). The per-geometry hashes are combined commutatively
+// because callers assemble the set from map iteration - the same scene must
+// hash identically regardless of geometry order, or every caller would
+// rebuild the field.
 func staticSetHash(geoms []spatialmath.Geometry) uint64 {
 	const fnvPrime = 0x100000001b3
 	total := uint64(len(geoms))
@@ -131,6 +180,7 @@ func staticSetHash(geoms []spatialmath.Geometry) uint64 {
 		for _, f := range [7]float64{pt.X, pt.Y, pt.Z, q.Real, q.Imag, q.Jmag, q.Kmag} {
 			mix(math.Float64bits(f))
 		}
+		mix(uint64(g.Hash()))
 		total += h
 	}
 	return total

--- a/motionplan/collision_cache.go
+++ b/motionplan/collision_cache.go
@@ -1,8 +1,11 @@
 package motionplan
 
 import (
+	"math"
 	"sync"
 	"sync/atomic"
+
+	"go.viam.com/rdk/spatialmath"
 )
 
 // CollisionCache holds planner-level temporal-coherence state for collision
@@ -32,6 +35,9 @@ type CollisionCache struct {
 	// for an interpolated edge. Key is the canonical {hashA, hashB} pair —
 	// uint64 fits inside sync.Map's interface{} slot without allocation.
 	edgeResults sync.Map // edgeResultKey -> edgeResultValue
+
+	// sdfs caches voxel distance fields per static geometry set (see SDFFor).
+	sdfs sync.Map // uint64 -> *spatialmath.VoxelSDF
 }
 
 // NewCollisionCache constructs an empty cache. Safe for concurrent use.
@@ -78,4 +84,54 @@ func (c *CollisionCache) StoreEdgeResult(hashA, hashB uint64, isClear bool) {
 		hashA, hashB = hashB, hashA
 	}
 	c.edgeResults.Store(edgeResultKey{a: hashA, b: hashB}, edgeResultValue{isClear: isClear})
+}
+
+// SDFFor returns the voxel distance field for the given static geometry set,
+// building it on first request. Keyed by a hash of the geometries' labels and
+// poses so all PlanSegmentContexts of a plan (which share their static scene)
+// share one field. sdfResolutionMM balances build time (~70ms for a dual-arm
+// scene at 10mm) against the conservative margin subtracted from every query
+// (half the voxel diagonal, ~8.7mm at 10mm).
+func (c *CollisionCache) SDFFor(static []spatialmath.Geometry) *spatialmath.VoxelSDF {
+	if c == nil || len(static) == 0 {
+		return nil
+	}
+	key := staticSetHash(static)
+	if v, ok := c.sdfs.Load(key); ok {
+		return v.(*spatialmath.VoxelSDF)
+	}
+	sdf := spatialmath.NewVoxelSDF(static, sdfResolutionMM)
+	if sdf == nil {
+		return nil
+	}
+	actual, _ := c.sdfs.LoadOrStore(key, sdf)
+	return actual.(*spatialmath.VoxelSDF)
+}
+
+const sdfResolutionMM = 10.0
+
+// staticSetHash fingerprints a static geometry set by label and pose. The
+// per-geometry hashes are combined commutatively because callers assemble the
+// set from map iteration - the same scene must hash identically regardless of
+// geometry order, or every segment context would rebuild the field.
+func staticSetHash(geoms []spatialmath.Geometry) uint64 {
+	const fnvPrime = 0x100000001b3
+	total := uint64(len(geoms))
+	for _, g := range geoms {
+		h := uint64(0xcbf29ce484222325)
+		mix := func(v uint64) {
+			h ^= v
+			h *= fnvPrime
+		}
+		for _, ch := range g.Label() {
+			mix(uint64(ch))
+		}
+		pt := g.Pose().Point()
+		q := g.Pose().Orientation().Quaternion()
+		for _, f := range [7]float64{pt.X, pt.Y, pt.Z, q.Real, q.Imag, q.Jmag, q.Kmag} {
+			mix(math.Float64bits(f))
+		}
+		total += h
+	}
+	return total
 }

--- a/motionplan/collision_cache_test.go
+++ b/motionplan/collision_cache_test.go
@@ -1,0 +1,59 @@
+package motionplan
+
+import (
+	"testing"
+
+	"github.com/golang/geo/r3"
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/spatialmath"
+)
+
+func testStaticScene(t *testing.T, dims r3.Vector) []spatialmath.Geometry {
+	t.Helper()
+	box, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{X: 100}), dims, "wall")
+	test.That(t, err, test.ShouldBeNil)
+	sphere, err := spatialmath.NewSphere(spatialmath.NewPoseFromPoint(r3.Vector{Y: 200}), 30, "ball")
+	test.That(t, err, test.ShouldBeNil)
+	return []spatialmath.Geometry{box, sphere}
+}
+
+func TestSDFRegistrySharing(t *testing.T) {
+	sceneA := testStaticScene(t, r3.Vector{X: 50, Y: 400, Z: 400})
+
+	c1 := NewCollisionCache()
+	sdf1 := c1.SDFFor(sceneA)
+	test.That(t, sdf1, test.ShouldNotBeNil)
+
+	// A different plan's cache, same scene in reversed order: same field.
+	c2 := NewCollisionCache()
+	sdf2 := c2.SDFFor([]spatialmath.Geometry{sceneA[1], sceneA[0]})
+	test.That(t, sdf2, test.ShouldEqual, sdf1)
+
+	// Same labels and poses but a resized geometry must not reuse the field.
+	sceneB := testStaticScene(t, r3.Vector{X: 50, Y: 400, Z: 800})
+	sdf3 := NewCollisionCache().SDFFor(sceneB)
+	test.That(t, sdf3, test.ShouldNotBeNil)
+	test.That(t, sdf3, test.ShouldNotEqual, sdf1)
+}
+
+func TestSDFRegistryEviction(t *testing.T) {
+	r := sdfRegistry{entries: map[uint64]*sdfRegistryEntry{}}
+	scene := testStaticScene(t, r3.Vector{X: 50, Y: 400, Z: 400})
+	sdf := spatialmath.NewVoxelSDF(scene, sdfResolutionMM)
+	test.That(t, sdf, test.ShouldNotBeNil)
+
+	for key := uint64(0); key < sdfRegistryCap+3; key++ {
+		r.insert(key, sdf)
+		if key > 0 {
+			// Keep key 0 warm so eviction drops the stale middle keys instead.
+			_, ok := r.lookup(0)
+			test.That(t, ok, test.ShouldBeTrue)
+		}
+	}
+	test.That(t, len(r.entries), test.ShouldEqual, sdfRegistryCap)
+	_, ok := r.lookup(0)
+	test.That(t, ok, test.ShouldBeTrue)
+	_, ok = r.lookup(1)
+	test.That(t, ok, test.ShouldBeFalse)
+}

--- a/motionplan/constraint.go
+++ b/motionplan/constraint.go
@@ -92,6 +92,45 @@ func (oc *OrientationConstraint) Distance(from, to, now spatialmath.Orientation)
 	return min(a, b)
 }
 
+// OrientationConstraintEval evaluates one OrientationConstraint against fixed
+// start and goal orientations. The endpoints never change during a plan, but
+// Distance re-derives their orientation-vector forms on every call -
+// precomputing them leaves one conversion (the current orientation) per check.
+type OrientationConstraintEval struct {
+	oc           OrientationConstraint
+	from, to     spatialmath.Orientation
+	fromOV, toOV *spatialmath.OrientationVectorDegrees
+}
+
+// NewOrientationConstraintEval precomputes the fixed endpoint conversions.
+func NewOrientationConstraintEval(oc OrientationConstraint, from, to spatialmath.Orientation) *OrientationConstraintEval {
+	return &OrientationConstraintEval{
+		oc: oc, from: from, to: to,
+		fromOV: from.OrientationVectorDegrees(), toOV: to.OrientationVectorDegrees(),
+	}
+}
+
+// Distance is OrientationConstraint.Distance with the endpoint conversions amortized.
+func (e *OrientationConstraintEval) Distance(now spatialmath.Orientation) float64 {
+	n := now.OrientationVectorDegrees()
+	if between(e.fromOV.OX, e.toOV.OX, n.OX) &&
+		between(e.fromOV.OY, e.toOV.OY, n.OY) &&
+		between(e.fromOV.OZ, e.toOV.OZ, n.OZ) &&
+		between(e.fromOV.Theta, e.toOV.Theta, n.Theta) {
+		return 0
+	}
+	return min(OrientDist(e.from, now), OrientDist(e.to, now))
+}
+
+// Score mirrors OrientationConstraint.Score.
+func (e *OrientationConstraintEval) Score(now spatialmath.Orientation) float64 {
+	d := e.Distance(now)
+	if d <= 0 {
+		return 0
+	}
+	return max(0, d-e.oc.OrientationToleranceDegs)
+}
+
 // CollisionSpecificationAllowedFrameCollisions is used to define frames that are allowed to collide.
 type CollisionSpecificationAllowedFrameCollisions struct {
 	Frame1, Frame2 string

--- a/motionplan/constraint_checker.go
+++ b/motionplan/constraint_checker.go
@@ -7,7 +7,6 @@ import (
 	"sync/atomic"
 
 	"github.com/pkg/errors"
-	"go.viam.com/utils/trace"
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/referenceframe"
@@ -169,13 +168,24 @@ func (c *ConstraintChecker) addTopoConstraints(
 		fromPoses[f] = x.(*referenceframe.PoseInFrame)
 	}
 
+	// Precompute per-frame orientation-constraint evaluators: the endpoint
+	// orientation-vector conversions are the expensive part of the check and
+	// the endpoints are fixed for the plan's lifetime.
+	orientationEvals := map[string][]*OrientationConstraintEval{}
+	for frame, toPIF := range toPoses {
+		fromPIF := fromPoses[frame]
+		if fromPIF.Parent() != toPIF.Parent() {
+			return fmt.Errorf("in topo constraint, from and to are in different frames %s != %s", fromPIF.Parent(), toPIF.Parent())
+		}
+		for _, oc := range constraints.OrientationConstraint {
+			orientationEvals[frame] = append(orientationEvals[frame],
+				NewOrientationConstraintEval(oc, fromPIF.Pose().Orientation(), toPIF.Pose().Orientation()))
+		}
+	}
+
 	c.topoConstraint = func(state *StateFS) error {
 		for frame, toPIF := range toPoses {
 			fromPIF := fromPoses[frame]
-
-			if fromPIF.Parent() != toPIF.Parent() {
-				return fmt.Errorf("in topo constraint, from and to are in different frames %s != %s", fromPIF.Parent(), toPIF.Parent())
-			}
 
 			currPosePIF, err := state.FS.Transform(state.Configuration, referenceframe.NewZeroPoseInFrame(frame), toPIF.Parent())
 			if err != nil {
@@ -200,8 +210,8 @@ func (c *ConstraintChecker) addTopoConstraints(
 				}
 			}
 
-			for _, oc := range constraints.OrientationConstraint {
-				err := checkOrientationConstraint(frame, oc, from, to, currPose)
+			for _, eval := range orientationEvals[frame] {
+				err := checkOrientationConstraintEval(frame, eval, currPose)
 				if err != nil {
 					return err
 				}
@@ -265,19 +275,29 @@ func checkPseudoLinearConstraint(frame string, plinConstraint PseudolinearConstr
 	return nil
 }
 
-func checkOrientationConstraint(frame string, c OrientationConstraint, from, to, currPose spatialmath.Pose) error {
-	dist := c.Distance(from.Orientation(), to.Orientation(), currPose.Orientation())
-	if dist > c.OrientationToleranceDegs {
-		return orientationError(frame, from.Orientation(), to.Orientation(), currPose.Orientation(), dist, c.OrientationToleranceDegs)
+func checkOrientationConstraintEval(frame string, e *OrientationConstraintEval, currPose spatialmath.Pose) error {
+	dist := e.Distance(currPose.Orientation())
+	if dist > e.oc.OrientationToleranceDegs {
+		return orientationError(frame, e.from, e.to, currPose.Orientation(), dist, e.oc.OrientationToleranceDegs)
 	}
 	return nil
 }
 
 // CheckStateFSConstraints will check a given input against all FS state constraints.
 // first is closest obstacle, negative if in collision
+// Deliberately no tracing span here: this runs hundreds of thousands of times
+// per plan, and per-call span creation plus exporter wakeups measurably
+// dominated planning time once the checks themselves became cheap.
 func (c *ConstraintChecker) CheckStateFSConstraints(ctx context.Context, state *StateFS) (float64, error) {
-	_, span := trace.StartSpan(ctx, "CheckStateFSConstraints")
-	defer span.End()
+	// Topological constraints (orientation/linear) cost a single FK pass —
+	// orders of magnitude cheaper than the collision sweeps below — so check
+	// them first: constrained planners generate many candidate states that fail
+	// only the topological check, and those shouldn't pay for collision work.
+	if c.topoConstraint != nil {
+		if err := c.topoConstraint(state); err != nil {
+			return math.Inf(1), err
+		}
+	}
 
 	closest := math.Inf(1)
 
@@ -299,13 +319,18 @@ func (c *ConstraintChecker) CheckStateFSConstraints(ctx context.Context, state *
 		}
 	}
 
-	if c.topoConstraint != nil {
-		err := c.topoConstraint(state)
-		if err != nil {
-			return closest, err
-		}
-	}
 	return closest, nil
+}
+
+// CheckStateFSTopoOnly evaluates only the topological (orientation/linear)
+// constraints for a state — the cheap, single-FK subset of
+// CheckStateFSConstraints. For callers that skip collision checks under a
+// clearance bound but must still verify topological validity per state.
+func (c *ConstraintChecker) CheckStateFSTopoOnly(state *StateFS) error {
+	if c.topoConstraint == nil {
+		return nil
+	}
+	return c.topoConstraint(state)
 }
 
 // InterpolateSegmentFS is a helper function which produces a list of intermediate inputs, between the start and end
@@ -355,9 +380,6 @@ func (c *ConstraintChecker) CheckStateConstraintsAcrossSegmentFS(
 	resolution float64,
 	checkFinal bool,
 ) (*SegmentFS, error) {
-	ctx, span := trace.StartSpan(ctx, "CheckStateConstraintsAcrossSegmentFS")
-	defer span.End()
-
 	interpolatedConfigurations, err := InterpolateSegmentFS(ci, resolution)
 	if err != nil {
 		return nil, err
@@ -382,8 +404,24 @@ func (c *ConstraintChecker) CheckStateConstraintsAcrossSegmentFS(
 		}
 		lastGood = interpC.Configuration
 
+		// The clearance at this state proves the next canSkip states cannot
+		// collide (the robot can't cross a gap faster than it moves), so the
+		// expensive collision constraints may be skipped for them. Topological
+		// constraints (orientation/linear) carry no such guarantee but are
+		// cheap - a single FK pass per state - so evaluate just those on the
+		// skipped states instead of disabling skipping altogether.
 		canSkip := int(min(100, math.Floor(closestObstacle/resolution)))
-		if canSkip > 0 && c.topoConstraint == nil {
+		if canSkip > 0 && c.topoConstraint != nil {
+			for j := i + 1; j <= i+canSkip && j < end; j++ {
+				topoC := &StateFS{FS: ci.FS, Configuration: interpolatedConfigurations[j]}
+				if err := c.topoConstraint(topoC); err != nil {
+					return &SegmentFS{StartConfiguration: ci.StartConfiguration, EndConfiguration: lastGood, FS: ci.FS}, err
+				}
+				// Collision-free by the clearance bound and topo-checked: valid.
+				lastGood = topoC.Configuration
+			}
+		}
+		if canSkip > 0 {
 			i += canSkip
 		}
 	}
@@ -416,6 +454,11 @@ func CreateAllCollisionConstraints(
 		selfHint = &cache.selfPairHint
 	}
 
+	// Precompute local-frame sphere covers for the moving frames once; the
+	// three constraint closures share the table (and, per state, the world
+	// covers computed from it) so most states never materialize geometry.
+	coverTable := buildFrameCoverTable(fs, movingFrameNames)
+
 	if len(worldGeometries) > 0 {
 		obstacleConstraintFS, err := NewCollisionConstraintFS(
 			fs,
@@ -427,6 +470,7 @@ func CreateAllCollisionConstraints(
 			false,
 			obstacleHint,
 			cache,
+			coverTable,
 			logger,
 		)
 		if err != nil {
@@ -446,6 +490,7 @@ func CreateAllCollisionConstraints(
 			false,
 			robotHint,
 			cache,
+			coverTable,
 			logger,
 		)
 		if err != nil {
@@ -465,6 +510,7 @@ func CreateAllCollisionConstraints(
 			true,
 			selfHint,
 			cache,
+			coverTable,
 			logger,
 		)
 		if err != nil {
@@ -491,9 +537,9 @@ func NewCollisionConstraintFS(
 	isSelfCollision bool,
 	pairHint *atomic.Pointer[[2]string],
 	cache *CollisionCache,
+	coverTable *frameCoverTable,
 	logger logging.Logger,
 ) (CollisionConstraintFunc, error) {
-	_ = cache // reserved for future planner-level caches (edge memoization lives elsewhere on the same struct)
 	ignoreCollisions, err := computeInitialCollisionsToIgnore(fs, moving, static,
 		collisionSpecifications, collisionBufferMM, logger)
 	if err != nil {
@@ -502,8 +548,144 @@ func NewCollisionConstraintFS(
 
 	allowed := makeAllowedCollisionsLookup(ignoreCollisions)
 
+	// Distance-field fast path for the moving-vs-static product: a voxel SDF
+	// over the static set answers "this moving geometry is at least D away
+	// from everything static" from a handful of array lookups against the
+	// geometry's conservative sphere cover. Only clear verdicts are used -
+	// anything near, uncovered, or colliding falls through to the exact
+	// checker, so allowed-collision pairs and near-contact distances keep
+	// their exact semantics. The field is built once per static scene and
+	// shared across all segment contexts through the plan cache.
+	var sdf *spatialmath.VoxelSDF
+	if !isSelfCollision {
+		sdf = cache.SDFFor(static)
+	}
+	sdfClearThreshold := math.Max(2.0, 2*collisionBufferMM)
+
+	// finish shares the tail of every path: convert a found collision into
+	// the constraint-violated error.
+	finish := func(collisions []Collision, minDist float64, err error) (float64, error) {
+		if err != nil {
+			return minDist, err
+		}
+		if len(collisions) != 0 {
+			return minDist, fmt.Errorf(
+				"violation between %s and %s geometries",
+				collisions[0].name1,
+				collisions[0].name2,
+			)
+		}
+		return minDist, nil
+	}
+
+	// checkStaticViaCovers evaluates the moving-vs-static constraint from the
+	// state's sphere covers and the distance field, materializing geometry
+	// only for the frames the sphere phase cannot clear.
+	checkStaticViaCovers := func(state *StateFS, cs *stateCoverSet) (float64, error) {
+		sdfMin := math.Inf(1)
+		needFrames := map[string]bool{}
+		for f := range coverTable.materialize {
+			needFrames[f] = true
+		}
+		for i := range cs.geoms {
+			cg := &cs.geoms[i]
+			lb := math.Inf(1)
+			for _, sb := range cg.world {
+				if v := sdf.PointClearance(sb.Center) - sb.R; v < lb {
+					lb = v
+				}
+			}
+			if lb > sdfClearThreshold {
+				sdfMin = math.Min(sdfMin, lb)
+			} else {
+				needFrames[cg.frameName] = true
+			}
+		}
+		if len(needFrames) == 0 {
+			return sdfMin, nil
+		}
+		geoms, err := materializedSubset(state, fs, needFrames)
+		if err != nil {
+			return 0, err
+		}
+		collisions, minDist, err := checkCollisionsHinted(
+			geoms, static, allowed, collisionBufferMM, false, pairHint, logger)
+		return finish(collisions, math.Min(minDist, sdfMin), err)
+	}
+
+	// checkSelfViaCovers evaluates self-collision pairwise from the covers'
+	// enclosing spheres; only frames belonging to a near pair (or without
+	// covers) are materialized and checked exactly.
+	checkSelfViaCovers := func(state *StateFS, cs *stateCoverSet) (float64, error) {
+		selfMin := math.Inf(1)
+		near := map[string]bool{}
+		for f := range coverTable.materialize {
+			near[f] = true
+		}
+		// Uncovered frames must pair against everything; materialize them
+		// first so their bounding spheres can prune covered partners.
+		var uncoveredBounds []spatialmath.SphereBound
+		if len(near) > 0 {
+			geoms, err := materializedSubset(state, fs, near)
+			if err != nil {
+				return 0, err
+			}
+			for _, g := range geoms {
+				if c, r, ok := spatialmath.BoundingSphere(g); ok {
+					uncoveredBounds = append(uncoveredBounds, spatialmath.SphereBound{Center: c, R: r})
+				} else {
+					// No cheap bound: everything is potentially near it.
+					for i := range cs.geoms {
+						near[cs.geoms[i].frameName] = true
+					}
+					uncoveredBounds = nil
+					break
+				}
+			}
+		}
+		for i := range cs.geoms {
+			a := &cs.geoms[i]
+			for j := i + 1; j < len(cs.geoms); j++ {
+				b := &cs.geoms[j]
+				gap := a.bound.Center.Sub(b.bound.Center).Norm() - a.bound.R - b.bound.R
+				if gap > sdfClearThreshold {
+					selfMin = math.Min(selfMin, gap)
+					continue
+				}
+				near[a.frameName] = true
+				near[b.frameName] = true
+			}
+			for _, ub := range uncoveredBounds {
+				if a.bound.Center.Sub(ub.Center).Norm()-a.bound.R-ub.R <= sdfClearThreshold {
+					near[a.frameName] = true
+				}
+			}
+		}
+		if len(near) == 0 {
+			return selfMin, nil
+		}
+		geoms, err := materializedSubset(state, fs, near)
+		if err != nil {
+			return 0, err
+		}
+		collisions, minDist, err := checkCollisionsHinted(
+			geoms, geoms, allowed, collisionBufferMM, false, pairHint, logger)
+		return finish(collisions, math.Min(minDist, selfMin), err)
+	}
+
 	// create constraint from reference collision graph
 	constraint := func(state *StateFS) (float64, error) {
+		if coverTable != nil {
+			if cs := coverSetFor(state, fs, coverTable); !cs.failed {
+				if isSelfCollision {
+					return checkSelfViaCovers(state, cs)
+				}
+				if sdf != nil {
+					return checkStaticViaCovers(state, cs)
+				}
+			}
+		}
+
 		// state.movingGeometries is shared across the three collision constraints
 		// (obstacle / robot-vs-robot / self-collision); whichever runs first for
 		// this state populates it, the others hit the cache. Safe because all
@@ -521,6 +703,34 @@ func NewCollisionConstraintFS(
 			internalGeoms = append(internalGeoms, geosInFrame.Geometries()...)
 		}
 
+		sdfMin := math.Inf(1)
+		if sdf != nil {
+			// Keep only the geometries the SDF cannot clear for the exact pass.
+			needExact := internalGeoms[:0:0]
+			for _, g := range internalGeoms {
+				cover := spatialmath.SphereCover(g)
+				if cover == nil {
+					needExact = append(needExact, g)
+					continue
+				}
+				lb := math.Inf(1)
+				for _, sb := range cover {
+					if v := sdf.PointClearance(sb.Center) - sb.R; v < lb {
+						lb = v
+					}
+				}
+				if lb > sdfClearThreshold {
+					sdfMin = math.Min(sdfMin, lb)
+				} else {
+					needExact = append(needExact, g)
+				}
+			}
+			if len(needExact) == 0 {
+				return sdfMin, nil
+			}
+			internalGeoms = needExact
+		}
+
 		// For self-collision, compare moving geometries against themselves
 		staticToCheck := static
 		if isSelfCollision {
@@ -529,6 +739,7 @@ func NewCollisionConstraintFS(
 
 		collisions, minDist, err := checkCollisionsHinted(
 			internalGeoms, staticToCheck, allowed, collisionBufferMM, false, pairHint, logger)
+		minDist = math.Min(minDist, sdfMin)
 		if err != nil {
 			return minDist, err
 		}

--- a/motionplan/cover_state.go
+++ b/motionplan/cover_state.go
@@ -1,0 +1,202 @@
+package motionplan
+
+import (
+	"math"
+
+	"github.com/golang/geo/r3"
+
+	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/spatialmath"
+)
+
+// The cover table lets the collision constraints evaluate most states without
+// materializing any world-space geometry objects. For every moving frame with
+// configuration-independent local geometry (zero degrees of freedom - the
+// normal case for the link frames of a flattened arm model), it precomputes
+// each geometry's conservative sphere cover in the frame's parent
+// coordinates. A state check then needs only memoized FK for the parent
+// frames plus point transforms of the cover centers; full geometry objects
+// are built only for the few frames the sphere phase cannot clear.
+
+// geomCover is one geometry's precomputed local-frame cover.
+type geomCover struct {
+	label string
+	// cover spheres in the owning frame's parent coordinates.
+	local []spatialmath.SphereBound
+	// bound encloses the whole cover: one sphere for pair-level broadphase.
+	bound spatialmath.SphereBound
+}
+
+// frameCoverEntry is the cover data for one moving frame.
+type frameCoverEntry struct {
+	frameName  string
+	parentName string
+	geoms      []geomCover
+}
+
+// frameCoverTable is the per-checker precomputation. materialize lists moving
+// frames whose geometry could not be covered (input-dependent geometry or
+// unsupported types); they are always evaluated exactly.
+type frameCoverTable struct {
+	entries     []frameCoverEntry
+	materialize map[string]bool
+}
+
+// buildFrameCoverTable precomputes covers for the moving frames. Returns nil
+// when nothing could be covered (callers then keep the materialize-everything
+// path).
+func buildFrameCoverTable(fs *referenceframe.FrameSystem, movingFrameNames map[string]bool) *frameCoverTable {
+	t := &frameCoverTable{materialize: map[string]bool{}}
+	for name := range movingFrameNames {
+		frame := fs.Frame(name)
+		if frame == nil {
+			continue
+		}
+		parent, err := fs.Parent(frame)
+		if err != nil || len(frame.DoF()) != 0 {
+			// Input-dependent geometry (or no parent): always exact.
+			t.materialize[name] = true
+			continue
+		}
+		gif, err := frame.Geometries([]referenceframe.Input{})
+		if err != nil || gif == nil || len(gif.Geometries()) == 0 {
+			if err != nil {
+				t.materialize[name] = true
+			}
+			continue
+		}
+		entry := frameCoverEntry{frameName: name, parentName: parent.Name()}
+		covered := true
+		for _, g := range gif.Geometries() {
+			cover := spatialmath.SphereCover(g)
+			if len(cover) == 0 {
+				covered = false
+				break
+			}
+			entry.geoms = append(entry.geoms, geomCover{
+				label: g.Label(),
+				local: cover,
+				bound: enclosingSphere(cover),
+			})
+		}
+		if !covered {
+			t.materialize[name] = true
+			continue
+		}
+		t.entries = append(t.entries, entry)
+	}
+	if len(t.entries) == 0 {
+		return nil
+	}
+	return t
+}
+
+// enclosingSphere returns one sphere containing every sphere of the cover.
+func enclosingSphere(cover []spatialmath.SphereBound) spatialmath.SphereBound {
+	minPt := r3.Vector{X: math.Inf(1), Y: math.Inf(1), Z: math.Inf(1)}
+	maxPt := r3.Vector{X: math.Inf(-1), Y: math.Inf(-1), Z: math.Inf(-1)}
+	for _, sb := range cover {
+		minPt.X = math.Min(minPt.X, sb.Center.X-sb.R)
+		minPt.Y = math.Min(minPt.Y, sb.Center.Y-sb.R)
+		minPt.Z = math.Min(minPt.Z, sb.Center.Z-sb.R)
+		maxPt.X = math.Max(maxPt.X, sb.Center.X+sb.R)
+		maxPt.Y = math.Max(maxPt.Y, sb.Center.Y+sb.R)
+		maxPt.Z = math.Max(maxPt.Z, sb.Center.Z+sb.R)
+	}
+	c := minPt.Add(maxPt).Mul(0.5)
+	return spatialmath.SphereBound{Center: c, R: maxPt.Sub(c).Norm()}
+}
+
+// coveredWorldGeom is one geometry's cover transformed into world coordinates
+// for a specific state.
+type coveredWorldGeom struct {
+	frameName string
+	label     string
+	world     []spatialmath.SphereBound
+	bound     spatialmath.SphereBound
+}
+
+// stateCoverSet is the per-state evaluation of a frameCoverTable, shared by
+// the three collision constraints of a checker via StateFS.
+type stateCoverSet struct {
+	geoms []coveredWorldGeom
+	// failed is set when FK failed; callers must use the exact path.
+	failed bool
+}
+
+// coverSetFor evaluates (and caches on the state) the world-space covers.
+func coverSetFor(state *StateFS, fs *referenceframe.FrameSystem, table *frameCoverTable) *stateCoverSet {
+	if state.coverSet != nil {
+		return state.coverSet.(*stateCoverSet)
+	}
+	cs := &stateCoverSet{}
+	fk := fs.NewFrameToWorld(state.Configuration)
+	for i := range table.entries {
+		e := &table.entries[i]
+		q, tr, err := fk.PoseQT(e.parentName)
+		if err != nil {
+			cs.failed = true
+			break
+		}
+		for gi := range e.geoms {
+			gc := &e.geoms[gi]
+			world := make([]spatialmath.SphereBound, len(gc.local))
+			for si, sb := range gc.local {
+				world[si] = spatialmath.SphereBound{Center: spatialmath.TransformPoint(q, tr, sb.Center), R: sb.R}
+			}
+			cs.geoms = append(cs.geoms, coveredWorldGeom{
+				frameName: e.frameName,
+				label:     gc.label,
+				world:     world,
+				bound: spatialmath.SphereBound{
+					Center: spatialmath.TransformPoint(q, tr, gc.bound.Center),
+					R:      gc.bound.R,
+				},
+			})
+		}
+	}
+	state.coverSet = cs
+	return cs
+}
+
+// materializedSubset returns the world-posed geometries of the requested
+// frames, materializing them on demand and caching per state so the three
+// constraints share the work.
+func materializedSubset(
+	state *StateFS, fs *referenceframe.FrameSystem, frames map[string]bool,
+) ([]spatialmath.Geometry, error) {
+	if len(frames) == 0 {
+		return nil, nil
+	}
+	if state.partialGeoms == nil {
+		state.partialGeoms = map[string]*referenceframe.GeometriesInFrame{}
+	}
+	missing := map[string]bool{}
+	for f := range frames {
+		if _, ok := state.partialGeoms[f]; !ok {
+			missing[f] = true
+		}
+	}
+	if len(missing) > 0 {
+		got, err := referenceframe.FrameSystemGeometriesForFrames(fs, state.Configuration, missing)
+		if err != nil {
+			return nil, err
+		}
+		for f, gif := range got {
+			state.partialGeoms[f] = gif
+		}
+		// Frames that produced no geometries still count as materialized.
+		for f := range missing {
+			if _, ok := state.partialGeoms[f]; !ok {
+				state.partialGeoms[f] = referenceframe.NewGeometriesInFrame(referenceframe.World, nil)
+			}
+		}
+	}
+	var out []spatialmath.Geometry
+	for f := range frames {
+		if gif := state.partialGeoms[f]; gif != nil {
+			out = append(out, gif.Geometries()...)
+		}
+	}
+	return out, nil
+}

--- a/motionplan/metrics.go
+++ b/motionplan/metrics.go
@@ -49,6 +49,14 @@ type StateFS struct {
 	geometries       map[string]*referenceframe.GeometriesInFrame
 	movingGeometries map[string]*referenceframe.GeometriesInFrame
 	poses            referenceframe.FrameSystemPoses
+
+	// coverSet caches the state's world-space sphere covers (see
+	// cover_state.go); partialGeoms caches per-frame materialized geometries
+	// for the exact-check fallback. Both are shared across the checker's
+	// three collision constraints. coverSet is `any` to keep this file free
+	// of the cover machinery's internals.
+	coverSet     any
+	partialGeoms map[string]*referenceframe.GeometriesInFrame
 }
 
 // Geometries get Geometries and cache
@@ -91,6 +99,30 @@ func OrientDist(o1, o2 spatial.Orientation) float64 {
 // WeightedSquaredNormDistance is a distance function between two poses to be used for gradient descent.
 func WeightedSquaredNormDistance(start, end spatial.Pose) float64 {
 	return WeightedSquaredNormDistanceWithOptions(start, end, 1.0, orientationDistanceScaling)
+}
+
+// WeightedSquaredNormDistanceWithTolerance is WeightedSquaredNormDistanceWithOptions
+// with a free orientation band: rotation within toleranceRads of the target
+// contributes nothing, and only the excess beyond the band is penalized. Used
+// when solving for intermediate keypoints whose orientation only needs to stay
+// within a constraint band (or does not matter at all).
+func WeightedSquaredNormDistanceWithTolerance(start, end spatial.Pose, cartesianScale, orientScale, toleranceRads float64) float64 {
+	orientDelta := 0.0
+	if orientScale > 0 && toleranceRads < math.Pi {
+		theta := spatial.QuatToR3AA(spatial.QuatBetween(
+			start.Orientation(),
+			end.Orientation(),
+		)).Norm()
+		theta = math.Max(0, theta-toleranceRads) * orientScale
+		orientDelta = theta * theta
+	}
+
+	ptDelta := 0.0
+	if cartesianScale > 0 {
+		ptDelta = end.Point().Mul(cartesianScale).Sub(start.Point().Mul(cartesianScale)).Norm2()
+	}
+
+	return ptDelta + orientDelta
 }
 
 // WeightedSquaredNormDistanceWithOptions is a distance function between two poses to be used for gradient descent.

--- a/spatialmath/bvh.go
+++ b/spatialmath/bvh.go
@@ -137,6 +137,24 @@ func computeGeometryAABB(g Geometry) (r3.Vector, r3.Vector) {
 	case *point:
 		pt := geom.position
 		return pt, pt
+	case *Cylinder:
+		// Conservative: the cylinder's bounding capsule (axis segment padded
+		// by radius on every axis), at most radius of slack along the axis.
+		center := geom.pose.Point()
+		q := geom.pose.Orientation().Quaternion()
+		half := TransformPoint(q, r3.Vector{}, r3.Vector{Z: geom.height / 2})
+		segA, segB := center.Sub(half), center.Add(half)
+		lo := r3.Vector{
+			X: math.Min(segA.X, segB.X) - geom.radius,
+			Y: math.Min(segA.Y, segB.Y) - geom.radius,
+			Z: math.Min(segA.Z, segB.Z) - geom.radius,
+		}
+		hi := r3.Vector{
+			X: math.Max(segA.X, segB.X) + geom.radius,
+			Y: math.Max(segA.Y, segB.Y) + geom.radius,
+			Z: math.Max(segA.Z, segB.Z) + geom.radius,
+		}
+		return lo, hi
 	case *Mesh:
 		// BVH stores bounds in local space. We must transform to world space via the mesh pose.
 		// Previously this returned bvh.min/max directly (local space), which caused collision

--- a/spatialmath/sdf_test.go
+++ b/spatialmath/sdf_test.go
@@ -19,7 +19,11 @@ func TestVoxelSDFConservative(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	tri := NewTriangle(r3.Vector{X: 0, Y: 200, Z: -50}, r3.Vector{X: 50, Y: 250, Z: 60}, r3.Vector{X: -60, Y: 220, Z: 40})
 	mesh := NewMesh(NewZeroPose(), []*Triangle{tri}, "m")
-	geoms := []Geometry{b, s, c, mesh}
+	// Tilted cylinder: regression for the whitelisted-but-unbuildable case
+	// (computeGeometryAABB used to panic on cylinders).
+	cyl, err := NewCylinder(NewPose(r3.Vector{X: 150, Y: 150, Z: -50}, &OrientationVectorDegrees{OX: 1, OZ: 1, Theta: 20}), 35, 120, "cyl")
+	test.That(t, err, test.ShouldBeNil)
+	geoms := []Geometry{b, s, c, mesh, cyl}
 
 	sdf := NewVoxelSDF(geoms, 10)
 	test.That(t, sdf, test.ShouldNotBeNil)


### PR DESCRIPTION
Part 4 of 4 of a motion-planning performance series. **Stacked on #6377** (which contains #6375 and #6376) — only the last commit (`armplanning: retreat corridors, search racing, and a learning roadmap`) is new here.

Restructures how the planner spends its time on hard scenes. Every piece was kept only after per-change ablations (6-run matrices per configuration, on captured production scenes) showed removing it hurt; several earlier ideas that ablated to no effect were deleted.

## What

- **Goal retreat corridors**: validated chains jogging the end effector upward out of the cluttered goal region are pre-wired into the goal tree, and the search's early iterations aim at their open-space entrances. The descent into goal clutter is where random sampling wasted most iterations.
- **Search racing**: constrained-search time is heavy-tailed — identical inputs span 10s to minutes depending on early random draws — so the search phase runs 4 independently-seeded cBiRRT searches concurrently (private RNG streams, cloned tree maps) and takes the first solution. Ablation at K=1 restores multi-minute tail draws. **Reviewer note:** this spends up to 4 cores during the search phase.
- **A lazy learning roadmap** (`roadmap.go`): a scene-free graph (600 sampled nodes; joint-space kNN edges plus workspace-kNN "bridge" edges connecting distinct joint families, e.g. wrist-flip configurations) whose edge validity is discovered per scene during A* and remembered, negatives included. Every successful plan is harvested back in: its compact smoothed waypoints become permanent nodes with scene-validated edges. Repeated planning on the captured hard scene converges from ~18s cold to a steady ~2.5s per plan.
- **Smaller wins**: fast nearest-neighbor scans over cached linearized inputs; a per-frame projection metric for `constrainNear` (formerly full-frame-system FK inside nlopt's gradient loop); a probe budget for smoothing; and a fixed held-object misclassification that made planning abort outright.
- **cmd-plan**: defaults GOGC to 300 for planning runs (reverting it measurably worsens medians; cmd-plan only, not the library) and extends the `-cpu` replan window so warm-cache behavior is observable.

## Numbers (captured hard scene, M-series laptop)

| | before series | after |
|---|---|---|
| cold plan | ~170s | ~8–25s |
| warm steady-state (replans) | — | 2.2–2.8s |
| aug-20 capture | ~35s | ~0.4s |

Race detector clean; motionplan/spatialmath/referenceframe suites pass; golangci-lint clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyqhmqkxS9B8bGjdUhTtAs