### PR TITLE
Keep segment-sweep collision skipping consistent with path finalization

### DIFF
--- a/motionplan/constraint_checker.go
+++ b/motionplan/constraint_checker.go
@@ -50,6 +50,8 @@ type ConstraintChecker struct {
 	collisionConstraints CollisionConstraints
 	topoConstraint       StateFSConstraint
 
+	collisionBufferMM float64
+
 	logger logging.Logger
 }
 
@@ -80,6 +82,7 @@ func NewConstraintChecker(
 		constraints = &Constraints{}
 	}
 	handler := NewEmptyConstraintChecker(logger)
+	handler.collisionBufferMM = collisionBufferMM
 
 	frameSystemGeometries, err := referenceframe.FrameSystemGeometriesLinearInputs(fs, seedMap)
 	if err != nil {
@@ -413,7 +416,18 @@ func (c *ConstraintChecker) CheckStateConstraintsAcrossSegmentFS(
 		// constraints (orientation/linear) carry no such guarantee but are
 		// cheap - a single FK pass per state - so evaluate just those on the
 		// skipped states instead of disabling skipping altogether.
-		canSkip := int(min(100, math.Floor(closestObstacle/resolution)))
+		//
+		// The cushion keeps this sweep's verdicts consistent with the
+		// full-resolution finalization pass (armplanning's
+		// findCloseObstacleWaypoints), which checks every state within
+		// 10x the collision buffer of an obstacle: skipping must never hop
+		// into that near zone, or a path accepted here can be rejected at
+		// finalization and fail an otherwise-solved plan. The interpolation
+		// step count also bounds only frame-origin and joint deltas, not
+		// distal geometry on a lever arm, so the raw clearance skip could
+		// overshoot through a thin obstacle; the cushion absorbs that too.
+		cushion := math.Max(0.1, 10*c.collisionBufferMM)
+		canSkip := int(min(100, math.Floor((closestObstacle-cushion)/resolution)))
 		if canSkip > 0 && c.topoConstraint != nil {
 			for j := i + 1; j <= i+canSkip && j < end; j++ {
 				topoC := &StateFS{FS: ci.FS, Configuration: interpolatedConfigurations[j]}


### PR DESCRIPTION
## Summary

Fixes intermittent `robot constraint: violation between <A> and <B> geometries` failures on feasible plans (five production coffee orders on machine `Cappuccina`, 28 Aug — captures in `mplans/inconsistent_collision_failures/`). The segment sweep's clearance skip (`canSkip = floor(clearance/resolution)`) rests on the assumption that one interpolation step moves geometry at most `resolution` — but step counts bound frame origins and joint deltas, not distal geometry on a lever arm, so the sweep could hop over a state where a protruding link grazes within the collision buffer. Finalization (`findCloseObstacleWaypoints`) checks every near-obstacle state, catches the graze, and the already-solved plan dies ~1.3 s in with the raw violation error.

This PR derives a skip cushion from the collision buffer — `max(0.1, 10×buffer)`, the same near-zone threshold finalization uses — so the sweep never skips a state finalization would examine, and search stops accepting paths that finalization rejects.

Full investigation, reproductions, and measurements: [Cappuccina Plan Autopsy](https://claude.ai/code/artifact/9952cdab-2b20-4383-8673-a08a3642545e).

Companion backstop for the residual seams (cached edge verdicts, post-smoothing step rewrites): #6402.

## Testing

- `go test ./motionplan/...` and `golangci-lint` clean
- Replaying the captured requests: stock main fails `ec047254` 2/15 quiet-machine runs (`smoothed path segment 2 invalid at full resolution`); with the cushion, 0 failures across all replay campaigns (same change on a v1.5.0 build: 0/25 under CPU contention vs 2/25 stock, reproducing the machine-log errors byte-for-byte). Measured cost on these captures: +12–28% planning time on main.

<details>
<summary>Claude Code prompts used</summary>

- "Hi Claude, I have observed some inconsistent motion planning failures. Here is a directory containing the plan requests and the details about the plans (suc as the planning failure errors we got): @mplans/inconsistent_collision_failures/ When we replan from those requests it usually succeeds. Those failures seem inconsistent, it looks like we encounter an error and return early assuming the plan is doomed. I would like you to figure out: where in the code did we encounter these errors? is this a trade-off we made in order to improve performances? If so, please assess the tradeoff; what could we do to make sure those plans succeed (since they are feasible) without negatively impacting performances too much on actual doomed plans? is there anything that would explain the behavior we have observed? If so what could we do. Feel free to create a new worktree. I want to understand why this happened and what we can do to prevent it"
- "Once the benchmarks finish, write up the full findings"
- "open a draft PR with the fix from the worktree. Nake sure to add a link to the report in the PR description"
- "Can you split Fix A and Fix B into 2 distinct PRs? Make sure each description is tailored to each fix and that they both include the link to the artifact. Provide a more in depth explanation in the PR description for the PR salvaging the raw path"

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
