### PR TITLE
armplanning: explain goals whose frame no DoF can move

### DIFF
--- a/motionplan/armplanning/errors.go
+++ b/motionplan/armplanning/errors.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/referenceframe"
@@ -20,6 +21,34 @@ var (
 
 	errIKConstraint = "all IK solutions failed constraints. Failures: "
 )
+
+// newImmovableGoalError is returned when a goal is unsatisfiable by construction rather than
+// merely hard: no DoF lies between the frame being moved and the goal's reference frame, so
+// their relative pose is fixed by the frame system and no configuration can change it.
+func newImmovableGoalError(fs *referenceframe.FrameSystem, moveFrameName, goalFrameName string) error {
+	return fmt.Errorf(
+		"cannot move frame %q relative to %q: no DoF lies between them, so their relative pose is fixed by the frame "+
+			"system and no motion plan can change it. %q is rigidly attached to the world frame through: %s. Check that "+
+			"the goal names a frame that some joint actually moves, such as an arm or a frame mounted on one",
+		moveFrameName, goalFrameName, moveFrameName, chainToWorldDescription(fs, moveFrameName))
+}
+
+// chainToWorldDescription renders a frame's parentage as "frame -> parent -> ... -> world".
+func chainToWorldDescription(fs *referenceframe.FrameSystem, frameName string) string {
+	frame := fs.Frame(frameName)
+	if frame == nil {
+		return frameName
+	}
+	chain, err := fs.TracebackFrame(frame)
+	if err != nil {
+		return frameName
+	}
+	names := make([]string, 0, len(chain))
+	for _, f := range chain {
+		names = append(names, f.Name())
+	}
+	return strings.Join(names, " -> ")
+}
 
 // NewAlgAndConstraintMismatchErr is returned when an incompatible planning_alg is specified and there are contraints.
 func NewAlgAndConstraintMismatchErr(planAlg string) error {

--- a/motionplan/armplanning/errors.go
+++ b/motionplan/armplanning/errors.go
@@ -23,14 +23,14 @@ var (
 )
 
 // newImmovableGoalError is returned when a goal is unsatisfiable by construction rather than
-// merely hard: no DoF lies between the frame being moved and the goal's reference frame, so
-// their relative pose is fixed by the frame system and no configuration can change it.
+// merely hard: no DoF moves the frame being moved, and planning only reconfigures that frame
+// and its ancestors.
 func newImmovableGoalError(fs *referenceframe.FrameSystem, moveFrameName, goalFrameName string) error {
 	return fmt.Errorf(
-		"cannot move frame %q relative to %q: no DoF lies between them, so their relative pose is fixed by the frame "+
-			"system and no motion plan can change it. %q is rigidly attached to the world frame through: %s. Check that "+
-			"the goal names a frame that some joint actually moves, such as an arm or a frame mounted on one",
-		moveFrameName, goalFrameName, moveFrameName, chainToWorldDescription(fs, moveFrameName))
+		"cannot move frame %q relative to %q: no DoF moves %q, so planning cannot reposition it. %q is rigidly "+
+			"attached to the world frame through: %s. Check that the frame being moved is one which some DoF "+
+			"actually moves, such as an arm or a frame mounted on one",
+		moveFrameName, goalFrameName, moveFrameName, moveFrameName, chainToWorldDescription(fs, moveFrameName))
 }
 
 // chainToWorldDescription renders a frame's parentage as "frame -> parent -> ... -> world".

--- a/motionplan/armplanning/functional_test.go
+++ b/motionplan/armplanning/functional_test.go
@@ -469,6 +469,49 @@ func TestArmOOBSolve(t *testing.T) {
 	}
 }
 
