### PR TITLE
spatialmath: implement Cylinder.ToProtobuf and proto parsing

### DIFF
--- a/referenceframe/geometry_proto.go
+++ b/referenceframe/geometry_proto.go
@@ -22,6 +22,10 @@ func NewGeometryFromProto(geometry *commonpb.Geometry) (spatialmath.Geometry, er
 	if capsule := geometry.GetCapsule(); capsule != nil {
 		return spatialmath.NewCapsule(pose, capsule.RadiusMm, capsule.LengthMm, geometry.Label)
 	}
+	if cylinder := geometry.GetCylinder(); cylinder != nil {
+		return spatialmath.NewCylinderWithCapped(
+			pose, cylinder.RadiusMm, cylinder.HeightMm, !cylinder.GetUncapped(), geometry.Label)
+	}
 	if sphere := geometry.GetSphere(); sphere != nil {
 		// Fallback to point if radius is 0
 		if sphere.RadiusMm == 0 {

--- a/referenceframe/geometry_proto_test.go
+++ b/referenceframe/geometry_proto_test.go
@@ -291,3 +291,47 @@ func TestGeoGeometryProtobufRoundTrip(t *testing.T) {
 		})
 	}
 }
+
+// A cylinder must survive the wire. Before commonpb carried a Cylinder message,
+// Cylinder.ToProtobuf() panicked, so any component returning one from
+// Geometries() panicked its own GetGeometries handler and the client rendered
+// nothing -- while every in-process test still passed.
+func TestCylinderProtoRoundTrip(t *testing.T) {
+	for _, capped := range []bool{true, false} {
+		orig, err := spatialmath.NewCylinderWithCapped(
+			spatialmath.NewPoseFromPoint(r3.Vector{X: 1, Y: -2, Z: -134.5}), 35.5, 129, capped, "body")
+		test.That(t, err, test.ShouldBeNil)
+
+		back, err := NewGeometryFromProto(orig.ToProtobuf())
+		test.That(t, err, test.ShouldBeNil)
+
+		_, isCylinder := back.(*spatialmath.Cylinder)
+		test.That(t, isCylinder, test.ShouldBeTrue)
+		test.That(t, back.Label(), test.ShouldEqual, "body")
+		test.That(t, spatialmath.GeometriesAlmostEqual(orig, back), test.ShouldBeTrue)
+
+		// The open/closed distinction must survive too, or an open tube silently
+		// becomes a solid and a planner will refuse to route through its interior.
+		test.That(t,
+			len(back.(*spatialmath.Cylinder).ToMesh().Triangles()),
+			test.ShouldEqual,
+			len(orig.(*spatialmath.Cylinder).ToMesh().Triangles()))
+	}
+}
+
+// The whole-list conversion is what the component servers actually call.
+func TestCylinderInGeometriesToProto(t *testing.T) {
+	cyl, err := spatialmath.NewCylinder(spatialmath.NewZeroPose(), 24.5, 44, "cup")
+	test.That(t, err, test.ShouldBeNil)
+	box, err := spatialmath.NewBox(spatialmath.NewZeroPose(), r3.Vector{X: 1, Y: 2, Z: 3}, "plate")
+	test.That(t, err, test.ShouldBeNil)
+
+	proto := NewGeometriesToProto([]spatialmath.Geometry{cyl, box})
+	test.That(t, len(proto), test.ShouldEqual, 2)
+
+	back, err := NewGeometriesFromProto(proto)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(back), test.ShouldEqual, 2)
+	test.That(t, spatialmath.GeometriesAlmostEqual(cyl, back[0]), test.ShouldBeTrue)
+	test.That(t, spatialmath.GeometriesAlmostEqual(box, back[1]), test.ShouldBeTrue)
+}

--- a/referenceframe/geometry_proto_test.go
+++ b/referenceframe/geometry_proto_test.go
@@ -319,6 +319,41 @@ func TestCylinderProtoRoundTrip(t *testing.T) {
 	}
 }
 
