### PR TITLE
armplanning: salvage the raw path when smoothing fails final validation

### DIFF
--- a/motionplan/armplanning/api.go
+++ b/motionplan/armplanning/api.go
@@ -244,6 +244,11 @@ type PlanMeta struct {
 	// straight-line path with small nudges around obstacles, skipping CBIRRT.
 	GoalsNudgeSolved int
 
+	// GoalsSalvagedRaw is the number of waypoints where the smoothed path
+	// failed full-resolution validation and the unsmoothed search path was
+	// returned instead.
+	GoalsSalvagedRaw int
+
 	// GoalsRoadmapSolved is the number of waypoints solved through the lazy
 	// roadmap, skipping CBIRRT.
 	GoalsRoadmapSolved int

--- a/motionplan/armplanning/plan_manager.go
+++ b/motionplan/armplanning/plan_manager.go
@@ -172,12 +172,15 @@ func (pm *planManager) planToDirectJoints(
 	if err != nil {
 		return nil, err
 	}
-	finalSteps.steps, _, err = smoothPath(ctx, psc, finalSteps.steps)
+	smoothed, _, err := smoothPath(ctx, psc, finalSteps.steps)
 	if err != nil {
-		return nil, err
+		smoothed, err = salvageRawPath(ctx, psc, finalSteps.steps, err)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return finalSteps.steps, nil
+	return smoothed, nil
 }
 
 func (pm *planManager) planSingleGoal(
@@ -301,7 +304,11 @@ func (pm *planManager) planSingleGoal(
 
 	steps, compact, err := smoothPath(ctx, psc, rawSteps)
 	if err != nil {
-		return nil, err
+		steps, err = salvageRawPath(ctx, psc, rawSteps, err)
+		if err != nil {
+			return nil, err
+		}
+		compact = rawSteps
 	}
 
 	pm.pc.planMeta.GoalsCBIRRTSolved++

--- a/motionplan/armplanning/smooth.go
+++ b/motionplan/armplanning/smooth.go
@@ -160,6 +160,27 @@ func smoothPath(
 	return final, compact, err
 }
 
+// salvageRawPath recovers a plan whose smoothed path failed full-resolution
+// validation. The segment sweeps that vet shortcuts skip states by clearance,
+// while addCloseObstacleWaypoints checks every near-obstacle state, so a
+// shortcut can thread a gap the sweep never sampled. The pre-smoothing path is
+// a searched, sweep-validated asset: re-validate it at full resolution and
+// return it unsmoothed rather than discarding the whole plan.
+func salvageRawPath(
+	ctx context.Context, psc *PlanSegmentContext, rawSteps []*referenceframe.LinearInputs, smoothErr error,
+) ([]*referenceframe.LinearInputs, error) {
+	validated, err := addCloseObstacleWaypoints(ctx, psc, rawSteps)
+	if err != nil {
+		// The raw path fails full-resolution validation too; the sweep missed
+		// a violation during search itself. Surface the original error.
+		return nil, smoothErr
+	}
+	psc.pc.logger.Infof("smoothed path failed full-resolution validation, salvaging unsmoothed path (%d waypoints): %v",
+		len(validated), smoothErr)
+	psc.pc.planMeta.GoalsSalvagedRaw++
+	return validated, nil
+}
+
 // addCloseObstacleWaypoints interpolates every segment at full resolution and
 // inserts waypoints wherever the path comes close to an obstacle, preventing
 // later interpolation from cutting corners.


### PR DESCRIPTION
## Summary

When a smoothed path fails the full-resolution finalization check (`addCloseObstacleWaypoints`), the planner currently discards the **entire plan** — even though the pre-smoothing search path was found, validated by the search sweeps, and is sitting right there. This PR re-validates that raw path at full resolution and returns it unsmoothed instead; the plan only fails if the raw path is itself blocked. A new `GoalsSalvagedRaw` meta counter and an Info log make every salvage observable.

This is the backstop half of the fix for the 28 Aug `Cappuccina` failures (captures in `mplans/inconsistent_collision_failures/`), where finalization killed already-solved plans ~1.3 s into a 300 s budget. The load-bearing half — making the search sweep consistent with finalization so the disagreement rarely happens at all — is #6400. Full investigation and measurements: [Cappuccina Plan Autopsy](https://claude.ai/code/artifact/9952cdab-2b20-4383-8673-a08a3642545e).

## Why keep a backstop once #6400 lands

#6400 aligns the *skip rule* of the sweep and finalization, but there remain code paths where a smoothed path reaches finalization without the (cushioned) sweep having examined what finalization examines:

1. **Anchor desynchronization.** The sweep and finalization walk the same interpolation grid with the same skip rule, but from different starting states (0 vs 1), so their hop sequences can sample different subsets. Since hop length is licensed by the clearance at whichever state a walk lands on — and per-step geometry motion can exceed `resolution` on a lever arm — a graze can in principle sit in a state finalization checks and the sweep hopped. The cushion makes this rare (0 occurrences in all post-cushion campaigns), not impossible.
2. **`tryOnlyMovingComponentsThatNeedToMove` leaves a segment unswept.** When it pins non-moving components in `steps[idx]`, it validates `(prev → updated)` only; if the next iteration has nothing to pin (`!changed`), the rewritten segment `(updated → steps[idx+1])` — genuinely new motion — is never checked by any sweep. Finalization is its first examination. No cushion can help a segment that was never swept; salvaging the (pre-rewrite, validated) raw path can.
3. **Cached edge verdicts bypass the sweep.** `CheckPath` returns cached "clear" verdicts keyed only by the two configuration hashes, from a cache shared across segment contexts whose checkers have different moving/static splits. A shortcut accepted from cache never runs the current context's sweep at all; finalization always re-checks fresh.
4. **Drift insurance.** The sweep and finalization are separately maintained twins — this incident was born from two individually reasonable PRs (#5526, #5653) diverging silently. If they diverge again, salvage turns "customer order dies with a misleading collision error" into an Info log, a `GoalsSalvagedRaw` tick, and a slightly less-smooth trajectory — which is also the alerting signal that the consistency invariant broke.

**Honest limits:** salvage cannot rescue a plan whose raw path also grazes — it returns the original error (this was the common case *before* #6400, which is why this change is a backstop, not the fix). Cost is zero unless a plan is already about to fail; when it fires, it spends one full-resolution validation of the raw path (~19 ms measured on the captured scenes).

## Testing

- `go test ./motionplan/...` and `golangci-lint` clean
- The salvage path was exercised extensively during the investigation on a v1.5.0 backport of this same change (see the report); with #6400 also applied, no reproduced failure reaches it — expected, per the backstop role above.

<details>
<summary>Claude Code prompts used</summary>

- "Hi Claude, I have observed some inconsistent motion planning failures. Here is a directory containing the plan requests and the details about the plans (suc as the planning failure errors we got): @mplans/inconsistent_collision_failures/ When we replan from those requests it usually succeeds. Those failures seem inconsistent, it looks like we encounter an error and return early assuming the plan is doomed. I would like you to figure out: where in the code did we encounter these errors? is this a trade-off we made in order to improve performances? If so, please assess the tradeoff; what could we do to make sure those plans succeed (since they are feasible) without negatively impacting performances too much on actual doomed plans? is there anything that would explain the behavior we have observed? If so what could we do. Feel free to create a new worktree. I want to understand why this happened and what we can do to prevent it"
- "Given the addition of the cushion (Fix B) is the salvaging of the raw path (Fix A) actually useful? Can you explain to me under which circumstances it would help?"
- "Can you split Fix A and Fix B into 2 distinct PRs? Make sure each description is tailored to each fix and that they both include the link to the artifact. Provide a more in depth explanation in the PR description for the PR salvaging the raw path"

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)