+func TestImmovableGoalFrame(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	fs := makeTestFS(t)
+
+	// A fixture bolted to world: nothing in its parent chain has any degrees of freedom, so no
+	// configuration of the arms changes where it sits.
+	fixture, err := frame.NewStaticFrame("fixture", spatialmath.NewPoseFromPoint(r3.Vector{X: 300, Y: 300, Z: 0}))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fs.AddFrame(fixture, fs.World()), test.ShouldBeNil)
+
+	goal := spatialmath.NewPoseFromPoint(r3.Vector{X: 400, Y: 300, Z: 100})
+	_, _, err = PlanMotion(context.Background(), logger, &PlanRequest{
+		FrameSystem:    fs,
+		Goals:          []*PlanState{{poses: frame.FrameSystemPoses{"fixture": frame.NewPoseInFrame(frame.World, goal)}}},
+		StartState:     &PlanState{structuredConfiguration: frame.NewNeutralFrameSystemInputs(fs)},
+		PlannerOptions: NewBasicPlannerOptions(),
+	})
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, `cannot move frame "fixture" relative to "world"`)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "no DoF lies between them")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "fixture -> world")
+
+	// A static frame is only immovable if its whole chain is: one hanging off an arm is fine, and
+	// so is an immovable frame whose goal is stated relative to a frame the arm carries.
+	tool, err := frame.NewStaticFrame("tool", spatialmath.NewPoseFromPoint(r3.Vector{Z: 50}))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fs.AddFrame(tool, fs.Frame("xArmVgripper")), test.ShouldBeNil)
+
+	for _, tc := range []struct {
+		moveFrame, goalParent string
+	}{
+		{"tool", frame.World},
+		{"xArm6", frame.World},
+		{"fixture", "tool"},
+	} {
+		chains, err := motionChainsFromPlanState(fs, frame.FrameSystemPoses{
+			tc.moveFrame: frame.NewPoseInFrame(tc.goalParent, goal),
+		})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, chains.immovableGoalError(), test.ShouldBeNil)
+	}
+}
+
 func TestArmObstacleSolve(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 

--- a/motionplan/armplanning/functional_test.go
+++ b/motionplan/armplanning/functional_test.go
@@ -2,6 +2,7 @@ package armplanning
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sort"
 	"testing"
@@ -488,27 +489,37 @@ func TestImmovableGoalFrame(t *testing.T) {
 	})
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, `cannot move frame "fixture" relative to "world"`)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "no DoF lies between them")
+	test.That(t, err.Error(), test.ShouldContainSubstring, `no DoF moves "fixture"`)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "fixture -> world")
 
-	// A static frame is only immovable if its whole chain is: one hanging off an arm is fine, and
-	// so is an immovable frame whose goal is stated relative to a frame the arm carries.
+	// A static frame is only immovable if its whole chain is: one hanging off an arm is fine. The
+	// mobility that counts is the moved frame's own - a goal stated relative to a frame the arm
+	// carries does not make a world-bolted frame reachable.
 	tool, err := frame.NewStaticFrame("tool", spatialmath.NewPoseFromPoint(r3.Vector{Z: 50}))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, fs.AddFrame(tool, fs.Frame("xArmVgripper")), test.ShouldBeNil)
 
 	for _, tc := range []struct {
 		moveFrame, goalParent string
+		immovable             bool
 	}{
-		{"tool", frame.World},
-		{"xArm6", frame.World},
-		{"fixture", "tool"},
+		{"tool", frame.World, false},
+		{"xArm6", frame.World, false},
+		{"fixture", "tool", true},
 	} {
 		chains, err := motionChainsFromPlanState(fs, frame.FrameSystemPoses{
 			tc.moveFrame: frame.NewPoseInFrame(tc.goalParent, goal),
 		})
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, chains.immovableGoalError(), test.ShouldBeNil)
+
+		immovableErr := chains.immovableGoalError()
+		if !tc.immovable {
+			test.That(t, immovableErr, test.ShouldBeNil)
+			continue
+		}
+		test.That(t, immovableErr, test.ShouldNotBeNil)
+		test.That(t, immovableErr.Error(), test.ShouldContainSubstring,
+			fmt.Sprintf("cannot move frame %q relative to %q", tc.moveFrame, tc.goalParent))
 	}
 }
 

--- a/motionplan/armplanning/motion_chains.go
+++ b/motionplan/armplanning/motion_chains.go
@@ -78,6 +78,22 @@ func (mC *motionChains) geometries(
 	return movingRobotGeometries, staticRobotGeometries, movingFrameNames
 }
 