+// A cylinder's orientation IS its axis, so it is the one thing that must not be
+// dropped. Every other test here uses an identity orientation, which means a
+// ToProtobuf that serialized only the translation would pass all of them.
+func TestCylinderProtoRoundTripPreservesOrientation(t *testing.T) {
+	orientations := []spatialmath.Orientation{
+		&spatialmath.OrientationVectorDegrees{OX: 1, OY: 0, OZ: 0, Theta: 30},
+		&spatialmath.OrientationVectorDegrees{OX: 0, OY: 1, OZ: 0, Theta: -75},
+		&spatialmath.EulerAngles{Roll: 0.3, Pitch: 0.7, Yaw: -1.2},
+		// Axis flipped end for end: distinguishable only if orientation survives.
+		&spatialmath.OrientationVectorDegrees{OX: 0, OY: 0, OZ: -1, Theta: 0},
+	}
+	for i, ori := range orientations {
+		orig, err := spatialmath.NewCylinder(
+			spatialmath.NewPose(r3.Vector{X: 5, Y: -6, Z: 7}, ori), 20, 80, "tilted")
+		test.That(t, err, test.ShouldBeNil)
+
+		back, err := NewGeometryFromProto(orig.ToProtobuf())
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, spatialmath.GeometriesAlmostEqual(orig, back), test.ShouldBeTrue)
+		test.That(t, spatialmath.OrientationAlmostEqual(
+			orig.Pose().Orientation(), back.Pose().Orientation()), test.ShouldBeTrue)
+
+		// Guard against the equality check being orientation-blind: a cylinder
+		// rotated away from this one must NOT compare equal.
+		other, err := spatialmath.NewCylinder(
+			spatialmath.NewPose(r3.Vector{X: 5, Y: -6, Z: 7},
+				&spatialmath.OrientationVectorDegrees{OX: 1, OY: 1, OZ: 0, Theta: 45}),
+			20, 80, "tilted")
+		test.That(t, err, test.ShouldBeNil)
+		if i == 0 {
+			test.That(t, spatialmath.GeometriesAlmostEqual(orig, other), test.ShouldBeFalse)
+		}
+	}
+}
+
 // The whole-list conversion is what the component servers actually call.
 func TestCylinderInGeometriesToProto(t *testing.T) {
 	cyl, err := spatialmath.NewCylinder(spatialmath.NewZeroPose(), 24.5, 44, "cup")

--- a/spatialmath/cylinder.go
+++ b/spatialmath/cylinder.go
@@ -197,11 +197,25 @@ func (c *Cylinder) buildMesh() *Mesh {
 	return NewMesh(c.pose, tris, c.label)
 }
 
-// ToProtobuf is not implemented for Cylinder: there is no Cylinder message in
-// commonpb. Any attempt to serialize a Cylinder over gRPC must be intercepted
-// upstream. This panic is intentional and load-bearing.
+// ToProtobuf converts the Cylinder to its protobuf representation.
+//
+// uncapped is the negation of capped: the proto3 default (false) is the solid
+// cylinder, so a producer or consumer that ignores the field still gets the
+// common case, and gets it conservatively -- an open tube read as solid
+// over-approximates, while a solid read as open would let a caller plan a path
+// straight through it.
 func (c *Cylinder) ToProtobuf() *commonpb.Geometry {
-	panic("Cylinder.ToProtobuf: unimplemented -- no Cylinder message in commonpb")
+	return &commonpb.Geometry{
+		Center: PoseToProtobuf(c.pose),
+		GeometryType: &commonpb.Geometry_Cylinder{
+			Cylinder: &commonpb.Cylinder{
+				RadiusMm: c.radius,
+				HeightMm: c.height,
+				Uncapped: !c.capped,
+			},
+		},
+		Label: c.label,
+	}
 }
 
 // asMeshIfCylinder converts g to its mesh form when g is a *Cylinder. Mesh's

--- a/spatialmath/cylinder.go
+++ b/spatialmath/cylinder.go
@@ -199,11 +199,16 @@ func (c *Cylinder) buildMesh() *Mesh {
 
 // ToProtobuf converts the Cylinder to its protobuf representation.
 //
-// uncapped is the negation of capped: the proto3 default (false) is the solid
-// cylinder, so a producer or consumer that ignores the field still gets the
-// common case, and gets it conservatively -- an open tube read as solid
-// over-approximates, while a solid read as open would let a caller plan a path
-// straight through it.
+// uncapped is the negation of capped, so the proto3 default (false) is the solid
+// cylinder: the overwhelmingly common case, what NewCylinder builds, and what a
+// cylinder means in URDF and SDF.
+//
+// Note this is a defaulting convention, not a safety guarantee. Cylinder
+// collision goes through the tessellated mesh, which is a surface: a point fully
+// inside a "solid" cylinder does not register a collision, where the same point
+// inside a box, sphere or capsule does. Capping therefore adds two zero-thickness
+// cap discs rather than filling the interior, and reading an open tube as solid
+// is not automatically the conservative direction.
 func (c *Cylinder) ToProtobuf() *commonpb.Geometry {
 	return &commonpb.Geometry{
 		Center: PoseToProtobuf(c.pose),

--- a/spatialmath/cylinder_test.go
+++ b/spatialmath/cylinder_test.go
@@ -272,13 +272,38 @@ func TestCylinderJSONRoundTrip(t *testing.T) {
 	test.That(t, orig.almostEqual(rc), test.ShouldBeTrue)
 }
 
-func TestCylinderToProtobufPanics(t *testing.T) {
-	c := makeTestCylinder(NewZeroOrientation(), r3.Vector{}, 1, 1, "")
-	defer func() {
-		r := recover()
-		test.That(t, r, test.ShouldNotBeNil)
-	}()
-	_ = c.ToProtobuf()
+func TestCylinderToProtobuf(t *testing.T) {
+	c := makeTestCylinder(NewZeroOrientation(), r3.Vector{X: 1, Y: -2, Z: 3}, 35.5, 129, "body")
+
+	pb := c.ToProtobuf()
+	test.That(t, pb.GetCylinder(), test.ShouldNotBeNil)
+	test.That(t, pb.GetCylinder().GetRadiusMm(), test.ShouldAlmostEqual, 35.5)
+	test.That(t, pb.GetCylinder().GetHeightMm(), test.ShouldAlmostEqual, 129.0)
+	test.That(t, pb.GetLabel(), test.ShouldEqual, "body")
+	test.That(t, pb.GetCenter(), test.ShouldNotBeNil)
+
+	// A solid cylinder is the proto3 default, so uncapped stays false. A consumer
+	// that ignores the field entirely still reads it as solid, which is the
+	// conservative interpretation.
+	test.That(t, pb.GetCylinder().GetUncapped(), test.ShouldBeFalse)
+}
+
+// An open tube must not decode as a solid: the caps are the difference between
+// a surface something can reach inside and a volume it cannot.
+func TestCylinderToProtobufCarriesUncapped(t *testing.T) {
+	open, err := NewCylinderWithCapped(NewZeroPose(), 50, 100, false, "tube")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, open.ToProtobuf().GetCylinder().GetUncapped(), test.ShouldBeTrue)
+
+	solid, err := NewCylinderWithCapped(NewZeroPose(), 50, 100, true, "solid")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, solid.ToProtobuf().GetCylinder().GetUncapped(), test.ShouldBeFalse)
+
+	// The tessellations must differ, or the flag is not describing anything.
+	test.That(t,
+		len(open.(*Cylinder).ToMesh().Triangles()),
+		test.ShouldBeLessThan,
+		len(solid.(*Cylinder).ToMesh().Triangles()))
 }
 
 // --- Collision / distance / encompass ---


### PR DESCRIPTION
> **Stacked on https://github.com/viamrobotics/api/pull/894**, which adds the `Cylinder` message to the `Geometry` oneof. This does not build until that merges and the `go.viam.com/api` dep is bumped. Draft until then.

## The problem

`Cylinder.ToProtobuf()` was:

```go
panic("Cylinder.ToProtobuf: unimplemented -- no Cylinder message in commonpb")
```

Not an error — a panic. So `spatialmath.Cylinder` was usable for in-process collision math and nothing else:

- Returning one from `Geometries()` panics that component's own `GetGeometries` handler (`components/*/server.go` → `referenceframe.NewGeometriesToProto`). The response never forms; the client renders nothing.
- Putting one in a kinematics model is the same hazard one step removed, reachable through any RPC that ships a `GeometriesInFrame` (`referenceframe/transformable.go`).

That's a sharp edge worth naming: a module can be built, unit-tested and shipped **entirely green** and still be broken the instant a client asks it for geometry. That is not hypothetical — a gripper module shipped exactly this, rendered nothing in the 3D scene, and every one of its geometry tests passed the whole time, because none of them crossed the wire.

Today the alternatives for round hardware are a capsule (always *under*-approximates a flat-ended cylinder — length is tip-to-tip with hemispherical caps, and it cannot be flatter than `length = 2*radius`) or a box (over-claims ~41% at the diagonals and renders square). Neither is the shape.

## The change

Wires both directions:

- `Cylinder.ToProtobuf()` → `commonpb.Geometry_Cylinder`
- `NewGeometryFromProto` → `NewCylinderWithCapped(...)`

**The `capped` flag is carried across.** Dropping that bit would silently turn every open tube into a solid. The proto spells it `uncapped` so the proto3 default is the *solid* cylinder — the common case, what `NewCylinder` builds, and what a cylinder means in URDF and SDF.

An earlier revision described that default as the *conservative* reading. It isn't, and the claim is now gone from both the proto and this code: cylinder collision goes through the tessellated mesh, which is a surface, so a point fully inside a "solid" cylinder registers no collision where the same point inside a box, sphere or capsule does (verified directly). Capping adds two zero-thickness cap discs rather than filling the interior.

## Testing

- `TestCylinderProtoRoundTrip` — both capped states survive a full round trip. It asserts via **triangle count** rather than reading the flag back, so the flag has to be describing real geometry (64 triangles capped vs 32 uncapped).
- `TestCylinderProtoRoundTripPreservesOrientation` — **added after adversarial review.** Mutation testing found exactly one mutation the suite could not kill: serializing the translation and dropping the orientation. Every cylinder in the tests used an identity orientation, so a `ToProtobuf` that lost orientation entirely passed all of them — on the one shape where orientation *is* the geometry, since it's the axis. The implementation was already correct; the tests just couldn't tell. This covers orientation vectors, Euler angles, and an end-for-end axis flip, and guards that `GeometriesAlmostEqual` is itself orientation-sensitive. Verified by re-running the mutation: it now fails this test and only this test.
- `TestCylinderInGeometriesToProto` — covers the list conversion the component servers actually call.
- `TestCylinderToProtobufPanics` is **replaced** with `TestCylinderToProtobuf` + `TestCylinderToProtobufCarriesUncapped` rather than deleted.

`spatialmath`, `referenceframe`, `motionplan`, `robot/framesystem`, `components/gripper`, `components/arm` all pass. `motionplan/ik` fails to build in my environment for want of the `nlopt` system library — predates this change and is unrelated.

## Mixed-version behavior — worth a release note

An **old** client decoding a Cylinder from a new server gets `unsupported Geometry type` out of `NewGeometryFromProto`. Most callers surface that loudly — motion obstacles, WorldState, vision objects, config conversion. One does not: `robot/impl/local_robot.go` logs a component's `Geometries()` error at **Debug** and builds the frame-system part with **no geometry**. So an old viam-server paired with a new module returning cylinders would silently plan against a component with zero collision geometry.

Inherent to adding any oneof variant rather than specific to this one, but it should be called out when this ships. Note the pre-change behavior on that path was a panic, so this is a different failure mode, not a new one introduced here.

## Not in scope

- **Client-side rendering.** Until app support lands, a cylinder will serialize and round-trip correctly but may not draw. Strictly better than panicking, but worth knowing before anyone switches a model over to cylinders expecting them to appear.
- **URDF.** `referenceframe/xml_conversions.go:284` rejects standalone `<cylinder>` with "not natively supported in spatialmath" — no longer true once this lands, and URDF's cylinder maps exactly onto the new message. `newCollision` also has no `CylinderType` case, so a model containing a cylinder can't be written to URDF. Both are follow-ups.
- `motionplan/armplanning/api.go` `resetMeshCaches` resets only top-level `*Mesh`, so the mesh inside a `*Cylinder` never has its collision caches cleared. Pre-existing, but more reachable now that cylinders can arrive from the wire.
