### PR TITLE
Fix non-compiling example in worldstatestore.Service doc comment

### DIFF
--- a/services/worldstatestore/world_state_store.go
+++ b/services/worldstatestore/world_state_store.go
@@ -101,7 +101,14 @@ func FromProvider(provider resource.Provider, name string) (Service, error) {
 //	if err != nil {
 //		logger.Fatal(err)
 //	}
-//	for change := range changes {
+//	for {
+//		change, err := changes.Next()
+//		if err == io.EOF {
+//			break
+//		}
+//		if err != nil {
+//			logger.Fatal(err)
+//		}
 //		fmt.Printf("Change: %v\n", change)
 //	}
 //


### PR DESCRIPTION
The `StreamTransformChanges` example in `Service`'s doc comment (`services/worldstatestore/world_state_store.go`) doesn't compile:

```go
changes, err := myWorldStateStoreService.StreamTransformChanges(ctx, nil)
if err != nil {
	logger.Fatal(err)
}
for change := range changes {
	fmt.Printf("Change: %v\n", change)
}
```

`StreamTransformChanges` returns a `*TransformChangeStream`, which is a plain struct with a `Next()` method, so `changes` here isn't rangeable.

Confirmed by compiling the example verbatim against this package. This is also user-visible on pkg.go.dev, not just in-repo.