### PR TITLE
armplanning: add -no-viz flag to cmd-plan

### DIFF
--- a/motionplan/armplanning/cmd-plan/cmd-plan.go
+++ b/motionplan/armplanning/cmd-plan/cmd-plan.go
@@ -74,6 +74,7 @@ func realMain() error {
 	showPoses := flag.Bool("show-poses", false, "show shadows at each path position")
 	tryManySeeds := flag.Int("try-many-seeds", 1, "try planning with more seeds and report L2 distances")
 	quiet := flag.Bool("quiet", false, "quiet")
+	noViz := flag.Bool("no-viz", false, "skip rendering the plan; useful for benchmarking success rate and planning speed")
 
 	flag.Parse()
 
@@ -308,7 +309,7 @@ func realMain() error {
 		}
 	}
 
-	for i := 0; i < *loop; i++ {
+	for i := 0; !*noViz && i < *loop; i++ {
 		err = visualize(req, plan, mylog, *showPoses)
 		if err != nil {
 			mylog.Println("Couldn't visualize motion plan. Motion-tools server is probably not running. Skipping. Err:", err)


### PR DESCRIPTION
## Summary

Add a `-no-viz` flag to `cmd-plan` that skips the render loop so the tool runs planning only. Intended for benchmarking planner success rate and speed, where the motion-tools render pass otherwise dominates wall time.

<details>
<summary>Claude Code prompts used</summary>

- "Hi Claude, I would like to modify the CLI at motionplan/armplanning/cmd-plan/cmd-plan.go to add a -no-viz flag to only run planning and not render it. This is intended to run benchmark on success rate and planning speed. Can you help with that?"
- "can you commit, push , and open a PR?"

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)