+// immovableGoalError returns a descriptive error if any goal is unsatisfiable no matter the
+// configuration, because neither the frame being moved nor the goal's reference frame is moved by
+// a joint.
+func (mC *motionChains) immovableGoalError() error {
+	for _, chain := range mC.inner {
+		solveFrame, goalFrame := mC.fs.Frame(chain.solveFrameName), mC.fs.Frame(chain.goalFrameName)
+		if solveFrame == nil || goalFrame == nil {
+			continue
+		}
+		if !frameCanMove(mC.fs, solveFrame) && !frameCanMove(mC.fs, goalFrame) {
+			return newImmovableGoalError(mC.fs, chain.solveFrameName, chain.goalFrameName)
+		}
+	}
+	return nil
+}
+
 func (mC *motionChains) framesFilteredByMovingAndNonmoving() (moving, nonmoving []string) {
 	movingMap := map[string]referenceframe.Frame{}
 	for _, chain := range mC.inner {

--- a/motionplan/armplanning/motion_chains.go
+++ b/motionplan/armplanning/motion_chains.go
@@ -79,15 +79,17 @@ func (mC *motionChains) geometries(
 }
 
 // immovableGoalError returns a descriptive error if any goal is unsatisfiable no matter the
-// configuration, because neither the frame being moved nor the goal's reference frame is moved by
-// a joint.
+// configuration, because no DoF moves the frame being solved for.
 func (mC *motionChains) immovableGoalError() error {
 	for _, chain := range mC.inner {
-		solveFrame, goalFrame := mC.fs.Frame(chain.solveFrameName), mC.fs.Frame(chain.goalFrameName)
-		if solveFrame == nil || goalFrame == nil {
+		solveFrame := mC.fs.Frame(chain.solveFrameName)
+		if solveFrame == nil {
 			continue
 		}
-		if !frameCanMove(mC.fs, solveFrame) && !frameCanMove(mC.fs, goalFrame) {
+		// NOTE: The goal frame's own mobility is deliberately not considered. Only the solve frame and
+		// its ancestors are granted explicit permission to change configuration, so a solve frame with no
+		// DoF above it stays put however the goal's reference frame is moved.
+		if !frameCanMove(mC.fs, solveFrame) {
 			return newImmovableGoalError(mC.fs, chain.solveFrameName, chain.goalFrameName)
 		}
 	}

--- a/motionplan/armplanning/node.go
+++ b/motionplan/armplanning/node.go
@@ -706,6 +706,12 @@ solutionLoop:
 	solvingState.flushFailuresToMeta()
 
 	if len(solvingState.solutions) == 0 {
+		// A goal whose frame no joint can move is unsatisfiable by construction, not merely
+		// hard.
+		if err := psc.motionChains.immovableGoalError(); err != nil {
+			return nil, err
+		}
+
 		if solvingState.fatal != nil {
 			return nil, solvingState.fatal
 		}

--- a/motionplan/armplanning/node.go
+++ b/motionplan/armplanning/node.go
@@ -706,8 +706,7 @@ solutionLoop:
 	solvingState.flushFailuresToMeta()
 
 	if len(solvingState.solutions) == 0 {
-		// A goal whose frame no joint can move is unsatisfiable by construction, not merely
-		// hard.
+		// A goal whose frame no DoF moves is unsatisfiable by construction, not merely hard.
 		if err := psc.motionChains.immovableGoalError(); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

A goal naming a frame that no DoF moves now says so, instead of failing as unreachable. The old error, `zero IK solutions produced, goal positions appears to be physically unreachable`, sent you hunting a reach or collision problem. Planning only reconfigures the frame being moved and its ancestors, so no configuration can reposition a world-bolted frame.

Found in a `planning_failure` plan request that asked to move `filter`, a fixture parented straight to `world`. It now fails with:

> cannot move frame "filter" relative to "world": no DoF moves "filter", so planning cannot reposition it. "filter" is rigidly attached to the world frame through: filter -> world. Check that the frame being moved is one which some DoF actually moves, such as an arm or a frame mounted on one

## Changes

- **motion_chains.go**: `immovableGoalError` keys on the frame being moved alone — a goal reference frame that some DoF *does* move never rescues it, because planning does not reconfigure that chain to meet a fixed frame
- **node.go**: the check runs only where IK already returned zero solutions, so nothing that used to plan now errors — that's why it isn't an up-front `validatePlanRequest` rejection
- **errors.go**: the message names the frame, its reference frame, and its parentage up to world, so the fix is visible without reading the frame system

## Testing

- `TestImmovableGoalFrame` covers the message end-to-end through `PlanMotion`, plus a chain table: a static frame on an arm and an arm itself must still plan, while a world-bolted frame whose goal sits on an arm-carried frame must now be rejected.
- That last case never planned before this either — under the previous condition it failed with the generic zero-solutions error. `go test ./motionplan/...` and `golangci-lint run motionplan/armplanning/` are clean.

<details>
<summary>Claude Code prompts used</summary>

- "Hi Claude, we are sometimes getting this error while doing motion planning with armplanning: ``` failed: motion planning failed: zero IK solutions produced, goal positions appears to be physically unreachable ``` We have seen this error when the component we are trying to move has no degrees of freedom in its parent chain up to the world frame. I think the message should be clearer that this is what is happening. You can find an example plan request by pulling from Viam cloud the plan requests for Viam machine c585ab45-d002-4c2a-a255-5f049f0af0ee and tag 382a38d3-cbe2-4fe6-951c-e5302b27fcb2 (order ID) and the tag "planning_failure". Can you look into it and see if we can return a better error message?"
- "let's commit, push, and open a PR"
- "Hi Claude, I have made a change to `motionplan/armplanning/motion_chains.go` to change the intended effect. Is there is anothing else I should change to make it match the new behavior?"
- "apply 1-3"
- "I have made some more manual adjustments. Can yoou check the linter and the tests and make sure everything is consistent"
- "commit everything and push"
- "update the PR description"

</details>
