### PR TITLE
APP-17486: add CLI commands to fetch machine and fragment configs

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -2919,22 +2919,14 @@ Note: There is no progress meter while copying is in progress.
 							Name:      "config",
 							Usage:     "print a machine part's config JSON to stdout",
 							UsageText: createUsageText("machines part config", []string{generalFlagPart}, true, false),
-							Flags: []cli.Flag{
-								&AliasStringFlag{
-									cli.StringFlag{
-										Name:     generalFlagPart,
-										Aliases:  []string{generalFlagPartID},
-										Required: true,
-										Usage:    "part ID whose config to fetch",
-									},
-								},
+							Flags: append(commonPartFlags,
 								&cli.StringFlag{
 									Name: generalFlagAt,
 									Usage: "ISO-8601 timestamp in RFC3339 format to fetch the config that was in effect at that " +
 										"time (e.g., 2025-01-15T14:00:00Z)",
 									DefaultText: "current config",
 								},
-							},
+							),
 							Action: createActionCommandWithT[machinesPartConfigArgs](machinesPartConfigAction),
 						},
 						{

--- a/cli/app.go
+++ b/cli/app.go
@@ -3446,13 +3446,13 @@ Example trigger for conditional_logs_ingested:
 				{
 					Name:      "list",
 					Usage:     "list fragments for an organization",
-					UsageText: createUsageText("fragment list", []string{generalFlagOrganization}, true, false),
+					UsageText: createUsageText("fragment list", nil, true, false),
 					Flags: []cli.Flag{
 						&AliasStringFlag{
 							cli.StringFlag{
-								Name:     generalFlagOrganization,
-								Aliases:  []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
-								Required: true,
+								Name:        generalFlagOrganization,
+								Aliases:     []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
+								DefaultText: "default-org value if set, else the first organization alphabetically",
 							},
 						},
 					},

--- a/cli/app.go
+++ b/cli/app.go
@@ -74,6 +74,7 @@ const (
 	generalFlagMethod            = "method"
 	generalFlagDestination       = "destination"
 	generalFlagVersion           = "version"
+	generalFlagAt                = "at"
 	generalFlagCount             = "count"
 	generalFlagPath              = "path"
 	generalFlagType              = "type"
@@ -2915,6 +2916,28 @@ Note: There is no progress meter while copying is in progress.
 							Action: createActionCommandWithT[machinesPartHistoryArgs](machinesPartHistoryAction),
 						},
 						{
+							Name:      "config",
+							Usage:     "print a machine part's config JSON to stdout",
+							UsageText: createUsageText("machines part config", []string{generalFlagPart}, true, false),
+							Flags: []cli.Flag{
+								&AliasStringFlag{
+									cli.StringFlag{
+										Name:     generalFlagPart,
+										Aliases:  []string{generalFlagPartID},
+										Required: true,
+										Usage:    "part ID whose config to fetch",
+									},
+								},
+								&cli.StringFlag{
+									Name: generalFlagAt,
+									Usage: "ISO-8601 timestamp in RFC3339 format to fetch the config that was in effect at that " +
+										"time (e.g., 2025-01-15T14:00:00Z)",
+									DefaultText: "current config",
+								},
+							},
+							Action: createActionCommandWithT[machinesPartConfigArgs](machinesPartConfigAction),
+						},
+						{
 							Name:      "logs",
 							Aliases:   []string{"log"},
 							Usage:     "display part logs",
@@ -3410,6 +3433,66 @@ Example trigger for conditional_logs_ingested:
 							Action:    createActionCommandWithT[machinesPartDeleteTriggerArgs](machinesPartDeleteTriggerAction),
 						},
 					},
+				},
+			},
+		},
+		{
+			Name:            "fragment",
+			Aliases:         []string{"fragments"},
+			Usage:           "work with fragments",
+			UsageText:       createUsageText("fragment", nil, false, true),
+			HideHelpCommand: true,
+			Commands: []*cli.Command{
+				{
+					Name:      "list",
+					Usage:     "list fragments for an organization",
+					UsageText: createUsageText("fragment list", []string{generalFlagOrganization}, true, false),
+					Flags: []cli.Flag{
+						&AliasStringFlag{
+							cli.StringFlag{
+								Name:     generalFlagOrganization,
+								Aliases:  []string{generalFlagAliasOrg, generalFlagOrgID, generalFlagAliasOrgName},
+								Required: true,
+							},
+						},
+					},
+					Action: createActionCommandWithT[fragmentListArgs](fragmentListAction),
+				},
+				{
+					Name:      "get",
+					Usage:     "print a fragment's config JSON to stdout",
+					UsageText: createUsageText("fragment get", []string{generalFlagFragment}, true, false),
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:     generalFlagFragment,
+							Required: true,
+							Usage:    "fragment ID to fetch",
+						},
+						&cli.StringFlag{
+							Name:        generalFlagVersion,
+							Usage:       "fragment revision or tag to fetch",
+							DefaultText: "latest",
+						},
+					},
+					Action: createActionCommandWithT[fragmentGetArgs](fragmentGetAction),
+				},
+				{
+					Name:      "history",
+					Usage:     "display revision history for a fragment",
+					UsageText: createUsageText("fragment history", []string{generalFlagFragment}, true, false),
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:     generalFlagFragment,
+							Required: true,
+							Usage:    "fragment ID whose history to display",
+						},
+						&cli.IntFlag{
+							Name:  generalFlagCount,
+							Value: defaultHistoryCount,
+							Usage: "maximum number of history entries to list, or 0 for every entry",
+						},
+					},
+					Action: createActionCommandWithT[fragmentHistoryArgs](fragmentHistoryAction),
 				},
 			},
 		},

