### PR TITLE
testutils: fix flaky viam-server teardown assertions on macOS

### DIFF
--- a/examples/customresources/demos/complexmodule/moduletest/module_test.go
+++ b/examples/customresources/demos/complexmodule/moduletest/module_test.go
@@ -54,9 +54,7 @@ func TestComplexModule(t *testing.T) {
 
 		if robottestutils.WaitForServing(observer, port) {
 			success = true
-			defer func() {
-				test.That(t, server.Stop(), test.ShouldBeNil)
-			}()
+			defer robottestutils.StopServerProcess(t, server)
 			break
 		}
 		server.Stop()
@@ -393,9 +391,7 @@ func TestValidationFailure(t *testing.T) {
 
 		if robottestutils.WaitForServing(logs, port) {
 			success = true
-			defer func() {
-				test.That(t, server.Stop(), test.ShouldBeNil)
-			}()
+			defer robottestutils.StopServerProcess(t, server)
 			break
 		}
 		server.Stop()

--- a/examples/customresources/demos/multiplemodules/moduletest/module_test.go
+++ b/examples/customresources/demos/multiplemodules/moduletest/module_test.go
@@ -54,9 +54,7 @@ func TestMultipleModules(t *testing.T) {
 
 		if robottestutils.WaitForServing(observer, port) {
 			success = true
-			defer func() {
-				test.That(t, server.Stop(), test.ShouldBeNil)
-			}()
+			defer robottestutils.StopServerProcess(t, server)
 			break
 		}
 		server.Stop()
@@ -201,9 +199,7 @@ func TestWebRTCSpans(t *testing.T) {
 
 		if robottestutils.WaitForServing(observer, port) {
 			success = true
-			defer func() {
-				test.That(t, server.Stop(), test.ShouldBeNil)
-			}()
+			defer robottestutils.StopServerProcess(t, server)
 			break
 		}
 		server.Stop()

--- a/module/module_interceptors_test.go
+++ b/module/module_interceptors_test.go
@@ -68,9 +68,7 @@ func TestOpID(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 
 		if success = robottestutils.WaitForServing(logObserver, port); success {
-			defer func() {
-				test.That(t, server.Stop(), test.ShouldBeNil)
-			}()
+			defer robottestutils.StopServerProcess(t, server)
 			break
 		}
 		logger.Infow("Port in use. Restarting on new port.", "port", port, "err", err)

--- a/testutils/robottestutils/robot_utils.go
+++ b/testutils/robottestutils/robot_utils.go
@@ -4,11 +4,13 @@ package robottestutils
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"regexp"
 	"runtime"
+	"syscall"
 	"testing"
 	"time"
 
@@ -152,6 +154,35 @@ func ServerAsSeparateProcess(t *testing.T, cfgFileName string, logger logging.Lo
 	}
 	server := pexec.NewManagedProcess(cfg.processConfig, logger)
 	return server
+}
+
+// StopServerProcess stops a viam-server subprocess started by [ServerAsSeparateProcess] and
+// asserts that it shut down cleanly.
+//
+// Prefer this to asserting on [pexec.ManagedProcess.Stop] directly. If the server has not been
+// reaped a few seconds after its SIGTERM, pexec signals the whole process group to sweep up any
+// orphaned children. A server that exited promptly but has not been reaped yet loses that race,
+// and the sweep then reports on an empty process group rather than on how the shutdown went:
+// Darwin returns EPERM while the exited process is still a zombie, and ESRCH once it has been
+// reaped. Both mean the process is gone, which is what stopping it was for, so treat them as
+// success — as modmanager already does for pexec.ProcessNotExistsError.
+func StopServerProcess(tb testing.TB, server pexec.ManagedProcess) {
+	tb.Helper()
+	if err := server.Stop(); !processAlreadyGone(err) {
+		test.That(tb, err, test.ShouldBeNil)
+	}
+}
+
+// processAlreadyGone reports whether err is pexec saying there was nothing left to signal
+// rather than a genuine failure to stop the process.
+func processAlreadyGone(err error) bool {
+	var notExists *pexec.ProcessNotExistsError
+	if errors.As(err, &notExists) {
+		return true
+	}
+	// pexec wraps the raw errno from its kill(2) on the process group.
+	var errno syscall.Errno
+	return errors.As(err, &errno) && (errno == syscall.ESRCH || errno == syscall.EPERM)
 }
 
 // WaitForServing will scan the logs in the `observer` input until seeing a "serving" or "error

--- a/testutils/robottestutils/robot_utils_test.go
+++ b/testutils/robottestutils/robot_utils_test.go
@@ -1,0 +1,40 @@
+package robottestutils
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+
+	pkgerrors "github.com/pkg/errors"
+	"go.viam.com/test"
+	"go.viam.com/utils/pexec"
+)
+
+func TestProcessAlreadyGone(t *testing.T) {
+	// The shape pexec gives an errno from its kill(2) on the process group. Wrapping it
+	// with github.com/pkg/errors is the part worth pinning: processAlreadyGone can only
+	// see the errno if that wrapper stays traversable by errors.As.
+	asPexecWrapsIt := func(errno syscall.Errno) error {
+		return pkgerrors.Wrapf(errno, "error signaling process group %d with signal %s", 1234, "SIGTERM")
+	}
+
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		// What Darwin reports for a group whose only member is an unreaped zombie.
+		{"wrapped EPERM", asPexecWrapsIt(syscall.EPERM), true},
+		// What both platforms report once the process has been reaped.
+		{"wrapped ESRCH", asPexecWrapsIt(syscall.ESRCH), true},
+		{"bare ESRCH", syscall.ESRCH, true},
+		{"ProcessNotExistsError", &pexec.ProcessNotExistsError{}, true},
+		{"unrelated errno", asPexecWrapsIt(syscall.EACCES), false},
+		{"unrelated error", errors.New("server failed to stop"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			test.That(t, processAlreadyGone(tc.err), test.ShouldEqual, tc.want)
+		})
+	}
+}

--- a/web/server/entrypoint_test.go
+++ b/web/server/entrypoint_test.go
@@ -69,9 +69,7 @@ func TestEntrypoint(t *testing.T) {
 			test.That(t, err, test.ShouldBeNil)
 
 			if success = robottestutils.WaitForServing(logObserver, port); success {
-				defer func() {
-					test.That(t, server.Stop(), test.ShouldBeNil)
-				}()
+				defer robottestutils.StopServerProcess(t, server)
 				break
 			}
 			logger.Infow("Port in use. Restarting on new port.", "port", port, "err", err)


### PR DESCRIPTION
## Summary

_Fixing a [flaky test](https://github.com/viamrobotics/rdk/actions/runs/32733237769/job/97450244897)_: **`TestEntrypoint` fails intermittently on macOS during teardown**. 

When `cmd.Wait` has not reaped the server within `StopTimeout/3` (3.33s), `pexec.Stop` signals its whole process group to sweep up orphans — and a server that exited promptly but is not reaped yet leaves that sweep signaling a group whose only member is a zombie. Darwin returns `EPERM` for that, where Linux signals a zombie's group happily. pexec maps `ESRCH` to `ProcessNotExistsError` but has no case for `EPERM`, so it escapes as a wrapped errno and fails `ShouldBeNil`.

**How this relates to viamrobotics/goutils#600.** That PR adds the missing `EPERM` case upstream. The two are complementary rather than alternatives: even with it, `Stop` still returns a `ProcessNotExistsError`, which is non-nil, so a bare `ShouldBeNil` assertion keeps failing — rdk has to tolerate that error either way. This PR accepts both the typed error and the raw errno, so it fixes the flake on its own, and stays correct once goutils#600 lands. Neither PR blocks the other.

## Changes

- **testutils/robottestutils**: add `StopServerProcess`, ignoring errors that mean only "the process is already gone" (`ProcessNotExistsError`, `ESRCH`, `EPERM`) and still failing on everything else — as `modmanager` already does
- **web/server, module, examples/customresources**: mechanical swap of the six `server.Stop()` assertions to the helper

## Testing

- New table test pins the classifier, including that `errors.As` still reaches the errno through pexec's `pkg/errors` wrapper. All six affected tests pass locally, though the timing race itself needs a loaded machine and was not reproduced — the diagnosis rests on an errno probe (Darwin: zombie → `EPERM`, reaped → `ESRCH`) and the CI log timing.

<details>
<summary>Claude Code prompts used</summary>

- "/check-ci"
- "Can you retrigger the CI check for this PR?
Then can you start a new worktree and investigate this flaky test? We should fix it"
- "commit and open a draft PR"
- "open a draft PR for goutils
Since the change in rdk is complementary you probably need to update the description, it states that the real fix is in goutils which turns out to not be true. You should link the goutils PR in the rdk PR description and explain how they are related"

</details>
