### PR TITLE
spatialmath: stop leaking mesh cache state through transient meshes

### DIFF
--- a/spatialmath/cylinder.go
+++ b/spatialmath/cylinder.go
@@ -115,6 +115,9 @@ func (c *Cylinder) almostEqual(g Geometry) bool {
 // Transform premultiplies the Cylinder's pose with the given pose and returns
 // a new Cylinder. The mesh's local-frame triangles depend only on radius and
 // height, so they are reused as-is; only the wrapping Mesh's pose changes.
+// Mesh.Transform (rather than NewMesh) keeps the mesh's shared cache state:
+// a fresh state per configuration both defeats the temporal-coherence caches
+// and leaks permanent entries into other meshes' state-keyed cache maps.
 func (c *Cylinder) Transform(toPremultiply Pose) Geometry {
 	newPose := Compose(toPremultiply, c.pose)
 	return &Cylinder{
@@ -123,7 +126,7 @@ func (c *Cylinder) Transform(toPremultiply Pose) Geometry {
 		height: c.height,
 		capped: c.capped,
 		label:  c.label,
-		mesh:   NewMesh(newPose, c.mesh.Triangles(), c.label),
+		mesh:   c.mesh.Transform(toPremultiply).(*Mesh),
 	}
 }
 

--- a/spatialmath/mesh.go
+++ b/spatialmath/mesh.go
@@ -608,15 +608,23 @@ func (m *Mesh) CollidesWith(g Geometry, collisionBufferMM float64) (bool, float6
 		}
 		return m.collidesWithGeometryAnchored(g, collisionBufferMM)
 	case *Triangle:
-		// Wrap in a Mesh so we get the negative-cache short-circuit in
-		// collidesWithMesh — RRT smoothing re-checks the same triangle at the
-		// same pose, and the geometry-BVH path has no negCache. The wrap is
-		// cheap now that NewMesh defers PLY serialization (ensurePLYBytes).
-		triMesh := NewMesh(NewZeroPose(), []*Triangle{other}, "")
-		return m.collidesWithMesh(triMesh, collisionBufferMM)
+		// Wrap in a (stateless) Mesh to reuse the mesh-vs-mesh BVH path; see
+		// wrapTriangle for why the wrapper deliberately carries no cache state.
+		return m.collidesWithMesh(wrapTriangle(other), collisionBufferMM)
 	default:
 		return true, math.Inf(1), newCollisionTypeUnsupportedError(m, g)
 	}
+}
+
+// wrapTriangle wraps a standalone *Triangle for the mesh-vs-mesh path.
+// Deliberately STATELESS (nil meshState): standalone triangles are usually
+// per-configuration transients, so a fresh meshState per wrapper both churned
+// allocation and - worse - permanently leaked entries into the other mesh's
+// state-identity-keyed caches (witnesses, distance anchors, negCache), whose
+// sync.Maps only ever grow. A nil state disables those caches for the
+// wrapper, which every consumer already guards for.
+func wrapTriangle(t *Triangle) *Mesh {
+	return &Mesh{pose: NewZeroPose(), triangles: []*Triangle{t}}
 }
 
 // EncompassedBy returns whether this mesh is completely contained within another geometry.
@@ -669,8 +677,7 @@ func (m *Mesh) DistanceFrom(g Geometry) (float64, error) {
 	case *sphere:
 		return m.distanceFromSphere(other), nil
 	case *Triangle:
-		triMesh := NewMesh(NewZeroPose(), []*Triangle{other}, "")
-		return m.distanceFromMesh(triMesh)
+		return m.distanceFromMesh(wrapTriangle(other))
 	case *Mesh:
 		return m.distanceFromMesh(other)
 	case *Cylinder:


### PR DESCRIPTION
Part of a dual-arm-scale performance series (with #6393, #6394, #6395); this one is standalone and is primarily a **leak fix**.

Mesh's temporal-coherence caches (witnesses, distance anchors, negCache) key on the *other* mesh's cache-state identity, and those sync.Maps only grow. Two code paths handed them a brand-new state per query:

- **mesh-vs-`*Triangle`** wrapped the triangle in a fresh stateful mesh per call — every wrapper defeated the caches it existed to reach *and* left a permanent dead entry behind. On a captured dual-arm scene this reached a **6.5GB live heap with GC at 55% of CPU**. Wrappers are now stateless (nil state disables the identity-keyed caches; every consumer already nil-guards).
- **`Cylinder.Transform`** rebuilt its tessellation mesh with `NewMesh` per transform — i.e., per configuration during planning — same leak, plus cache-defeat for cylinder collision. It now goes through `Mesh.Transform`, which shares state like every other per-configuration clone (the new `capped` field is carried through).

After this plus #6394/#6395, that scene's GC share fell to ~15%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyqhmqkxS9B8bGjdUhTtAs