--- a/cli/client.go
+++ b/cli/client.go
@@ -3329,6 +3329,10 @@ func (c *viamClient) machinesPartConfigAction(ctx context.Context, cmd *cli.Comm
 // store the config as it was *before* each edit (Old), so the config live at `at` is the Old of
 // the earliest edit made strictly after `at`. If no edit happened after `at`, `at` is at or after
 // the most recent change and the current config applies.
+//
+// GetRobotPartHistory returns entries newest-first (the server sorts by edit time descending), so
+// with Start bounding the query to edits at/after `at`, the earliest edit after `at` is simply the
+// last entry we see — we page to the end and keep the most recent assignment.
 func (c *viamClient) robotPartConfigAt(ctx context.Context, partID string, at time.Time) (*structpb.Struct, error) {
 	startTime := timestamppb.New(at)
 	pageLimit := int64(historyFetchPageSize)
@@ -3347,13 +3351,10 @@ func (c *viamClient) robotPartConfigAt(ctx context.Context, partID string, at ti
 		if len(resp.History) == 0 {
 			break
 		}
-		// Don't assume a page ordering: keep the entry with the smallest When that is still after
-		// `at`, so whichever way the server sorts we converge on the same boundary edit.
+		// Entries arrive newest-first, so the last one still after `at` (the oldest edit after
+		// `at`) is the boundary we want; keep overwriting and the final value wins.
 		for _, entry := range resp.History {
-			if entry.When == nil || !entry.When.AsTime().After(at) {
-				continue
-			}
-			if earliestAfter == nil || entry.When.AsTime().Before(earliestAfter.When.AsTime()) {
+			if entry.When != nil && entry.When.AsTime().After(at) {
 				earliestAfter = entry
 			}
 		}

--- a/cli/client.go
+++ b/cli/client.go
@@ -3620,10 +3620,12 @@ func fragmentListAction(ctx context.Context, cmd *cli.Command, args fragmentList
 }
 
 func (c *viamClient) fragmentListAction(ctx context.Context, cmd *cli.Command, args fragmentListArgs) error {
-	org, err := c.getOrg(ctx, args.Organization)
-	if err != nil {
+	// An empty --organization falls back to the default (or first) org, so the flag stays optional
+	// and configured default-org values are respected.
+	if err := c.selectOrganization(ctx, args.Organization); err != nil {
 		return err
 	}
+	org := c.selectedOrg
 
 	resp, err := c.client.ListFragments(ctx, &apppb.ListFragmentsRequest{OrganizationId: org.Id})
 	if err != nil {

--- a/cli/client.go
+++ b/cli/client.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"text/tabwriter"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -3266,6 +3267,115 @@ func (c *viamClient) machinesPartHistoryAction(ctx context.Context, cmd *cli.Com
 	return nil
 }
 
+type machinesPartConfigArgs struct {
+	Part string
+	At   string
+}
+
+// marshalConfigJSON renders a config struct as indented JSON. Going through AsMap means
+// encoding/json sorts object keys alphabetically, so the output is deterministic and diffs
+// cleanly between two snapshots regardless of how the fields were ordered on the server.
+func marshalConfigJSON(config *structpb.Struct) (string, error) {
+	b, err := json.MarshalIndent(config.AsMap(), "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// machinesPartConfigAction is the corresponding action for 'machines part config'.
+func machinesPartConfigAction(ctx context.Context, cmd *cli.Command, args machinesPartConfigArgs) error {
+	client, err := newViamClient(ctx, cmd)
+	if err != nil {
+		return err
+	}
+	return client.machinesPartConfigAction(ctx, cmd, args)
+}
+
+func (c *viamClient) machinesPartConfigAction(ctx context.Context, cmd *cli.Command, args machinesPartConfigArgs) error {
+	at, err := parseTimeString(args.At)
+	if err != nil {
+		return err
+	}
+
+	var config *structpb.Struct
+	if at == nil {
+		resp, err := c.getRobotPart(ctx, args.Part)
+		if err != nil {
+			return errors.Wrap(err, "could not get machine part")
+		}
+		config = resp.Part.GetRobotConfig()
+	} else {
+		config, err = c.robotPartConfigAt(ctx, args.Part, at.AsTime())
+		if err != nil {
+			return err
+		}
+	}
+
+	if config == nil {
+		return errors.New("no configuration found for machine part")
+	}
+	out, err := marshalConfigJSON(config)
+	if err != nil {
+		return err
+	}
+	// The config JSON is the only thing on stdout so `viam machines part config ... > file.json`
+	// captures a clean file; any human-facing notes go to stderr via warningf.
+	printf(cmd.Root().Writer, "%s", out)
+	return nil
+}
+
+// robotPartConfigAt returns the machine config that was in effect at time `at`. History entries
+// store the config as it was *before* each edit (Old), so the config live at `at` is the Old of
+// the earliest edit made strictly after `at`. If no edit happened after `at`, `at` is at or after
+// the most recent change and the current config applies.
+func (c *viamClient) robotPartConfigAt(ctx context.Context, partID string, at time.Time) (*structpb.Struct, error) {
+	startTime := timestamppb.New(at)
+	pageLimit := int64(historyFetchPageSize)
+	var pageToken string
+	var earliestAfter *apppb.RobotPartHistoryEntry
+	for {
+		resp, err := c.client.GetRobotPartHistory(ctx, &apppb.GetRobotPartHistoryRequest{
+			Id:        partID,
+			Start:     startTime,
+			PageLimit: &pageLimit,
+			PageToken: &pageToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if len(resp.History) == 0 {
+			break
+		}
+		// Don't assume a page ordering: keep the entry with the smallest When that is still after
+		// `at`, so whichever way the server sorts we converge on the same boundary edit.
+		for _, entry := range resp.History {
+			if entry.When == nil || !entry.When.AsTime().After(at) {
+				continue
+			}
+			if earliestAfter == nil || entry.When.AsTime().Before(earliestAfter.When.AsTime()) {
+				earliestAfter = entry
+			}
+		}
+		if pageToken = resp.NextPageToken; pageToken == "" {
+			break
+		}
+	}
+
+	if earliestAfter == nil {
+		resp, err := c.getRobotPart(ctx, partID)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get machine part")
+		}
+		return resp.Part.GetRobotConfig(), nil
+	}
+	if earliestAfter.Old == nil || earliestAfter.Old.GetRobotConfig() == nil {
+		return nil, errors.Errorf("configuration change at %s has no recorded config to return",
+			earliestAfter.When.AsTime().Format(time.RFC3339))
+	}
+	return earliestAfter.Old.GetRobotConfig(), nil
+}
+
 type robotsPartAddFragmentArgs struct {
 	Organization string
 	Location     string
@@ -3493,6 +3603,180 @@ func RobotsPartRemoveFragmentAction(ctx context.Context, cmd *cli.Command, args 
 	}
 
 	printf(cmd.Root().Writer, "successfully removed fragment %s from part %s", whichFragment, part.Name)
+	return nil
+}
+
+type fragmentListArgs struct {
+	Organization string
+}
+
+// fragmentListAction is the corresponding action for 'fragment list'.
+func fragmentListAction(ctx context.Context, cmd *cli.Command, args fragmentListArgs) error {
+	client, err := newViamClient(ctx, cmd)
+	if err != nil {
+		return err
+	}
+	return client.fragmentListAction(ctx, cmd, args)
+}
+
+func (c *viamClient) fragmentListAction(ctx context.Context, cmd *cli.Command, args fragmentListArgs) error {
+	org, err := c.getOrg(ctx, args.Organization)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.client.ListFragments(ctx, &apppb.ListFragmentsRequest{OrganizationId: org.Id})
+	if err != nil {
+		return err
+	}
+
+	if len(resp.Fragments) == 0 {
+		warningf(cmd.Root().ErrWriter, "no fragments found for organization %s", org.Name)
+		return nil
+	}
+
+	// table format rules: minwidth, tabwidth, padding int, padchar byte, flags uint
+	w := tabwriter.NewWriter(cmd.Root().Writer, 5, 4, 1, ' ', 0)
+	tableFormat := "%s\t%s\t%s\t%s\n"
+	fmt.Fprintf(w, tableFormat, "ID", "NAME", "REVISION", "UPDATED") //nolint:errcheck
+	for _, f := range resp.Fragments {
+		fmt.Fprintf(w, tableFormat, f.Id, f.Name, fragmentRevisionOrNone(f.Revision), formatTimestamp(f.LastUpdated)) //nolint:errcheck
+	}
+	//nolint:errcheck
+	w.Flush()
+	return nil
+}
+
+// formatTimestamp renders a proto timestamp as RFC3339, guarding against both a nil and a
+// zero-value timestamp (fragments that have never been updated come back as the zero time,
+// which would otherwise print as "0001-01-01T00:00:00Z").
+func formatTimestamp(ts *timestamppb.Timestamp) string {
+	if ts == nil || ts.AsTime().IsZero() {
+		return "<unknown>"
+	}
+	return ts.AsTime().Format(time.RFC3339)
+}
+
+func fragmentRevisionOrNone(revision string) string {
+	if revision == "" {
+		return "<none>"
+	}
+	return revision
+}
+
+type fragmentGetArgs struct {
+	Fragment string
+	Version  string
+}
+
+// fragmentGetAction is the corresponding action for 'fragment get'.
+func fragmentGetAction(ctx context.Context, cmd *cli.Command, args fragmentGetArgs) error {
+	client, err := newViamClient(ctx, cmd)
+	if err != nil {
+		return err
+	}
+	return client.fragmentGetAction(ctx, cmd, args)
+}
+
+func (c *viamClient) fragmentGetAction(ctx context.Context, cmd *cli.Command, args fragmentGetArgs) error {
+	req := apppb.GetFragmentRequest{Id: args.Fragment}
+	if args.Version != "" {
+		req.Version = &args.Version
+	}
+	resp, err := c.client.GetFragment(ctx, &req)
+	if err != nil {
+		return err
+	}
+	if resp.Fragment == nil || resp.Fragment.GetFragment() == nil {
+		return errors.New("fragment has no configuration")
+	}
+	out, err := marshalConfigJSON(resp.Fragment.GetFragment())
+	if err != nil {
+		return err
+	}
+	// JSON only on stdout so the output redirects cleanly into a file for diffing.
+	printf(cmd.Root().Writer, "%s", out)
+	return nil
+}
+
+type fragmentHistoryArgs struct {
+	Fragment string
+	Count    int
+}
+
+// fragmentHistoryAction is the corresponding action for 'fragment history'.
+func fragmentHistoryAction(ctx context.Context, cmd *cli.Command, args fragmentHistoryArgs) error {
+	client, err := newViamClient(ctx, cmd)
+	if err != nil {
+		return err
+	}
+	return client.fragmentHistoryAction(ctx, cmd, args)
+}
+
+func (c *viamClient) fragmentHistoryAction(ctx context.Context, cmd *cli.Command, args fragmentHistoryArgs) error {
+	if args.Count < 0 {
+		return errors.Errorf("%q cannot be negative", generalFlagCount)
+	}
+
+	// table format rules: minwidth, tabwidth, padding int, padchar byte, flags uint
+	w := tabwriter.NewWriter(cmd.Root().Writer, 5, 4, 1, ' ', 0)
+	tableFormat := "%s\t%s\t%s\n"
+
+	pageLimit := int64(historyFetchPageSize)
+	var pageToken string
+	listed := 0
+	truncated := false
+	for {
+		resp, err := c.client.GetFragmentHistory(ctx, &apppb.GetFragmentHistoryRequest{
+			Id:        args.Fragment,
+			PageLimit: &pageLimit,
+			PageToken: &pageToken,
+		})
+		if err != nil {
+			return err
+		}
+
+		// An empty page ends the walk even if a token came back, mirroring machinesPartHistoryAction
+		// so a server that keeps handing out tokens can't spin this loop forever.
+		if len(resp.History) == 0 {
+			break
+		}
+
+		for _, entry := range resp.History {
+			if listed == 0 {
+				// The revision number is the natural ordinal, so there's no separate counter column.
+				fmt.Fprintf(w, tableFormat, "REVISION", "EDITED ON", "EDITED BY") //nolint:errcheck
+			}
+			editedBy := "<unknown>"
+			if entry.EditedBy != nil && entry.EditedBy.Value != "" {
+				editedBy = entry.EditedBy.Value
+			}
+			fmt.Fprintf(w, tableFormat, entry.Revision, formatTimestamp(entry.EditedOn), editedBy) //nolint:errcheck
+			listed++
+
+			if args.Count > 0 && listed == args.Count {
+				truncated = true
+				break
+			}
+		}
+
+		if truncated {
+			break
+		}
+		if pageToken = resp.NextPageToken; pageToken == "" {
+			break
+		}
+	}
+	//nolint:errcheck
+	w.Flush()
+
+	if listed == 0 {
+		printf(cmd.Root().Writer, "no history found for fragment %s", args.Fragment)
+		return nil
+	}
+	if truncated {
+		warningf(cmd.Root().ErrWriter, "stopped at --%s=%d; raise it to see more", generalFlagCount, args.Count)
+	}
 	return nil
 }
 

--- a/cli/client.go
+++ b/cli/client.go
@@ -3268,8 +3268,11 @@ func (c *viamClient) machinesPartHistoryAction(ctx context.Context, cmd *cli.Com
 }
 
 type machinesPartConfigArgs struct {
-	Part string
-	At   string
+	Organization string
+	Location     string
+	Machine      string
+	Part         string
+	At           string
 }
 
 // marshalConfigJSON renders a config struct as indented JSON. Going through AsMap means
@@ -3298,15 +3301,14 @@ func (c *viamClient) machinesPartConfigAction(ctx context.Context, cmd *cli.Comm
 		return err
 	}
 
-	var config *structpb.Struct
-	if at == nil {
-		resp, err := c.getRobotPart(ctx, args.Part)
-		if err != nil {
-			return errors.Wrap(err, "could not get machine part")
-		}
-		config = resp.Part.GetRobotConfig()
-	} else {
-		config, err = c.robotPartConfigAt(ctx, args.Part, at.AsTime())
+	part, err := c.robotPart(ctx, args.Organization, args.Location, args.Machine, args.Part)
+	if err != nil {
+		return errors.Wrap(err, "could not get machine part")
+	}
+
+	config := part.GetRobotConfig()
+	if at != nil {
+		config, err = c.robotPartConfigAt(ctx, part.Id, at.AsTime())
 		if err != nil {
 			return err
 		}
@@ -3643,7 +3645,7 @@ func (c *viamClient) fragmentListAction(ctx context.Context, cmd *cli.Command, a
 	tableFormat := "%s\t%s\t%s\t%s\n"
 	fmt.Fprintf(w, tableFormat, "ID", "NAME", "REVISION", "UPDATED") //nolint:errcheck
 	for _, f := range resp.Fragments {
-		fmt.Fprintf(w, tableFormat, f.Id, f.Name, fragmentRevisionOrNone(f.Revision), formatTimestamp(f.LastUpdated)) //nolint:errcheck
+		fmt.Fprintf(w, tableFormat, f.Id, f.Name, orUnknown(f.Revision), formatTimestamp(f.LastUpdated)) //nolint:errcheck
 	}
 	//nolint:errcheck
 	w.Flush()
@@ -3660,11 +3662,13 @@ func formatTimestamp(ts *timestamppb.Timestamp) string {
 	return ts.AsTime().Format(time.RFC3339)
 }
 
-func fragmentRevisionOrNone(revision string) string {
-	if revision == "" {
-		return "<none>"
+// orUnknown renders empty string values as the same "<unknown>" placeholder used by
+// formatTimestamp, so blank table cells read consistently.
+func orUnknown(s string) string {
+	if s == "" {
+		return "<unknown>"
 	}
-	return revision
+	return s
 }
 
 type fragmentGetArgs struct {

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1362,6 +1362,244 @@ func TestMachinesPartHistoryAction(t *testing.T) {
 	})
 }
 
+func TestMachinesPartConfigAction(t *testing.T) {
+	partID := "test-part-id"
+	partName := "test-part"
+
+	currentConf, err := structpb.NewStruct(map[string]any{"components": []any{}, "marker": "current"})
+	test.That(t, err, test.ShouldBeNil)
+	oldConf, err := structpb.NewStruct(map[string]any{"components": []any{}, "marker": "old"})
+	test.That(t, err, test.ShouldBeNil)
+
+	getRobotPartFunc := func(ctx context.Context, in *apppb.GetRobotPartRequest,
+		opts ...grpc.CallOption,
+	) (*apppb.GetRobotPartResponse, error) {
+		test.That(t, in.Id, test.ShouldEqual, partID)
+		return &apppb.GetRobotPartResponse{
+			Part: &apppb.RobotPart{Id: partID, Name: partName, RobotConfig: currentConf},
+		}, nil
+	}
+
+	// A single edit at editTime: its Old is the config that was live *before* editTime.
+	editTime := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	var lastHistReq *apppb.GetRobotPartHistoryRequest
+	getRobotPartHistoryFunc := func(ctx context.Context, in *apppb.GetRobotPartHistoryRequest,
+		opts ...grpc.CallOption,
+	) (*apppb.GetRobotPartHistoryResponse, error) {
+		lastHistReq = in
+		return &apppb.GetRobotPartHistoryResponse{
+			History: []*apppb.RobotPartHistoryEntry{
+				{Part: partID, When: timestamppb.New(editTime), Old: &apppb.RobotPart{Id: partID, RobotConfig: oldConf}},
+			},
+		}, nil
+	}
+
+	asc := &inject.AppServiceClient{
+		GetRobotPartFunc:        getRobotPartFunc,
+		GetRobotPartHistoryFunc: getRobotPartHistoryFunc,
+	}
+
+	t.Run("current config prints to stdout", func(t *testing.T) {
+		cCtx, ac, out, errOut := setup(asc, nil, nil, nil, "token")
+		err := ac.machinesPartConfigAction(context.Background(), cCtx, machinesPartConfigArgs{Part: partID})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+		test.That(t, len(out.messages), test.ShouldEqual, 1)
+		test.That(t, out.messages[0], test.ShouldContainSubstring, `"marker": "current"`)
+	})
+
+	t.Run("--at before the edit resolves forward to the config that was live then", func(t *testing.T) {
+		cCtx, ac, out, errOut := setup(asc, nil, nil, nil, "token")
+		err := ac.machinesPartConfigAction(context.Background(), cCtx,
+			machinesPartConfigArgs{Part: partID, At: "2026-01-15T09:00:00Z"})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+		test.That(t, len(out.messages), test.ShouldEqual, 1)
+		// The edit is after `at`, so its Old config is what applied at `at`.
+		test.That(t, out.messages[0], test.ShouldContainSubstring, `"marker": "old"`)
+		test.That(t, lastHistReq.Start.AsTime().Equal(time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)), test.ShouldBeTrue)
+	})
+
+	t.Run("--at after the last edit falls back to the current config", func(t *testing.T) {
+		cCtx, ac, out, _ := setup(asc, nil, nil, nil, "token")
+		err := ac.machinesPartConfigAction(context.Background(), cCtx,
+			machinesPartConfigArgs{Part: partID, At: "2026-01-15T18:00:00Z"})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(out.messages), test.ShouldEqual, 1)
+		test.That(t, out.messages[0], test.ShouldContainSubstring, `"marker": "current"`)
+	})
+
+	t.Run("unparseable --at errors", func(t *testing.T) {
+		cCtx, ac, _, _ := setup(asc, nil, nil, nil, "token")
+		err := ac.machinesPartConfigAction(context.Background(), cCtx,
+			machinesPartConfigArgs{Part: partID, At: "yesterday"})
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "could not parse time string")
+	})
+}
+
+func TestFragmentActions(t *testing.T) {
+	fragmentID := "test-fragment-id"
+	fragmentName := "test-fragment"
+	orgID := "11111111-1111-1111-1111-111111111111"
+	orgName := "test-org"
+
+	fragConf, err := structpb.NewStruct(map[string]any{"components": []any{}, "marker": "frag"})
+	test.That(t, err, test.ShouldBeNil)
+
+	listOrganizationsFunc := func(ctx context.Context, in *apppb.ListOrganizationsRequest,
+		opts ...grpc.CallOption,
+	) (*apppb.ListOrganizationsResponse, error) {
+		return &apppb.ListOrganizationsResponse{
+			Organizations: []*apppb.Organization{{Id: orgID, Name: orgName}},
+		}, nil
+	}
+
+	t.Run("list prints a table of fragments for an org", func(t *testing.T) {
+		var lastReq *apppb.ListFragmentsRequest
+		asc := &inject.AppServiceClient{
+			ListOrganizationsFunc: listOrganizationsFunc,
+			ListFragmentsFunc: func(ctx context.Context, in *apppb.ListFragmentsRequest,
+				opts ...grpc.CallOption,
+			) (*apppb.ListFragmentsResponse, error) {
+				lastReq = in
+				return &apppb.ListFragmentsResponse{
+					Fragments: []*apppb.Fragment{
+						{Id: fragmentID, Name: fragmentName, Revision: "rev-1", LastUpdated: timestamppb.New(time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC))},
+						// A fragment that has never been updated comes back as the zero time.
+						{Id: "second-id", Name: "never-updated", Revision: "rev-9"},
+					},
+				}, nil
+			},
+		}
+		cCtx, ac, out, errOut := setup(asc, nil, nil, nil, "token")
+		err := ac.fragmentListAction(context.Background(), cCtx, fragmentListArgs{Organization: orgName})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+		test.That(t, lastReq.OrganizationId, test.ShouldEqual, orgID)
+		joined := strings.Join(out.messages, "")
+		test.That(t, joined, test.ShouldContainSubstring, "ID")
+		test.That(t, joined, test.ShouldContainSubstring, "NAME")
+		test.That(t, joined, test.ShouldContainSubstring, "REVISION")
+		test.That(t, joined, test.ShouldContainSubstring, fragmentID)
+		test.That(t, joined, test.ShouldContainSubstring, "rev-1")
+		test.That(t, joined, test.ShouldContainSubstring, "2026-01-15T10:00:00Z")
+		// The zero-time fragment renders as unknown, not year 0001.
+		test.That(t, joined, test.ShouldContainSubstring, "<unknown>")
+		test.That(t, joined, test.ShouldNotContainSubstring, "0001")
+	})
+
+	t.Run("get prints the fragment config and forwards the version", func(t *testing.T) {
+		var lastReq *apppb.GetFragmentRequest
+		asc := &inject.AppServiceClient{
+			GetFragmentFunc: func(ctx context.Context, in *apppb.GetFragmentRequest,
+				opts ...grpc.CallOption,
+			) (*apppb.GetFragmentResponse, error) {
+				lastReq = in
+				return &apppb.GetFragmentResponse{
+					Fragment: &apppb.Fragment{Id: fragmentID, Name: fragmentName, Fragment: fragConf},
+				}, nil
+			},
+		}
+		cCtx, ac, out, errOut := setup(asc, nil, nil, nil, "token")
+		err := ac.fragmentGetAction(context.Background(), cCtx,
+			fragmentGetArgs{Fragment: fragmentID, Version: "rev-2"})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+		test.That(t, lastReq.Id, test.ShouldEqual, fragmentID)
+		test.That(t, lastReq.Version, test.ShouldNotBeNil)
+		test.That(t, *lastReq.Version, test.ShouldEqual, "rev-2")
+		test.That(t, len(out.messages), test.ShouldEqual, 1)
+		test.That(t, out.messages[0], test.ShouldContainSubstring, `"marker": "frag"`)
+	})
+
+	t.Run("get omits an unset version", func(t *testing.T) {
+		var lastReq *apppb.GetFragmentRequest
+		asc := &inject.AppServiceClient{
+			GetFragmentFunc: func(ctx context.Context, in *apppb.GetFragmentRequest,
+				opts ...grpc.CallOption,
+			) (*apppb.GetFragmentResponse, error) {
+				lastReq = in
+				return &apppb.GetFragmentResponse{
+					Fragment: &apppb.Fragment{Id: fragmentID, Fragment: fragConf},
+				}, nil
+			},
+		}
+		cCtx, ac, _, _ := setup(asc, nil, nil, nil, "token")
+		err := ac.fragmentGetAction(context.Background(), cCtx, fragmentGetArgs{Fragment: fragmentID})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, lastReq.Version, test.ShouldBeNil)
+	})
+
+	t.Run("history lists revisions as a table without a redundant counter", func(t *testing.T) {
+		ts := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+		asc := &inject.AppServiceClient{
+			GetFragmentHistoryFunc: func(ctx context.Context, in *apppb.GetFragmentHistoryRequest,
+				opts ...grpc.CallOption,
+			) (*apppb.GetFragmentHistoryResponse, error) {
+				test.That(t, in.Id, test.ShouldEqual, fragmentID)
+				return &apppb.GetFragmentHistoryResponse{
+					History: []*apppb.FragmentHistoryEntry{
+						{Revision: "3", EditedOn: timestamppb.New(ts), EditedBy: &apppb.AuthenticatorInfo{Value: "alice@viam.com"}},
+						{Revision: "2", EditedOn: timestamppb.New(ts.Add(-time.Hour)), EditedBy: &apppb.AuthenticatorInfo{Value: "bob@viam.com"}},
+					},
+				}, nil
+			},
+		}
+		cCtx, ac, out, errOut := setup(asc, nil, nil, nil, "token")
+		err := ac.fragmentHistoryAction(context.Background(), cCtx, fragmentHistoryArgs{Fragment: fragmentID})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(errOut.messages), test.ShouldEqual, 0)
+		joined := strings.Join(out.messages, "")
+		test.That(t, joined, test.ShouldContainSubstring, "REVISION")
+		test.That(t, joined, test.ShouldContainSubstring, "EDITED BY")
+		test.That(t, joined, test.ShouldContainSubstring, "alice@viam.com")
+		test.That(t, joined, test.ShouldContainSubstring, "2026-01-15T10:00:00Z")
+		// The confusing "[1] revision 3" counter is gone; the revision number stands on its own.
+		test.That(t, joined, test.ShouldNotContainSubstring, "[1]")
+	})
+
+	t.Run("history --count caps rows and warns on stderr", func(t *testing.T) {
+		ts := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+		asc := &inject.AppServiceClient{
+			GetFragmentHistoryFunc: func(ctx context.Context, in *apppb.GetFragmentHistoryRequest,
+				opts ...grpc.CallOption,
+			) (*apppb.GetFragmentHistoryResponse, error) {
+				return &apppb.GetFragmentHistoryResponse{
+					History: []*apppb.FragmentHistoryEntry{
+						{Revision: "3", EditedOn: timestamppb.New(ts)},
+						{Revision: "2", EditedOn: timestamppb.New(ts.Add(-time.Hour))},
+					},
+				}, nil
+			},
+		}
+		cCtx, ac, out, errOut := setup(asc, nil, nil, nil, "token")
+		err := ac.fragmentHistoryAction(context.Background(), cCtx, fragmentHistoryArgs{Fragment: fragmentID, Count: 1})
+		test.That(t, err, test.ShouldBeNil)
+		joined := strings.Join(out.messages, "")
+		test.That(t, joined, test.ShouldContainSubstring, "3")
+		test.That(t, joined, test.ShouldNotContainSubstring, "2\t")
+		test.That(t, strings.Join(errOut.messages, ""), test.ShouldContainSubstring, "stopped at --count=1")
+	})
+
+	t.Run("history reports an empty fragment", func(t *testing.T) {
+		asc := &inject.AppServiceClient{
+			GetFragmentHistoryFunc: func(ctx context.Context, in *apppb.GetFragmentHistoryRequest,
+				opts ...grpc.CallOption,
+			) (*apppb.GetFragmentHistoryResponse, error) {
+				return &apppb.GetFragmentHistoryResponse{}, nil
+			},
+		}
+		cCtx, ac, out, _ := setup(asc, nil, nil, nil, "token")
+		err := ac.fragmentHistoryAction(context.Background(), cCtx, fragmentHistoryArgs{Fragment: fragmentID})
+		test.That(t, err, test.ShouldBeNil)
+		joined := strings.Join(out.messages, "")
+		test.That(t, joined, test.ShouldContainSubstring, "no history found")
+		// With no rows the table has no header.
+		test.That(t, joined, test.ShouldNotContainSubstring, "REVISION")
+	})
+}
+
 // TestMachinesPartHistoryCountDefault pins the flag default: without one, printing every revision
 // of a frequently-edited part takes minutes and buries anything useful.
 func TestMachinesPartHistoryCountDefault(t *testing.T) {

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1394,7 +1394,16 @@ func TestMachinesPartConfigAction(t *testing.T) {
 		}, nil
 	}
 
+	// ListOrganizations errors so robotPart falls back to a direct ID lookup via GetRobotPartFunc,
+	// mirroring TestMachinesPartHistoryAction.
+	listOrganizationsFunc := func(ctx context.Context, in *apppb.ListOrganizationsRequest,
+		opts ...grpc.CallOption,
+	) (*apppb.ListOrganizationsResponse, error) {
+		return nil, errors.New("not used in this test")
+	}
+
 	asc := &inject.AppServiceClient{
+		ListOrganizationsFunc:   listOrganizationsFunc,
 		GetRobotPartFunc:        getRobotPartFunc,
 		GetRobotPartHistoryFunc: getRobotPartHistoryFunc,
 	}
@@ -1449,7 +1458,8 @@ func TestMachinesPartConfigAction(t *testing.T) {
 			return s
 		}
 		multiAsc := &inject.AppServiceClient{
-			GetRobotPartFunc: getRobotPartFunc,
+			ListOrganizationsFunc: listOrganizationsFunc,
+			GetRobotPartFunc:      getRobotPartFunc,
 			GetRobotPartHistoryFunc: func(ctx context.Context, in *apppb.GetRobotPartHistoryRequest,
 				opts ...grpc.CallOption,
 			) (*apppb.GetRobotPartHistoryResponse, error) {
@@ -1629,9 +1639,12 @@ func TestFragmentActions(t *testing.T) {
 		cCtx, ac, out, errOut := setup(asc, nil, nil, nil, "token")
 		err := ac.fragmentHistoryAction(context.Background(), cCtx, fragmentHistoryArgs{Fragment: fragmentID, Count: 1})
 		test.That(t, err, test.ShouldBeNil)
-		joined := strings.Join(out.messages, "")
-		test.That(t, joined, test.ShouldContainSubstring, "3")
-		test.That(t, joined, test.ShouldNotContainSubstring, "2\t")
+		// tabwriter turns the column tabs into spaces on Flush, so assert on the rendered row count
+		// rather than a tab-delimited substring: header + exactly one data row means --count capped it.
+		lines := strings.Split(strings.TrimRight(strings.Join(out.messages, ""), "\n"), "\n")
+		test.That(t, len(lines), test.ShouldEqual, 2)
+		test.That(t, lines[0], test.ShouldContainSubstring, "REVISION")
+		test.That(t, lines[1], test.ShouldContainSubstring, "3")
 		test.That(t, strings.Join(errOut.messages, ""), test.ShouldContainSubstring, "stopped at --count=1")
 	})
 

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1489,6 +1489,26 @@ func TestFragmentActions(t *testing.T) {
 		test.That(t, joined, test.ShouldNotContainSubstring, "0001")
 	})
 
+	t.Run("list with no --organization falls back to the default org", func(t *testing.T) {
+		var lastReq *apppb.ListFragmentsRequest
+		asc := &inject.AppServiceClient{
+			ListOrganizationsFunc: listOrganizationsFunc,
+			ListFragmentsFunc: func(ctx context.Context, in *apppb.ListFragmentsRequest,
+				opts ...grpc.CallOption,
+			) (*apppb.ListFragmentsResponse, error) {
+				lastReq = in
+				return &apppb.ListFragmentsResponse{
+					Fragments: []*apppb.Fragment{{Id: fragmentID, Name: fragmentName, Revision: "rev-1"}},
+				}, nil
+			},
+		}
+		cCtx, ac, _, _ := setup(asc, nil, nil, nil, "token")
+		err := ac.fragmentListAction(context.Background(), cCtx, fragmentListArgs{})
+		test.That(t, err, test.ShouldBeNil)
+		// With no org specified, the first organization is used.
+		test.That(t, lastReq.OrganizationId, test.ShouldEqual, orgID)
+	})
+
 	t.Run("get prints the fragment config and forwards the version", func(t *testing.T) {
 		var lastReq *apppb.GetFragmentRequest
 		asc := &inject.AppServiceClient{

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1436,6 +1436,39 @@ func TestMachinesPartConfigAction(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "could not parse time string")
 	})
+
+	t.Run("--at picks the earliest edit after the timestamp from a newest-first list", func(t *testing.T) {
+		// Three edits, returned newest-first as the server sorts them. `at` predates all of them,
+		// so the config live at `at` is the Old of the oldest edit (the last entry in the list).
+		e3 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+		e2 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+		e1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		conf := func(marker string) *structpb.Struct {
+			s, cerr := structpb.NewStruct(map[string]any{"marker": marker})
+			test.That(t, cerr, test.ShouldBeNil)
+			return s
+		}
+		multiAsc := &inject.AppServiceClient{
+			GetRobotPartFunc: getRobotPartFunc,
+			GetRobotPartHistoryFunc: func(ctx context.Context, in *apppb.GetRobotPartHistoryRequest,
+				opts ...grpc.CallOption,
+			) (*apppb.GetRobotPartHistoryResponse, error) {
+				return &apppb.GetRobotPartHistoryResponse{
+					History: []*apppb.RobotPartHistoryEntry{
+						{Part: partID, When: timestamppb.New(e3), Old: &apppb.RobotPart{RobotConfig: conf("before-e3")}},
+						{Part: partID, When: timestamppb.New(e2), Old: &apppb.RobotPart{RobotConfig: conf("before-e2")}},
+						{Part: partID, When: timestamppb.New(e1), Old: &apppb.RobotPart{RobotConfig: conf("before-e1")}},
+					},
+				}, nil
+			},
+		}
+		cCtx, ac, out, _ := setup(multiAsc, nil, nil, nil, "token")
+		err := ac.machinesPartConfigAction(context.Background(), cCtx,
+			machinesPartConfigArgs{Part: partID, At: "2025-12-01T00:00:00Z"})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(out.messages), test.ShouldEqual, 1)
+		test.That(t, out.messages[0], test.ShouldContainSubstring, `"marker": "before-e1"`)
+	})
 }
 
 func TestFragmentActions(t *testing.T) {


### PR DESCRIPTION
Adds CLI commands to download machine part and fragment configs as JSON, so they can be saved and diffed offline (e.g. comparing two fragment revisions).

## Commands

- `viam machines part config --part <id> [--at <RFC3339>]` — print a part's config JSON. `--at` returns the config that was in effect at that time (resolved from part history).
- `viam fragment list --organization <id|name>` — list an org's fragments.
- `viam fragment get --fragment <id> [--version <rev|tag>]` — print a fragment's config JSON.
- `viam fragment history --fragment <id>` — list a fragment's revisions.

Config JSON is printed to stdout with sorted keys (human-facing notes go to stderr), so redirecting stdout to a file captures a clean, diff-friendly config.

## Examples

```
$ viam fragment list --organization my-org
ID                                   NAME             REVISION UPDATED
0a1b2c3d-1111-2222-3333-444455556666 sensor-fragment  4        2026-01-15T10:00:00Z
7f8e9d0c-aaaa-bbbb-cccc-ddddeeeeffff never-updated    1        <unknown>

$ viam fragment history --fragment 0a1b2c3d-1111-2222-3333-444455556666
REVISION EDITED ON            EDITED BY
4        2026-01-15T10:00:00Z alice@example.com
3        2026-01-10T09:12:00Z bob@example.com

# save two snapshots and diff them
$ viam machines part config --part 11112222-3333-4444-5555-666677778888 --at 2026-01-01T00:00:00Z > old.json
$ viam machines part config --part 11112222-3333-4444-5555-666677778888 > new.json
$ diff old.json new.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)