### PR TITLE
armplanning: persistent learning roadmap, budget-true racing, wall diagnosis

### DIFF
--- a/motionplan/armplanning/cmd-plan/cmd-plan.go
+++ b/motionplan/armplanning/cmd-plan/cmd-plan.go
@@ -109,6 +109,16 @@ func realMain() error {
 
 	// The default logger keeps `mp` at the default INFO level. But all loggers underneath only emit
 	// WARN+ logs. Let's start with DEBUG everywhere and:
+	// Persist learned roadmaps across runs: harvested corridors and scene
+	// verdicts are what make replans of a hard scene sub-second, and replaying
+	// captures cold defeats them otherwise. Respect an explicit setting;
+	// export MOTION_ROADMAP_CACHE_DIR="" to disable.
+	if _, ok := os.LookupEnv("MOTION_ROADMAP_CACHE_DIR"); !ok {
+		if cacheDir, err := os.UserCacheDir(); err == nil {
+			utils.UncheckedError(os.Setenv("MOTION_ROADMAP_CACHE_DIR", filepath.Join(cacheDir, "viam-motion-roadmap")))
+		}
+	}
+
 	logger.SetLevel(logging.DEBUG)
 	if *verbose {
 		// For verbose keep everything at DEBUG and only claw back `ik` logs to INFO.

--- a/motionplan/armplanning/nudge.go
+++ b/motionplan/armplanning/nudge.go
@@ -40,6 +40,25 @@ const (
 // repairable with a barely different configuration.
 var nudgeRadiusSchedule = []float64{0.1, 0.2, 0.4, 0.7}
 
+// nudgeRadiusScheduleFor picks the perturbation schedule for this segment.
+// Under a linear constraint the entire repair must stay inside a tube of the
+// constraint's tolerance; on an arm-scale lever the default 0.1-0.7 rad
+// radii move the end effector tens to hundreds of millimeters, so every
+// candidate died on the topological constraint before collision was even
+// consulted - nudge could never repair a constrained segment. Scale the
+// radii so candidate deviation is on the order of the tube radius.
+func nudgeRadiusScheduleFor(psc *PlanSegmentContext) []float64 {
+	lc := tightestLinearConstraintMM(psc.pc.request.Constraints)
+	if lc <= 0 {
+		return nudgeRadiusSchedule
+	}
+	// Conservative effective lever: EE deviation (mm) per radian of joint
+	// motion on an arm-scale chain.
+	const leverMM = 700.0
+	base := lc / leverMM
+	return []float64{base / 4, base / 2, base, base * 2}
+}
+
 // jointDelta is a per-moving-frame joint-space offset.
 type jointDelta map[string][]float64
 
@@ -184,7 +203,7 @@ func nudgeRepair(
 		clearance float64
 	}
 
-	for _, radius := range nudgeRadiusSchedule {
+	for _, radius := range nudgeRadiusScheduleFor(psc) {
 		// Screen candidates with cheap state checks first.
 		candidates := []candidate{}
 		for i := 0; i < nudgeCandidatesPerRadius; i++ {

--- a/motionplan/armplanning/plan_manager.go
+++ b/motionplan/armplanning/plan_manager.go
@@ -241,17 +241,53 @@ func (pm *planManager) planSingleGoal(
 		}
 	}
 	if path := pm.tryRoadmap(ctx, psc, goalRoots, pm.logger.Sublogger("roadmap")); path != nil {
+		rm := getRoadmap(psc, pm.logger)
+		sceneKey := uint64(0)
+		if rm != nil {
+			sceneKey = pm.roadmapSceneKey(psc, rm)
+			// Replayed corridor in an unchanged scene: the smoothed and
+			// close-obstacle-expanded trajectory is deterministic and was
+			// validated when first computed - skip recomputing it.
+			if cached := rm.cachedSmoothed(psc, sceneKey, path); cached != nil {
+				pm.logger.Debugf("solved via roadmap (cached smooth): %d waypoints", len(cached))
+				pm.pc.planMeta.GoalsRoadmapSolved++
+				return cached, nil
+			}
+		}
 		smoothed, compact, err := smoothPath(ctx, psc, path)
 		if err == nil {
 			pm.logger.Debugf("solved via roadmap: %d -> %d waypoints", len(path), len(smoothed))
 			pm.pc.planMeta.GoalsRoadmapSolved++
+			if rm != nil {
+				rm.storeSmoothed(sceneKey, path, smoothed)
+			}
 			pm.harvestPlan(psc, compact, pm.logger)
 			return smoothed, nil
 		}
 		pm.logger.Debugf("roadmap path failed to smooth, falling back: %v", err)
 	}
 
-	rawSteps, err := pm.raceCBiRRT(ctx, psc, planSeed.maps)
+	// Reconfiguration-vs-constraint detection: when every reachable goal
+	// configuration is a large joint-space move while the end effector barely
+	// moves AND a linear constraint pins the path to a narrow tube, the
+	// reconfiguration swing almost certainly cannot stay inside the tube.
+	// Search still gets one full racing round (the heuristic is not a proof),
+	// but relaunching draws against a wall like that only burns the budget -
+	// and the warning tells the caller what to actually fix.
+	allowRelaunch := true
+	if lc := tightestLinearConstraintMM(pm.request.Constraints); lc > 0 && planSeed.maps.optNode != nil {
+		eeDelta := maxGoalTranslationMM(psc)
+		if eeDelta >= 0 && eeDelta < 50 && lc <= 50 && planSeed.maps.optNode.cost > 1.5 {
+			pm.logger.Warnf("goal is %0.1fmm of end-effector motion but the nearest valid goal configuration is "+
+				"%0.2f rad of joint motion; a linear constraint of %0.0fmm likely cannot accommodate that "+
+				"reconfiguration. Planning one search round only. Consider relaxing the constraint for this step "+
+				"or approaching in a different joint configuration.",
+				eeDelta, planSeed.maps.optNode.cost, lc)
+			allowRelaunch = false
+		}
+	}
+
+	rawSteps, err := pm.raceCBiRRT(ctx, psc, planSeed.maps, allowRelaunch)
 	if err != nil {
 		return nil, err
 	}
@@ -461,6 +497,7 @@ func (pm *planManager) raceCBiRRT(
 	ctx context.Context,
 	psc *PlanSegmentContext,
 	maps *rrtMaps,
+	allowRelaunch bool,
 ) ([]*referenceframe.LinearInputs, error) {
 	attempts := max(1, cbirrtRaceAttempts)
 
@@ -485,7 +522,7 @@ func (pm *planManager) raceCBiRRT(
 	// converting a solvable plan into a timeout. The corridor-aiming already
 	// biases racers toward corridor-bearing roots without excluding the rest.
 
-	for a := 0; a < attempts; a++ {
+	launch := func(a int) {
 		go func(a int) {
 			logger := pm.logger.Sublogger(fmt.Sprintf("cbirrt%d", a))
 			planner, err := newCBiRRTMotionPlanner(raceCtx, pm.pc, psc, logger)
@@ -493,10 +530,11 @@ func (pm *planManager) raceCBiRRT(
 				results <- raceResult{nil, err, a}
 				return
 			}
-			// Continuous searches (restart-chopping was tried and hurt: the
-			// trees are the asset, and successful searches historically need
-			// several hundred iterations). Diversity comes from the racers'
-			// distinct RNG streams.
+			// Each attempt is a continuous full-budget search (restart-CHOPPING
+			// - truncating attempts below the full iteration budget - was tried
+			// and hurt: the trees are the asset, and successful searches
+			// historically need several hundred iterations). Diversity comes
+			// from the attempts' distinct RNG streams.
 			//nolint:gosec
 			planner.rnd = rand.New(rand.NewSource(int64(pm.pc.planOpts.RandomSeed) + int64(a)*7919))
 			sol, err := planner.rrtRunner(raceCtx, cloneRRTMaps(maps))
@@ -507,13 +545,34 @@ func (pm *planManager) raceCBiRRT(
 			results <- raceResult{sol.steps, nil, a}
 		}(a)
 	}
+	for a := 0; a < attempts; a++ {
+		launch(a)
+	}
 
+	// Search time is heavy-tailed: a full-budget attempt that exhausts its
+	// iterations was simply a bad draw, and with request budget remaining the
+	// slot is worth relaunching with a fresh stream and fresh tree clones.
+	// Fresh trees also keep the linear nearest-neighbor scan fast - letting
+	// one tree grow without bound makes each extend progressively slower.
+	// Before this, racers could exhaust 5000 iterations in 20s of a 300s
+	// request and fail the plan with 280s unused. maxTotalAttempts is a
+	// backstop against tight failure loops, not a budget.
+	const maxTotalAttempts = 64
+	totalLaunched := attempts
 	var firstErr error
-	for i := 0; i < attempts; i++ {
+	for inFlight := attempts; inFlight > 0; {
 		r := <-results
 		if r.err == nil {
 			pm.logger.Debugf("cbirrt race: attempt %d finished first (%d raw nodes)", r.attempt, len(r.steps))
 			return r.steps, nil
+		}
+		inFlight--
+		if allowRelaunch && raceCtx.Err() == nil && totalLaunched < maxTotalAttempts {
+			pm.logger.Debugf("cbirrt race: attempt %d exhausted (%v); relaunching as attempt %d", r.attempt, r.err, totalLaunched)
+			launch(totalLaunched)
+			totalLaunched++
+			inFlight++
+			continue
 		}
 		// Context cancellation of the losers is expected once someone wins;
 		// remember only the first real failure.
@@ -522,4 +581,36 @@ func (pm *planManager) raceCBiRRT(
 		}
 	}
 	return nil, firstErr
+}
+
+// tightestLinearConstraintMM returns the smallest line tolerance among the
+// request's linear constraints, or 0 when none are set.
+func tightestLinearConstraintMM(c *motionplan.Constraints) float64 {
+	if c == nil {
+		return 0
+	}
+	out := 0.0
+	for _, lc := range c.LinearConstraint {
+		if lc.LineToleranceMm > 0 && (out == 0 || lc.LineToleranceMm < out) {
+			out = lc.LineToleranceMm
+		}
+	}
+	return out
+}
+
+// maxGoalTranslationMM returns the largest straight-line translation any goal
+// frame must cover for this segment, or -1 when it cannot be computed.
+func maxGoalTranslationMM(psc *PlanSegmentContext) float64 {
+	out := -1.0
+	for f, gp := range psc.goal {
+		sp, ok := psc.startPoses[f]
+		if !ok {
+			return -1
+		}
+		d := gp.Pose().Point().Sub(sp.Pose().Point()).Norm()
+		if d > out {
+			out = d
+		}
+	}
+	return out
 }

--- a/motionplan/armplanning/plan_manager.go
+++ b/motionplan/armplanning/plan_manager.go
@@ -3,6 +3,7 @@ package armplanning
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"time"
 
@@ -277,12 +278,18 @@ func (pm *planManager) planSingleGoal(
 	allowRelaunch := true
 	if lc := tightestLinearConstraintMM(pm.request.Constraints); lc > 0 && planSeed.maps.optNode != nil {
 		eeDelta := maxGoalTranslationMM(psc)
-		if eeDelta >= 0 && eeDelta < 50 && lc <= 50 && planSeed.maps.optNode.cost > 1.5 {
+		// True joint-space L2 in radians, computed directly: optNode.cost is
+		// the configured distance metric plus a neutral-pose bias, so it is
+		// not a joint angle and cannot back the threshold or the message.
+		reconfigL2 := math.Sqrt(flatL2Sq(
+			psc.start.GetLinearizedInputs(), planSeed.maps.optNode.inputs.GetLinearizedInputs()))
+		const reconfigWallRad = 1.5
+		if eeDelta >= 0 && eeDelta < 50 && lc <= 50 && reconfigL2 > reconfigWallRad {
 			pm.logger.Warnf("goal is %0.1fmm of end-effector motion but the nearest valid goal configuration is "+
-				"%0.2f rad of joint motion; a linear constraint of %0.0fmm likely cannot accommodate that "+
+				"%0.2f rad (joint-space L2) away; a linear constraint of %0.0fmm likely cannot accommodate that "+
 				"reconfiguration. Planning one search round only. Consider relaxing the constraint for this step "+
 				"or approaching in a different joint configuration.",
-				eeDelta, planSeed.maps.optNode.cost, lc)
+				eeDelta, reconfigL2, lc)
 			allowRelaunch = false
 		}
 	}
@@ -473,6 +480,12 @@ func initRRTSolutions(ctx context.Context, psc *PlanSegmentContext, logger loggi
 // and tree maps.
 var cbirrtRaceAttempts = utils.GetenvInt("CBIRRT_RACE_ATTEMPTS", 4)
 
+// maxTotalAttempts caps how many search attempts (initial racers plus
+// relaunches) one raceCBiRRT call may spawn over its lifetime - a backstop
+// against tight failure loops, not a budget. Also sizes the results channel
+// so senders can never block.
+const maxTotalAttempts = 64
+
 // cloneRRTMaps gives one racing attempt its own tree maps. Nodes are shared
 // (they are never mutated after insertion); only the map structure - tree
 // membership and parentage - must be private per attempt.
@@ -509,7 +522,13 @@ func (pm *planManager) raceCBiRRT(
 		err     error
 		attempt int
 	}
-	results := make(chan raceResult, attempts)
+	// Buffered to the lifetime attempt cap so no sender can ever block: once
+	// a winner returns, the remaining in-flight attempts each deposit their
+	// result and exit regardless of readers. (In-flight concurrency is still
+	// bounded by `attempts` - relaunches only follow a consumed result - but
+	// sizing the buffer to the cap makes the no-blocked-sender property
+	// unconditional rather than an invariant of the reader loop.)
+	results := make(chan raceResult, maxTotalAttempts)
 
 	// Seed the goal retreat corridors once on the master maps; every attempt's
 	// clone inherits them, so restarts don't repeat the corridor IK.
@@ -557,7 +576,6 @@ func (pm *planManager) raceCBiRRT(
 	// Before this, racers could exhaust 5000 iterations in 20s of a 300s
 	// request and fail the plan with 280s unused. maxTotalAttempts is a
 	// backstop against tight failure loops, not a budget.
-	const maxTotalAttempts = 64
 	totalLaunched := attempts
 	var firstErr error
 	for inFlight := attempts; inFlight > 0; {

--- a/motionplan/armplanning/roadmap.go
+++ b/motionplan/armplanning/roadmap.go
@@ -3,16 +3,25 @@ package armplanning
 import (
 	"container/heap"
 	"context"
+	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"math"
 	"math/rand"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
+
+	"github.com/golang/geo/r3"
 
 	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/spatialmath"
 )
 
 // This file implements a lazy probabilistic roadmap: a reusable graph over the
@@ -76,11 +85,48 @@ type roadmap struct {
 	// readers (peekRoadmap) must check it before touching any other field.
 	built atomic.Bool
 
+	// key is the registry key; used to derive the disk-cache filename.
+	key string
+	// lastSaveNs throttles disk saves (unix nanos of the last save).
+	lastSaveNs atomic.Int64
+
 	// sceneVerdicts caches per-scene edge validity: key -> bool.
 	sceneVerdicts sync.Map // roadmapVerdictKey -> bool
 
+	// Dynamic-roadmap (DRM-style) state, all scene-independent and persisted:
+	// edgeVox holds each structural edge's swept workspace volume as sorted
+	// coarse voxel keys (computed lazily on first touch); cleanValid records
+	// edges that were fully validated in a scene whose occupancy did not
+	// intersect their swept volume - such a verdict transfers to any other
+	// scene that also misses the volume (same constraint fingerprint), which
+	// is what keeps a learned roadmap warm when obstacles move a little
+	// (per Leven & Hutchinson's dynamic roadmaps).
+	edgeVoxMu  sync.RWMutex
+	edgeVox    map[uint64][]uint64
+	cleanValid sync.Map // drmVerdictKey -> bool(true)
+	// sceneOcc caches per-scene occupancy voxel sets (in-memory only).
+	// sceneOccCount bounds it: a robot whose obstacles move sees a new scene
+	// fingerprint every plan, and an unbounded per-scene cache is a leak.
+	sceneOcc      sync.Map // uint64 -> map[uint64]struct{}
+	sceneOccCount atomic.Int64
+
+	// smoothedCache memoizes the final smoothed-and-expanded trajectory for a
+	// (scene, raw roadmap path) pair. Smoothing plus close-obstacle expansion
+	// is the dominant cost of a warm roadmap solve (~0.5s of a 0.75s plan on
+	// a captured dual-arm scene) and is deterministic given the same scene
+	// and the same raw waypoints, which is exactly what a replayed corridor
+	// produces. Persisted with the roadmap.
+	smoothedCache sync.Map // uint64 -> [][]float64 (linearized configs)
+	// smoothedCount bounds smoothedCache growth.
+	smoothedCount atomic.Int64
+
 	buildOnce sync.Once
 	buildErr  error
+}
+
+type drmVerdictKey struct {
+	constraints uint64
+	a, b        int32
 }
 
 type roadmapVerdictKey struct {
@@ -112,9 +158,13 @@ func getRoadmap(psc *PlanSegmentContext, logger logging.Logger) *roadmap {
 	}
 	sort.Strings(frames)
 	key := roadmapKeyFor(psc, frames)
-	v, _ := roadmapRegistry.LoadOrStore(key, &roadmap{frames: frames})
+	v, _ := roadmapRegistry.LoadOrStore(key, &roadmap{frames: frames, key: key})
 	rm := v.(*roadmap)
 	rm.buildOnce.Do(func() {
+		if rm.loadFromDisk(logger) {
+			rm.built.Store(true)
+			return
+		}
 		rm.buildErr = rm.build(psc, logger)
 	})
 	if rm.buildErr != nil {
@@ -362,6 +412,163 @@ func flatL2Sq(a, b []float64) float64 {
 	return t
 }
 
+// DRM voxel grid: fixed world-aligned grid so voxel keys are stable across
+// processes and scenes.
+const drmVoxelMM = 50.0
+
+// drmEdgeSampleL2 is the joint-space interval between swept-volume samples.
+// Finer sampling costs build time; the end-to-end validation in smoothPath
+// backstops the (rare) case where motion between samples clips a voxel the
+// sweep missed.
+const drmEdgeSampleL2 = 0.1
+
+func drmVoxelKey(x, y, z int32) uint64 {
+	return uint64(uint16(x))<<32 | uint64(uint16(y))<<16 | uint64(uint16(z))
+}
+
+// drmRasterizeSphere marks all voxels overlapping the sphere's AABB.
+func drmRasterizeSphere(c r3.Vector, r float64, out map[uint64]struct{}) {
+	x0, x1 := int32(math.Floor((c.X-r)/drmVoxelMM)), int32(math.Floor((c.X+r)/drmVoxelMM))
+	y0, y1 := int32(math.Floor((c.Y-r)/drmVoxelMM)), int32(math.Floor((c.Y+r)/drmVoxelMM))
+	z0, z1 := int32(math.Floor((c.Z-r)/drmVoxelMM)), int32(math.Floor((c.Z+r)/drmVoxelMM))
+	for x := x0; x <= x1; x++ {
+		for y := y0; y <= y1; y++ {
+			for z := z0; z <= z1; z++ {
+				out[drmVoxelKey(x, y, z)] = struct{}{}
+			}
+		}
+	}
+}
+
+func drmEdgeKey(a, b int) uint64 {
+	if a > b {
+		a, b = b, a
+	}
+	return uint64(a)<<32 | uint64(b)
+}
+
+// edgeSweptVoxels returns (computing and persisting on first touch) the
+// sorted voxel keys covering the chain's swept volume along edge a-b.
+func (rm *roadmap) edgeSweptVoxels(psc *PlanSegmentContext, a, b int) []uint64 {
+	ek := drmEdgeKey(a, b)
+	rm.edgeVoxMu.RLock()
+	v, ok := rm.edgeVox[ek]
+	rm.edgeVoxMu.RUnlock()
+	if ok {
+		return v
+	}
+	cfgA := rm.compose(psc.start, rm.flat[a])
+	cfgB := rm.compose(psc.start, rm.flat[b])
+	steps := int(math.Ceil(flatL2(rm.flat[a], rm.flat[b])/drmEdgeSampleL2)) + 1
+	if steps < 2 {
+		steps = 2
+	}
+	chain := map[string]bool{}
+	for _, f := range rm.frames {
+		chain[f] = true
+	}
+	set := map[uint64]struct{}{}
+	for i := 0; i <= steps; i++ {
+		cfg, err := referenceframe.InterpolateFS(psc.pc.fs, cfgA, cfgB, float64(i)/float64(steps))
+		if err != nil {
+			return nil
+		}
+		geoms, err := referenceframe.FrameSystemGeometriesForFrames(psc.pc.fs, cfg, chain)
+		if err != nil {
+			return nil
+		}
+		for _, gif := range geoms {
+			for _, g := range gif.Geometries() {
+				for _, sb := range spatialmath.SphereCover(g) {
+					drmRasterizeSphere(sb.Center, sb.R+drmVoxelMM/2, set)
+				}
+			}
+		}
+	}
+	out := make([]uint64, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	rm.edgeVoxMu.Lock()
+	if rm.edgeVox == nil {
+		rm.edgeVox = map[uint64][]uint64{}
+	}
+	rm.edgeVox[ek] = out
+	rm.edgeVoxMu.Unlock()
+	return out
+}
+
+func flatL2(a, b []float64) float64 { return math.Sqrt(flatL2Sq(a, b)) }
+
+// sceneOccupancy returns (cached per scene) the occupancy voxel set of
+// everything the chain can collide with: world obstacles plus the rest of the
+// robot at the query's start configuration, inflated by the collision buffer.
+func (rm *roadmap) sceneOccupancy(pm *planManager, psc *PlanSegmentContext, sceneKey uint64) map[uint64]struct{} {
+	if v, ok := rm.sceneOcc.Load(sceneKey); ok {
+		return v.(map[uint64]struct{})
+	}
+	occ := map[uint64]struct{}{}
+	inflate := drmVoxelMM/2 + pm.request.PlannerOptions.CollisionBufferMM
+	if pm.request.ObstaclesInWorldFrame != nil {
+		for _, g := range pm.request.ObstaclesInWorldFrame.Geometries() {
+			for _, sb := range spatialmath.SphereCover(g) {
+				drmRasterizeSphere(sb.Center, sb.R+inflate, occ)
+			}
+		}
+	}
+	chain := map[string]bool{}
+	for _, f := range rm.frames {
+		chain[f] = true
+	}
+	nonChain := map[string]bool{}
+	for _, name := range psc.pc.fs.FrameNames() {
+		if !chain[name] {
+			nonChain[name] = true
+		}
+	}
+	if geoms, err := referenceframe.FrameSystemGeometriesForFrames(psc.pc.fs, psc.start, nonChain); err == nil {
+		for _, gif := range geoms {
+			for _, g := range gif.Geometries() {
+				for _, sb := range spatialmath.SphereCover(g) {
+					drmRasterizeSphere(sb.Center, sb.R+inflate, occ)
+				}
+			}
+		}
+	}
+	const sceneOccCap = 32
+	if rm.sceneOccCount.Load() >= sceneOccCap {
+		// Cache full: serve the computed set without retaining it.
+		return occ
+	}
+	actual, loaded := rm.sceneOcc.LoadOrStore(sceneKey, occ)
+	if !loaded {
+		rm.sceneOccCount.Add(1)
+	}
+	return actual.(map[uint64]struct{})
+}
+
+func drmOverlaps(occ map[uint64]struct{}, voxels []uint64) bool {
+	for _, v := range voxels {
+		if _, hit := occ[v]; hit {
+			return true
+		}
+	}
+	return false
+}
+
+// constraintsFingerprint hashes the request's constraints; DRM verdict
+// transfer is only valid between scenes planned under identical constraints.
+func constraintsFingerprint(c *motionplan.Constraints) uint64 {
+	data, err := json.Marshal(c)
+	if err != nil {
+		return 0
+	}
+	h := fnv.New64a()
+	h.Write(data)
+	return h.Sum64()
+}
+
 // tryRoadmap answers the query start -> any goal root through the roadmap
 // with lazily-validated edges. Returns the waypoint list (full
 // configurations, start included) or nil.
@@ -402,6 +609,11 @@ func (pm *planManager) tryRoadmap(
 	if len(goals) == 0 {
 		return nil
 	}
+
+	// DRM state for this query: scene occupancy and the constraint
+	// fingerprint under which clean verdicts may transfer.
+	occ := rm.sceneOccupancy(pm, psc, sceneKey)
+	constraintKey := constraintsFingerprint(pm.request.Constraints)
 
 	// Query graph ids: 0..N-1 roadmap, N = start, N+1+i = goal i.
 	n := len(rm.flat)
@@ -505,6 +717,16 @@ func (pm *planManager) tryRoadmap(
 			if v, ok := rm.sceneVerdicts.Load(key); ok {
 				return v.(bool)
 			}
+			// DRM transfer: this edge was fully validated under the same
+			// constraints in a scene whose occupancy missed its swept volume;
+			// if this scene's occupancy misses it too, the verdict carries
+			// over without a collision check.
+			if _, clean := rm.cleanValid.Load(drmVerdictKey{constraints: constraintKey, a: ka, b: kb}); clean {
+				if vox := rm.edgeSweptVoxels(psc, a, b); vox != nil && !drmOverlaps(occ, vox) {
+					rm.sceneVerdicts.Store(key, true)
+					return true
+				}
+			}
 		}
 		if budget <= 0 {
 			return false
@@ -514,6 +736,14 @@ func (pm *planManager) tryRoadmap(
 		ok := psc.CheckPath(ctx, cfgOf(a), cfgOf(b), true, nil) == nil
 		if cacheable {
 			rm.sceneVerdicts.Store(key, ok)
+			if ok {
+				// Record a clean verdict when nothing in this scene was near
+				// the edge's swept volume: validity then owed nothing to this
+				// scene's obstacles and is transferable.
+				if vox := rm.edgeSweptVoxels(psc, a, b); vox != nil && !drmOverlaps(occ, vox) {
+					rm.cleanValid.Store(drmVerdictKey{constraints: constraintKey, a: ka, b: kb}, true)
+				}
+			}
 		}
 		return ok
 	}
@@ -718,4 +948,273 @@ func (pm *planManager) harvestPlan(psc *PlanSegmentContext, steps []*referencefr
 		return
 	}
 	rm.harvest(psc, pm.roadmapSceneKey(psc, rm), steps, logger)
+	rm.saveToDiskThrottled(logger)
+}
+
+// roadmapSmoothedCacheCap bounds how many smoothed trajectories one roadmap
+// retains; corridors beyond that simply re-smooth.
+const roadmapSmoothedCacheCap = 64
+
+// smoothedPathKey hashes a scene fingerprint plus the raw path's configs.
+func smoothedPathKey(scene uint64, path []*referenceframe.LinearInputs) uint64 {
+	h := fnv.New64a()
+	var buf [8]byte
+	put := func(v uint64) {
+		for i := 0; i < 8; i++ {
+			buf[i] = byte(v >> (8 * i))
+		}
+		h.Write(buf[:])
+	}
+	put(scene)
+	for _, cfg := range path {
+		for _, f := range cfg.GetLinearizedInputs() {
+			put(math.Float64bits(f))
+		}
+	}
+	return h.Sum64()
+}
+
+// cachedSmoothed returns the memoized final trajectory for this scene+path,
+// or nil.
+func (rm *roadmap) cachedSmoothed(
+	psc *PlanSegmentContext, scene uint64, path []*referenceframe.LinearInputs,
+) []*referenceframe.LinearInputs {
+	v, ok := rm.smoothedCache.Load(smoothedPathKey(scene, path))
+	if !ok {
+		return nil
+	}
+	flat := v.([][]float64)
+	out := make([]*referenceframe.LinearInputs, 0, len(flat))
+	for _, f := range flat {
+		cfg, err := psc.pc.lis.FloatsToInputs(f)
+		if err != nil {
+			return nil
+		}
+		out = append(out, cfg)
+	}
+	return out
+}
+
+// storeSmoothed memoizes a final trajectory for this scene+path. At capacity
+// an arbitrary entry is evicted: a scene-changing robot would otherwise fill
+// the cache with stale scenes once and never cache again.
+func (rm *roadmap) storeSmoothed(scene uint64, path, smoothed []*referenceframe.LinearInputs) {
+	if rm.smoothedCount.Load() >= roadmapSmoothedCacheCap {
+		rm.smoothedCache.Range(func(k, _ any) bool {
+			rm.smoothedCache.Delete(k)
+			rm.smoothedCount.Add(-1)
+			return false
+		})
+	}
+	flat := make([][]float64, 0, len(smoothed))
+	for _, cfg := range smoothed {
+		src := cfg.GetLinearizedInputs()
+		f := make([]float64, len(src))
+		copy(f, src)
+		flat = append(flat, f)
+	}
+	if _, loaded := rm.smoothedCache.LoadOrStore(smoothedPathKey(scene, path), flat); !loaded {
+		rm.smoothedCount.Add(1)
+	}
+}
+
+// Roadmap disk persistence. The roadmap's value compounds with experience:
+// harvested corridors and per-scene edge verdicts are what turn a 45-120s
+// cold search into a sub-second warm replay. A process restart threw all of
+// that away. When MOTION_ROADMAP_CACHE_DIR is set (cmd-plan sets a default;
+// the library leaves it opt-in), each roadmap is saved there after harvests
+// and loaded instead of built on the next process start. Safety: the
+// filename is derived from the registry key (frame system + chain + goal
+// frame), the file carries the frames/dims for an identity check, and edge
+// verdicts stay keyed by the scene fingerprint, so a changed scene simply
+// misses rather than misapplies. A corrupt or mismatched file is ignored and
+// the roadmap is rebuilt.
+
+type roadmapDiskVerdict struct {
+	Scene uint64 `json:"s"`
+	A     int32  `json:"a"`
+	B     int32  `json:"b"`
+	Clear bool   `json:"c"`
+}
+
+type roadmapDisk struct {
+	Frames    []string             `json:"frames"`
+	Dims      []int                `json:"dims"`
+	GoalFrame string               `json:"goal_frame"`
+	Flat      [][]float64          `json:"flat"`
+	Neighbors [][]int              `json:"neighbors"`
+	EePos     [][3]float64         `json:"ee_pos"`
+	Verdicts  []roadmapDiskVerdict `json:"verdicts"`
+	// Smoothed maps smoothedPathKey (as decimal string; JSON keys must be
+	// strings) to the final trajectory's linearized configs.
+	Smoothed map[string][][]float64 `json:"smoothed,omitempty"`
+	// EdgeVox maps drmEdgeKey (decimal string) to sorted swept-volume voxels.
+	EdgeVox map[string][]uint64 `json:"edge_vox,omitempty"`
+	// CleanValid lists constraint-fingerprinted transferable edge verdicts.
+	CleanValid []roadmapDiskClean `json:"clean_valid,omitempty"`
+}
+
+type roadmapDiskClean struct {
+	Constraints uint64 `json:"k"`
+	A           int32  `json:"a"`
+	B           int32  `json:"b"`
+}
+
+// roadmapSaveMinInterval bounds how often one roadmap writes its cache file.
+const roadmapSaveMinInterval = 5 * time.Second
+
+func roadmapCachePath(key string) string {
+	dir := os.Getenv("MOTION_ROADMAP_CACHE_DIR")
+	if dir == "" {
+		return ""
+	}
+	h := fnv.New64a()
+	h.Write([]byte(key))
+	return filepath.Join(dir, fmt.Sprintf("roadmap-%016x.json", h.Sum64()))
+}
+
+func (rm *roadmap) loadFromDisk(logger logging.Logger) bool {
+	path := roadmapCachePath(rm.key)
+	if path == "" {
+		return false
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path derives from the operator-set cache-dir env var plus a hash
+	if err != nil {
+		return false
+	}
+	var d roadmapDisk
+	if err := json.Unmarshal(data, &d); err != nil {
+		logger.Debugf("roadmap cache %s unreadable, rebuilding: %v", path, err)
+		return false
+	}
+	if len(d.Frames) != len(rm.frames) || len(d.Flat) == 0 || len(d.Flat) != len(d.Neighbors) || len(d.Flat) != len(d.EePos) {
+		return false
+	}
+	for i, f := range rm.frames {
+		if d.Frames[i] != f {
+			return false
+		}
+	}
+	// A corrupt or hand-edited file must degrade to a rebuild, not a panic:
+	// validate the graph's internal consistency before adopting it.
+	totalDoF := 0
+	for _, dof := range d.Dims {
+		if dof < 0 {
+			return false
+		}
+		totalDoF += dof
+	}
+	for _, row := range d.Flat {
+		if len(row) != totalDoF {
+			return false
+		}
+	}
+	for _, nbs := range d.Neighbors {
+		for _, nb := range nbs {
+			if nb < 0 || nb >= len(d.Flat) {
+				return false
+			}
+		}
+	}
+	rm.dims = d.Dims
+	rm.goalFrame = d.GoalFrame
+	rm.flat = d.Flat
+	rm.neighbors = d.Neighbors
+	rm.eePos = d.EePos
+	for _, v := range d.Verdicts {
+		rm.sceneVerdicts.Store(roadmapVerdictKey{scene: v.Scene, a: v.A, b: v.B}, v.Clear)
+	}
+	for k, traj := range d.Smoothed {
+		var key uint64
+		if _, err := fmt.Sscanf(k, "%d", &key); err == nil {
+			rm.smoothedCache.Store(key, traj)
+			rm.smoothedCount.Add(1)
+		}
+	}
+	if len(d.EdgeVox) > 0 {
+		rm.edgeVox = make(map[uint64][]uint64, len(d.EdgeVox))
+		for k, vox := range d.EdgeVox {
+			var key uint64
+			if _, err := fmt.Sscanf(k, "%d", &key); err == nil {
+				rm.edgeVox[key] = vox
+			}
+		}
+	}
+	for _, cv := range d.CleanValid {
+		rm.cleanValid.Store(drmVerdictKey{constraints: cv.Constraints, a: cv.A, b: cv.B}, true)
+	}
+	logger.Debugf("roadmap loaded from %s: %d nodes, %d verdicts", path, len(rm.flat), len(d.Verdicts))
+	return true
+}
+
+func (rm *roadmap) saveToDiskThrottled(logger logging.Logger) {
+	path := roadmapCachePath(rm.key)
+	if path == "" {
+		return
+	}
+	now := time.Now().UnixNano()
+	last := rm.lastSaveNs.Load()
+	if last != 0 && time.Duration(now-last) < roadmapSaveMinInterval {
+		return
+	}
+	if !rm.lastSaveNs.CompareAndSwap(last, now) {
+		return
+	}
+	d := roadmapDisk{GoalFrame: rm.goalFrame}
+	rm.mu.RLock()
+	d.Frames = append([]string{}, rm.frames...)
+	d.Dims = append([]int{}, rm.dims...)
+	// flat and eePos rows are never mutated after insertion, so snapshotting
+	// the outer slices is safe; neighbors rows are appended to in place by
+	// harvest, so they must be deep-copied under the lock.
+	d.Flat = rm.flat[:len(rm.flat):len(rm.flat)]
+	d.EePos = rm.eePos[:len(rm.eePos):len(rm.eePos)]
+	d.Neighbors = make([][]int, len(rm.neighbors))
+	for i, nb := range rm.neighbors {
+		d.Neighbors[i] = append([]int{}, nb...)
+	}
+	rm.mu.RUnlock()
+	// Verdicts accumulate one entry per (scene, edge) for the life of the
+	// robot; cap what the file carries. The set is a cache - arbitrary
+	// truncation only costs re-validation - and cleanValid (bounded by edge
+	// count) carries the transferable knowledge regardless.
+	const maxPersistedVerdicts = 20000
+	rm.sceneVerdicts.Range(func(k, v any) bool {
+		kk := k.(roadmapVerdictKey)
+		d.Verdicts = append(d.Verdicts, roadmapDiskVerdict{Scene: kk.scene, A: kk.a, B: kk.b, Clear: v.(bool)})
+		return len(d.Verdicts) < maxPersistedVerdicts
+	})
+	d.Smoothed = map[string][][]float64{}
+	rm.smoothedCache.Range(func(k, v any) bool {
+		d.Smoothed[fmt.Sprintf("%d", k.(uint64))] = v.([][]float64)
+		return true
+	})
+	rm.edgeVoxMu.RLock()
+	if len(rm.edgeVox) > 0 {
+		d.EdgeVox = make(map[string][]uint64, len(rm.edgeVox))
+		for k, vox := range rm.edgeVox {
+			d.EdgeVox[fmt.Sprintf("%d", k)] = vox
+		}
+	}
+	rm.edgeVoxMu.RUnlock()
+	rm.cleanValid.Range(func(k, v any) bool {
+		kk := k.(drmVerdictKey)
+		d.CleanValid = append(d.CleanValid, roadmapDiskClean{Constraints: kk.constraints, A: kk.a, B: kk.b})
+		return true
+	})
+	data, err := json.Marshal(&d)
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return
+	}
+	logger.Debugf("roadmap saved to %s: %d nodes, %d verdicts", path, len(d.Flat), len(d.Verdicts))
 }

--- a/motionplan/armplanning/roadmap_disk_test.go
+++ b/motionplan/armplanning/roadmap_disk_test.go
@@ -1,0 +1,55 @@
+package armplanning
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.viam.com/test"
+
+	"go.viam.com/rdk/logging"
+)
+
+func TestRoadmapDiskRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("MOTION_ROADMAP_CACHE_DIR", dir)
+	logger := logging.NewTestLogger(t)
+
+	rm := &roadmap{
+		key:       "test-key",
+		frames:    []string{"arm"},
+		dims:      []int{2},
+		goalFrame: "arm",
+		flat:      [][]float64{{0, 0}, {1, 1}, {2, 0}},
+		neighbors: [][]int{{1}, {0, 2}, {1}},
+		eePos:     [][3]float64{{0, 0, 0}, {10, 0, 0}, {20, 0, 0}},
+	}
+	rm.sceneVerdicts.Store(roadmapVerdictKey{scene: 42, a: 0, b: 1}, true)
+	rm.sceneVerdicts.Store(roadmapVerdictKey{scene: 42, a: 1, b: 2}, false)
+	rm.saveToDiskThrottled(logger)
+
+	files, err := filepath.Glob(filepath.Join(dir, "roadmap-*.json"))
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(files), test.ShouldEqual, 1)
+
+	loaded := &roadmap{key: "test-key", frames: []string{"arm"}}
+	test.That(t, loaded.loadFromDisk(logger), test.ShouldBeTrue)
+	test.That(t, loaded.flat, test.ShouldResemble, rm.flat)
+	test.That(t, loaded.neighbors, test.ShouldResemble, rm.neighbors)
+	test.That(t, loaded.eePos, test.ShouldResemble, rm.eePos)
+	test.That(t, loaded.goalFrame, test.ShouldEqual, "arm")
+	v, ok := loaded.sceneVerdicts.Load(roadmapVerdictKey{scene: 42, a: 0, b: 1})
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, v.(bool), test.ShouldBeTrue)
+	v, ok = loaded.sceneVerdicts.Load(roadmapVerdictKey{scene: 42, a: 1, b: 2})
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, v.(bool), test.ShouldBeFalse)
+
+	// A different frame layout must refuse the cache.
+	mismatch := &roadmap{key: "test-key", frames: []string{"arm", "arm2"}}
+	test.That(t, mismatch.loadFromDisk(logger), test.ShouldBeFalse)
+
+	// Corrupt file must refuse and not error.
+	test.That(t, os.WriteFile(files[0], []byte("{bad"), 0o644), test.ShouldBeNil)
+	test.That(t, (&roadmap{key: "test-key", frames: []string{"arm"}}).loadFromDisk(logger), test.ShouldBeFalse)
+}


### PR DESCRIPTION
Part of a dual-arm-scale performance series; armplanning-only and standalone (composes with #6392/#6393/#6394 but does not require them).

Captured gambit (dual-arm chess robot) scenes exposed three planner behaviors:

**1. Racing stranded its time budget.** Attempts exhausting their 5000 iterations in ~20s of a 300s request failed the whole plan with 280s unused. Exhausted attempts now relaunch with fresh RNG streams and fresh tree clones — search time is heavy-tailed, so more independent draws beat one giant tree, and bounded per-attempt trees keep the linear nearest-neighbor scan fast (64-attempt runaway backstop). Ablations: 12 concurrent racers was 3× *worse* (cache contention); unbounded single-tree iteration also lost.

**2. Learned knowledge died with the process.** When `MOTION_ROADMAP_CACHE_DIR` is set — **cmd-plan defaults it on; the library leaves it opt-in (whether viam-server should default it to its data dir is a product call for this review)** — roadmaps persist across processes: base graph, harvested corridor nodes, per-scene structural edge verdicts, final smoothed trajectories keyed by (scene fingerprint, exact corridor configs), and — after Leven & Hutchinson's *dynamic roadmaps* — each edge's swept workspace volume as coarse voxels, so a verdict earned in a scene whose occupancy missed that volume **transfers to any other such scene** under the same constraint fingerprint. Files are fingerprint-checked, bounds-validated on load, size-capped, and written atomically; corruption degrades to a rebuild; `smoothPath`'s end-to-end validation backstops residual optimism (an optimistic edge surfaces as a smoothing failure → search fallback, never a bad trajectory).

Measured on captured scenes that previously hung past 300s:
| | first-ever solve | any later process | never-seen scene, obstacle moved 20mm |
|---|---|---|---|
| time | 8–63s | **0.3–0.9s** | **0.57s** (vs 35.9s cold) |

**3. Infeasible-as-specified requests burned the budget silently.** A 6.7mm end-effector goal whose nearest valid configuration was 5.47 rad away, under a 20mm linear constraint, searched 3.5 minutes before failing. The planner now detects tiny-constrained-move/large-reconfiguration goal sets, warns with the actual numbers and remediation, runs one racing round, and fails in seconds.

Also: nudge's perturbation radii now scale to the linear-constraint tolerance — the fixed 0.1–0.7 rad schedule deviates the EE tens of millimeters, so no candidate could ever survive a tight tube's topological check. *Reasoned fix, no capture demonstrates a win yet; guardrail scenes unchanged.*

Existing benchmark scenes are unaffected (the CI benchmark harness does not set the env var); all motionplan suites and the race detector pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyqhmqkxS9B8bGjdUhTtAs
