### PR TITLE
Add a motion planning order-replay benchmark

### DIFF
--- a/.artifact/tree.json
+++ b/.artifact/tree.json
@@ -3691,6 +3691,404 @@
       }
     }
   },
+  "motionplan": {
+    "order-replay": {
+      "cappuccina-5fb95a4c": {
+        "000-153126.083-grinding-move.json": {
+          "hash": "d9afb60374b7b84d0d0d57457f2d3d4f",
+          "size": 578556
+        },
+        "001-153129.698-grinding-move.json": {
+          "hash": "125b9944c422d7339655488073643bc1",
+          "size": 703897
+        },
+        "002-153130.689-grinding-move.json": {
+          "hash": "dfbf0be24dda41f39566c9cdb03ddbd1",
+          "size": 703796
+        },
+        "003-153131.847-grinding-circular.json": {
+          "hash": "fd6819579e41171677785f99ff219fec",
+          "size": 1080984
+        },
+        "004-153143.958-tamping-move.json": {
+          "hash": "e352c48b941c368e363c3283f9f779af",
+          "size": 638962
+        },
+        "005-153147.607-tamping-move.json": {
+          "hash": "99113eea91a0f1491415aab68732633a",
+          "size": 1618872
+        },
+        "006-153152.592-tamping-move.json": {
+          "hash": "d87969a9acd9ea409d1df6fae3b52afc",
+          "size": 1619099
+        },
+        "007-153209.673-locking_portafilter-move.json": {
+          "hash": "b10d7e1feb33ceb6c747d94a376f59a0",
+          "size": 720883
+        },
+        "008-153214.999-locking_portafilter-move.json": {
+          "hash": "90cfff039ec2d98db13d2117bf2b1847",
+          "size": 1015590
+        },
+        "009-153216.395-locking_portafilter-pivot.json": {
+          "hash": "1f94d5c1ba1104f1a04cd89ca652cac1",
+          "size": 1372568
+        },
+        "010-153224.639-releasing_filter-move.json": {
+          "hash": "f1258e55311cea251a099b362de02d3d",
+          "size": 1812532
+        },
+        "011-153227.696-placing_cup-move.json": {
+          "hash": "c7fe2acbadf69c7446b9fb82bb06a0d7",
+          "size": 578034
+        },
+        "012-153235.149-placing_cup-move.json": {
+          "hash": "32736e02997fa64f9e7a05b4d906d6c4",
+          "size": 578027
+        },
+        "013-153235.711-placing_cup-move.json": {
+          "hash": "6a9759922f152aa9f52f24357a286c24",
+          "size": 1961196
+        },
+        "014-153244.672-placing_cup-move.json": {
+          "hash": "382f284da6a7d3f7643dfda749a973c2",
+          "size": 1978383
+        },
+        "015-153257.279-placing_cup-move.json": {
+          "hash": "0f97b75841944d67e31a2227cbb62f42",
+          "size": 835312
+        },
+        "016-153310.154-placing_cup-move.json": {
+          "hash": "ffb6e3a3af6c7dabaeca44007b03703c",
+          "size": 2454585
+        },
+        "017-153314.165-placing_cup-move.json": {
+          "hash": "70d1bf2883553a235910bcce29198028",
+          "size": 2409161
+        },
+        "018-153332.655-brewing-move.json": {
+          "hash": "e7d596749c127925277e14c154e7bcd5",
+          "size": 663331
+        },
+        "019-153336.155-brewing-move.json": {
+          "hash": "8b3736aedde40f26643d985005a1b248",
+          "size": 846129
+        },
+        "020-153337.336-brewing-move.json": {
+          "hash": "83d7cdbc2a21c634f19a3de3f24de406",
+          "size": 846051
+        },
+        "021-153338.286-brewing-move.json": {
+          "hash": "9e4dd2b6c6e5234802ea158eeb3ba647",
+          "size": 578003
+        },
+        "022-153346.202-brewing-move.json": {
+          "hash": "f300fdd024c5b98d01b23cab4f09074c",
+          "size": 577988
+        },
+        "023-153346.645-brewing-move.json": {
+          "hash": "c83f51b0afae1af0791ea77c801094de",
+          "size": 1795210
+        },
+        "024-153352.938-brewing-move.json": {
+          "hash": "0aa06c6bad7512372a2244fa1234a19b",
+          "size": 1810376
+        },
+        "025-153404.593-brewing-move.json": {
+          "hash": "7f0a34532b54f295a51c448ce476ae2f",
+          "size": 915731
+        },
+        "026-153415.753-brewing-move.json": {
+          "hash": "3773cdf7e516ff4b7458ee419a12610c",
+          "size": 1811254
+        },
+        "027-153433.046-brewing-move.json": {
+          "hash": "ce58331577f9327b7326445bd6796184",
+          "size": 1808962
+        },
+        "028-153435.099-brewing-carry.json": {
+          "hash": "a149cb0c7e74f467a4f00995935c12ad",
+          "size": 663768
+        },
+        "029-153439.206-brewing-move.json": {
+          "hash": "cf8d7ae21078a3d7629ac2d871785447",
+          "size": 1979424
+        },
+        "030-153443.810-brewing-move.json": {
+          "hash": "9fc384bb975c95d0e063f49e0787c313",
+          "size": 1967616
+        },
+        "031-153448.198-opening_fridge-move.json": {
+          "hash": "ea807472a20c8001ca12d757c3a5cdf5",
+          "size": 794189
+        },
+        "032-153503.048-opening_fridge-move.json": {
+          "hash": "2cea29fa8a99b169b2821559825a5f29",
+          "size": 1488762
+        },
+        "033-153505.743-opening_fridge-open_door.json": {
+          "hash": "94b8c10a19b5ad68adce97c0e1daa8a3",
+          "size": 601744
+        },
+        "034-153505.957-opening_fridge-open_door.json": {
+          "hash": "9167ef4f217eb500f0f2708d72d96514",
+          "size": 579832
+        },
+        "035-153506.192-opening_fridge-open_door.json": {
+          "hash": "3a118369d80b302211d6ea9661cb71dc",
+          "size": 579690
+        },
+        "036-153506.394-opening_fridge-open_door.json": {
+          "hash": "f486cf54f6282bb0b4d58d8b4a4d6a8d",
+          "size": 579231
+        },
+        "037-153506.598-opening_fridge-open_door.json": {
+          "hash": "971cb93a4e18a28a9b0606653e529250",
+          "size": 579162
+        },
+        "038-153506.794-opening_fridge-open_door.json": {
+          "hash": "5496299b538bf2550eef03900d3e354c",
+          "size": 579352
+        },
+        "039-153507.001-opening_fridge-open_door.json": {
+          "hash": "4015a204d67acd923e3a8519463ea2f5",
+          "size": 579463
+        },
+        "040-153507.196-opening_fridge-open_door.json": {
+          "hash": "91c728396d7d311ff69e680c12bdfa3e",
+          "size": 579381
+        },
+        "041-153514.279-opening_fridge-move.json": {
+          "hash": "b7bfa3eb0c413916c32babf13c83555f",
+          "size": 1500141
+        },
+        "042-153516.784-adding_milk-move.json": {
+          "hash": "9de52f67f7210fd63d8cb68afb2942eb",
+          "size": 630787
+        },
+        "043-153521.282-adding_milk-move.json": {
+          "hash": "63f57b7162be80d96dc3906576d7e867",
+          "size": 579377
+        },
+        "044-153521.781-adding_milk-move.json": {
+          "hash": "3d7e8eee437076b91a018c4dc51e6e3c",
+          "size": 2531219
+        },
+        "045-153529.604-adding_milk-move.json": {
+          "hash": "1d75a2ebce859252c5fee235d7766602",
+          "size": 2551896
+        },
+        "046-153535.297-adding_milk-move.json": {
+          "hash": "580b726aa85e1ef8e9212e20a66cbae4",
+          "size": 794004
+        },
+        "047-153542.859-adding_milk-pivot.json": {
+          "hash": "b0b6863fdc64751967d44a2c5e827956",
+          "size": 1331421
+        },
+        "048-153548.126-adding_milk-pivot.json": {
+          "hash": "32fedca5879b2be9df48cd3a54022a4f",
+          "size": 1330651
+        },
+        "049-153550.610-adding_milk-move.json": {
+          "hash": "9ed988d7669469c2c79dfc5acfce86ff",
+          "size": 798434
+        },
+        "050-153558.469-adding_milk-move.json": {
+          "hash": "1219dbc8c0af61e9e206fec99d7a9c1e",
+          "size": 2553698
+        },
+        "051-153603.443-adding_milk-move.json": {
+          "hash": "587d41924d7deccbe0aca3cf6894b54c",
+          "size": 2528490
+        },
+        "052-153608.679-closing_fridge-move.json": {
+          "hash": "1b19cf1a87e923640c9f88403f55ef97",
+          "size": 706785
+        },
+        "053-153613.932-closing_fridge-move.json": {
+          "hash": "5efae368f06f6d3580298dcd7d93c913",
+          "size": 1500227
+        },
+        "054-153616.186-closing_fridge-close_door.json": {
+          "hash": "97101c383ed80eb53fccf4fd5b13d376",
+          "size": 579564
+        },
+        "055-153616.384-closing_fridge-close_door.json": {
+          "hash": "bb416e9ec9220589bcc86d09f4ebfae4",
+          "size": 579358
+        },
+        "056-153616.607-closing_fridge-close_door.json": {
+          "hash": "13da347495e7fb3a268658dc1d99cee0",
+          "size": 579001
+        },
+        "057-153616.814-closing_fridge-close_door.json": {
+          "hash": "f18825d6a8eea5b5e0a5dd846d4434e2",
+          "size": 579143
+        },
+        "058-153617.011-closing_fridge-close_door.json": {
+          "hash": "cb7be13cbebb6ec51605baca687316ae",
+          "size": 579645
+        },
+        "059-153617.272-closing_fridge-close_door.json": {
+          "hash": "fff8fa848e28191a62d0d6644bd76dba",
+          "size": 579851
+        },
+        "060-153617.462-closing_fridge-close_door.json": {
+          "hash": "dfde4a02c9dec204faa8db0553a82b7b",
+          "size": 579951
+        },
+        "061-153617.649-closing_fridge-close_door.json": {
+          "hash": "af250993664ee618992d1f8e8a772de5",
+          "size": 578752
+        },
+        "062-153624.673-closing_fridge-move.json": {
+          "hash": "40df823488d3973f83db989c0ea0a81f",
+          "size": 1488819
+        },
+        "063-153628.349-serving-move.json": {
+          "hash": "af0503003686890ac831ad015d846f66",
+          "size": 753394
+        },
+        "064-153638.882-serving-move.json": {
+          "hash": "428bb649c53f733142fa2e80ad4962fd",
+          "size": 2439061
+        },
+        "065-153642.369-serving-move.json": {
+          "hash": "8988566293eeecbca7dd21b2318d62c6",
+          "size": 2438291
+        },
+        "066-153644.748-serving-carry.json": {
+          "hash": "cb57c1d095e9531c595287f8356c4ca6",
+          "size": 643548
+        },
+        "067-153647.477-serving-pivot.json": {
+          "hash": "af89fe7d05c5d8c09fd4b74fa6b06279",
+          "size": 1002934
+        },
+        "068-153651.758-serving-pivot.json": {
+          "hash": "48efba643906f94ac9d88e2f19a0b645",
+          "size": 1003008
+        },
+        "069-153653.214-serving-carry.json": {
+          "hash": "fb7e671c3b6f640fb821e019bceda003",
+          "size": 686096
+        },
+        "070-153659.568-serving-move.json": {
+          "hash": "619a5d87101ffb684d3f816a1b3ee85c",
+          "size": 2047138
+        },
+        "071-153703.339-serving-move.json": {
+          "hash": "c3c36c307e92f414b629773dafb68105",
+          "size": 2026703
+        },
+        "072-153706.529-serving-move.json": {
+          "hash": "40698efacd64103487803add8fbb7e4c",
+          "size": 578534
+        },
+        "073-153712.604-serving-move.json": {
+          "hash": "e9ca85d069cecede3c4fc7e94ad810f7",
+          "size": 1966943
+        },
+        "074-153716.800-serving-move.json": {
+          "hash": "7f27714443e21f71326bb6b0362a02cf",
+          "size": 1978945
+        },
+        "075-153733.046-serving-carry.json": {
+          "hash": "d4033a93722cb0e51c009cfced389a08",
+          "size": 909035
+        },
+        "076-153746.084-serving-move.json": {
+          "hash": "aaadbc3b72f6e2cc9840aa9f98454e81",
+          "size": 2040186
+        },
+        "077-153749.872-serving-move.json": {
+          "hash": "00a13a615b81493eb08225840c62c6e5",
+          "size": 2020837
+        },
+        "078-153807.814-grabbing_filter-move.json": {
+          "hash": "07ceaea1fd431a5980d031f9ad06c747",
+          "size": 704174
+        },
+        "079-153815.779-grabbing_filter-move.json": {
+          "hash": "6a53aae187796d6aa57ad6d46e2ee167",
+          "size": 1812534
+        },
+        "080-153819.582-unlocking_portafilter-pivot.json": {
+          "hash": "7d0afc02958518231074c2159dd7f57a",
+          "size": 1247397
+        },
+        "081-153824.736-unlocking_portafilter-move.json": {
+          "hash": "835a23741a81e6bffc52ee3d8adcb766",
+          "size": 703435
+        },
+        "082-153825.312-unlocking_portafilter-circular.json": {
+          "hash": "ba17d9d784f804b8d4c488884e46e086",
+          "size": 726096
+        },
+        "083-153826.144-unlocking_portafilter-move.json": {
+          "hash": "fc8dba2ce3c4666154e5859c1ad3a4e4",
+          "size": 703598
+        },
+        "084-153826.731-unlocking_portafilter-move.json": {
+          "hash": "2e4cc9100836460a30e023afe77e5946",
+          "size": 703479
+        },
+        "085-153827.773-unlocking_portafilter-circular.json": {
+          "hash": "57e1cc5fe5c2e68cf3f5147eb2438034",
+          "size": 726124
+        },
+        "086-153828.689-unlocking_portafilter-move.json": {
+          "hash": "86f0a803290afd2060c1315e63df3bda",
+          "size": 869660
+        },
+        "087-153833.922-cleaning-move.json": {
+          "hash": "6483bfc645caa72c5903710340b7c005",
+          "size": 645186
+        },
+        "088-153836.752-cleaning-move.json": {
+          "hash": "2f63905a7ee49364ce72f6a0e64f79ee",
+          "size": 578681
+        },
+        "089-153842.065-cleaning-move.json": {
+          "hash": "41d902915531149df359cd635688c461",
+          "size": 1245807
+        },
+        "090-153843.194-cleaning-circular.json": {
+          "hash": "a607d9b5e92b90386ece1abf26a13867",
+          "size": 726081
+        },
+        "091-153846.164-cleaning-move.json": {
+          "hash": "876acad2fb381ab9ab34fb4d611905b1",
+          "size": 1245143
+        },
+        "092-153847.685-cleaning-move.json": {
+          "hash": "f2e8108b49233ab610a0628aaaef552e",
+          "size": 1412793
+        },
+        "093-153849.454-cleaning-move.json": {
+          "hash": "d1dc4d8877396857f3e5c84b66112ec6",
+          "size": 1245965
+        },
+        "094-153850.584-cleaning-circular.json": {
+          "hash": "ccea90c5966eb4a5f4718778cd167bd5",
+          "size": 726106
+        },
+        "095-153853.741-cleaning-move.json": {
+          "hash": "ba66d2c467a17ec54ca4c1f5a3c6efb9",
+          "size": 1246211
+        },
+        "096-153854.899-cleaning-move.json": {
+          "hash": "18b264f861bc64d1f370eb30f5d5be8f",
+          "size": 578656
+        },
+        "097-153900.281-finishing_up-move.json": {
+          "hash": "3ecf64e3dc2f892267cadc89db9744f0",
+          "size": 578470
+        }
+      }
+    }
+  },
   "pointcloud": {
     "bun0.pcd": {
       "hash": "2a8eeb771a594acc62d68b2032b62349",

--- a/.github/workflows/motion-order-benchmark.yml
+++ b/.github/workflows/motion-order-benchmark.yml
@@ -6,10 +6,6 @@ on:
     inputs:
       pr_number:
         type: string
-      mode:
-        description: 'Replay mode: warm (one process, recorded order) or cold (fresh process per plan).'
-        type: string
-        default: warm
       passes:
         description: 'Independent replays per side. Each is a fresh process; the comparator takes a median.'
         type: string
@@ -19,9 +15,16 @@ on:
         type: boolean
         default: false
 
+# Read-only by default; the job below takes the one write it needs for the sticky comment.
+permissions:
+  contents: read
+
 jobs:
   motion_order_benchmark:
     name: Motion Order Benchmark
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-large
     container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
     timeout-minutes: 45
@@ -32,7 +35,6 @@ jobs:
       # viam-server never sets this, so production plans cold. Leaving the on-disk roadmap enabled
       # would let the newer revision replay learned corridors the older one structurally cannot have.
       MOTION_ROADMAP_CACHE_DIR: ''
-      MODE: ${{ inputs.mode || 'warm' }}
       PASSES: ${{ inputs.passes || '2' }}
     steps:
     - name: Check out head code
@@ -88,15 +90,19 @@ jobs:
         # entirely on whichever side ran second. Each invocation is a fresh process, which is what
         # makes the passes independent samples rather than progressively warmer ones.
         #
-        # The pinned settings are repeated on each command line because `sudo -H` resets the
-        # environment: a job-level `env:` block never reaches the replay. The harness pins both
-        # itself, so this is redundancy rather than the only line of defence -- but a comparison
-        # whose controls depend on the harness under test is not much of a control.
+        # `sudo env VAR=...` rather than a job-level `env:` block, because `sudo -H` resets the
+        # environment and the block would never reach the replay. The harness pins both itself, so
+        # this is redundancy rather than the only line of defence -- but a comparison whose controls
+        # depend on the harness under test is not much of a control.
+        #
+        # The binary is invoked directly instead of through `bash -lc`: it needs no Go toolchain on
+        # PATH, and every argument then stays a shell word rather than being re-parsed by a nested
+        # shell.
         for pass in $(seq 1 "$PASSES"); do
-          sudo -Hu testbot bash -lc \
-            "GOGC=$GOGC MOTION_ROADMAP_CACHE_DIR='$MOTION_ROADMAP_CACHE_DIR' ./orderbench-base run -corpus ./corpus -mode $MODE -out base-$pass.ndjson"
-          sudo -Hu testbot bash -lc \
-            "GOGC=$GOGC MOTION_ROADMAP_CACHE_DIR='$MOTION_ROADMAP_CACHE_DIR' ./orderbench-head run -corpus ./corpus -mode $MODE -out head-$pass.ndjson"
+          sudo -Hu testbot env GOGC="$GOGC" MOTION_ROADMAP_CACHE_DIR="$MOTION_ROADMAP_CACHE_DIR" \
+            ./orderbench-base run -corpus ./corpus -out "base-$pass.ndjson"
+          sudo -Hu testbot env GOGC="$GOGC" MOTION_ROADMAP_CACHE_DIR="$MOTION_ROADMAP_CACHE_DIR" \
+            ./orderbench-head run -corpus ./corpus -out "head-$pass.ndjson"
         done
         cat base-*.ndjson > base.ndjson
         cat head-*.ndjson > head.ndjson
@@ -106,21 +112,28 @@ jobs:
       env:
         BASELINE: ${{ github.event.pull_request.base.label || 'main' }}
         MODIFIED: ${{ github.event.pull_request.head.label || github.ref_name }}
-        FAIL_ON_REGRESSION: ${{ inputs.fail_on_regression && '-fail-on-regression' || '' }}
+        FAIL_ON_REGRESSION: ${{ inputs.fail_on_regression }}
       run: |
-        sudo -Hu testbot bash -lc "./orderbench-head compare \
+        # BASELINE and MODIFIED are branch labels from the pull request, so they are attacker
+        # controlled on a fork PR and a git ref may legally contain a single quote. They reach the
+        # binary as quoted shell words, never as text inside a nested `bash -lc` script.
+        args=()
+        if [ "$FAIL_ON_REGRESSION" = "true" ]; then
+          args+=(-fail-on-regression)
+        fi
+        sudo -Hu testbot ./orderbench-head compare \
           -base base.ndjson -head head.ndjson \
-          -base-label '$BASELINE' -head-label '$MODIFIED' \
+          -base-label "$BASELINE" -head-label "$MODIFIED" \
           -out motion-order-benchmark.md \
           -json-out motion-order-benchmark.json \
-          $FAIL_ON_REGRESSION"
+          "${args[@]}"
         cat motion-order-benchmark.md
 
     - name: Upload raw records
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: motion-order-benchmark-${{ env.MODE }}
+        name: motion-order-benchmark
         path: |
           base.ndjson
           head.ndjson
@@ -131,7 +144,7 @@ jobs:
       uses: marocchino/sticky-pull-request-comment@v2
       if: ${{ inputs.pr_number }}
       with:
-        header: motion-order-benchmark-${{ env.MODE }}
+        header: motion-order-benchmark
         number: ${{ inputs.pr_number }}
         recreate: true
         path: motion-order-benchmark.md

--- a/.github/workflows/motion-order-benchmark.yml
+++ b/.github/workflows/motion-order-benchmark.yml
@@ -1,0 +1,130 @@
+name: Motion Order Benchmark
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      pr_number:
+        type: string
+      mode:
+        description: 'Replay mode: warm (one process, recorded order) or cold (fresh process per plan).'
+        type: string
+        default: warm
+      passes:
+        description: 'Independent replays per side. Each is a fresh process; the comparator takes a median.'
+        type: string
+        default: '2'
+      fail_on_regression:
+        description: 'Fail the job when the comparison verdict is a regression.'
+        type: boolean
+        default: false
+
+jobs:
+  motion_order_benchmark:
+    name: Motion Order Benchmark
+    runs-on: ubuntu-large
+    container: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
+    timeout-minutes: 45
+    env:
+      # Pinned rather than inherited: an unset GOGC means "whatever this revision's code decides",
+      # which is exactly the difference a cross-revision comparison must not absorb.
+      GOGC: '300'
+      # viam-server never sets this, so production plans cold. Leaving the on-disk roadmap enabled
+      # would let the newer revision replay learned corridors the older one structurally cannot have.
+      MOTION_ROADMAP_CACHE_DIR: ''
+      MODE: ${{ inputs.mode || 'warm' }}
+      PASSES: ${{ inputs.passes || '2' }}
+    steps:
+    - name: Check out head code
+      uses: actions/checkout@v4
+      with:
+        path: head
+        ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+        # Fork PRs only reach pull_request_target runs behind the 'safe to test' label
+        # (see motion-pull-request-trusted.yml).
+        allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
+
+    - name: Check out base code
+      uses: actions/checkout@v4
+      with:
+        path: base
+        ref: ${{ github.event.pull_request.base.sha || 'main' }}
+
+    - name: Graft the head harness onto the base checkout
+      shell: bash
+      run: |
+        # The base binary must measure the base library with the *head* harness. Building the base
+        # revision's own copy would compare two harnesses as well as two libraries, and would not
+        # work at all for a base that predates the harness.
+        rm -rf base/motionplan/armplanning/orderbench
+        cp -r head/motionplan/armplanning/orderbench base/motionplan/armplanning/orderbench
+
+    - name: Change ownership to testbot
+      run: chown -R testbot:testbot .
+
+    - name: Build both binaries
+      shell: bash
+      run: |
+        sudo -Hu testbot bash -lc "cd head && go build -o ../orderbench-head ./motionplan/armplanning/orderbench/cmd/orderbench"
+        sudo -Hu testbot bash -lc "cd base && go build -o ../orderbench-base ./motionplan/armplanning/orderbench/cmd/orderbench"
+
+    - name: Fetch the plan corpus
+      shell: bash
+      run: |
+        # Pull the ~100MB corpus out of the artifact store up front, so that a first-use download
+        # cannot land inside a timed replay. The artifact path comes from the manifest compiled into
+        # the binary, so the workflow never restates where the payloads live. Both binaries embed
+        # the same manifest -- the head one, after the graft -- so one fetch serves both.
+        #
+        # Run from inside the checkout, because artifact resolution searches upwards for
+        # .artifact/config.json; stage into a shared directory so the base binary, which has no
+        # checkout-relative artifact config of its own to find, can read the same payloads by path.
+        sudo -Hu testbot bash -lc "cd head && ../orderbench-head fetch -out ../corpus"
+
+    - name: Replay both revisions
+      shell: bash
+      run: |
+        # Interleaved, not batched: a runner that slows down halfway through would otherwise land
+        # entirely on whichever side ran second. Each invocation is a fresh process, which is what
+        # makes the passes independent samples rather than progressively warmer ones.
+        for pass in $(seq 1 "$PASSES"); do
+          sudo -Hu testbot bash -lc "./orderbench-base run -corpus ./corpus -mode $MODE -out base-$pass.ndjson"
+          sudo -Hu testbot bash -lc "./orderbench-head run -corpus ./corpus -mode $MODE -out head-$pass.ndjson"
+        done
+        cat base-*.ndjson > base.ndjson
+        cat head-*.ndjson > head.ndjson
+
+    - name: Compare
+      shell: bash
+      env:
+        BASELINE: ${{ github.event.pull_request.base.label || 'main' }}
+        MODIFIED: ${{ github.event.pull_request.head.label || github.ref_name }}
+        FAIL_ON_REGRESSION: ${{ inputs.fail_on_regression && '-fail-on-regression' || '' }}
+      run: |
+        sudo -Hu testbot bash -lc "./orderbench-head compare \
+          -base base.ndjson -head head.ndjson \
+          -base-label '$BASELINE' -head-label '$MODIFIED' \
+          -out motion-order-benchmark.md \
+          -json-out motion-order-benchmark.json \
+          $FAIL_ON_REGRESSION"
+        cat motion-order-benchmark.md
+
+    - name: Upload raw records
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: motion-order-benchmark-${{ env.MODE }}
+        path: |
+          base.ndjson
+          head.ndjson
+          motion-order-benchmark.md
+          motion-order-benchmark.json
+
+    - name: Add Motion Order Benchmark Comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      if: ${{ inputs.pr_number }}
+      with:
+        header: motion-order-benchmark-${{ env.MODE }}
+        number: ${{ inputs.pr_number }}
+        recreate: true
+        path: motion-order-benchmark.md

--- a/.github/workflows/motion-order-benchmark.yml
+++ b/.github/workflows/motion-order-benchmark.yml
@@ -87,9 +87,16 @@ jobs:
         # Interleaved, not batched: a runner that slows down halfway through would otherwise land
         # entirely on whichever side ran second. Each invocation is a fresh process, which is what
         # makes the passes independent samples rather than progressively warmer ones.
+        #
+        # The pinned settings are repeated on each command line because `sudo -H` resets the
+        # environment: a job-level `env:` block never reaches the replay. The harness pins both
+        # itself, so this is redundancy rather than the only line of defence -- but a comparison
+        # whose controls depend on the harness under test is not much of a control.
         for pass in $(seq 1 "$PASSES"); do
-          sudo -Hu testbot bash -lc "./orderbench-base run -corpus ./corpus -mode $MODE -out base-$pass.ndjson"
-          sudo -Hu testbot bash -lc "./orderbench-head run -corpus ./corpus -mode $MODE -out head-$pass.ndjson"
+          sudo -Hu testbot bash -lc \
+            "GOGC=$GOGC MOTION_ROADMAP_CACHE_DIR='$MOTION_ROADMAP_CACHE_DIR' ./orderbench-base run -corpus ./corpus -mode $MODE -out base-$pass.ndjson"
+          sudo -Hu testbot bash -lc \
+            "GOGC=$GOGC MOTION_ROADMAP_CACHE_DIR='$MOTION_ROADMAP_CACHE_DIR' ./orderbench-head run -corpus ./corpus -mode $MODE -out head-$pass.ndjson"
         done
         cat base-*.ndjson > base.ndjson
         cat head-*.ndjson > head.ndjson

--- a/.github/workflows/motion-pull-request-trusted.yml
+++ b/.github/workflows/motion-pull-request-trusted.yml
@@ -20,9 +20,23 @@ on:
 jobs:
   motion_benchmarks:
     if: |
-      github.event_name == 'workflow_dispatch' || 
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' && github.event.label.name == 'safe to test' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
     uses: viamrobotics/rdk/.github/workflows/motion-benchmarks.yml@main
     with:
       pr_number: ${{ github.event.pull_request.number }}
+
+  motion_order_benchmark:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' && github.event.label.name == 'safe to test' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
+    uses: viamrobotics/rdk/.github/workflows/motion-order-benchmark.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      mode: warm
+      passes: '2'
+      # The job fails on a regression so the verdict is unmissable, but the check is deliberately
+      # not marked required: planner timings on a shared runner are noisy enough that a red mark
+      # should prompt a look at the comment, not block the merge.
+      fail_on_regression: true
 

--- a/.github/workflows/motion-pull-request-trusted.yml
+++ b/.github/workflows/motion-pull-request-trusted.yml
@@ -33,7 +33,6 @@ jobs:
     uses: viamrobotics/rdk/.github/workflows/motion-order-benchmark.yml@main
     with:
       pr_number: ${{ github.event.pull_request.number }}
-      mode: warm
       passes: '2'
       # The job fails on a regression so the verdict is unmissable, but the check is deliberately
       # not marked required: planner timings on a shared runner are noisy enough that a red mark

--- a/motionplan/armplanning/orderbench/README.md
+++ b/motionplan/armplanning/orderbench/README.md
@@ -109,13 +109,25 @@ base revision, so a planner that buys latency with a worse path does not read as
 
 ## Adding a corpus
 
+Export the captures for one order:
+
 ```bash
 viam data export binary filter --destination ./order-export --tags <order-tag> --timeout 120
+```
 
-go run ./motionplan/armplanning/orderbench/cmd/orderbench ingest \
-  -export ./order-export -order <order-tag> \
-  -out ./corpus -artifact-path motionplan/order-replay/<name>
+Then build the corpus with `orderbench.Ingest`, which flattens the export's nested `tag=`
+directories, orders the plans by capture timestamp and writes the manifest. This is a rare
+maintenance task rather than part of running a benchmark, so it is a library call and not a CLI
+subcommand — a throwaway `main` is enough:
 
+```go
+manifest, err := orderbench.Ingest(
+    "./order-export", "<order-tag>", "./corpus", "motionplan/order-replay/<name>")
+```
+
+Commit the manifest, stage the payloads, and push:
+
+```bash
 cp ./corpus/manifest.json motionplan/armplanning/orderbench/corpora/<name>.json
 mkdir -p .artifact/data/motionplan/order-replay/<name>
 cp ./corpus/*.json .artifact/data/motionplan/order-replay/<name>/
@@ -124,7 +136,7 @@ artifact push   # needs ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS
 ```
 
 The export mixes in unrelated captures that share the order tag — the current one carries 215 MB of
-video alongside 107 MB of plans — which `ingest` filters out. Payloads go to the artifact store;
+video alongside 107 MB of plans — which `Ingest` filters out. Payloads go to the artifact store;
 only the manifest is committed, and it is what pins order, labels and content hashes. The replay
 verifies every payload against it before running, because a corpus that has silently drifted would
 invalidate every comparison made against it.

--- a/motionplan/armplanning/orderbench/README.md
+++ b/motionplan/armplanning/orderbench/README.md
@@ -12,21 +12,10 @@ which plans ran before it. A benchmark built from independent requests cannot se
 where real regressions have hidden — the same plan can be 0.07x or 5x depending on what the roadmap
 learned earlier in the order.
 
-So the corpus is ordered by the capture timestamp in each source filename, and the default replay
-runs the whole order in one process.
-
-## The two modes measure different things
-
-| mode   | what it does                                            | what it tells you                                       |
-| ------ | ------------------------------------------------------- | ------------------------------------------------------- |
-| `warm` | one process, plans in recorded order, caches accumulate | what production experiences over a shift                |
-| `cold` | a fresh forked process per plan                         | the per-plan floor — preprocessing that never amortises |
-
-They routinely disagree, which is the point. On the current corpus, the first few plans run 10–24 ms
-warm and 145–156 ms cold: that gap is scene preprocessing that a long-lived process pays once.
-
-Cold mode forks because the state that has to be discarded is process-global; there is nothing to
-reset from inside the process.
+So the corpus is ordered by the capture timestamp in each source filename, and the replay runs the
+whole order in a single process, letting those caches accumulate exactly as they do during a real
+shift. That is the only thing it measures, deliberately: an isolated per-plan number would be a
+different benchmark answering a question production never asks.
 
 ## Usage
 
@@ -34,7 +23,7 @@ Replay against the current checkout, pulling the corpus from the artifact store:
 
 ```bash
 go run ./motionplan/armplanning/orderbench/cmd/orderbench fetch
-go run ./motionplan/armplanning/orderbench/cmd/orderbench run -mode warm -out head.ndjson
+go run ./motionplan/armplanning/orderbench/cmd/orderbench run -out head.ndjson
 ```
 
 Compare two revisions. The harness must be the *same* on both sides or you are comparing harnesses
@@ -50,8 +39,8 @@ go build -o /tmp/orderbench-head ./motionplan/armplanning/orderbench/cmd/orderbe
 
 # Interleave the passes: a machine that drifts mid-run would otherwise charge it all to one side.
 for pass in 1 2; do
-  /tmp/orderbench-base run -corpus ./corpus -mode warm -out base-$pass.ndjson
-  /tmp/orderbench-head run -corpus ./corpus -mode warm -out head-$pass.ndjson
+  /tmp/orderbench-base run -corpus ./corpus -out base-$pass.ndjson
+  /tmp/orderbench-head run -corpus ./corpus -out head-$pass.ndjson
 done
 cat base-*.ndjson > base.ndjson; cat head-*.ndjson > head.ndjson
 
@@ -73,13 +62,13 @@ go test ./motionplan/armplanning/orderbench -run xxx -bench OrderReplay -benchti
 Each of these has silently produced a wrong answer at least once:
 
 - **On-disk roadmap cache.** `MOTION_ROADMAP_CACHE_DIR` is set explicitly (empty by default).
-  `viam-server` never sets it, so production runs cold; left enabled, the newer revision replays
-  learned corridors the older one structurally cannot have.
+  `viam-server` never sets it, so production starts with no roadmap on disk; left enabled, the newer
+  revision replays learned corridors the older one structurally cannot have.
 - **`GOGC`.** Pinned to 300 by the harness and by the workflow. `cmd-plan` sets this only on newer
   revisions, so an unpinned run measures the CLI difference rather than the library.
-- **Cold versus warm is a fork, not noise.** In-process repetitions reuse the in-memory roadmap, so
-  `-repeat N` measures the *warm* path getting warmer. Independent samples need separate processes —
-  which is why the workflow loops the binary instead of raising `-repeat`.
+- **Repetition inside one process is not replication.** In-process repeats reuse the in-memory
+  roadmap, so `-repeat N` measures the same warm path getting warmer. Independent samples need
+  separate processes — which is why the workflow loops the binary instead of raising `-repeat`.
 - **Records go to a file, never stdout.** `smart_seed.go` holds a package-level logger that writes
   to stdout and that no caller can silence, so anything parsing stdout eventually reads a log line
   as a result.

--- a/motionplan/armplanning/orderbench/README.md
+++ b/motionplan/armplanning/orderbench/README.md
@@ -104,5 +104,22 @@ Export the captures for one order:
 viam data export binary filter --destination ./order-export --tags <order-tag> --timeout 120
 ```
 
-Create a manifest similar to `motionplan/armplanning/orderbench/corpora/cappuccina-5fb95a4c.json`
-Use `artifact push` to push those our files storage
+Create a manifest similar to `motionplan/armplanning/orderbench/corpora/cappuccina-5fb95a4c.json`,
+ordering the entries by the capture timestamp in each source filename. The export mixes in unrelated
+captures that share the order tag — the current one carries 215 MB of video alongside 107 MB of
+plans — so the manifest is also what decides which files are part of the corpus.
+
+Then stage the payloads and push them to our file storage. `artifact push` uploads whatever sits
+under the manifest's `artifact_path`, so a manifest whose payloads were never staged points at
+nothing:
+
+```bash
+mkdir -p .artifact/data/motionplan/order-replay/<name>
+cp <plans> .artifact/data/motionplan/order-replay/<name>/
+artifact push   # needs ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS
+```
+
+Do not put the manifest itself in that directory: it is committed to the repo, and a stray file
+there would be swept up as corpus payload by the next push. The replay verifies every payload
+against the manifest before running, because a corpus that has silently drifted would invalidate
+every comparison made against it.

--- a/motionplan/armplanning/orderbench/README.md
+++ b/motionplan/armplanning/orderbench/README.md
@@ -104,28 +104,5 @@ Export the captures for one order:
 viam data export binary filter --destination ./order-export --tags <order-tag> --timeout 120
 ```
 
-Then build the corpus with `orderbench.Ingest`, which flattens the export's nested `tag=`
-directories, orders the plans by capture timestamp and writes the manifest. This is a rare
-maintenance task rather than part of running a benchmark, so it is a library call and not a CLI
-subcommand — a throwaway `main` is enough:
-
-```go
-manifest, err := orderbench.Ingest(
-    "./order-export", "<order-tag>", "./corpus", "motionplan/order-replay/<name>")
-```
-
-Commit the manifest, stage the payloads, and push:
-
-```bash
-cp ./corpus/manifest.json motionplan/armplanning/orderbench/corpora/<name>.json
-mkdir -p .artifact/data/motionplan/order-replay/<name>
-cp ./corpus/*.json .artifact/data/motionplan/order-replay/<name>/
-rm .artifact/data/motionplan/order-replay/<name>/manifest.json
-artifact push   # needs ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS
-```
-
-The export mixes in unrelated captures that share the order tag — the current one carries 215 MB of
-video alongside 107 MB of plans — which `Ingest` filters out. Payloads go to the artifact store;
-only the manifest is committed, and it is what pins order, labels and content hashes. The replay
-verifies every payload against it before running, because a corpus that has silently drifted would
-invalidate every comparison made against it.
+Create a manifest similar to `motionplan/armplanning/orderbench/corpora/cappuccina-5fb95a4c.json`
+Use `artifact push` to push those our files storage

--- a/motionplan/armplanning/orderbench/README.md
+++ b/motionplan/armplanning/orderbench/README.md
@@ -1,0 +1,130 @@
+# orderbench — motion planning order replay
+
+Replays a recorded sequence of production plan requests — one full robot order, in the order the
+robot actually planned them — and compares planner latency and trajectory quality across two RDK
+revisions.
+
+## Why a sequence, and not a set of plans
+
+`armplanning` carries state between calls inside a process: learned roadmaps, the smart-seed cache,
+and a process-wide registry of static-scene distance fields. What a plan costs therefore depends on
+which plans ran before it. A benchmark built from independent requests cannot see that, and it is
+where real regressions have hidden — the same plan can be 0.07x or 5x depending on what the roadmap
+learned earlier in the order.
+
+So the corpus is ordered by the capture timestamp in each source filename, and the default replay
+runs the whole order in one process.
+
+## The two modes measure different things
+
+| mode   | what it does                                            | what it tells you                                       |
+| ------ | ------------------------------------------------------- | ------------------------------------------------------- |
+| `warm` | one process, plans in recorded order, caches accumulate | what production experiences over a shift                |
+| `cold` | a fresh forked process per plan                         | the per-plan floor — preprocessing that never amortises |
+
+They routinely disagree, which is the point. On the current corpus, the first few plans run 10–24 ms
+warm and 145–156 ms cold: that gap is scene preprocessing that a long-lived process pays once.
+
+Cold mode forks because the state that has to be discarded is process-global; there is nothing to
+reset from inside the process.
+
+## Usage
+
+Replay against the current checkout, pulling the corpus from the artifact store:
+
+```bash
+go run ./motionplan/armplanning/orderbench/cmd/orderbench fetch
+go run ./motionplan/armplanning/orderbench/cmd/orderbench run -mode warm -out head.ndjson
+```
+
+Compare two revisions. The harness must be the *same* on both sides or you are comparing harnesses
+as well as libraries, so build the head harness against the base library:
+
+```bash
+git worktree add /tmp/rdk-base <base-sha>
+rm -rf /tmp/rdk-base/motionplan/armplanning/orderbench
+cp -r motionplan/armplanning/orderbench /tmp/rdk-base/motionplan/armplanning/orderbench
+
+go build -o /tmp/orderbench-head ./motionplan/armplanning/orderbench/cmd/orderbench
+(cd /tmp/rdk-base && go build -o /tmp/orderbench-base ./motionplan/armplanning/orderbench/cmd/orderbench)
+
+# Interleave the passes: a machine that drifts mid-run would otherwise charge it all to one side.
+for pass in 1 2; do
+  /tmp/orderbench-base run -corpus ./corpus -mode warm -out base-$pass.ndjson
+  /tmp/orderbench-head run -corpus ./corpus -mode warm -out head-$pass.ndjson
+done
+cat base-*.ndjson > base.ndjson; cat head-*.ndjson > head.ndjson
+
+/tmp/orderbench-head compare -base base.ndjson -head head.ndjson \
+  -base-label base -head-label head
+```
+
+The solver-attribution fields are read reflectively precisely so that the head harness still builds
+against an older `PlanMeta`.
+
+There is also a Go benchmark, which skips when the corpus cannot be fetched:
+
+```bash
+go test ./motionplan/armplanning/orderbench -run xxx -bench OrderReplay -benchtime 1x
+```
+
+## Controls that must stay pinned
+
+Each of these has silently produced a wrong answer at least once:
+
+- **On-disk roadmap cache.** `MOTION_ROADMAP_CACHE_DIR` is set explicitly (empty by default).
+  `viam-server` never sets it, so production runs cold; left enabled, the newer revision replays
+  learned corridors the older one structurally cannot have.
+- **`GOGC`.** Pinned to 300 by the harness and by the workflow. `cmd-plan` sets this only on newer
+  revisions, so an unpinned run measures the CLI difference rather than the library.
+- **Cold versus warm is a fork, not noise.** In-process repetitions reuse the in-memory roadmap, so
+  `-repeat N` measures the *warm* path getting warmer. Independent samples need separate processes —
+  which is why the workflow loops the binary instead of raising `-repeat`.
+- **Records go to a file, never stdout.** `smart_seed.go` holds a package-level logger that writes
+  to stdout and that no caller can silence, so anything parsing stdout eventually reads a log line
+  as a result.
+
+Only `PlanMotion` is timed. Parsing and `PrepSmartSeed` are recorded separately: they are roughly
+version-neutral and would dilute the signal.
+
+## Thresholds
+
+The report and the gate use different thresholds on purpose. Replaying the *same* build twice puts
+one or two of 98 plans past 1.25x, so a build cannot fail on that.
+
+| threshold          | default                    | gates?                                         |
+| ------------------ | -------------------------- | ---------------------------------------------- |
+| order total        | 1.10x                      | yes — repeat runs of one build land within ~2% |
+| per-plan, listed   | 1.25x                      | no                                             |
+| per-plan, gated    | 2.0x **and** ≥250 ms added | yes                                            |
+| newly failing plan | any                        | yes                                            |
+
+The absolute-time condition on the per-plan gate matters. A change that adds a flat per-plan cost to
+scene preprocessing shows up as a fleet of 7x regressions on the cheapest plans in the order — true
+as ratios, nearly irrelevant to how long the order takes. Those belong in the order total, and the
+tables are sorted by time added rather than by ratio for the same reason.
+
+Trajectory length is compared against the plan the robot actually executed as well as against the
+base revision, so a planner that buys latency with a worse path does not read as a win.
+
+## Adding a corpus
+
+```bash
+viam data export binary filter --destination ./order-export --tags <order-tag> --timeout 120
+
+go run ./motionplan/armplanning/orderbench/cmd/orderbench ingest \
+  -export ./order-export -order <order-tag> \
+  -out ./corpus -artifact-path motionplan/order-replay/<name>
+
+cp ./corpus/manifest.json motionplan/armplanning/orderbench/corpora/<name>.json
+mkdir -p .artifact/data/motionplan/order-replay/<name>
+cp ./corpus/*.json .artifact/data/motionplan/order-replay/<name>/
+rm .artifact/data/motionplan/order-replay/<name>/manifest.json
+artifact push   # needs ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS
+```
+
+The export mixes in unrelated captures that share the order tag — the current one carries 215 MB of
+video alongside 107 MB of plans — which `ingest` filters out. Payloads go to the artifact store;
+only the manifest is committed, and it is what pins order, labels and content hashes. The replay
+verifies every payload against it before running, because a corpus that has silently drifted would
+invalidate every comparison made against it.

--- a/motionplan/armplanning/orderbench/cmd/orderbench/main.go
+++ b/motionplan/armplanning/orderbench/cmd/orderbench/main.go
@@ -1,9 +1,12 @@
-// Package main is the CLI for the motion order benchmark: it turns a `viam data export` tree into
-// a replayable corpus, replays that corpus against the current revision, and diffs two runs.
+// Package main is the CLI for the motion order benchmark: it fetches a recorded corpus of plan
+// requests, replays it against the current revision, and diffs two runs.
 //
-//	orderbench ingest -export ./order-export -order <tag> -out ./corpus
-//	orderbench run    -corpus ./corpus -mode warm -out head.ndjson
+//	orderbench fetch   -out ./corpus
+//	orderbench run     -corpus ./corpus -mode warm -out head.ndjson
 //	orderbench compare -base base.ndjson -head head.ndjson -out report.md
+//
+// Building a corpus from a `viam data export` tree is a rare maintenance task rather than part of
+// running a benchmark, so it lives in orderbench.Ingest rather than here.
 package main
 
 import (
@@ -30,11 +33,9 @@ func main() {
 
 func run() error {
 	if len(os.Args) < 2 {
-		return errors.New("usage: orderbench <ingest|run|replay-one|compare> [flags]")
+		return errors.New("usage: orderbench <fetch|run|replay-one|compare> [flags]")
 	}
 	switch os.Args[1] {
-	case "ingest":
-		return runIngest(os.Args[2:])
 	case "fetch":
 		return runFetch(os.Args[2:])
 	case "run":
@@ -44,7 +45,7 @@ func run() error {
 	case "compare":
 		return runCompare(os.Args[2:])
 	default:
-		return fmt.Errorf("unknown command %q; want ingest, fetch, run, replay-one or compare", os.Args[1])
+		return fmt.Errorf("unknown command %q; want fetch, run, replay-one or compare", os.Args[1])
 	}
 }
 
@@ -77,33 +78,6 @@ func runFetch(args []string) error {
 		manifest.Order, len(manifest.Entries), float64(manifest.TotalBytes())/(1024*1024))
 	// The resolved path goes to stdout alone so a shell can capture it.
 	log.New(os.Stdout, "", 0).Print(dir)
-	return nil
-}
-
-func runIngest(args []string) error {
-	fs := flag.NewFlagSet("ingest", flag.ExitOnError)
-	exportDir := fs.String("export", "", "directory written by `viam data export binary filter --destination`")
-	order := fs.String("order", "", "order tag the captures were filtered by")
-	out := fs.String("out", "", "corpus directory to create")
-	artifactPath := fs.String("artifact-path", "", "path this corpus will occupy in the artifact tree")
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-	if *exportDir == "" || *order == "" || *out == "" {
-		return errors.New("ingest requires -export, -order and -out")
-	}
-
-	manifest, err := orderbench.Ingest(*exportDir, *order, *out, *artifactPath)
-	if err != nil {
-		return err
-	}
-
-	stdout := log.New(os.Stdout, "", 0)
-	stdout.Printf("ingested %d plans (%.1f MB) into %s",
-		len(manifest.Entries), float64(manifest.TotalBytes())/(1024*1024), *out)
-	stdout.Printf("recorded span: %s .. %s",
-		manifest.Entries[0].RecordedAt.Format(time.TimeOnly),
-		manifest.Entries[len(manifest.Entries)-1].RecordedAt.Format(time.TimeOnly))
 	return nil
 }
 

--- a/motionplan/armplanning/orderbench/cmd/orderbench/main.go
+++ b/motionplan/armplanning/orderbench/cmd/orderbench/main.go
@@ -2,7 +2,7 @@
 // requests, replays it against the current revision, and diffs two runs.
 //
 //	orderbench fetch   -out ./corpus
-//	orderbench run     -corpus ./corpus -mode warm -out head.ndjson
+//	orderbench run     -corpus ./corpus -out head.ndjson
 //	orderbench compare -base base.ndjson -head head.ndjson -out report.md
 //
 // Building a corpus from a `viam data export` tree is a rare maintenance task rather than part of
@@ -33,19 +33,17 @@ func main() {
 
 func run() error {
 	if len(os.Args) < 2 {
-		return errors.New("usage: orderbench <fetch|run|replay-one|compare> [flags]")
+		return errors.New("usage: orderbench <fetch|run|compare> [flags]")
 	}
 	switch os.Args[1] {
 	case "fetch":
 		return runFetch(os.Args[2:])
 	case "run":
 		return runReplay(os.Args[2:])
-	case "replay-one":
-		return runReplayOne(os.Args[2:])
 	case "compare":
 		return runCompare(os.Args[2:])
 	default:
-		return fmt.Errorf("unknown command %q; want fetch, run, replay-one or compare", os.Args[1])
+		return fmt.Errorf("unknown command %q; want fetch, run or compare", os.Args[1])
 	}
 }
 
@@ -84,7 +82,6 @@ func runFetch(args []string) error {
 type replayFlags struct {
 	corpus      string
 	corpusName  string
-	mode        string
 	repeat      int
 	limit       int
 	only        string
@@ -99,8 +96,6 @@ func (f *replayFlags) bind(fs *flag.FlagSet) {
 		"local corpus directory; when empty, -corpus-name is pulled from the artifact store")
 	fs.StringVar(&f.corpusName, "corpus-name", orderbench.DefaultCorpus,
 		"name of a compiled-in corpus manifest to resolve from the artifact store")
-	fs.StringVar(&f.mode, "mode", string(orderbench.ModeWarm),
-		"warm (one process, recorded order, caches accumulate) or cold (fresh process per plan)")
 	fs.IntVar(&f.repeat, "repeat", 1, "replay the whole order this many times")
 	fs.IntVar(&f.limit, "limit", 0, "replay only the first N plans (0 = all)")
 	fs.StringVar(&f.only, "only", "", "comma-separated substrings; keep only matching plans")
@@ -116,7 +111,6 @@ func (f *replayFlags) options() orderbench.Options {
 	opts := orderbench.Options{
 		CorpusDir:       f.corpus,
 		CorpusName:      f.corpusName,
-		Mode:            orderbench.Mode(f.mode),
 		Repeat:          f.repeat,
 		Limit:           f.limit,
 		RoadmapCacheDir: f.roadmapDir,
@@ -152,8 +146,8 @@ func runReplay(args []string) error {
 		source = "artifact:" + opts.CorpusName
 	}
 	stderr := log.New(os.Stderr, "", 0)
-	stderr.Printf("replaying %s in %s mode (repeat=%d, gc=%d, roadmap-cache=%q)",
-		source, opts.Mode, opts.Repeat, opts.GCPercent, opts.RoadmapCacheDir)
+	stderr.Printf("replaying %s (repeat=%d, gc=%d, roadmap-cache=%q)",
+		source, opts.Repeat, opts.GCPercent, opts.RoadmapCacheDir)
 
 	start := time.Now()
 	records, err := orderbench.Run(context.Background(), opts)
@@ -176,43 +170,6 @@ func runReplay(args []string) error {
 	stderr.Printf("replayed %d plans in %s wall clock; planning total %.2fs, %d failed",
 		len(stats), time.Since(start).Round(time.Millisecond), total/1000, failures)
 	return nil
-}
-
-// runReplayOne plans a single request in this fresh process and writes its record out. Cold mode
-// spawns this once per plan.
-func runReplayOne(args []string) error {
-	fs := flag.NewFlagSet("replay-one", flag.ExitOnError)
-	var flags replayFlags
-	flags.bind(fs)
-	recordOut := fs.String("record-out", "", "write the single JSON record here (required)")
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-	if fs.NArg() != 1 {
-		return errors.New("replay-one takes exactly one plan file")
-	}
-	if *recordOut == "" {
-		return errors.New("replay-one requires -record-out")
-	}
-
-	entry, err := orderbench.EntryFromEnv()
-	if err != nil {
-		return err
-	}
-
-	opts := flags.options()
-	opts.Mode = orderbench.ModeWarm // the child plans in-process; it *is* the fresh process
-	orderbench.ApplyProcessControls(opts)
-
-	record, err := orderbench.PlanOne(context.Background(), fs.Arg(0), entry, opts)
-	if err != nil {
-		return err
-	}
-	data, err := json.Marshal(record)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(*recordOut, data, 0o600)
 }
 
 func runCompare(args []string) error {

--- a/motionplan/armplanning/orderbench/cmd/orderbench/main.go
+++ b/motionplan/armplanning/orderbench/cmd/orderbench/main.go
@@ -4,9 +4,7 @@
 //	orderbench fetch   -out ./corpus
 //	orderbench run     -corpus ./corpus -out head.ndjson
 //	orderbench compare -base base.ndjson -head head.ndjson -out report.md
-//
-// Building a corpus from a `viam data export` tree is a rare maintenance task rather than part of
-// running a benchmark, so it lives in orderbench.Ingest rather than here.
+
 package main
 
 import (

--- a/motionplan/armplanning/orderbench/cmd/orderbench/main.go
+++ b/motionplan/armplanning/orderbench/cmd/orderbench/main.go
@@ -4,7 +4,6 @@
 //	orderbench fetch   -out ./corpus
 //	orderbench run     -corpus ./corpus -out head.ndjson
 //	orderbench compare -base base.ndjson -head head.ndjson -out report.md
-
 package main
 
 import (

--- a/motionplan/armplanning/orderbench/cmd/orderbench/main.go
+++ b/motionplan/armplanning/orderbench/cmd/orderbench/main.go
@@ -1,0 +1,301 @@
+// Package main is the CLI for the motion order benchmark: it turns a `viam data export` tree into
+// a replayable corpus, replays that corpus against the current revision, and diffs two runs.
+//
+//	orderbench ingest -export ./order-export -order <tag> -out ./corpus
+//	orderbench run    -corpus ./corpus -mode warm -out head.ndjson
+//	orderbench compare -base base.ndjson -head head.ndjson -out report.md
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/motionplan/armplanning/orderbench"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.New(os.Stderr, "", 0).Printf("error: %v", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if len(os.Args) < 2 {
+		return errors.New("usage: orderbench <ingest|run|replay-one|compare> [flags]")
+	}
+	switch os.Args[1] {
+	case "ingest":
+		return runIngest(os.Args[2:])
+	case "fetch":
+		return runFetch(os.Args[2:])
+	case "run":
+		return runReplay(os.Args[2:])
+	case "replay-one":
+		return runReplayOne(os.Args[2:])
+	case "compare":
+		return runCompare(os.Args[2:])
+	default:
+		return fmt.Errorf("unknown command %q; want ingest, fetch, run, replay-one or compare", os.Args[1])
+	}
+}
+
+// runFetch pulls a corpus out of the artifact store ahead of time, so that a replay's timings are
+// not polluted by a first-use download.
+func runFetch(args []string) error {
+	fs := flag.NewFlagSet("fetch", flag.ExitOnError)
+	name := fs.String("name", orderbench.DefaultCorpus, "corpus manifest compiled into this binary")
+	out := fs.String("out", "", "stage the corpus into this directory as symlinks (optional)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	manifest, err := orderbench.LoadEmbeddedManifest(*name)
+	if err != nil {
+		return err
+	}
+	dir, err := orderbench.Resolve(manifest)
+	if err != nil {
+		return err
+	}
+	if *out != "" {
+		if err := orderbench.StageCorpus(dir, manifest, *out); err != nil {
+			return err
+		}
+		dir = *out
+	}
+
+	log.New(os.Stderr, "", 0).Printf("corpus %s: %d plans, %.1f MB, verified",
+		manifest.Order, len(manifest.Entries), float64(manifest.TotalBytes())/(1024*1024))
+	// The resolved path goes to stdout alone so a shell can capture it.
+	log.New(os.Stdout, "", 0).Print(dir)
+	return nil
+}
+
+func runIngest(args []string) error {
+	fs := flag.NewFlagSet("ingest", flag.ExitOnError)
+	exportDir := fs.String("export", "", "directory written by `viam data export binary filter --destination`")
+	order := fs.String("order", "", "order tag the captures were filtered by")
+	out := fs.String("out", "", "corpus directory to create")
+	artifactPath := fs.String("artifact-path", "", "path this corpus will occupy in the artifact tree")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *exportDir == "" || *order == "" || *out == "" {
+		return errors.New("ingest requires -export, -order and -out")
+	}
+
+	manifest, err := orderbench.Ingest(*exportDir, *order, *out, *artifactPath)
+	if err != nil {
+		return err
+	}
+
+	stdout := log.New(os.Stdout, "", 0)
+	stdout.Printf("ingested %d plans (%.1f MB) into %s",
+		len(manifest.Entries), float64(manifest.TotalBytes())/(1024*1024), *out)
+	stdout.Printf("recorded span: %s .. %s",
+		manifest.Entries[0].RecordedAt.Format(time.TimeOnly),
+		manifest.Entries[len(manifest.Entries)-1].RecordedAt.Format(time.TimeOnly))
+	return nil
+}
+
+type replayFlags struct {
+	corpus      string
+	corpusName  string
+	mode        string
+	repeat      int
+	limit       int
+	only        string
+	roadmapDir  string
+	gcPercent   int
+	planTimeout time.Duration
+	verbose     bool
+}
+
+func (f *replayFlags) bind(fs *flag.FlagSet) {
+	fs.StringVar(&f.corpus, "corpus", "",
+		"local corpus directory; when empty, -corpus-name is pulled from the artifact store")
+	fs.StringVar(&f.corpusName, "corpus-name", orderbench.DefaultCorpus,
+		"name of a compiled-in corpus manifest to resolve from the artifact store")
+	fs.StringVar(&f.mode, "mode", string(orderbench.ModeWarm),
+		"warm (one process, recorded order, caches accumulate) or cold (fresh process per plan)")
+	fs.IntVar(&f.repeat, "repeat", 1, "replay the whole order this many times")
+	fs.IntVar(&f.limit, "limit", 0, "replay only the first N plans (0 = all)")
+	fs.StringVar(&f.only, "only", "", "comma-separated substrings; keep only matching plans")
+	fs.StringVar(&f.roadmapDir, "roadmap-cache", "",
+		"MOTION_ROADMAP_CACHE_DIR for the replay; empty disables the on-disk roadmap, matching viam-server")
+	fs.IntVar(&f.gcPercent, "gc-percent", 0, "GC target to pin (0 = harness default)")
+	fs.DurationVar(&f.planTimeout, "plan-timeout", 60*time.Second,
+		"per-plan wall clock cap, overriding the timeout recorded in the request (0 = use recorded)")
+	fs.BoolVar(&f.verbose, "v", false, "let planner logs through to stderr")
+}
+
+func (f *replayFlags) options() orderbench.Options {
+	opts := orderbench.Options{
+		CorpusDir:       f.corpus,
+		CorpusName:      f.corpusName,
+		Mode:            orderbench.Mode(f.mode),
+		Repeat:          f.repeat,
+		Limit:           f.limit,
+		RoadmapCacheDir: f.roadmapDir,
+		GCPercent:       f.gcPercent,
+		PlanTimeout:     f.planTimeout,
+	}
+	if f.only != "" {
+		opts.Only = strings.Split(f.only, ",")
+	}
+	if f.verbose {
+		opts.Logger = logging.NewLogger("orderbench")
+	}
+	return opts.WithDefaults()
+}
+
+func runReplay(args []string) error {
+	fs := flag.NewFlagSet("run", flag.ExitOnError)
+	var flags replayFlags
+	flags.bind(fs)
+	out := fs.String("out", "", "write newline-delimited JSON records here (required)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *out == "" {
+		return errors.New("run requires -out")
+	}
+
+	opts := flags.options()
+	orderbench.ApplyProcessControls(opts)
+
+	source := opts.CorpusDir
+	if source == "" {
+		source = "artifact:" + opts.CorpusName
+	}
+	stderr := log.New(os.Stderr, "", 0)
+	stderr.Printf("replaying %s in %s mode (repeat=%d, gc=%d, roadmap-cache=%q)",
+		source, opts.Mode, opts.Repeat, opts.GCPercent, opts.RoadmapCacheDir)
+
+	start := time.Now()
+	records, err := orderbench.Run(context.Background(), opts)
+	if err != nil {
+		return err
+	}
+	if err := orderbench.WriteRecords(*out, records); err != nil {
+		return err
+	}
+
+	stats := orderbench.Summarize(records)
+	var total float64
+	var failures int
+	for _, s := range stats {
+		total += s.PlanMS
+		if s.Failures > 0 {
+			failures++
+		}
+	}
+	stderr.Printf("replayed %d plans in %s wall clock; planning total %.2fs, %d failed",
+		len(stats), time.Since(start).Round(time.Millisecond), total/1000, failures)
+	return nil
+}
+
+// runReplayOne plans a single request in this fresh process and writes its record out. Cold mode
+// spawns this once per plan.
+func runReplayOne(args []string) error {
+	fs := flag.NewFlagSet("replay-one", flag.ExitOnError)
+	var flags replayFlags
+	flags.bind(fs)
+	recordOut := fs.String("record-out", "", "write the single JSON record here (required)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("replay-one takes exactly one plan file")
+	}
+	if *recordOut == "" {
+		return errors.New("replay-one requires -record-out")
+	}
+
+	entry, err := orderbench.EntryFromEnv()
+	if err != nil {
+		return err
+	}
+
+	opts := flags.options()
+	opts.Mode = orderbench.ModeWarm // the child plans in-process; it *is* the fresh process
+	orderbench.ApplyProcessControls(opts)
+
+	record, err := orderbench.PlanOne(context.Background(), fs.Arg(0), entry, opts)
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(*recordOut, data, 0o600)
+}
+
+func runCompare(args []string) error {
+	fs := flag.NewFlagSet("compare", flag.ExitOnError)
+	basePath := fs.String("base", "", "records from the baseline revision")
+	headPath := fs.String("head", "", "records from the revision under test")
+	baseLabel := fs.String("base-label", "base", "label for the baseline in the report")
+	headLabel := fs.String("head-label", "head", "label for the head revision in the report")
+	out := fs.String("out", "", "write the markdown report here (default stdout)")
+	jsonOut := fs.String("json-out", "", "also write the full report as JSON here")
+	planThreshold := fs.Float64("plan-threshold", orderbench.DefaultRegressionThreshold,
+		"per-plan slowdown ratio at which a plan is listed in the report")
+	gateThreshold := fs.Float64("gate-threshold", orderbench.DefaultGateThreshold,
+		"per-plan slowdown ratio that fails the build")
+	totalThreshold := fs.Float64("total-threshold", orderbench.DefaultTotalThreshold,
+		"whole-order slowdown ratio that fails the build")
+	failOnRegression := fs.Bool("fail-on-regression", false, "exit non-zero when the verdict is a regression")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *basePath == "" || *headPath == "" {
+		return errors.New("compare requires -base and -head")
+	}
+
+	base, err := orderbench.ReadRecords(*basePath)
+	if err != nil {
+		return err
+	}
+	head, err := orderbench.ReadRecords(*headPath)
+	if err != nil {
+		return err
+	}
+
+	report := orderbench.Compare(base, head, *baseLabel, *headLabel)
+	report.PlanThreshold = *planThreshold
+	report.GateThreshold = *gateThreshold
+	report.TotalThreshold = *totalThreshold
+
+	markdown := report.Markdown()
+	if *out == "" {
+		log.New(os.Stdout, "", 0).Print(markdown)
+	} else if err := os.WriteFile(*out, []byte(markdown), 0o600); err != nil {
+		return err
+	}
+
+	if *jsonOut != "" {
+		data, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(*jsonOut, append(data, '\n'), 0o600); err != nil {
+			return err
+		}
+	}
+
+	if verdict := report.Verdict(); verdict != nil && *failOnRegression {
+		return verdict
+	}
+	return nil
+}

--- a/motionplan/armplanning/orderbench/compare.go
+++ b/motionplan/armplanning/orderbench/compare.go
@@ -1,0 +1,470 @@
+package orderbench
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// DefaultRegressionThreshold is the per-plan slowdown ratio at which a plan is listed in the
+// report. This is a reporting threshold, not a gate: replaying the same build twice puts one or two
+// of 98 plans past it, so failing a build on it would be pure flake.
+const DefaultRegressionThreshold = 1.25
+
+// DefaultGateThreshold is the per-plan slowdown that actually fails a build. It sits well clear of
+// run-to-run noise, and comfortably below the multiples that real regressions have produced -- the
+// #6378 blow-up moved seven plans by 6.1x.
+const DefaultGateThreshold = 2.0
+
+// DefaultTotalThreshold is the slowdown ratio for the order as a whole, which does gate. It can be
+// far tighter than the per-plan number because summing 98 plans averages the jitter away: repeat
+// runs of one build land within about 2% of each other.
+const DefaultTotalThreshold = 1.10
+
+// minReportedMS keeps ratios of trivially short plans out of the regression list. A plan that goes
+// from 3ms to 9ms is a 3x that means nothing.
+const minReportedMS = 50.0
+
+// minGatedDeltaMS is the wall time a plan must actually add before its ratio can fail a build.
+// Without it, a change that puts a flat per-plan cost on scene preprocessing reads as a fleet of
+// 7x regressions on the cheapest plans in the order -- true as ratios, and nearly irrelevant to how
+// long the order takes.
+const minGatedDeltaMS = 250.0
+
+// maxTableRows caps how many plans each table lists. A pull request comment that runs to a hundred
+// rows does not get read.
+const maxTableRows = 12
+
+// PlanStat is one plan's result reduced across repeat passes.
+type PlanStat struct {
+	Index         int     `json:"index"`
+	Name          string  `json:"name"`
+	Step          string  `json:"step"`
+	Motion        string  `json:"motion"`
+	Passes        int     `json:"passes"`
+	PlanMS        float64 `json:"plan_ms"`
+	TrajectoryLen int     `json:"trajectory_len"`
+	TotalL2       float64 `json:"total_l2"`
+	Failures      int     `json:"failures"`
+	// RoadmapSolved and CBiRRTSolved are summed across passes; they explain where a latency change
+	// came from when the totals move.
+	RoadmapSolved int    `json:"roadmap_solved"`
+	CBiRRTSolved  int    `json:"cbirrt_solved"`
+	FirstErr      string `json:"first_err,omitempty"`
+}
+
+// Aggregate summarises one side of a comparison.
+type Aggregate struct {
+	Plans    int     `json:"plans"`
+	TotalMS  float64 `json:"total_ms"`
+	Failures int     `json:"failures"`
+	TotalL2  float64 `json:"total_l2"`
+}
+
+// PlanDelta pairs one plan's result on each side.
+type PlanDelta struct {
+	Name   string    `json:"name"`
+	Index  int       `json:"index"`
+	Step   string    `json:"step"`
+	Motion string    `json:"motion"`
+	Base   *PlanStat `json:"base,omitempty"`
+	Head   *PlanStat `json:"head,omitempty"`
+	// Ratio is head/base plan time. Zero when either side is missing or the base is zero.
+	Ratio float64 `json:"ratio"`
+	// DeltaMS is head minus base wall time. Ratios rank what changed most; this ranks what costs
+	// most, and the two orderings routinely disagree.
+	DeltaMS float64 `json:"delta_ms"`
+	// TrajectoryRatio is head/base trajectory length: a planner that buys speed with a worse path
+	// should not read as a win.
+	TrajectoryRatio float64 `json:"trajectory_ratio"`
+	NewFailure      bool    `json:"new_failure"`
+	FixedFailure    bool    `json:"fixed_failure"`
+}
+
+// Report is a full base-vs-head comparison for one replay mode.
+type Report struct {
+	Mode      string      `json:"mode"`
+	BaseLabel string      `json:"base_label"`
+	HeadLabel string      `json:"head_label"`
+	Base      Aggregate   `json:"base"`
+	Head      Aggregate   `json:"head"`
+	Deltas    []PlanDelta `json:"deltas"`
+
+	// PlanThreshold is the ratio above which a plan is listed; GateThreshold is the ratio above
+	// which it fails the build. Keeping them separate is what lets the report stay informative
+	// without the gate becoming flaky.
+	PlanThreshold  float64 `json:"plan_threshold"`
+	GateThreshold  float64 `json:"gate_threshold"`
+	TotalThreshold float64 `json:"total_threshold"`
+}
+
+// TotalRatio is head/base wall time for the whole order.
+func (r *Report) TotalRatio() float64 {
+	if r.Base.TotalMS == 0 {
+		return 0
+	}
+	return r.Head.TotalMS / r.Base.TotalMS
+}
+
+// Summarize reduces raw records to one PlanStat per plan, taking the median across repeat passes.
+// A median, not a mean: one interfering CI job should not move the answer.
+func Summarize(records []Record) map[string]*PlanStat {
+	type acc struct {
+		stat    *PlanStat
+		planMS  []float64
+		trajLen []float64
+		l2      []float64
+	}
+	byName := map[string]*acc{}
+
+	for _, rec := range records {
+		a, ok := byName[rec.Name]
+		if !ok {
+			a = &acc{stat: &PlanStat{
+				Index:  rec.Index,
+				Name:   rec.Name,
+				Step:   rec.Step,
+				Motion: rec.Motion,
+			}}
+			byName[rec.Name] = a
+		}
+		a.stat.Passes++
+		a.stat.RoadmapSolved += rec.GoalsRoadmapSolved
+		a.stat.CBiRRTSolved += rec.GoalsCBIRRTSolved
+		a.planMS = append(a.planMS, rec.PlanMS)
+		if rec.Failed() {
+			a.stat.Failures++
+			if a.stat.FirstErr == "" {
+				a.stat.FirstErr = rec.Err
+			}
+			continue
+		}
+		a.trajLen = append(a.trajLen, float64(rec.TrajectoryLen))
+		a.l2 = append(a.l2, rec.TotalL2)
+	}
+
+	out := make(map[string]*PlanStat, len(byName))
+	for name, a := range byName {
+		a.stat.PlanMS = median(a.planMS)
+		a.stat.TrajectoryLen = int(median(a.trajLen))
+		a.stat.TotalL2 = median(a.l2)
+		out[name] = a.stat
+	}
+	return out
+}
+
+func aggregate(stats map[string]*PlanStat) Aggregate {
+	var agg Aggregate
+	for _, s := range stats {
+		agg.Plans++
+		agg.TotalMS += s.PlanMS
+		agg.TotalL2 += s.TotalL2
+		if s.Failures > 0 {
+			agg.Failures++
+		}
+	}
+	return agg
+}
+
+// Compare builds a report from two sets of raw records. Records are joined on plan name, which is
+// derived from the manifest and so is stable across revisions.
+func Compare(base, head []Record, baseLabel, headLabel string) *Report {
+	baseStats := Summarize(base)
+	headStats := Summarize(head)
+
+	report := &Report{
+		BaseLabel:      baseLabel,
+		HeadLabel:      headLabel,
+		Base:           aggregate(baseStats),
+		Head:           aggregate(headStats),
+		PlanThreshold:  DefaultRegressionThreshold,
+		GateThreshold:  DefaultGateThreshold,
+		TotalThreshold: DefaultTotalThreshold,
+	}
+	if len(head) > 0 {
+		report.Mode = head[0].Mode
+	}
+
+	names := map[string]bool{}
+	for name := range baseStats {
+		names[name] = true
+	}
+	for name := range headStats {
+		names[name] = true
+	}
+
+	for name := range names {
+		b, h := baseStats[name], headStats[name]
+		delta := PlanDelta{Name: name, Base: b, Head: h}
+		switch {
+		case h != nil:
+			delta.Index, delta.Step, delta.Motion = h.Index, h.Step, h.Motion
+		case b != nil:
+			delta.Index, delta.Step, delta.Motion = b.Index, b.Step, b.Motion
+		}
+		if b != nil && h != nil {
+			delta.DeltaMS = h.PlanMS - b.PlanMS
+			if b.PlanMS > 0 {
+				delta.Ratio = h.PlanMS / b.PlanMS
+			}
+			if b.TrajectoryLen > 0 && h.TrajectoryLen > 0 {
+				delta.TrajectoryRatio = float64(h.TrajectoryLen) / float64(b.TrajectoryLen)
+			}
+			delta.NewFailure = b.Failures == 0 && h.Failures > 0
+			delta.FixedFailure = b.Failures > 0 && h.Failures == 0
+		}
+		report.Deltas = append(report.Deltas, delta)
+	}
+
+	sort.Slice(report.Deltas, func(i, j int) bool { return report.Deltas[i].Index < report.Deltas[j].Index })
+	return report
+}
+
+// Regressions returns the plans that got materially slower, ordered by the wall time they add.
+// Plans too short to time reliably are excluded regardless of their ratio.
+func (r *Report) Regressions() []PlanDelta {
+	out := r.slowerThan(r.PlanThreshold)
+	sort.Slice(out, func(i, j int) bool { return out[i].DeltaMS > out[j].DeltaMS })
+	return out
+}
+
+// GateFailures returns the plans slow enough to fail a build, worst first. A plan qualifies only if
+// it both exceeds the gate ratio and adds real wall time, so a flat per-plan cost spread over the
+// cheapest plans in the order cannot by itself fail a build -- it will show up in the order total
+// instead, which is where it belongs.
+func (r *Report) GateFailures() []PlanDelta {
+	var out []PlanDelta
+	for _, d := range r.slowerThan(r.GateThreshold) {
+		if d.DeltaMS >= minGatedDeltaMS {
+			out = append(out, d)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].DeltaMS > out[j].DeltaMS })
+	return out
+}
+
+func (r *Report) slowerThan(threshold float64) []PlanDelta {
+	var out []PlanDelta
+	for _, d := range r.Deltas {
+		if d.Base == nil || d.Head == nil {
+			continue
+		}
+		if d.Base.PlanMS < minReportedMS && d.Head.PlanMS < minReportedMS {
+			continue
+		}
+		if d.Ratio > threshold {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// Improvements returns the plans that got materially faster, ordered by the wall time they save.
+func (r *Report) Improvements() []PlanDelta {
+	var out []PlanDelta
+	for _, d := range r.Deltas {
+		if d.Base == nil || d.Head == nil || d.Ratio == 0 {
+			continue
+		}
+		if d.Base.PlanMS < minReportedMS && d.Head.PlanMS < minReportedMS {
+			continue
+		}
+		if d.Ratio < 1/r.PlanThreshold {
+			out = append(out, d)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].DeltaMS < out[j].DeltaMS })
+	return out
+}
+
+// QualityRegressions returns plans whose trajectory got materially longer. A planner that buys
+// latency with a worse path has not improved, and the latency table alone would call it a win.
+func (r *Report) QualityRegressions() []PlanDelta {
+	var out []PlanDelta
+	for _, d := range r.Deltas {
+		if d.TrajectoryRatio > trajectoryRegressionRatio {
+			out = append(out, d)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TrajectoryRatio > out[j].TrajectoryRatio })
+	return out
+}
+
+// trajectoryRegressionRatio is how much longer a trajectory has to get before it is called out.
+// The planner is stochastic, so short paths wander a little between runs.
+const trajectoryRegressionRatio = 1.15
+
+// NewFailures returns plans the head revision failed and the base revision solved.
+func (r *Report) NewFailures() []PlanDelta {
+	var out []PlanDelta
+	for _, d := range r.Deltas {
+		if d.NewFailure {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// Verdict reports whether the head revision regressed against the gate. A whole-order slowdown and
+// a newly failing plan both count; so does a single plan blowing up, because that is exactly the
+// shape past regressions took -- a handful of plans carrying a total that the mean hides.
+func (r *Report) Verdict() error {
+	var problems []string
+	if ratio := r.TotalRatio(); ratio > r.TotalThreshold {
+		problems = append(problems, fmt.Sprintf("order total %.2fx slower (threshold %.2fx)", ratio, r.TotalThreshold))
+	}
+	if failures := r.NewFailures(); len(failures) > 0 {
+		names := make([]string, 0, len(failures))
+		for _, d := range failures {
+			names = append(names, d.Name)
+		}
+		problems = append(problems, fmt.Sprintf("%d newly failing plan(s): %s", len(failures), strings.Join(names, ", ")))
+	}
+	if gated := r.GateFailures(); len(gated) > 0 {
+		worst := gated[0]
+		problems = append(problems, fmt.Sprintf("%d plan(s) over %.2fx, worst %s at %.2fx",
+			len(gated), r.GateThreshold, worst.Name, worst.Ratio))
+	}
+	if len(problems) == 0 {
+		return nil
+	}
+	return fmt.Errorf("motion order benchmark regressed: %s", strings.Join(problems, "; "))
+}
+
+// Markdown renders the report for a pull request comment.
+func (r *Report) Markdown() string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "### Motion order benchmark — `%s` replay\n\n", r.Mode)
+	fmt.Fprintf(&b, "`%s` (base) vs `%s` (head), %d plans replayed in recorded order.\n\n", r.BaseLabel, r.HeadLabel, r.Head.Plans)
+
+	fmt.Fprintf(&b, "| | base | head | ratio |\n|---|---:|---:|---:|\n")
+	fmt.Fprintf(&b, "| order total | %s | %s | **%s** |\n",
+		formatMS(r.Base.TotalMS), formatMS(r.Head.TotalMS), formatRatio(r.TotalRatio()))
+	fmt.Fprintf(&b, "| plans solved | %d | %d | |\n", r.Base.Plans-r.Base.Failures, r.Head.Plans-r.Head.Failures)
+	fmt.Fprintf(&b, "| plans failed | %d | %d | |\n", r.Base.Failures, r.Head.Failures)
+	if r.Base.TotalL2 > 0 {
+		fmt.Fprintf(&b, "| total joint travel (L2) | %.1f | %.1f | %s |\n",
+			r.Base.TotalL2, r.Head.TotalL2, formatRatio(r.Head.TotalL2/r.Base.TotalL2))
+	}
+	b.WriteString("\n")
+
+	if failures := r.NewFailures(); len(failures) > 0 {
+		fmt.Fprintf(&b, "#### ⛔ Newly failing plans (%d)\n\n", len(failures))
+		for _, d := range failures {
+			fmt.Fprintf(&b, "- `%s` — %s\n", d.Name, firstLine(d.Head.FirstErr))
+		}
+		b.WriteString("\n")
+	}
+
+	regressions := r.Regressions()
+	if len(regressions) > 0 {
+		fmt.Fprintf(&b, "#### 🔻 Slower than %.2fx (%d), by time added\n\n", r.PlanThreshold, len(regressions))
+		writeDeltaTable(&b, regressions)
+	}
+
+	improvements := r.Improvements()
+	if len(improvements) > 0 {
+		fmt.Fprintf(&b, "#### 🔺 Faster than %.2fx (%d), by time saved\n\n", r.PlanThreshold, len(improvements))
+		writeDeltaTable(&b, improvements)
+	}
+
+	if len(regressions) == 0 && len(improvements) == 0 {
+		fmt.Fprintf(&b, "No individual plan moved by more than %.2fx.\n\n", r.PlanThreshold)
+	}
+
+	if quality := r.QualityRegressions(); len(quality) > 0 {
+		fmt.Fprintf(&b, "#### 📏 Longer trajectories (%d)\n\n", len(quality))
+		b.WriteString("| plan | base | head | ratio | plan time |\n|---|---:|---:|---:|---:|\n")
+		shown := quality
+		if len(shown) > maxTableRows {
+			shown = shown[:maxTableRows]
+		}
+		for _, d := range shown {
+			fmt.Fprintf(&b, "| `%s` | %d | %d | **%s** | %s |\n",
+				d.Name, d.Base.TrajectoryLen, d.Head.TrajectoryLen, formatRatio(d.TrajectoryRatio), formatRatio(d.Ratio))
+		}
+		if len(quality) > len(shown) {
+			fmt.Fprintf(&b, "\n…and %d more.\n", len(quality)-len(shown))
+		}
+		b.WriteString("\n")
+	}
+
+	if err := r.Verdict(); err != nil {
+		fmt.Fprintf(&b, "\n**%s**\n", err.Error())
+	}
+	return b.String()
+}
+
+func writeDeltaTable(b *strings.Builder, deltas []PlanDelta) {
+	b.WriteString("| plan | base | head | Δ | ratio | traj len | roadmap/cBiRRT |\n")
+	b.WriteString("|---|---:|---:|---:|---:|---:|---:|\n")
+
+	shown := deltas
+	var hidden []PlanDelta
+	if len(deltas) > maxTableRows {
+		shown, hidden = deltas[:maxTableRows], deltas[maxTableRows:]
+	}
+
+	for _, d := range shown {
+		trajCell := "—"
+		if d.TrajectoryRatio > 0 {
+			trajCell = fmt.Sprintf("%d → %d (%s)", d.Base.TrajectoryLen, d.Head.TrajectoryLen, formatRatio(d.TrajectoryRatio))
+		}
+		fmt.Fprintf(b, "| `%s` | %s | %s | %s | **%s** | %s | %d/%d → %d/%d |\n",
+			d.Name, formatMS(d.Base.PlanMS), formatMS(d.Head.PlanMS), formatDelta(d.DeltaMS), formatRatio(d.Ratio), trajCell,
+			d.Base.RoadmapSolved, d.Base.CBiRRTSolved, d.Head.RoadmapSolved, d.Head.CBiRRTSolved)
+	}
+
+	if len(hidden) > 0 {
+		var tail float64
+		for _, d := range hidden {
+			tail += d.DeltaMS
+		}
+		fmt.Fprintf(b, "\n…and %d more, %s in total.\n", len(hidden), formatDelta(tail))
+	}
+	b.WriteString("\n")
+}
+
+func formatMS(ms float64) string {
+	if ms >= 1000 {
+		return fmt.Sprintf("%.2fs", ms/1000)
+	}
+	return fmt.Sprintf("%.0fms", ms)
+}
+
+// formatDelta always carries a sign, so a table sorted by time added stays readable when it runs
+// past zero into the plans that got faster.
+func formatDelta(ms float64) string {
+	sign := "+"
+	if ms < 0 {
+		sign = "−"
+		ms = -ms
+	}
+	return sign + formatMS(ms)
+}
+
+func formatRatio(ratio float64) string {
+	if ratio == 0 {
+		return "—"
+	}
+	return fmt.Sprintf("%.2fx", ratio)
+}
+
+func firstLine(s string) string {
+	line, _, _ := strings.Cut(s, "\n")
+	return line
+}
+
+func median(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[mid]
+	}
+	return (sorted[mid-1] + sorted[mid]) / 2
+}

--- a/motionplan/armplanning/orderbench/compare.go
+++ b/motionplan/armplanning/orderbench/compare.go
@@ -81,9 +81,8 @@ type PlanDelta struct {
 	FixedFailure    bool    `json:"fixed_failure"`
 }
 
-// Report is a full base-vs-head comparison for one replay mode.
+// Report is a full base-vs-head comparison.
 type Report struct {
-	Mode      string      `json:"mode"`
 	BaseLabel string      `json:"base_label"`
 	HeadLabel string      `json:"head_label"`
 	Base      Aggregate   `json:"base"`
@@ -180,9 +179,6 @@ func Compare(base, head []Record, baseLabel, headLabel string) *Report {
 		PlanThreshold:  DefaultRegressionThreshold,
 		GateThreshold:  DefaultGateThreshold,
 		TotalThreshold: DefaultTotalThreshold,
-	}
-	if len(head) > 0 {
-		report.Mode = head[0].Mode
 	}
 
 	names := map[string]bool{}
@@ -335,7 +331,7 @@ func (r *Report) Verdict() error {
 func (r *Report) Markdown() string {
 	var b strings.Builder
 
-	fmt.Fprintf(&b, "### Motion order benchmark — `%s` replay\n\n", r.Mode)
+	b.WriteString("### Motion order benchmark\n\n")
 	fmt.Fprintf(&b, "`%s` (base) vs `%s` (head), %d plans replayed in recorded order.\n\n", r.BaseLabel, r.HeadLabel, r.Head.Plans)
 
 	fmt.Fprintf(&b, "| | base | head | ratio |\n|---|---:|---:|---:|\n")

--- a/motionplan/armplanning/orderbench/corpora/cappuccina-5fb95a4c.json
+++ b/motionplan/armplanning/orderbench/corpora/cappuccina-5fb95a4c.json
@@ -1,0 +1,986 @@
+{
+  "order": "5fb95a4c-83f8-4e66-862d-52cbca842ed5",
+  "artifact_path": "motionplan/order-replay/cappuccina-5fb95a4c",
+  "entries": [
+    {
+      "index": 0,
+      "file": "000-153126.083-grinding-move.json",
+      "recorded_at": "2026-08-28T15:31:26.083Z",
+      "step": "grinding",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 578556,
+      "sha256": "7dd8a43435a8d32429c3beacbaf9f1121e1fef34a4705f63793958127799a05c"
+    },
+    {
+      "index": 1,
+      "file": "001-153129.698-grinding-move.json",
+      "recorded_at": "2026-08-28T15:31:29.698Z",
+      "step": "grinding",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 703897,
+      "sha256": "a047013d607d6a784b3b18a03fa13a31fd089f67a114d219c44861ffbfedcec1"
+    },
+    {
+      "index": 2,
+      "file": "002-153130.689-grinding-move.json",
+      "recorded_at": "2026-08-28T15:31:30.689Z",
+      "step": "grinding",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 703796,
+      "sha256": "c6d27b1c4fb01f80961974d6794abfdc71e08a6780ff4a552c2c4df7489caad9"
+    },
+    {
+      "index": 3,
+      "file": "003-153131.847-grinding-circular.json",
+      "recorded_at": "2026-08-28T15:31:31.847Z",
+      "step": "grinding",
+      "motion": "circular",
+      "outcome": "success",
+      "bytes": 1080984,
+      "sha256": "b7539d3e246e6dd51112a201ac57449ecd558e6effac40843dc2d941f1211e60"
+    },
+    {
+      "index": 4,
+      "file": "004-153143.958-tamping-move.json",
+      "recorded_at": "2026-08-28T15:31:43.958Z",
+      "step": "tamping",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 638962,
+      "sha256": "692d5dcc893b4e59b6ac567c26d44e1a921ee365992cde0cb934a77d9532afe5"
+    },
+    {
+      "index": 5,
+      "file": "005-153147.607-tamping-move.json",
+      "recorded_at": "2026-08-28T15:31:47.607Z",
+      "step": "tamping",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1618872,
+      "sha256": "0622c436f7b14111b2ec9750946e41bb5682f85613b135d1897d748ebc35c568"
+    },
+    {
+      "index": 6,
+      "file": "006-153152.592-tamping-move.json",
+      "recorded_at": "2026-08-28T15:31:52.592Z",
+      "step": "tamping",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1619099,
+      "sha256": "69c08140b31b0262bca3d9112189a9704ce81eba9ab10918f77999a24941e299"
+    },
+    {
+      "index": 7,
+      "file": "007-153209.673-locking_portafilter-move.json",
+      "recorded_at": "2026-08-28T15:32:09.673Z",
+      "step": "locking_portafilter",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 720883,
+      "sha256": "df52c97aa122f88e6dc563bbed7d81b7381454822193cdd125845c2f4f02984d"
+    },
+    {
+      "index": 8,
+      "file": "008-153214.999-locking_portafilter-move.json",
+      "recorded_at": "2026-08-28T15:32:14.999Z",
+      "step": "locking_portafilter",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1015590,
+      "sha256": "8f4a32244bad255b27d51726a68a7b931de64e1e19f11e23e4d5b6355d0ff1c9"
+    },
+    {
+      "index": 9,
+      "file": "009-153216.395-locking_portafilter-pivot.json",
+      "recorded_at": "2026-08-28T15:32:16.395Z",
+      "step": "locking_portafilter",
+      "motion": "pivot",
+      "outcome": "success",
+      "bytes": 1372568,
+      "sha256": "59aeff56e86e9dc0c08959097a62524d60ed98662f9cf5381ec70032d1ad41c7"
+    },
+    {
+      "index": 10,
+      "file": "010-153224.639-releasing_filter-move.json",
+      "recorded_at": "2026-08-28T15:32:24.639Z",
+      "step": "releasing_filter",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1812532,
+      "sha256": "30b0e5f186ba470a2582e9f7c5deda40cc3e190e975beab2d7308dd11bbb1e8d"
+    },
+    {
+      "index": 11,
+      "file": "011-153227.696-placing_cup-move.json",
+      "recorded_at": "2026-08-28T15:32:27.696Z",
+      "step": "placing_cup",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 578034,
+      "sha256": "fa212d140894e400c45132cda3f3950d678fc80b73566aa8d9451e9f8ffd3f26"
+    },
+    {
+      "index": 12,
+      "file": "012-153235.149-placing_cup-move.json",
+      "recorded_at": "2026-08-28T15:32:35.149Z",
+      "step": "placing_cup",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 578027,
+      "sha256": "c6cbfed5cd7e12d9ea672e7aa1dd67fd2ca08ee6cfc53660d7f2029eaad39ae4"
+    },
+    {
+      "index": 13,
+      "file": "013-153235.711-placing_cup-move.json",
+      "recorded_at": "2026-08-28T15:32:35.711Z",
+      "step": "placing_cup",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1961196,
+      "sha256": "e143aac080de1994dcba78a7c8b210d2c56f717d03b26f8c17b616e44257f704"
+    },
+    {
+      "index": 14,
+      "file": "014-153244.672-placing_cup-move.json",
+      "recorded_at": "2026-08-28T15:32:44.672Z",
+      "step": "placing_cup",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1978383,
+      "sha256": "d023d3ffed62329b6a638a252dbdd95f312f3cb1320dba9643d93928dd8501da"
+    },
+    {
+      "index": 15,
+      "file": "015-153257.279-placing_cup-move.json",
+      "recorded_at": "2026-08-28T15:32:57.279Z",
+      "step": "placing_cup",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 835312,
+      "sha256": "5a7012eaae058302ac9e00361017ef65945406d6e7fbaf1939e28f3a550d595d"
+    },
+    {
+      "index": 16,
+      "file": "016-153310.154-placing_cup-move.json",
+      "recorded_at": "2026-08-28T15:33:10.154Z",
+      "step": "placing_cup",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 2454585,
+      "sha256": "7e0f30ae6d6eb39f43a516612f59954cc0535c93cf5155f22bf552f9261db27e"
+    },
+    {
+      "index": 17,
+      "file": "017-153314.165-placing_cup-move.json",
+      "recorded_at": "2026-08-28T15:33:14.165Z",
+      "step": "placing_cup",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 2409161,
+      "sha256": "5b33d737939fa068857437f7a85997c4463f31ee2b81da241016fb3df4ba516e"
+    },
+    {
+      "index": 18,
+      "file": "018-153332.655-brewing-move.json",
+      "recorded_at": "2026-08-28T15:33:32.655Z",
+      "step": "brewing",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 663331,
+      "sha256": "4d98f706bd115c32e6ba8646b8a486b55e4f3ea9ea9cf9f01f8f798db17624c6"
+    },
+    {
+      "index": 19,
+      "file": "019-153336.155-brewing-move.json",
+      "recorded_at": "2026-08-28T15:33:36.155Z",
+      "step": "brewing",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 846129,
+      "sha256": "b1f4b9145452168c68acfbe037ef14910eab12e25c44cb88bba9f0e45e35fd44"
+    },
+    {
+      "index": 20,
+      "file": "020-153337.336-brewing-move.json",
+      "recorded_at": "2026-08-28T15:33:37.336Z",
+      "step": "brewing",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 846051,
+      "sha256": "b59165713ad31a6bd935ee56991206ed8433055812cecb39368813b2a4d8fbb8"
+    },
+    {
+      "index": 21,
+      "file": "021-153338.286-brewing-move.json",
+      "recorded_at": "2026-08-28T15:33:38.286Z",
+      "step": "brewing",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 578003,
+      "sha256": "89f8a3a97e1df2b3c564c1aaba098926927c404cd17f078b29c85bad69657c7b"
+    },
+    {
+      "index": 22,
+      "file": "022-153346.202-brewing-move.json",
+      "recorded_at": "2026-08-28T15:33:46.202Z",
+      "step": "brewing",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 577988,
+      "sha256": "176a263c7ec12f80c3578b5bb379c12601f49a1f4cecc3bbf7f55f24c6f487b7"
+    },
+    {
+      "index": 23,
+      "file": "023-153346.645-brewing-move.json",
+      "recorded_at": "2026-08-28T15:33:46.645Z",
+      "step": "brewing",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1795210,
+      "sha256": "37d65860a38e3fb2d684885512ee626594bdcd63865e7d18d59282c022354812"
+    },
+    {
+      "index": 24,
+      "file": "024-153352.938-brewing-move.json",
+      "recorded_at": "2026-08-28T15:33:52.938Z",
+      "step": "brewing",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1810376,
+      "sha256": "ea4243c5d438e4b6264bf832a742cc3d226350dcb29ab8ae0c45790694890e78"
+    },
+    {
+      "index": 25,
+      "file": "025-153404.593-brewing-move.json",
+      "recorded_at": "2026-08-28T15:34:04.593Z",
+      "step": "brewing",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 915731,
+      "sha256": "04fd9770714bfa3a428a4b79634eadf88db6ee73da117684c9f0e3bd46ce537d"
+    },
+    {
+      "index": 26,
+      "file": "026-153415.753-brewing-move.json",
+      "recorded_at": "2026-08-28T15:34:15.753Z",
+      "step": "brewing",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1811254,
+      "sha256": "f6fdebc8dc6d277f91aeed3bf63536f5bada0ebb0a557fbc255f267faac14a0f"
+    },
+    {
+      "index": 27,
+      "file": "027-153433.046-brewing-move.json",
+      "recorded_at": "2026-08-28T15:34:33.046Z",
+      "step": "brewing",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1808962,
+      "sha256": "898003fb36b08d16e16cc567325fe3cf119d40ee7db259e8bf25ddbe6af8cc6c"
+    },
+    {
+      "index": 28,
+      "file": "028-153435.099-brewing-carry.json",
+      "recorded_at": "2026-08-28T15:34:35.099Z",
+      "step": "brewing",
+      "motion": "carry",
+      "outcome": "success",
+      "bytes": 663768,
+      "sha256": "b4d84532a3ec0a261d3f7a6d469bec7e739284f48271358f7f337cc53a1e13dd"
+    },
+    {
+      "index": 29,
+      "file": "029-153439.206-brewing-move.json",
+      "recorded_at": "2026-08-28T15:34:39.206Z",
+      "step": "brewing",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1979424,
+      "sha256": "7584706d43a20d784bd1f8c33344ff97c0d31840ebb1a28267bf0c23364f531e"
+    },
+    {
+      "index": 30,
+      "file": "030-153443.810-brewing-move.json",
+      "recorded_at": "2026-08-28T15:34:43.81Z",
+      "step": "brewing",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1967616,
+      "sha256": "eb419d4e6328da83670f0fa345b2b072ae6dce7d665d58b4f334f73c80f9ef52"
+    },
+    {
+      "index": 31,
+      "file": "031-153448.198-opening_fridge-move.json",
+      "recorded_at": "2026-08-28T15:34:48.198Z",
+      "step": "opening_fridge",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 794189,
+      "sha256": "700560385550cdd30e6c0a2e836e3b53eadca90f0bd3a5304d8f0becbfb02516"
+    },
+    {
+      "index": 32,
+      "file": "032-153503.048-opening_fridge-move.json",
+      "recorded_at": "2026-08-28T15:35:03.048Z",
+      "step": "opening_fridge",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1488762,
+      "sha256": "f51e3786e339b8bc1df434b7c3bea414e5d1b1451dc87cd0e66dcd36c79d9844"
+    },
+    {
+      "index": 33,
+      "file": "033-153505.743-opening_fridge-open_door.json",
+      "recorded_at": "2026-08-28T15:35:05.743Z",
+      "step": "opening_fridge",
+      "motion": "open_door",
+      "outcome": "success",
+      "bytes": 601744,
+      "sha256": "37c63d9202793fc04e88825f85cdcc7e8e064443917869f051e9db9f4e58e2bd"
+    },
+    {
+      "index": 34,
+      "file": "034-153505.957-opening_fridge-open_door.json",
+      "recorded_at": "2026-08-28T15:35:05.957Z",
+      "step": "opening_fridge",
+      "motion": "open_door",
+      "outcome": "success",
+      "bytes": 579832,
+      "sha256": "af14e950053f5532315a451d5822e84ad308778e3a4c893c25c309cac4c2f720"
+    },
+    {
+      "index": 35,
+      "file": "035-153506.192-opening_fridge-open_door.json",
+      "recorded_at": "2026-08-28T15:35:06.192Z",
+      "step": "opening_fridge",
+      "motion": "open_door",
+      "outcome": "success",
+      "bytes": 579690,
+      "sha256": "bf2f82bdf8b3c0993dbe96095097929f9c0d93345cd2d8c81fff725dffec2c19"
+    },
+    {
+      "index": 36,
+      "file": "036-153506.394-opening_fridge-open_door.json",
+      "recorded_at": "2026-08-28T15:35:06.394Z",
+      "step": "opening_fridge",
+      "motion": "open_door",
+      "outcome": "success",
+      "bytes": 579231,
+      "sha256": "3a30fc34036099f419e045066873446e56e9b83ab6f71949175c8ac8f5aa5eda"
+    },
+    {
+      "index": 37,
+      "file": "037-153506.598-opening_fridge-open_door.json",
+      "recorded_at": "2026-08-28T15:35:06.598Z",
+      "step": "opening_fridge",
+      "motion": "open_door",
+      "outcome": "success",
+      "bytes": 579162,
+      "sha256": "6d01a82038c980fd49d54dfe7cbe10b069fefcd9d6b2cc0ba37afdf26fcf9da2"
+    },
+    {
+      "index": 38,
+      "file": "038-153506.794-opening_fridge-open_door.json",
+      "recorded_at": "2026-08-28T15:35:06.794Z",
+      "step": "opening_fridge",
+      "motion": "open_door",
+      "outcome": "success",
+      "bytes": 579352,
+      "sha256": "479a51ab57d05ac0c5480df73253536634df8d3dbd91131094335aab323044b3"
+    },
+    {
+      "index": 39,
+      "file": "039-153507.001-opening_fridge-open_door.json",
+      "recorded_at": "2026-08-28T15:35:07.001Z",
+      "step": "opening_fridge",
+      "motion": "open_door",
+      "outcome": "success",
+      "bytes": 579463,
+      "sha256": "2d6c8795c534f554fa2b6b9f3cd51bc0589b3d8e3de846713f236681811b96ec"
+    },
+    {
+      "index": 40,
+      "file": "040-153507.196-opening_fridge-open_door.json",
+      "recorded_at": "2026-08-28T15:35:07.196Z",
+      "step": "opening_fridge",
+      "motion": "open_door",
+      "outcome": "success",
+      "bytes": 579381,
+      "sha256": "51ebc6a6b76e8c2e6ab154d8b9f0874396365503850df853973ca8b9d2cc2e1b"
+    },
+    {
+      "index": 41,
+      "file": "041-153514.279-opening_fridge-move.json",
+      "recorded_at": "2026-08-28T15:35:14.279Z",
+      "step": "opening_fridge",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1500141,
+      "sha256": "c4e2187bf843e7bf7193685f188fc28f785bde56993ddf23d651ea64d88d19ea"
+    },
+    {
+      "index": 42,
+      "file": "042-153516.784-adding_milk-move.json",
+      "recorded_at": "2026-08-28T15:35:16.784Z",
+      "step": "adding_milk",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 630787,
+      "sha256": "b9fb68851557e86d1de730131477f8c13e274ff6e1667e9b5ded514a5943dac7"
+    },
+    {
+      "index": 43,
+      "file": "043-153521.282-adding_milk-move.json",
+      "recorded_at": "2026-08-28T15:35:21.282Z",
+      "step": "adding_milk",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 579377,
+      "sha256": "8aee2e2a9dae6bacfdbe5f0c8a7bfb4dc5778b88b510f4e805c7b1cfbf941c7e"
+    },
+    {
+      "index": 44,
+      "file": "044-153521.781-adding_milk-move.json",
+      "recorded_at": "2026-08-28T15:35:21.781Z",
+      "step": "adding_milk",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 2531219,
+      "sha256": "fb0671d372f01836de6b9cdb93b5af1a9875a4d81f1e48af94431b5597485693"
+    },
+    {
+      "index": 45,
+      "file": "045-153529.604-adding_milk-move.json",
+      "recorded_at": "2026-08-28T15:35:29.604Z",
+      "step": "adding_milk",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 2551896,
+      "sha256": "15af490c011ba04dc20dc05ba478abf261486c989edd53a0506c32a7b74a0790"
+    },
+    {
+      "index": 46,
+      "file": "046-153535.297-adding_milk-move.json",
+      "recorded_at": "2026-08-28T15:35:35.297Z",
+      "step": "adding_milk",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 794004,
+      "sha256": "dd635578ea61ca4f27d020a417055eca49b9dd81c3f43422582461b97201d67d"
+    },
+    {
+      "index": 47,
+      "file": "047-153542.859-adding_milk-pivot.json",
+      "recorded_at": "2026-08-28T15:35:42.859Z",
+      "step": "adding_milk",
+      "motion": "pivot",
+      "outcome": "success",
+      "bytes": 1331421,
+      "sha256": "84a929676737202a8e0454976424abae8df02cc209e193812fc7eecb64eed6a8"
+    },
+    {
+      "index": 48,
+      "file": "048-153548.126-adding_milk-pivot.json",
+      "recorded_at": "2026-08-28T15:35:48.126Z",
+      "step": "adding_milk",
+      "motion": "pivot",
+      "outcome": "success",
+      "bytes": 1330651,
+      "sha256": "7e8a8f0c3fe6da36b06cf3eb79b8353d6ba9fb4b33841bf9bf0f81c41a321b14"
+    },
+    {
+      "index": 49,
+      "file": "049-153550.610-adding_milk-move.json",
+      "recorded_at": "2026-08-28T15:35:50.61Z",
+      "step": "adding_milk",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 798434,
+      "sha256": "fa7670af0a92b32871cf2ca5d366346465b3278853d6159536bf135acd60c62b"
+    },
+    {
+      "index": 50,
+      "file": "050-153558.469-adding_milk-move.json",
+      "recorded_at": "2026-08-28T15:35:58.469Z",
+      "step": "adding_milk",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 2553698,
+      "sha256": "ddf38117e85dc074a428a1a736d616961e7ca6281ba89bccf0c3bbaaf9eb241b"
+    },
+    {
+      "index": 51,
+      "file": "051-153603.443-adding_milk-move.json",
+      "recorded_at": "2026-08-28T15:36:03.443Z",
+      "step": "adding_milk",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 2528490,
+      "sha256": "515abae39ba714dcfd57b4a52bf090263c8378929de4eda605797c31c0b8af1a"
+    },
+    {
+      "index": 52,
+      "file": "052-153608.679-closing_fridge-move.json",
+      "recorded_at": "2026-08-28T15:36:08.679Z",
+      "step": "closing_fridge",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 706785,
+      "sha256": "d6b68e43b16ff1c195c0b27cdc8ff607ed6899fe04dd11f940c2adb46f424828"
+    },
+    {
+      "index": 53,
+      "file": "053-153613.932-closing_fridge-move.json",
+      "recorded_at": "2026-08-28T15:36:13.932Z",
+      "step": "closing_fridge",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1500227,
+      "sha256": "59c829728e312cd6683214be8a376127639f6c0b723620ee2efad6bd33ead34a"
+    },
+    {
+      "index": 54,
+      "file": "054-153616.186-closing_fridge-close_door.json",
+      "recorded_at": "2026-08-28T15:36:16.186Z",
+      "step": "closing_fridge",
+      "motion": "close_door",
+      "outcome": "success",
+      "bytes": 579564,
+      "sha256": "3bacbb6f3c48d03b53f9582c507fda5afd7468a61cf803f05e8d1d24506440ea"
+    },
+    {
+      "index": 55,
+      "file": "055-153616.384-closing_fridge-close_door.json",
+      "recorded_at": "2026-08-28T15:36:16.384Z",
+      "step": "closing_fridge",
+      "motion": "close_door",
+      "outcome": "success",
+      "bytes": 579358,
+      "sha256": "7da8a077f2f26aff50737bcd5b5c92eadb70519a975b16844c5f7f7797fac15a"
+    },
+    {
+      "index": 56,
+      "file": "056-153616.607-closing_fridge-close_door.json",
+      "recorded_at": "2026-08-28T15:36:16.607Z",
+      "step": "closing_fridge",
+      "motion": "close_door",
+      "outcome": "success",
+      "bytes": 579001,
+      "sha256": "e90edf2955ce9743c91f1e1940dba24af09e52e3e00669069e219b5b294ef7bc"
+    },
+    {
+      "index": 57,
+      "file": "057-153616.814-closing_fridge-close_door.json",
+      "recorded_at": "2026-08-28T15:36:16.814Z",
+      "step": "closing_fridge",
+      "motion": "close_door",
+      "outcome": "success",
+      "bytes": 579143,
+      "sha256": "51e345f8a517ba3f14f8884c1b545b5963c4c06a7d9d2843a8d974ba82141432"
+    },
+    {
+      "index": 58,
+      "file": "058-153617.011-closing_fridge-close_door.json",
+      "recorded_at": "2026-08-28T15:36:17.011Z",
+      "step": "closing_fridge",
+      "motion": "close_door",
+      "outcome": "success",
+      "bytes": 579645,
+      "sha256": "53b2886ac362f2e3c479600ad6bf48d8b4f535d4653ac677a1f9d7d96db64bdd"
+    },
+    {
+      "index": 59,
+      "file": "059-153617.272-closing_fridge-close_door.json",
+      "recorded_at": "2026-08-28T15:36:17.272Z",
+      "step": "closing_fridge",
+      "motion": "close_door",
+      "outcome": "success",
+      "bytes": 579851,
+      "sha256": "c857bf35266804bb1246688c0538fc8547c800ba8309ef07a4af4c2081793c9c"
+    },
+    {
+      "index": 60,
+      "file": "060-153617.462-closing_fridge-close_door.json",
+      "recorded_at": "2026-08-28T15:36:17.462Z",
+      "step": "closing_fridge",
+      "motion": "close_door",
+      "outcome": "success",
+      "bytes": 579951,
+      "sha256": "7b093d057ec0cf753d4058715727b4947577bea4dc8e37d9a0ef0873fca23fac"
+    },
+    {
+      "index": 61,
+      "file": "061-153617.649-closing_fridge-close_door.json",
+      "recorded_at": "2026-08-28T15:36:17.649Z",
+      "step": "closing_fridge",
+      "motion": "close_door",
+      "outcome": "success",
+      "bytes": 578752,
+      "sha256": "47fb3e8f62efc566eb841fee7fcb1bf546a22970c020b4eb954cae2f07023a2f"
+    },
+    {
+      "index": 62,
+      "file": "062-153624.673-closing_fridge-move.json",
+      "recorded_at": "2026-08-28T15:36:24.673Z",
+      "step": "closing_fridge",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1488819,
+      "sha256": "c4fac7c48dbeda16b2ebe9b2c60e3cf35f3baec34f08e7511bbf1dac97186559"
+    },
+    {
+      "index": 63,
+      "file": "063-153628.349-serving-move.json",
+      "recorded_at": "2026-08-28T15:36:28.349Z",
+      "step": "serving",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 753394,
+      "sha256": "579d5e526d7a7d759155cd432b5fb35c92bc2e05fa01f64f814e3a16c363a671"
+    },
+    {
+      "index": 64,
+      "file": "064-153638.882-serving-move.json",
+      "recorded_at": "2026-08-28T15:36:38.882Z",
+      "step": "serving",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 2439061,
+      "sha256": "4f059d8ee73221f87678f4502bb3ec1b7b9922a47748b54ea51d4aae525e3541"
+    },
+    {
+      "index": 65,
+      "file": "065-153642.369-serving-move.json",
+      "recorded_at": "2026-08-28T15:36:42.369Z",
+      "step": "serving",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 2438291,
+      "sha256": "9d87865571b5d6ec8f3e79688d962b5407fa3213331aee05f1b7ac945e0e9adf"
+    },
+    {
+      "index": 66,
+      "file": "066-153644.748-serving-carry.json",
+      "recorded_at": "2026-08-28T15:36:44.748Z",
+      "step": "serving",
+      "motion": "carry",
+      "outcome": "success",
+      "bytes": 643548,
+      "sha256": "2d5aebfd5de2910c710df8c16ff749e6b082b8f022937eb8441b68bdad19928a"
+    },
+    {
+      "index": 67,
+      "file": "067-153647.477-serving-pivot.json",
+      "recorded_at": "2026-08-28T15:36:47.477Z",
+      "step": "serving",
+      "motion": "pivot",
+      "outcome": "success",
+      "bytes": 1002934,
+      "sha256": "d061a1cb458870c68e8f69745a4f7b26fdd2334aa4d4d473fdec4d26f17435a1"
+    },
+    {
+      "index": 68,
+      "file": "068-153651.758-serving-pivot.json",
+      "recorded_at": "2026-08-28T15:36:51.758Z",
+      "step": "serving",
+      "motion": "pivot",
+      "outcome": "success",
+      "bytes": 1003008,
+      "sha256": "8a0e83923cc994acdb3de2edd2819af26471f026c8a530489481be206447a039"
+    },
+    {
+      "index": 69,
+      "file": "069-153653.214-serving-carry.json",
+      "recorded_at": "2026-08-28T15:36:53.214Z",
+      "step": "serving",
+      "motion": "carry",
+      "outcome": "success",
+      "bytes": 686096,
+      "sha256": "040acc94d9b032cb4c05c4fe88ffd5ebb58f6d47ddcd1c55cbcd211339943411"
+    },
+    {
+      "index": 70,
+      "file": "070-153659.568-serving-move.json",
+      "recorded_at": "2026-08-28T15:36:59.568Z",
+      "step": "serving",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 2047138,
+      "sha256": "9f4479ab342f2033dd85823bce8bd06ca8e1a213fef780a63c646e6ef30a900c"
+    },
+    {
+      "index": 71,
+      "file": "071-153703.339-serving-move.json",
+      "recorded_at": "2026-08-28T15:37:03.339Z",
+      "step": "serving",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 2026703,
+      "sha256": "c4f16c254c2ff554a16f1d04d0e93645fd04bcce52f245dea759bb20f48538e6"
+    },
+    {
+      "index": 72,
+      "file": "072-153706.529-serving-move.json",
+      "recorded_at": "2026-08-28T15:37:06.529Z",
+      "step": "serving",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 578534,
+      "sha256": "5df69f9255e2f6e8df2796022788de50824100541ac707098827606501a638f8"
+    },
+    {
+      "index": 73,
+      "file": "073-153712.604-serving-move.json",
+      "recorded_at": "2026-08-28T15:37:12.604Z",
+      "step": "serving",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1966943,
+      "sha256": "bf3ce9998f959158078683f95329cbdf3c2435d21ee503155accd80846896efb"
+    },
+    {
+      "index": 74,
+      "file": "074-153716.800-serving-move.json",
+      "recorded_at": "2026-08-28T15:37:16.8Z",
+      "step": "serving",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1978945,
+      "sha256": "c179b9b4d7f681485320c8b6790508ccb78f6466f1b2f9b104a1509efc7f0de0"
+    },
+    {
+      "index": 75,
+      "file": "075-153733.046-serving-carry.json",
+      "recorded_at": "2026-08-28T15:37:33.046Z",
+      "step": "serving",
+      "motion": "carry",
+      "outcome": "success",
+      "bytes": 909035,
+      "sha256": "a560224b47c7e849eb74a2a0f4d7ebbaa14acf1e988eee5bc357ba6097491ebf"
+    },
+    {
+      "index": 76,
+      "file": "076-153746.084-serving-move.json",
+      "recorded_at": "2026-08-28T15:37:46.084Z",
+      "step": "serving",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 2040186,
+      "sha256": "6578f8a72b5c227f5acc736934eafa173610efae5f9d82fb1bb0fc97ecb82305"
+    },
+    {
+      "index": 77,
+      "file": "077-153749.872-serving-move.json",
+      "recorded_at": "2026-08-28T15:37:49.872Z",
+      "step": "serving",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 2020837,
+      "sha256": "eee6725a083726d0ec1f296a0c64c11c1a119013bc765e745e2afe5d2c2b88a4"
+    },
+    {
+      "index": 78,
+      "file": "078-153807.814-grabbing_filter-move.json",
+      "recorded_at": "2026-08-28T15:38:07.814Z",
+      "step": "grabbing_filter",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 704174,
+      "sha256": "4dff5fcd1ba02482c05efde8f8b1b42b59945d130e5ae467595a90825cbfd429"
+    },
+    {
+      "index": 79,
+      "file": "079-153815.779-grabbing_filter-move.json",
+      "recorded_at": "2026-08-28T15:38:15.779Z",
+      "step": "grabbing_filter",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1812534,
+      "sha256": "45ddd106c060e705008f360e156e07c8803e97dbaf46224435652c03ab6d35b1"
+    },
+    {
+      "index": 80,
+      "file": "080-153819.582-unlocking_portafilter-pivot.json",
+      "recorded_at": "2026-08-28T15:38:19.582Z",
+      "step": "unlocking_portafilter",
+      "motion": "pivot",
+      "outcome": "success",
+      "bytes": 1247397,
+      "sha256": "772acabd49a29d0aa6aa9c5d737fb3f9ee875c2a97f9cfe33d1b22a6176da424"
+    },
+    {
+      "index": 81,
+      "file": "081-153824.736-unlocking_portafilter-move.json",
+      "recorded_at": "2026-08-28T15:38:24.736Z",
+      "step": "unlocking_portafilter",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 703435,
+      "sha256": "e7695348bfae16e8abb33d03630f43b048bd4f934a6e641c7d2ef5c7ac8fc2f0"
+    },
+    {
+      "index": 82,
+      "file": "082-153825.312-unlocking_portafilter-circular.json",
+      "recorded_at": "2026-08-28T15:38:25.312Z",
+      "step": "unlocking_portafilter",
+      "motion": "circular",
+      "outcome": "success",
+      "bytes": 726096,
+      "sha256": "5fac032097a749eb3bc56defb40684e8459d6bad5255f8b1df0650539fc59da2"
+    },
+    {
+      "index": 83,
+      "file": "083-153826.144-unlocking_portafilter-move.json",
+      "recorded_at": "2026-08-28T15:38:26.144Z",
+      "step": "unlocking_portafilter",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 703598,
+      "sha256": "30c733988943214b00344369ed1f3434e136a2f143e48708d94c8b50e079b7b5"
+    },
+    {
+      "index": 84,
+      "file": "084-153826.731-unlocking_portafilter-move.json",
+      "recorded_at": "2026-08-28T15:38:26.731Z",
+      "step": "unlocking_portafilter",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 703479,
+      "sha256": "3168c111619b68a8d0287a17223ed2f278fc226ceb3284295fa5436afa18ea20"
+    },
+    {
+      "index": 85,
+      "file": "085-153827.773-unlocking_portafilter-circular.json",
+      "recorded_at": "2026-08-28T15:38:27.773Z",
+      "step": "unlocking_portafilter",
+      "motion": "circular",
+      "outcome": "success",
+      "bytes": 726124,
+      "sha256": "a538f83bc424f577e407374a58a6303017a32b4ae18cc5f3dc98e7ed576d0608"
+    },
+    {
+      "index": 86,
+      "file": "086-153828.689-unlocking_portafilter-move.json",
+      "recorded_at": "2026-08-28T15:38:28.689Z",
+      "step": "unlocking_portafilter",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 869660,
+      "sha256": "42c4eeac94b87b050fc99b357d6deb2cda11f38d1a51b22318ac364827e0f7fd"
+    },
+    {
+      "index": 87,
+      "file": "087-153833.922-cleaning-move.json",
+      "recorded_at": "2026-08-28T15:38:33.922Z",
+      "step": "cleaning",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 645186,
+      "sha256": "91c263e9a9e4bdce615519bfb7079f457ab074df2f8a9b86182f8037c939c099"
+    },
+    {
+      "index": 88,
+      "file": "088-153836.752-cleaning-move.json",
+      "recorded_at": "2026-08-28T15:38:36.752Z",
+      "step": "cleaning",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 578681,
+      "sha256": "133eb4252ad82319c2d33b472e30f125b48bf3764bdb13a5e911d8ba92a62c04"
+    },
+    {
+      "index": 89,
+      "file": "089-153842.065-cleaning-move.json",
+      "recorded_at": "2026-08-28T15:38:42.065Z",
+      "step": "cleaning",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1245807,
+      "sha256": "9bb5f4379b66eb260a2bccb2c05b5a6e577838b5ef6c93e74a522b28e6980a80"
+    },
+    {
+      "index": 90,
+      "file": "090-153843.194-cleaning-circular.json",
+      "recorded_at": "2026-08-28T15:38:43.194Z",
+      "step": "cleaning",
+      "motion": "circular",
+      "outcome": "success",
+      "bytes": 726081,
+      "sha256": "99346fd10f11460ed8b04ffa0ac3984ccb706522f8d423846ab6698e57a11d9d"
+    },
+    {
+      "index": 91,
+      "file": "091-153846.164-cleaning-move.json",
+      "recorded_at": "2026-08-28T15:38:46.164Z",
+      "step": "cleaning",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1245143,
+      "sha256": "95b7b9be2fef84aeea11d48229f8d8cf1206619eac5b8ddee73d70e2f7319f04"
+    },
+    {
+      "index": 92,
+      "file": "092-153847.685-cleaning-move.json",
+      "recorded_at": "2026-08-28T15:38:47.685Z",
+      "step": "cleaning",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1412793,
+      "sha256": "a2cdd776db3e26f84b196ee6cde332ac45278bd6ae8f1943ae06343f14fda5dc"
+    },
+    {
+      "index": 93,
+      "file": "093-153849.454-cleaning-move.json",
+      "recorded_at": "2026-08-28T15:38:49.454Z",
+      "step": "cleaning",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1245965,
+      "sha256": "dd6a972dab930306b5dd4cba15277d64d76aa37592b7dfb6a21dbe54d283f2d7"
+    },
+    {
+      "index": 94,
+      "file": "094-153850.584-cleaning-circular.json",
+      "recorded_at": "2026-08-28T15:38:50.584Z",
+      "step": "cleaning",
+      "motion": "circular",
+      "outcome": "success",
+      "bytes": 726106,
+      "sha256": "50468c2f2be2cf101b3c9d47988e7e9a8544ac88886ef3f8d0cf88713075e2f6"
+    },
+    {
+      "index": 95,
+      "file": "095-153853.741-cleaning-move.json",
+      "recorded_at": "2026-08-28T15:38:53.741Z",
+      "step": "cleaning",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 1246211,
+      "sha256": "83a99a343d0fbdad5c0c3cf6f8fcad2c39f72c859074f5b735973fce4702aa0c"
+    },
+    {
+      "index": 96,
+      "file": "096-153854.899-cleaning-move.json",
+      "recorded_at": "2026-08-28T15:38:54.899Z",
+      "step": "cleaning",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 578656,
+      "sha256": "10a6162d52871ccce47fd7a7ed3ff04eebb9dddbd64ae34bdf37d5d7326bc653"
+    },
+    {
+      "index": 97,
+      "file": "097-153900.281-finishing_up-move.json",
+      "recorded_at": "2026-08-28T15:39:00.281Z",
+      "step": "finishing_up",
+      "motion": "move",
+      "outcome": "success",
+      "bytes": 578470,
+      "sha256": "409ab62caf834f2dcb4adb18cc38faec986f53297c9fe0f16e98b5927f4bd770"
+    }
+  ]
+}

--- a/motionplan/armplanning/orderbench/corpus.go
+++ b/motionplan/armplanning/orderbench/corpus.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 )
@@ -68,96 +67,6 @@ func (m *Manifest) TotalBytes() int64 {
 		total += e.Bytes
 	}
 	return total
-}
-
-// Ingest converts a `viam data export binary` tree into a flat, ordered corpus directory plus its
-// manifest. The export layout nests each capture under `tag=` directories that carry the labels we
-// want to keep, and mixes in unrelated captures (video uploads) that share the order tag, so this
-// cannot be a plain directory copy.
-func Ingest(exportDir, order, dstDir, artifactPath string) (*Manifest, error) {
-	dataRoot := filepath.Join(exportDir, "data", "tag="+order)
-	if _, err := os.Stat(dataRoot); err != nil {
-		return nil, fmt.Errorf("no captures for order %q under %q: %w", order, exportDir, err)
-	}
-
-	type found struct {
-		src   string
-		entry Entry
-	}
-	var candidates []found
-
-	err := filepath.WalkDir(dataRoot, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-		match := exportFileRe.FindStringSubmatch(d.Name())
-		if match == nil {
-			return nil
-		}
-		recordedAt, err := time.Parse(recordedTimeLayout, match[1])
-		if err != nil {
-			return fmt.Errorf("unparseable timestamp in %q: %w", path, err)
-		}
-		rel, err := filepath.Rel(dataRoot, path)
-		if err != nil {
-			return err
-		}
-		labels := tagLabels(rel)
-		info, err := d.Info()
-		if err != nil {
-			return err
-		}
-		candidates = append(candidates, found{
-			src: path,
-			entry: Entry{
-				RecordedAt: recordedAt,
-				Step:       labels["step"],
-				Motion:     labels["motion"],
-				Outcome:    labels["planning"],
-				Bytes:      info.Size(),
-			},
-		})
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	if len(candidates) == 0 {
-		return nil, fmt.Errorf("no plan captures found under %q", dataRoot)
-	}
-
-	// Ties would make the corpus order depend on filesystem walk order, which differs between
-	// machines; fall back to the source path so the manifest is reproducible.
-	sort.Slice(candidates, func(i, j int) bool {
-		if !candidates[i].entry.RecordedAt.Equal(candidates[j].entry.RecordedAt) {
-			return candidates[i].entry.RecordedAt.Before(candidates[j].entry.RecordedAt)
-		}
-		return candidates[i].src < candidates[j].src
-	})
-
-	if err := os.MkdirAll(dstDir, 0o750); err != nil {
-		return nil, err
-	}
-
-	manifest := &Manifest{Order: order, ArtifactPath: artifactPath}
-	for i := range candidates {
-		c := &candidates[i]
-		c.entry.Index = i
-		c.entry.File = fmt.Sprintf("%03d-%s-%s-%s.json",
-			i, c.entry.RecordedAt.Format("150405.000"), c.entry.Step, c.entry.Motion)
-
-		sum, err := copyFile(c.src, filepath.Join(dstDir, c.entry.File))
-		if err != nil {
-			return nil, err
-		}
-		c.entry.SHA256 = sum
-		manifest.Entries = append(manifest.Entries, c.entry)
-	}
-
-	return manifest, manifest.WriteToFile(filepath.Join(dstDir, ManifestName))
 }
 
 // tagLabels pulls the `tag=<key>_<value>` path components the export uses to encode capture

--- a/motionplan/armplanning/orderbench/corpus.go
+++ b/motionplan/armplanning/orderbench/corpus.go
@@ -1,0 +1,248 @@
+// Package orderbench replays an ordered sequence of production plan requests captured from a
+// single robot order, so that planner latency and trajectory quality can be compared across two
+// RDK revisions.
+//
+// A single plan request in isolation says very little about the planner: armplanning carries
+// learned roadmaps, smart-seed caches and a static-scene SDF registry across calls within a
+// process, so the cost of a plan depends on which plans ran before it. Replaying a whole order in
+// recorded order is what exercises that, and it is the shape production actually runs.
+package orderbench
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ManifestName is the file, committed alongside the corpus, that pins replay order and labels.
+const ManifestName = "manifest.json"
+
+// recordedTimeLayout matches the timestamp prefix that the data capture pipeline puts on every
+// exported plan file, e.g. "20260828_153733.046_carry.json".
+const recordedTimeLayout = "20060102_150405.000"
+
+var exportFileRe = regexp.MustCompile(`^(\d{8}_\d{6}\.\d{3})_(.+)\.json$`)
+
+// Entry describes one captured plan request within a corpus. Entries are ordered by RecordedAt,
+// which is the order the robot actually planned them in.
+type Entry struct {
+	Index      int       `json:"index"`
+	File       string    `json:"file"`
+	RecordedAt time.Time `json:"recorded_at"`
+	Step       string    `json:"step"`
+	Motion     string    `json:"motion"`
+	Outcome    string    `json:"outcome"`
+	Bytes      int64     `json:"bytes"`
+	SHA256     string    `json:"sha256"`
+}
+
+// Name is the stable label used to join a plan across two runs of the benchmark. It must not
+// depend on timing or on the revision under test.
+func (e Entry) Name() string {
+	return fmt.Sprintf("%03d/%s/%s", e.Index, e.Step, e.Motion)
+}
+
+// Manifest is the committed index of a corpus. The payloads themselves are far too large for git
+// and live in the artifact store; this file is what makes the replay reproducible: it fixes the
+// order, the labels, and the content hashes.
+type Manifest struct {
+	// Order is the data-capture tag the corpus was exported from.
+	Order string `json:"order"`
+	// ArtifactPath is where the payloads live in the artifact tree.
+	ArtifactPath string  `json:"artifact_path"`
+	Entries      []Entry `json:"entries"`
+}
+
+// TotalBytes reports the on-disk size of the corpus payloads.
+func (m *Manifest) TotalBytes() int64 {
+	var total int64
+	for _, e := range m.Entries {
+		total += e.Bytes
+	}
+	return total
+}
+
+// Ingest converts a `viam data export binary` tree into a flat, ordered corpus directory plus its
+// manifest. The export layout nests each capture under `tag=` directories that carry the labels we
+// want to keep, and mixes in unrelated captures (video uploads) that share the order tag, so this
+// cannot be a plain directory copy.
+func Ingest(exportDir, order, dstDir, artifactPath string) (*Manifest, error) {
+	dataRoot := filepath.Join(exportDir, "data", "tag="+order)
+	if _, err := os.Stat(dataRoot); err != nil {
+		return nil, fmt.Errorf("no captures for order %q under %q: %w", order, exportDir, err)
+	}
+
+	type found struct {
+		src   string
+		entry Entry
+	}
+	var candidates []found
+
+	err := filepath.WalkDir(dataRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		match := exportFileRe.FindStringSubmatch(d.Name())
+		if match == nil {
+			return nil
+		}
+		recordedAt, err := time.Parse(recordedTimeLayout, match[1])
+		if err != nil {
+			return fmt.Errorf("unparseable timestamp in %q: %w", path, err)
+		}
+		rel, err := filepath.Rel(dataRoot, path)
+		if err != nil {
+			return err
+		}
+		labels := tagLabels(rel)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		candidates = append(candidates, found{
+			src: path,
+			entry: Entry{
+				RecordedAt: recordedAt,
+				Step:       labels["step"],
+				Motion:     labels["motion"],
+				Outcome:    labels["planning"],
+				Bytes:      info.Size(),
+			},
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no plan captures found under %q", dataRoot)
+	}
+
+	// Ties would make the corpus order depend on filesystem walk order, which differs between
+	// machines; fall back to the source path so the manifest is reproducible.
+	sort.Slice(candidates, func(i, j int) bool {
+		if !candidates[i].entry.RecordedAt.Equal(candidates[j].entry.RecordedAt) {
+			return candidates[i].entry.RecordedAt.Before(candidates[j].entry.RecordedAt)
+		}
+		return candidates[i].src < candidates[j].src
+	})
+
+	if err := os.MkdirAll(dstDir, 0o750); err != nil {
+		return nil, err
+	}
+
+	manifest := &Manifest{Order: order, ArtifactPath: artifactPath}
+	for i := range candidates {
+		c := &candidates[i]
+		c.entry.Index = i
+		c.entry.File = fmt.Sprintf("%03d-%s-%s-%s.json",
+			i, c.entry.RecordedAt.Format("150405.000"), c.entry.Step, c.entry.Motion)
+
+		sum, err := copyFile(c.src, filepath.Join(dstDir, c.entry.File))
+		if err != nil {
+			return nil, err
+		}
+		c.entry.SHA256 = sum
+		manifest.Entries = append(manifest.Entries, c.entry)
+	}
+
+	return manifest, manifest.WriteToFile(filepath.Join(dstDir, ManifestName))
+}
+
+// tagLabels pulls the `tag=<key>_<value>` path components the export uses to encode capture
+// labels. The order step, the motion kind and the planning outcome all arrive this way.
+func tagLabels(relPath string) map[string]string {
+	labels := map[string]string{}
+	for part := range strings.SplitSeq(filepath.ToSlash(relPath), "/") {
+		tag, ok := strings.CutPrefix(part, "tag=")
+		if !ok {
+			continue
+		}
+		key, value, ok := strings.Cut(tag, "_")
+		if !ok {
+			continue
+		}
+		labels[key] = value
+	}
+	return labels
+}
+
+func copyFile(src, dst string) (string, error) {
+	in, err := os.Open(filepath.Clean(src))
+	if err != nil {
+		return "", err
+	}
+	defer in.Close() //nolint:errcheck
+
+	out, err := os.OpenFile(filepath.Clean(dst), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return "", err
+	}
+
+	hasher := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(out, hasher), in); err != nil {
+		out.Close() //nolint:errcheck
+		return "", err
+	}
+	if err := out.Close(); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+// WriteToFile writes the manifest as indented JSON, which keeps it reviewable in a diff.
+func (m *Manifest) WriteToFile(path string) error {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o600)
+}
+
+// LoadManifest reads a manifest from a corpus directory or from a direct path to the file.
+func LoadManifest(path string) (*Manifest, error) {
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		path = filepath.Join(path, ManifestName)
+	}
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	if len(m.Entries) == 0 {
+		return nil, fmt.Errorf("manifest %q has no entries", path)
+	}
+	return &m, nil
+}
+
+// Verify checks that every payload named by the manifest is present in dir and unmodified. A
+// corpus that has silently drifted would invalidate a cross-revision comparison, so the replay
+// refuses to run without this passing.
+func (m *Manifest) Verify(dir string) error {
+	for _, e := range m.Entries {
+		path := filepath.Join(dir, e.File)
+		data, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			return fmt.Errorf("corpus entry %s: %w", e.Name(), err)
+		}
+		sum := sha256.Sum256(data)
+		if got := hex.EncodeToString(sum[:]); got != e.SHA256 {
+			return fmt.Errorf("corpus entry %s: content hash %s does not match manifest %s", e.Name(), got, e.SHA256)
+		}
+	}
+	return nil
+}

--- a/motionplan/armplanning/orderbench/corpus.go
+++ b/motionplan/armplanning/orderbench/corpus.go
@@ -13,22 +13,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strings"
 	"time"
 )
 
 // ManifestName is the file, committed alongside the corpus, that pins replay order and labels.
 const ManifestName = "manifest.json"
-
-// recordedTimeLayout matches the timestamp prefix that the data capture pipeline puts on every
-// exported plan file, e.g. "20260828_153733.046_carry.json".
-const recordedTimeLayout = "20060102_150405.000"
-
-var exportFileRe = regexp.MustCompile(`^(\d{8}_\d{6}\.\d{3})_(.+)\.json$`)
 
 // Entry describes one captured plan request within a corpus. Entries are ordered by RecordedAt,
 // which is the order the robot actually planned them in.
@@ -67,47 +58,6 @@ func (m *Manifest) TotalBytes() int64 {
 		total += e.Bytes
 	}
 	return total
-}
-
-// tagLabels pulls the `tag=<key>_<value>` path components the export uses to encode capture
-// labels. The order step, the motion kind and the planning outcome all arrive this way.
-func tagLabels(relPath string) map[string]string {
-	labels := map[string]string{}
-	for part := range strings.SplitSeq(filepath.ToSlash(relPath), "/") {
-		tag, ok := strings.CutPrefix(part, "tag=")
-		if !ok {
-			continue
-		}
-		key, value, ok := strings.Cut(tag, "_")
-		if !ok {
-			continue
-		}
-		labels[key] = value
-	}
-	return labels
-}
-
-func copyFile(src, dst string) (string, error) {
-	in, err := os.Open(filepath.Clean(src))
-	if err != nil {
-		return "", err
-	}
-	defer in.Close() //nolint:errcheck
-
-	out, err := os.OpenFile(filepath.Clean(dst), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		return "", err
-	}
-
-	hasher := sha256.New()
-	if _, err := io.Copy(io.MultiWriter(out, hasher), in); err != nil {
-		out.Close() //nolint:errcheck
-		return "", err
-	}
-	if err := out.Close(); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
 // WriteToFile writes the manifest as indented JSON, which keeps it reviewable in a diff.

--- a/motionplan/armplanning/orderbench/embedded.go
+++ b/motionplan/armplanning/orderbench/embedded.go
@@ -1,0 +1,123 @@
+package orderbench
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"go.viam.com/utils/artifact"
+)
+
+// DefaultCorpus is the corpus replayed when none is named: one full espresso-drink order captured
+// from a Cappuccina machine, 98 plans over about seven and a half minutes.
+const DefaultCorpus = "cappuccina-5fb95a4c"
+
+// corpora holds the committed manifests. They are embedded rather than read from disk so the
+// harness stays self-contained when it is compiled inside a checkout of an older revision, which is
+// how a base-vs-head comparison is built.
+//
+//go:embed corpora/*.json
+var corpora embed.FS
+
+// ListCorpora names every manifest compiled into this binary.
+func ListCorpora() []string {
+	entries, err := corpora.ReadDir("corpora")
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, strings.TrimSuffix(e.Name(), ".json"))
+	}
+	sort.Strings(names)
+	return names
+}
+
+// LoadEmbeddedManifest returns the committed manifest for a named corpus.
+func LoadEmbeddedManifest(name string) (*Manifest, error) {
+	if name == "" {
+		name = DefaultCorpus
+	}
+	data, err := corpora.ReadFile(filepath.Join("corpora", name+".json"))
+	if err != nil {
+		return nil, fmt.Errorf("no corpus named %q is compiled in; have %v", name, ListCorpora())
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// Resolve fetches a corpus's payloads from the artifact store and returns the directory holding
+// them. The payloads run to about 100 MB, far past what belongs in git, so the manifest names an
+// artifact path and this pulls it on demand -- the same mechanism the rest of the repo's large test
+// fixtures use.
+//
+// The returned directory is verified against the manifest before use: a corpus that has silently
+// drifted would invalidate every comparison made against it.
+func Resolve(m *Manifest) (string, error) {
+	if m.ArtifactPath == "" {
+		return "", fmt.Errorf("corpus %q has no artifact path", m.Order)
+	}
+
+	dir, err := artifact.Path(m.ArtifactPath)
+	if err != nil {
+		return "", fmt.Errorf("fetching corpus %q from the artifact store: %w", m.ArtifactPath, err)
+	}
+
+	// Nothing is written into the resolved directory: it is the artifact cache, and a stray file
+	// there would be swept up by the next `artifact push` as though it were corpus payload.
+	if err := m.Verify(dir); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// ResolveCorpusDir works out which directory a replay should read, given either an explicit local
+// directory or the name of an embedded corpus.
+func ResolveCorpusDir(dir, name string) (string, *Manifest, error) {
+	if dir != "" {
+		manifest, err := LoadManifest(dir)
+		if err != nil {
+			return "", nil, err
+		}
+		return dir, manifest, manifest.Verify(dir)
+	}
+
+	manifest, err := LoadEmbeddedManifest(name)
+	if err != nil {
+		return "", nil, err
+	}
+	resolved, err := Resolve(manifest)
+	if err != nil {
+		return "", nil, err
+	}
+	return resolved, manifest, nil
+}
+
+// StageCorpus materializes a corpus into dstDir as symlinks to the artifact cache, plus the
+// manifest. Useful when a run wants a stable path (a CI step, say) without copying 100 MB.
+func StageCorpus(srcDir string, m *Manifest, dstDir string) error {
+	if err := os.MkdirAll(dstDir, 0o750); err != nil {
+		return err
+	}
+	srcAbs, err := filepath.Abs(srcDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range m.Entries {
+		link := filepath.Join(dstDir, entry.File)
+		if err := os.Remove(link); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		if err := os.Symlink(filepath.Join(srcAbs, entry.File), link); err != nil {
+			return err
+		}
+	}
+	return m.WriteToFile(filepath.Join(dstDir, ManifestName))
+}

--- a/motionplan/armplanning/orderbench/orderbench_test.go
+++ b/motionplan/armplanning/orderbench/orderbench_test.go
@@ -2,12 +2,10 @@ package orderbench
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"go.viam.com/test"
 )
@@ -116,19 +114,17 @@ func TestSummarizeExcludesFailedPlansFromQuality(t *testing.T) {
 
 func TestCompareFlagsRegressionsAndFailures(t *testing.T) {
 	base := []Record{
-		{Mode: "warm", Index: 0, Name: "000/a/move", PlanMS: 1000, TrajectoryLen: 100, TotalL2: 3},
-		{Mode: "warm", Index: 1, Name: "001/b/move", PlanMS: 500, TrajectoryLen: 50, TotalL2: 2},
-		{Mode: "warm", Index: 2, Name: "002/c/move", PlanMS: 200, TrajectoryLen: 20, TotalL2: 1},
+		{Index: 0, Name: "000/a/move", PlanMS: 1000, TrajectoryLen: 100, TotalL2: 3},
+		{Index: 1, Name: "001/b/move", PlanMS: 500, TrajectoryLen: 50, TotalL2: 2},
+		{Index: 2, Name: "002/c/move", PlanMS: 200, TrajectoryLen: 20, TotalL2: 1},
 	}
 	head := []Record{
-		{Mode: "warm", Index: 0, Name: "000/a/move", PlanMS: 6000, TrajectoryLen: 140, TotalL2: 4},
-		{Mode: "warm", Index: 1, Name: "001/b/move", PlanMS: 480, TrajectoryLen: 50, TotalL2: 2},
-		{Mode: "warm", Index: 2, Name: "002/c/move", PlanMS: 210, Err: "no path found"},
+		{Index: 0, Name: "000/a/move", PlanMS: 6000, TrajectoryLen: 140, TotalL2: 4},
+		{Index: 1, Name: "001/b/move", PlanMS: 480, TrajectoryLen: 50, TotalL2: 2},
+		{Index: 2, Name: "002/c/move", PlanMS: 210, Err: "no path found"},
 	}
 
 	report := Compare(base, head, "v1.5.0", "main")
-	test.That(t, report.Mode, test.ShouldEqual, "warm")
-
 	regressions := report.Regressions()
 	test.That(t, len(regressions), test.ShouldEqual, 1)
 	test.That(t, regressions[0].Name, test.ShouldEqual, "000/a/move")
@@ -152,8 +148,8 @@ func TestCompareFlagsRegressionsAndFailures(t *testing.T) {
 
 func TestCompareIgnoresRatiosOnTrivialPlans(t *testing.T) {
 	// A 3ms plan going to 9ms is a 3x that says nothing about the planner.
-	base := []Record{{Mode: "warm", Name: "000/a/move", PlanMS: 3, TrajectoryLen: 2}}
-	head := []Record{{Mode: "warm", Name: "000/a/move", PlanMS: 9, TrajectoryLen: 2}}
+	base := []Record{{Name: "000/a/move", PlanMS: 3, TrajectoryLen: 2}}
+	head := []Record{{Name: "000/a/move", PlanMS: 9, TrajectoryLen: 2}}
 
 	report := Compare(base, head, "base", "head")
 	test.That(t, len(report.Regressions()), test.ShouldEqual, 0)
@@ -161,12 +157,12 @@ func TestCompareIgnoresRatiosOnTrivialPlans(t *testing.T) {
 
 func TestCompareCleanRunHasNoVerdict(t *testing.T) {
 	base := []Record{
-		{Mode: "warm", Index: 0, Name: "000/a/move", PlanMS: 1000, TrajectoryLen: 100},
-		{Mode: "warm", Index: 1, Name: "001/b/move", PlanMS: 500, TrajectoryLen: 50},
+		{Index: 0, Name: "000/a/move", PlanMS: 1000, TrajectoryLen: 100},
+		{Index: 1, Name: "001/b/move", PlanMS: 500, TrajectoryLen: 50},
 	}
 	head := []Record{
-		{Mode: "warm", Index: 0, Name: "000/a/move", PlanMS: 1010, TrajectoryLen: 100},
-		{Mode: "warm", Index: 1, Name: "001/b/move", PlanMS: 495, TrajectoryLen: 50},
+		{Index: 0, Name: "000/a/move", PlanMS: 1010, TrajectoryLen: 100},
+		{Index: 1, Name: "001/b/move", PlanMS: 495, TrajectoryLen: 50},
 	}
 	report := Compare(base, head, "base", "head")
 	test.That(t, report.Verdict(), test.ShouldBeNil)
@@ -176,8 +172,8 @@ func TestCompareCleanRunHasNoVerdict(t *testing.T) {
 func TestRecordsRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "records.ndjson")
 	records := []Record{
-		{Mode: "cold", Index: 0, Name: "000/a/move", PlanMS: 1.5},
-		{Mode: "cold", Index: 1, Name: "001/b/move", PlanMS: 2.5, Err: "boom"},
+		{Index: 0, Name: "000/a/move", PlanMS: 1.5},
+		{Index: 1, Name: "001/b/move", PlanMS: 2.5, Err: "boom"},
 	}
 	test.That(t, WriteRecords(path, records), test.ShouldBeNil)
 
@@ -188,29 +184,20 @@ func TestRecordsRoundTrip(t *testing.T) {
 
 func TestOptionsDefaults(t *testing.T) {
 	opts := Options{}.WithDefaults()
-	test.That(t, opts.Mode, test.ShouldEqual, ModeWarm)
 	test.That(t, opts.Repeat, test.ShouldEqual, 1)
 	test.That(t, opts.GCPercent, test.ShouldEqual, defaultGCPercent)
 	test.That(t, opts.Logger, test.ShouldNotBeNil)
 
 	// An explicit zero GC target is not reachable through the options; that is deliberate, since an
 	// unpinned GC target is the difference a cross-revision comparison would silently absorb.
-	opts = Options{Mode: ModeCold, Repeat: 3, GCPercent: 100}.WithDefaults()
-	test.That(t, opts.Mode, test.ShouldEqual, ModeCold)
+	opts = Options{Repeat: 3, GCPercent: 100}.WithDefaults()
 	test.That(t, opts.Repeat, test.ShouldEqual, 3)
 	test.That(t, opts.GCPercent, test.ShouldEqual, 100)
 }
 
-func TestEntryFromEnvRoundTrip(t *testing.T) {
-	entry := Entry{Index: 7, File: "007-x.json", Step: "brewing", Motion: "move", RecordedAt: time.Now().UTC().Truncate(time.Millisecond)}
-	data, err := json.Marshal(entry)
-	test.That(t, err, test.ShouldBeNil)
-	t.Setenv(subprocessEnvEntry, string(data))
-
-	got, err := EntryFromEnv()
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, got, test.ShouldResemble, entry)
-	test.That(t, got.Name(), test.ShouldEqual, "007/brewing/move")
+func TestEntryName(t *testing.T) {
+	entry := Entry{Index: 7, Step: "brewing", Motion: "move"}
+	test.That(t, entry.Name(), test.ShouldEqual, "007/brewing/move")
 }
 
 // writeCapture lays down one file in the nested `tag=` layout that `viam data export binary`

--- a/motionplan/armplanning/orderbench/orderbench_test.go
+++ b/motionplan/armplanning/orderbench/orderbench_test.go
@@ -1,0 +1,225 @@
+package orderbench
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.viam.com/test"
+)
+
+func TestTagLabels(t *testing.T) {
+	labels := tagLabels("tag=step_opening_fridge/tag=motion_open_door/tag=planning_success/20260828_153733.046_carry.json")
+	test.That(t, labels["step"], test.ShouldEqual, "opening_fridge")
+	test.That(t, labels["motion"], test.ShouldEqual, "open_door")
+	test.That(t, labels["planning"], test.ShouldEqual, "success")
+}
+
+func TestIngestOrdersByRecordedTime(t *testing.T) {
+	exportDir := t.TempDir()
+	order := "test-order"
+
+	// Written in an order that is neither recorded order nor alphabetical by step, so a walk that
+	// forgot to sort would not accidentally pass.
+	writeCapture(t, exportDir, order, "serving", "carry", "20260828_153900.100")
+	writeCapture(t, exportDir, order, "grinding", "move", "20260828_153126.083")
+	writeCapture(t, exportDir, order, "tamping", "move", "20260828_153143.958")
+
+	// A video capture shares the order tag but is not a plan; ingest must not pick it up.
+	videoDir := filepath.Join(exportDir, "data", "video-upload")
+	test.That(t, os.MkdirAll(videoDir, 0o750), test.ShouldBeNil)
+	test.That(t, os.WriteFile(filepath.Join(videoDir, "20260828_153200.000_clip.mp4"), []byte("not json"), 0o600), test.ShouldBeNil)
+
+	dstDir := filepath.Join(t.TempDir(), "corpus")
+	manifest, err := Ingest(exportDir, order, dstDir, "motionplan/order-replay/test")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(manifest.Entries), test.ShouldEqual, 3)
+
+	test.That(t, manifest.Entries[0].Step, test.ShouldEqual, "grinding")
+	test.That(t, manifest.Entries[1].Step, test.ShouldEqual, "tamping")
+	test.That(t, manifest.Entries[2].Step, test.ShouldEqual, "serving")
+	for i, entry := range manifest.Entries {
+		test.That(t, entry.Index, test.ShouldEqual, i)
+		test.That(t, strings.HasPrefix(entry.Name(), entry.File[:3]), test.ShouldBeTrue)
+	}
+
+	// The manifest must round-trip and validate against what was written.
+	reloaded, err := LoadManifest(dstDir)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, reloaded.Order, test.ShouldEqual, order)
+	test.That(t, reloaded.Verify(dstDir), test.ShouldBeNil)
+}
+
+func TestVerifyRejectsDriftedCorpus(t *testing.T) {
+	exportDir := t.TempDir()
+	writeCapture(t, exportDir, "o", "grinding", "move", "20260828_153126.083")
+
+	dstDir := filepath.Join(t.TempDir(), "corpus")
+	manifest, err := Ingest(exportDir, "o", dstDir, "")
+	test.That(t, err, test.ShouldBeNil)
+
+	payload := filepath.Join(dstDir, manifest.Entries[0].File)
+	test.That(t, os.WriteFile(payload, []byte(`{"changed": true}`), 0o600), test.ShouldBeNil)
+
+	err = manifest.Verify(dstDir)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "does not match manifest")
+}
+
+func TestRunAcceptsAManifestForADirectoryWithoutOne(t *testing.T) {
+	exportDir := t.TempDir()
+	writeCapture(t, exportDir, "o", "grinding", "move", "20260828_153126.083")
+
+	dstDir := filepath.Join(t.TempDir(), "corpus")
+	manifest, err := Ingest(exportDir, "o", dstDir, "")
+	test.That(t, err, test.ShouldBeNil)
+
+	// A corpus resolved from the artifact store has no manifest of its own, by design. Passing the
+	// manifest explicitly has to be enough, or every caller that already resolved one would have to
+	// write a stray file into the artifact cache to use it.
+	test.That(t, os.Remove(filepath.Join(dstDir, ManifestName)), test.ShouldBeNil)
+
+	_, err = Run(context.Background(), Options{CorpusDir: dstDir, Manifest: manifest, Limit: 1})
+	// The capture is a stub, so planning cannot succeed -- but resolution must get far enough to
+	// try, rather than failing on the missing manifest.
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldNotContainSubstring, ManifestName)
+}
+
+func TestSummarizeTakesMedianAcrossPasses(t *testing.T) {
+	records := []Record{
+		{Name: "000/a/move", PlanMS: 100, TrajectoryLen: 10, TotalL2: 1},
+		{Name: "000/a/move", PlanMS: 900, TrajectoryLen: 10, TotalL2: 1},
+		{Name: "000/a/move", PlanMS: 110, TrajectoryLen: 10, TotalL2: 1},
+	}
+	stats := Summarize(records)
+	test.That(t, stats["000/a/move"].Passes, test.ShouldEqual, 3)
+	// The 900ms outlier must not drag the estimate; that is the whole point of a median.
+	test.That(t, stats["000/a/move"].PlanMS, test.ShouldEqual, 110)
+}
+
+func TestSummarizeExcludesFailedPlansFromQuality(t *testing.T) {
+	records := []Record{
+		{Name: "000/a/move", PlanMS: 100, TrajectoryLen: 40, TotalL2: 2},
+		{Name: "000/a/move", PlanMS: 120, Err: "timed out"},
+	}
+	stats := Summarize(records)
+	test.That(t, stats["000/a/move"].Failures, test.ShouldEqual, 1)
+	test.That(t, stats["000/a/move"].FirstErr, test.ShouldEqual, "timed out")
+	// A failure contributes no trajectory, so the quality figures come from the successful pass.
+	test.That(t, stats["000/a/move"].TrajectoryLen, test.ShouldEqual, 40)
+}
+
+func TestCompareFlagsRegressionsAndFailures(t *testing.T) {
+	base := []Record{
+		{Mode: "warm", Index: 0, Name: "000/a/move", PlanMS: 1000, TrajectoryLen: 100, TotalL2: 3},
+		{Mode: "warm", Index: 1, Name: "001/b/move", PlanMS: 500, TrajectoryLen: 50, TotalL2: 2},
+		{Mode: "warm", Index: 2, Name: "002/c/move", PlanMS: 200, TrajectoryLen: 20, TotalL2: 1},
+	}
+	head := []Record{
+		{Mode: "warm", Index: 0, Name: "000/a/move", PlanMS: 6000, TrajectoryLen: 140, TotalL2: 4},
+		{Mode: "warm", Index: 1, Name: "001/b/move", PlanMS: 480, TrajectoryLen: 50, TotalL2: 2},
+		{Mode: "warm", Index: 2, Name: "002/c/move", PlanMS: 210, Err: "no path found"},
+	}
+
+	report := Compare(base, head, "v1.5.0", "main")
+	test.That(t, report.Mode, test.ShouldEqual, "warm")
+
+	regressions := report.Regressions()
+	test.That(t, len(regressions), test.ShouldEqual, 1)
+	test.That(t, regressions[0].Name, test.ShouldEqual, "000/a/move")
+	test.That(t, regressions[0].Ratio, test.ShouldEqual, 6.0)
+	test.That(t, regressions[0].TrajectoryRatio, test.ShouldEqual, 1.4)
+
+	failures := report.NewFailures()
+	test.That(t, len(failures), test.ShouldEqual, 1)
+	test.That(t, failures[0].Name, test.ShouldEqual, "002/c/move")
+
+	verdict := report.Verdict()
+	test.That(t, verdict, test.ShouldNotBeNil)
+	test.That(t, verdict.Error(), test.ShouldContainSubstring, "newly failing")
+	test.That(t, verdict.Error(), test.ShouldContainSubstring, "order total")
+
+	markdown := report.Markdown()
+	test.That(t, markdown, test.ShouldContainSubstring, "v1.5.0")
+	test.That(t, markdown, test.ShouldContainSubstring, "000/a/move")
+	test.That(t, markdown, test.ShouldContainSubstring, "no path found")
+}
+
+func TestCompareIgnoresRatiosOnTrivialPlans(t *testing.T) {
+	// A 3ms plan going to 9ms is a 3x that says nothing about the planner.
+	base := []Record{{Mode: "warm", Name: "000/a/move", PlanMS: 3, TrajectoryLen: 2}}
+	head := []Record{{Mode: "warm", Name: "000/a/move", PlanMS: 9, TrajectoryLen: 2}}
+
+	report := Compare(base, head, "base", "head")
+	test.That(t, len(report.Regressions()), test.ShouldEqual, 0)
+}
+
+func TestCompareCleanRunHasNoVerdict(t *testing.T) {
+	base := []Record{
+		{Mode: "warm", Index: 0, Name: "000/a/move", PlanMS: 1000, TrajectoryLen: 100},
+		{Mode: "warm", Index: 1, Name: "001/b/move", PlanMS: 500, TrajectoryLen: 50},
+	}
+	head := []Record{
+		{Mode: "warm", Index: 0, Name: "000/a/move", PlanMS: 1010, TrajectoryLen: 100},
+		{Mode: "warm", Index: 1, Name: "001/b/move", PlanMS: 495, TrajectoryLen: 50},
+	}
+	report := Compare(base, head, "base", "head")
+	test.That(t, report.Verdict(), test.ShouldBeNil)
+	test.That(t, report.Markdown(), test.ShouldContainSubstring, "No individual plan moved")
+}
+
+func TestRecordsRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "records.ndjson")
+	records := []Record{
+		{Mode: "cold", Index: 0, Name: "000/a/move", PlanMS: 1.5},
+		{Mode: "cold", Index: 1, Name: "001/b/move", PlanMS: 2.5, Err: "boom"},
+	}
+	test.That(t, WriteRecords(path, records), test.ShouldBeNil)
+
+	got, err := ReadRecords(path)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, got, test.ShouldResemble, records)
+}
+
+func TestOptionsDefaults(t *testing.T) {
+	opts := Options{}.WithDefaults()
+	test.That(t, opts.Mode, test.ShouldEqual, ModeWarm)
+	test.That(t, opts.Repeat, test.ShouldEqual, 1)
+	test.That(t, opts.GCPercent, test.ShouldEqual, defaultGCPercent)
+	test.That(t, opts.Logger, test.ShouldNotBeNil)
+
+	// An explicit zero GC target is not reachable through the options; that is deliberate, since an
+	// unpinned GC target is the difference a cross-revision comparison would silently absorb.
+	opts = Options{Mode: ModeCold, Repeat: 3, GCPercent: 100}.WithDefaults()
+	test.That(t, opts.Mode, test.ShouldEqual, ModeCold)
+	test.That(t, opts.Repeat, test.ShouldEqual, 3)
+	test.That(t, opts.GCPercent, test.ShouldEqual, 100)
+}
+
+func TestEntryFromEnvRoundTrip(t *testing.T) {
+	entry := Entry{Index: 7, File: "007-x.json", Step: "brewing", Motion: "move", RecordedAt: time.Now().UTC().Truncate(time.Millisecond)}
+	data, err := json.Marshal(entry)
+	test.That(t, err, test.ShouldBeNil)
+	t.Setenv(subprocessEnvEntry, string(data))
+
+	got, err := EntryFromEnv()
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, got, test.ShouldResemble, entry)
+	test.That(t, got.Name(), test.ShouldEqual, "007/brewing/move")
+}
+
+// writeCapture lays down one file in the nested `tag=` layout that `viam data export binary`
+// produces, with just enough content for the ingest to treat it as a plan capture.
+func writeCapture(t *testing.T, exportDir, order, step, motion, stamp string) {
+	t.Helper()
+	dir := filepath.Join(exportDir, "data", "tag="+order, "tag=step_"+step, "tag=motion_"+motion, "tag=planning_success")
+	test.That(t, os.MkdirAll(dir, 0o750), test.ShouldBeNil)
+	path := filepath.Join(dir, stamp+"_"+motion+".json")
+	body := `{"step":"` + step + `"}`
+	test.That(t, os.WriteFile(path, []byte(body), 0o600), test.ShouldBeNil)
+}

--- a/motionplan/armplanning/orderbench/orderbench_test.go
+++ b/motionplan/armplanning/orderbench/orderbench_test.go
@@ -1,19 +1,11 @@
 package orderbench
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
 	"go.viam.com/test"
 )
-
-func TestTagLabels(t *testing.T) {
-	labels := tagLabels("tag=step_opening_fridge/tag=motion_open_door/tag=planning_success/20260828_153733.046_carry.json")
-	test.That(t, labels["step"], test.ShouldEqual, "opening_fridge")
-	test.That(t, labels["motion"], test.ShouldEqual, "open_door")
-	test.That(t, labels["planning"], test.ShouldEqual, "success")
-}
 
 func TestSummarizeTakesMedianAcrossPasses(t *testing.T) {
 	records := []Record{
@@ -125,15 +117,4 @@ func TestOptionsDefaults(t *testing.T) {
 func TestEntryName(t *testing.T) {
 	entry := Entry{Index: 7, Step: "brewing", Motion: "move"}
 	test.That(t, entry.Name(), test.ShouldEqual, "007/brewing/move")
-}
-
-// writeCapture lays down one file in the nested `tag=` layout that `viam data export binary`
-// produces, with just enough content for the ingest to treat it as a plan capture.
-func writeCapture(t *testing.T, exportDir, order, step, motion, stamp string) {
-	t.Helper()
-	dir := filepath.Join(exportDir, "data", "tag="+order, "tag=step_"+step, "tag=motion_"+motion, "tag=planning_success")
-	test.That(t, os.MkdirAll(dir, 0o750), test.ShouldBeNil)
-	path := filepath.Join(dir, stamp+"_"+motion+".json")
-	body := `{"step":"` + step + `"}`
-	test.That(t, os.WriteFile(path, []byte(body), 0o600), test.ShouldBeNil)
 }

--- a/motionplan/armplanning/orderbench/orderbench_test.go
+++ b/motionplan/armplanning/orderbench/orderbench_test.go
@@ -1,10 +1,8 @@
 package orderbench
 
 import (
-	"context"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"go.viam.com/test"
@@ -15,77 +13,6 @@ func TestTagLabels(t *testing.T) {
 	test.That(t, labels["step"], test.ShouldEqual, "opening_fridge")
 	test.That(t, labels["motion"], test.ShouldEqual, "open_door")
 	test.That(t, labels["planning"], test.ShouldEqual, "success")
-}
-
-func TestIngestOrdersByRecordedTime(t *testing.T) {
-	exportDir := t.TempDir()
-	order := "test-order"
-
-	// Written in an order that is neither recorded order nor alphabetical by step, so a walk that
-	// forgot to sort would not accidentally pass.
-	writeCapture(t, exportDir, order, "serving", "carry", "20260828_153900.100")
-	writeCapture(t, exportDir, order, "grinding", "move", "20260828_153126.083")
-	writeCapture(t, exportDir, order, "tamping", "move", "20260828_153143.958")
-
-	// A video capture shares the order tag but is not a plan; ingest must not pick it up.
-	videoDir := filepath.Join(exportDir, "data", "video-upload")
-	test.That(t, os.MkdirAll(videoDir, 0o750), test.ShouldBeNil)
-	test.That(t, os.WriteFile(filepath.Join(videoDir, "20260828_153200.000_clip.mp4"), []byte("not json"), 0o600), test.ShouldBeNil)
-
-	dstDir := filepath.Join(t.TempDir(), "corpus")
-	manifest, err := Ingest(exportDir, order, dstDir, "motionplan/order-replay/test")
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, len(manifest.Entries), test.ShouldEqual, 3)
-
-	test.That(t, manifest.Entries[0].Step, test.ShouldEqual, "grinding")
-	test.That(t, manifest.Entries[1].Step, test.ShouldEqual, "tamping")
-	test.That(t, manifest.Entries[2].Step, test.ShouldEqual, "serving")
-	for i, entry := range manifest.Entries {
-		test.That(t, entry.Index, test.ShouldEqual, i)
-		test.That(t, strings.HasPrefix(entry.Name(), entry.File[:3]), test.ShouldBeTrue)
-	}
-
-	// The manifest must round-trip and validate against what was written.
-	reloaded, err := LoadManifest(dstDir)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, reloaded.Order, test.ShouldEqual, order)
-	test.That(t, reloaded.Verify(dstDir), test.ShouldBeNil)
-}
-
-func TestVerifyRejectsDriftedCorpus(t *testing.T) {
-	exportDir := t.TempDir()
-	writeCapture(t, exportDir, "o", "grinding", "move", "20260828_153126.083")
-
-	dstDir := filepath.Join(t.TempDir(), "corpus")
-	manifest, err := Ingest(exportDir, "o", dstDir, "")
-	test.That(t, err, test.ShouldBeNil)
-
-	payload := filepath.Join(dstDir, manifest.Entries[0].File)
-	test.That(t, os.WriteFile(payload, []byte(`{"changed": true}`), 0o600), test.ShouldBeNil)
-
-	err = manifest.Verify(dstDir)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "does not match manifest")
-}
-
-func TestRunAcceptsAManifestForADirectoryWithoutOne(t *testing.T) {
-	exportDir := t.TempDir()
-	writeCapture(t, exportDir, "o", "grinding", "move", "20260828_153126.083")
-
-	dstDir := filepath.Join(t.TempDir(), "corpus")
-	manifest, err := Ingest(exportDir, "o", dstDir, "")
-	test.That(t, err, test.ShouldBeNil)
-
-	// A corpus resolved from the artifact store has no manifest of its own, by design. Passing the
-	// manifest explicitly has to be enough, or every caller that already resolved one would have to
-	// write a stray file into the artifact cache to use it.
-	test.That(t, os.Remove(filepath.Join(dstDir, ManifestName)), test.ShouldBeNil)
-
-	_, err = Run(context.Background(), Options{CorpusDir: dstDir, Manifest: manifest, Limit: 1})
-	// The capture is a stub, so planning cannot succeed -- but resolution must get far enough to
-	// try, rather than failing on the missing manifest.
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldNotContainSubstring, ManifestName)
 }
 
 func TestSummarizeTakesMedianAcrossPasses(t *testing.T) {

--- a/motionplan/armplanning/orderbench/replay.go
+++ b/motionplan/armplanning/orderbench/replay.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -20,26 +19,6 @@ import (
 	"go.viam.com/rdk/referenceframe"
 )
 
-// Mode selects how much planner state carries from one plan in the order to the next. The two
-// modes measure genuinely different things and routinely disagree, so a comparison must name which
-// one it ran.
-type Mode string
-
-const (
-	// ModeWarm replays the whole order in one process, in recorded order. Learned roadmaps,
-	// smart-seed caches and the static-scene SDF registry accumulate exactly as they do during a
-	// real shift, so this is the number that reflects production behaviour.
-	ModeWarm Mode = "warm"
-
-	// ModeCold plans each request in a freshly forked process. Nothing is shared between plans, so
-	// this isolates the per-plan floor -- scene preprocessing that does not amortise -- and is
-	// insensitive to the order the plans run in.
-	ModeCold Mode = "cold"
-)
-
-// Modes lists every valid replay mode.
-var Modes = []Mode{ModeWarm, ModeCold}
-
 // defaultGCPercent matches what cmd-plan (and therefore the planner's tuned behaviour) uses. It is
 // set explicitly rather than inherited so that a GOGC difference between two revisions' CLIs
 // cannot masquerade as a planner change.
@@ -47,6 +26,11 @@ const defaultGCPercent = 300
 
 // Options configures a replay. Every field that can move a timing number is explicit: a
 // cross-revision comparison is only meaningful if both sides ran with an identical configuration.
+//
+// The whole order is replayed in a single process, in recorded order, so learned roadmaps, the
+// smart-seed cache and the static-scene SDF registry accumulate exactly as they do during a real
+// shift. That is deliberate rather than incidental: it is the shape production runs, and a plan's
+// cost depends on which plans preceded it.
 type Options struct {
 	// CorpusDir holds the payloads and the manifest. Leave empty to resolve CorpusName from the
 	// artifact store instead.
@@ -59,7 +43,6 @@ type Options struct {
 	// there would put a stray file in the artifact cache -- so a caller that has already resolved
 	// passes what it got back through here.
 	Manifest *Manifest
-	Mode     Mode
 	// Repeat runs the whole order this many times. Passes are recorded separately so the
 	// comparator can take a median and shrug off a noisy runner.
 	Repeat int
@@ -83,9 +66,6 @@ type Options struct {
 // WithDefaults fills in the fields that were left zero. Callers that report their configuration
 // should normalize through this first, so what they print is what actually ran.
 func (o Options) WithDefaults() Options {
-	if o.Mode == "" {
-		o.Mode = ModeWarm
-	}
 	if o.Repeat <= 0 {
 		o.Repeat = 1
 	}
@@ -101,7 +81,6 @@ func (o Options) WithDefaults() Options {
 // Record is one plan's result. Field names are the join keys between two runs, so they are part of
 // the file format and should only be added to.
 type Record struct {
-	Mode   string `json:"mode"`
 	Pass   int    `json:"pass"`
 	Index  int    `json:"index"`
 	Name   string `json:"name"`
@@ -166,23 +145,11 @@ func Run(ctx context.Context, opts Options) ([]Record, error) {
 			if err := ctx.Err(); err != nil {
 				return records, err
 			}
-			var (
-				rec Record
-				err error
-			)
-			switch o.Mode {
-			case ModeWarm:
-				rec, err = planOne(ctx, filepath.Join(o.CorpusDir, entry.File), entry, o)
-			case ModeCold:
-				rec, err = planInSubprocess(ctx, filepath.Join(o.CorpusDir, entry.File), entry, o)
-			default:
-				return nil, fmt.Errorf("unknown mode %q", o.Mode)
-			}
+			rec, err := planOne(ctx, filepath.Join(o.CorpusDir, entry.File), entry, o)
 			if err != nil {
 				return records, err
 			}
 			rec.Pass = pass
-			rec.Mode = string(o.Mode)
 			records = append(records, rec)
 		}
 	}
@@ -210,12 +177,6 @@ func matchesAny(name string, patterns []string) bool {
 		}
 	}
 	return false
-}
-
-// PlanOne parses and plans a single captured request in the current process. Exported so the cold
-// mode's forked child can reach it.
-func PlanOne(ctx context.Context, path string, entry Entry, opts Options) (Record, error) {
-	return planOne(ctx, path, entry, opts.WithDefaults())
 }
 
 func planOne(ctx context.Context, path string, entry Entry, o Options) (Record, error) {
@@ -317,86 +278,6 @@ func trajectoryL2(traj motionplan.Trajectory) float64 {
 
 func msSince(start time.Time) float64 {
 	return float64(time.Since(start).Microseconds()) / 1000.0
-}
-
-// subprocessEnvEntry names the environment variable the parent uses to hand an entry to its forked
-// child in cold mode.
-const subprocessEnvEntry = "ORDERBENCH_ENTRY"
-
-// planInSubprocess runs one plan in a fresh copy of this binary. armplanning keeps process-global
-// state -- the learned roadmap, the smart-seed cache, the static-scene SDF registry -- so a cold
-// measurement is not reachable by resetting anything from inside the process.
-func planInSubprocess(ctx context.Context, path string, entry Entry, o Options) (Record, error) {
-	self, err := os.Executable()
-	if err != nil {
-		return Record{}, fmt.Errorf("locating own executable for cold mode: %w", err)
-	}
-
-	entryJSON, err := json.Marshal(entry)
-	if err != nil {
-		return Record{}, err
-	}
-
-	// The child hands its record back through a file, not stdout. armplanning holds package-level
-	// loggers (smart_seed.go's cache-build logger, for one) that write to stdout and that no caller
-	// can silence, so anything parsing the child's stdout would eventually read a log line as a
-	// result.
-	recordFile, err := os.CreateTemp("", "orderbench-record-*.json")
-	if err != nil {
-		return Record{}, err
-	}
-	recordPath := recordFile.Name()
-	if err := recordFile.Close(); err != nil {
-		return Record{}, err
-	}
-	defer os.Remove(recordPath) //nolint:errcheck
-
-	args := []string{
-		"replay-one",
-		"-corpus", o.CorpusDir,
-		"-gc-percent", fmt.Sprint(o.GCPercent),
-		"-record-out", recordPath,
-	}
-	if o.PlanTimeout > 0 {
-		args = append(args, "-plan-timeout", o.PlanTimeout.String())
-	}
-	args = append(args, path)
-
-	cmd := exec.CommandContext(ctx, self, args...) //nolint:gosec // self-exec with harness-built args
-	cmd.Env = append(os.Environ(),
-		subprocessEnvEntry+"="+string(entryJSON),
-		"MOTION_ROADMAP_CACHE_DIR="+o.RoadmapCacheDir,
-		"GOGC="+fmt.Sprint(o.GCPercent),
-	)
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		return Record{}, fmt.Errorf("cold replay of %s failed: %w", entry.Name(), err)
-	}
-
-	data, err := os.ReadFile(recordPath) //nolint:gosec // path created by this process
-	if err != nil {
-		return Record{}, fmt.Errorf("cold replay of %s wrote no record: %w", entry.Name(), err)
-	}
-	var rec Record
-	if err := json.Unmarshal(data, &rec); err != nil {
-		return Record{}, fmt.Errorf("cold replay of %s returned unparseable record: %w", entry.Name(), err)
-	}
-	return rec, nil
-}
-
-// EntryFromEnv reads the entry a cold-mode parent handed to this child process.
-func EntryFromEnv() (Entry, error) {
-	raw, ok := os.LookupEnv(subprocessEnvEntry)
-	if !ok {
-		return Entry{}, fmt.Errorf("%s is not set; replay-one is only meant to be spawned by a cold replay", subprocessEnvEntry)
-	}
-	var entry Entry
-	if err := json.Unmarshal([]byte(raw), &entry); err != nil {
-		return Entry{}, err
-	}
-	return entry, nil
 }
 
 // ApplyProcessControls pins the process-wide settings that would otherwise silently differ between

--- a/motionplan/armplanning/orderbench/replay.go
+++ b/motionplan/armplanning/orderbench/replay.go
@@ -1,0 +1,451 @@
+package orderbench
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/motionplan"
+	"go.viam.com/rdk/motionplan/armplanning"
+	"go.viam.com/rdk/referenceframe"
+)
+
+// Mode selects how much planner state carries from one plan in the order to the next. The two
+// modes measure genuinely different things and routinely disagree, so a comparison must name which
+// one it ran.
+type Mode string
+
+const (
+	// ModeWarm replays the whole order in one process, in recorded order. Learned roadmaps,
+	// smart-seed caches and the static-scene SDF registry accumulate exactly as they do during a
+	// real shift, so this is the number that reflects production behaviour.
+	ModeWarm Mode = "warm"
+
+	// ModeCold plans each request in a freshly forked process. Nothing is shared between plans, so
+	// this isolates the per-plan floor -- scene preprocessing that does not amortise -- and is
+	// insensitive to the order the plans run in.
+	ModeCold Mode = "cold"
+)
+
+// Modes lists every valid replay mode.
+var Modes = []Mode{ModeWarm, ModeCold}
+
+// defaultGCPercent matches what cmd-plan (and therefore the planner's tuned behaviour) uses. It is
+// set explicitly rather than inherited so that a GOGC difference between two revisions' CLIs
+// cannot masquerade as a planner change.
+const defaultGCPercent = 300
+
+// Options configures a replay. Every field that can move a timing number is explicit: a
+// cross-revision comparison is only meaningful if both sides ran with an identical configuration.
+type Options struct {
+	// CorpusDir holds the payloads and the manifest. Leave empty to resolve CorpusName from the
+	// artifact store instead.
+	CorpusDir string
+	// CorpusName selects one of the manifests compiled into the binary. Ignored when CorpusDir is
+	// set.
+	CorpusName string
+	// Manifest, when set, is used as-is instead of being loaded from CorpusDir. A directory
+	// resolved from the artifact store deliberately holds no manifest of its own -- writing one
+	// there would put a stray file in the artifact cache -- so a caller that has already resolved
+	// passes what it got back through here.
+	Manifest *Manifest
+	Mode     Mode
+	// Repeat runs the whole order this many times. Passes are recorded separately so the
+	// comparator can take a median and shrug off a noisy runner.
+	Repeat int
+	// Limit truncates the order to its first N plans. Zero replays all of them.
+	Limit int
+	// Only, when non-empty, keeps just the plans whose name contains one of these substrings.
+	Only []string
+	// RoadmapCacheDir is the on-disk roadmap cache. Empty disables it, which is what viam-server
+	// does; the disk cache would otherwise let one side of a comparison replay corridors the other
+	// structurally cannot have.
+	RoadmapCacheDir string
+	// GCPercent is the GC target applied before planning. Zero means defaultGCPercent.
+	GCPercent int
+	// PlanTimeout caps each individual plan. Captured requests carry a 300s planner timeout, which
+	// is far too long to let a pathological regression burn a CI budget. Zero leaves the recorded
+	// timeout alone.
+	PlanTimeout time.Duration
+	Logger      logging.Logger
+}
+
+// WithDefaults fills in the fields that were left zero. Callers that report their configuration
+// should normalize through this first, so what they print is what actually ran.
+func (o Options) WithDefaults() Options {
+	if o.Mode == "" {
+		o.Mode = ModeWarm
+	}
+	if o.Repeat <= 0 {
+		o.Repeat = 1
+	}
+	if o.GCPercent == 0 {
+		o.GCPercent = defaultGCPercent
+	}
+	if o.Logger == nil {
+		o.Logger = logging.NewBlankLogger("orderbench")
+	}
+	return o
+}
+
+// Record is one plan's result. Field names are the join keys between two runs, so they are part of
+// the file format and should only be added to.
+type Record struct {
+	Mode   string `json:"mode"`
+	Pass   int    `json:"pass"`
+	Index  int    `json:"index"`
+	Name   string `json:"name"`
+	Step   string `json:"step"`
+	Motion string `json:"motion"`
+
+	// PlanMS times armplanning.PlanMotion alone. Parsing and smart-seed preparation are recorded
+	// separately because they are not what a planner change is expected to move.
+	PlanMS  float64 `json:"plan_ms"`
+	ParseMS float64 `json:"parse_ms"`
+	PrepMS  float64 `json:"prep_ms"`
+
+	TrajectoryLen int     `json:"trajectory_len"`
+	PathLen       int     `json:"path_len"`
+	TotalL2       float64 `json:"total_l2"`
+
+	// RecordedTrajectoryLen and RecordedTotalL2 come from the plan the robot actually executed,
+	// giving every plan a quality baseline that does not depend on either revision under test.
+	RecordedTrajectoryLen int     `json:"recorded_trajectory_len"`
+	RecordedTotalL2       float64 `json:"recorded_total_l2"`
+
+	// Solver attribution, straight off PlanMeta. A latency change with no matching shift here is a
+	// different story from one where work moved between the roadmap and the search.
+	GoalsProcessed     int `json:"goals_processed"`
+	GoalsCBIRRTSolved  int `json:"goals_cbirrt_solved"`
+	GoalsNudgeSolved   int `json:"goals_nudge_solved"`
+	GoalsRoadmapSolved int `json:"goals_roadmap_solved"`
+
+	HeapAllocMB float64 `json:"heap_alloc_mb"`
+	Partial     bool    `json:"partial"`
+	Err         string  `json:"err,omitempty"`
+}
+
+// Failed reports whether the plan did not produce a usable trajectory.
+func (r Record) Failed() bool {
+	return r.Err != ""
+}
+
+// Run replays the corpus and returns one Record per plan per pass.
+func Run(ctx context.Context, opts Options) ([]Record, error) {
+	o := opts.WithDefaults()
+
+	corpusDir, manifest := o.CorpusDir, o.Manifest
+	if manifest == nil {
+		var err error
+		if corpusDir, manifest, err = ResolveCorpusDir(o.CorpusDir, o.CorpusName); err != nil {
+			return nil, err
+		}
+	} else if err := manifest.Verify(corpusDir); err != nil {
+		return nil, err
+	}
+	o.CorpusDir = corpusDir
+
+	entries := selectEntries(manifest.Entries, o)
+	if len(entries) == 0 {
+		return nil, errors.New("no corpus entries selected")
+	}
+
+	records := make([]Record, 0, len(entries)*o.Repeat)
+	for pass := range o.Repeat {
+		for _, entry := range entries {
+			if err := ctx.Err(); err != nil {
+				return records, err
+			}
+			var (
+				rec Record
+				err error
+			)
+			switch o.Mode {
+			case ModeWarm:
+				rec, err = planOne(ctx, filepath.Join(o.CorpusDir, entry.File), entry, o)
+			case ModeCold:
+				rec, err = planInSubprocess(ctx, filepath.Join(o.CorpusDir, entry.File), entry, o)
+			default:
+				return nil, fmt.Errorf("unknown mode %q", o.Mode)
+			}
+			if err != nil {
+				return records, err
+			}
+			rec.Pass = pass
+			rec.Mode = string(o.Mode)
+			records = append(records, rec)
+		}
+	}
+	return records, nil
+}
+
+func selectEntries(all []Entry, o Options) []Entry {
+	var out []Entry
+	for _, e := range all {
+		if len(o.Only) > 0 && !matchesAny(e.Name(), o.Only) {
+			continue
+		}
+		out = append(out, e)
+		if o.Limit > 0 && len(out) == o.Limit {
+			break
+		}
+	}
+	return out
+}
+
+func matchesAny(name string, patterns []string) bool {
+	for _, p := range patterns {
+		if strings.Contains(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// PlanOne parses and plans a single captured request in the current process. Exported so the cold
+// mode's forked child can reach it.
+func PlanOne(ctx context.Context, path string, entry Entry, opts Options) (Record, error) {
+	return planOne(ctx, path, entry, opts.WithDefaults())
+}
+
+func planOne(ctx context.Context, path string, entry Entry, o Options) (Record, error) {
+	rec := Record{
+		Index:  entry.Index,
+		Name:   entry.Name(),
+		Step:   entry.Step,
+		Motion: entry.Motion,
+	}
+
+	parseStart := time.Now()
+	req, recorded, err := armplanning.ReadRequestAndResponseFromFile(path)
+	rec.ParseMS = msSince(parseStart)
+	if err != nil {
+		return rec, fmt.Errorf("reading %q: %w", path, err)
+	}
+	if recorded != nil {
+		rec.RecordedTrajectoryLen = len(recorded.Trajectory())
+		rec.RecordedTotalL2 = trajectoryL2(recorded.Trajectory())
+	}
+	if o.PlanTimeout > 0 {
+		req.PlannerOptions.Timeout = o.PlanTimeout.Seconds()
+	}
+
+	prepStart := time.Now()
+	if err := armplanning.PrepSmartSeed(req.FrameSystem, o.Logger); err != nil {
+		return rec, fmt.Errorf("preparing smart seed for %q: %w", path, err)
+	}
+	rec.PrepMS = msSince(prepStart)
+
+	planCtx := ctx
+	if o.PlanTimeout > 0 {
+		var cancel context.CancelFunc
+		// The planner's own timeout is advisory; a hard deadline is what keeps one pathological
+		// plan from consuming the entire run.
+		planCtx, cancel = context.WithTimeout(ctx, o.PlanTimeout+planTimeoutGrace)
+		defer cancel()
+	}
+
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	planStart := time.Now()
+	plan, meta, err := armplanning.PlanMotion(planCtx, o.Logger, req)
+	rec.PlanMS = msSince(planStart)
+
+	runtime.ReadMemStats(&after)
+	rec.HeapAllocMB = float64(after.TotalAlloc-before.TotalAlloc) / (1024 * 1024)
+
+	if meta != nil {
+		rec.Partial = meta.Partial
+		rec.GoalsProcessed = meta.GoalsProcessed
+		rec.GoalsCBIRRTSolved = metaCounter(meta, "GoalsCBIRRTSolved")
+		rec.GoalsNudgeSolved = metaCounter(meta, "GoalsNudgeSolved")
+		rec.GoalsRoadmapSolved = metaCounter(meta, "GoalsRoadmapSolved")
+	}
+	if err != nil {
+		// A planner failure is a result, not a harness error: the whole point is to notice when a
+		// revision starts failing plans the other one solved.
+		rec.Err = err.Error()
+		return rec, nil
+	}
+
+	rec.TrajectoryLen = len(plan.Trajectory())
+	rec.PathLen = len(plan.Path())
+	rec.TotalL2 = trajectoryL2(plan.Trajectory())
+	return rec, nil
+}
+
+// planTimeoutGrace lets the planner hit its own timeout and unwind before the context deadline
+// fires, so a timed-out plan reports the planner's error rather than a context cancellation.
+const planTimeoutGrace = 15 * time.Second
+
+// metaCounter reads an integer counter off PlanMeta by name, yielding zero when the field does not
+// exist on this revision.
+//
+// This harness is built to be compiled against an older RDK than the one it ships with -- that is
+// how a base-vs-head comparison isolates a library change from a harness change -- and PlanMeta's
+// solver attribution has grown over time (GoalsRoadmapSolved arrived with the lazy roadmap). A
+// direct field reference would make the harness refuse to build against exactly the revisions it
+// most needs to measure.
+func metaCounter(meta *armplanning.PlanMeta, field string) int {
+	value := reflect.ValueOf(meta).Elem().FieldByName(field)
+	if !value.IsValid() || value.Kind() != reflect.Int {
+		return 0
+	}
+	return int(value.Int())
+}
+
+func trajectoryL2(traj motionplan.Trajectory) float64 {
+	total := 0.0
+	for i := 1; i < len(traj); i++ {
+		for frame, inputs := range traj[i] {
+			total += referenceframe.InputsL2Distance(traj[i-1][frame], inputs)
+		}
+	}
+	return total
+}
+
+func msSince(start time.Time) float64 {
+	return float64(time.Since(start).Microseconds()) / 1000.0
+}
+
+// subprocessEnvEntry names the environment variable the parent uses to hand an entry to its forked
+// child in cold mode.
+const subprocessEnvEntry = "ORDERBENCH_ENTRY"
+
+// planInSubprocess runs one plan in a fresh copy of this binary. armplanning keeps process-global
+// state -- the learned roadmap, the smart-seed cache, the static-scene SDF registry -- so a cold
+// measurement is not reachable by resetting anything from inside the process.
+func planInSubprocess(ctx context.Context, path string, entry Entry, o Options) (Record, error) {
+	self, err := os.Executable()
+	if err != nil {
+		return Record{}, fmt.Errorf("locating own executable for cold mode: %w", err)
+	}
+
+	entryJSON, err := json.Marshal(entry)
+	if err != nil {
+		return Record{}, err
+	}
+
+	// The child hands its record back through a file, not stdout. armplanning holds package-level
+	// loggers (smart_seed.go's cache-build logger, for one) that write to stdout and that no caller
+	// can silence, so anything parsing the child's stdout would eventually read a log line as a
+	// result.
+	recordFile, err := os.CreateTemp("", "orderbench-record-*.json")
+	if err != nil {
+		return Record{}, err
+	}
+	recordPath := recordFile.Name()
+	if err := recordFile.Close(); err != nil {
+		return Record{}, err
+	}
+	defer os.Remove(recordPath) //nolint:errcheck
+
+	args := []string{
+		"replay-one",
+		"-corpus", o.CorpusDir,
+		"-gc-percent", fmt.Sprint(o.GCPercent),
+		"-record-out", recordPath,
+	}
+	if o.PlanTimeout > 0 {
+		args = append(args, "-plan-timeout", o.PlanTimeout.String())
+	}
+	args = append(args, path)
+
+	cmd := exec.CommandContext(ctx, self, args...) //nolint:gosec // self-exec with harness-built args
+	cmd.Env = append(os.Environ(),
+		subprocessEnvEntry+"="+string(entryJSON),
+		"MOTION_ROADMAP_CACHE_DIR="+o.RoadmapCacheDir,
+		"GOGC="+fmt.Sprint(o.GCPercent),
+	)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return Record{}, fmt.Errorf("cold replay of %s failed: %w", entry.Name(), err)
+	}
+
+	data, err := os.ReadFile(recordPath) //nolint:gosec // path created by this process
+	if err != nil {
+		return Record{}, fmt.Errorf("cold replay of %s wrote no record: %w", entry.Name(), err)
+	}
+	var rec Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return Record{}, fmt.Errorf("cold replay of %s returned unparseable record: %w", entry.Name(), err)
+	}
+	return rec, nil
+}
+
+// EntryFromEnv reads the entry a cold-mode parent handed to this child process.
+func EntryFromEnv() (Entry, error) {
+	raw, ok := os.LookupEnv(subprocessEnvEntry)
+	if !ok {
+		return Entry{}, fmt.Errorf("%s is not set; replay-one is only meant to be spawned by a cold replay", subprocessEnvEntry)
+	}
+	var entry Entry
+	if err := json.Unmarshal([]byte(raw), &entry); err != nil {
+		return Entry{}, err
+	}
+	return entry, nil
+}
+
+// ApplyProcessControls pins the process-wide settings that would otherwise silently differ between
+// two revisions. It must run before any planning.
+func ApplyProcessControls(o Options) {
+	opts := o.WithDefaults()
+	debug.SetGCPercent(opts.GCPercent)
+	// Set rather than defaulted: an unset value means "whatever this revision's code decides",
+	// which is exactly the ambiguity a comparison cannot tolerate.
+	os.Setenv("MOTION_ROADMAP_CACHE_DIR", opts.RoadmapCacheDir) //nolint:errcheck
+}
+
+// WriteRecords writes records as one JSON object per line, which lets a run be appended to and
+// compared without loading the whole thing as a single document.
+func WriteRecords(path string, records []Record) error {
+	file, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	defer file.Close() //nolint:errcheck
+
+	enc := json.NewEncoder(file)
+	for _, rec := range records {
+		if err := enc.Encode(rec); err != nil {
+			return err
+		}
+	}
+	return file.Close()
+}
+
+// ReadRecords reads a file written by WriteRecords.
+func ReadRecords(path string) ([]Record, error) {
+	file, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close() //nolint:errcheck
+
+	var records []Record
+	dec := json.NewDecoder(file)
+	for dec.More() {
+		var rec Record
+		if err := dec.Decode(&rec); err != nil {
+			return nil, err
+		}
+		records = append(records, rec)
+	}
+	if len(records) == 0 {
+		return nil, fmt.Errorf("%q contains no records", path)
+	}
+	return records, nil
+}

--- a/motionplan/armplanning/orderbench/replay_bench_test.go
+++ b/motionplan/armplanning/orderbench/replay_bench_test.go
@@ -10,26 +10,16 @@ import (
 	"go.viam.com/rdk/motionplan/armplanning"
 )
 
-// BenchmarkOrderReplay replays the whole captured order. It is the local equivalent of what the
-// Motion Order Benchmark workflow runs, and the number that matters is the reported order_ms rather
-// than the ns/op Go prints -- one iteration is a whole order, not a single operation.
+// BenchmarkOrderReplay replays the whole captured order in one process, in recorded order. It is
+// the local equivalent of what the Motion Order Benchmark workflow runs, and the number that
+// matters is the reported order_ms rather than the ns/op Go prints -- one iteration is a whole
+// order, not a single operation.
 //
 //	go test ./motionplan/armplanning/orderbench -run xxx -bench OrderReplay -benchtime 1x
 //
 // To compare two revisions, use the CLI rather than benchstat: it builds the harness against both
 // libraries and joins plans by name.
 func BenchmarkOrderReplay(b *testing.B) {
-	benchmarkOrder(b, ModeWarm)
-}
-
-// BenchmarkOrderReplayCold plans each request in a fresh process, isolating the per-plan floor from
-// anything that amortises across the order. It forks once per plan, so it is much slower than the
-// warm replay.
-func BenchmarkOrderReplayCold(b *testing.B) {
-	benchmarkOrder(b, ModeCold)
-}
-
-func benchmarkOrder(b *testing.B, mode Mode) {
 	if armplanning.IsTooSmallForCache() {
 		b.Skip("machine is too small for the smart-seed cache; timings would not be comparable")
 	}
@@ -45,7 +35,6 @@ func benchmarkOrder(b *testing.B, mode Mode) {
 	opts := Options{
 		CorpusDir:   corpusDir,
 		Manifest:    manifest,
-		Mode:        mode,
 		PlanTimeout: 60 * time.Second,
 	}
 

--- a/motionplan/armplanning/orderbench/replay_bench_test.go
+++ b/motionplan/armplanning/orderbench/replay_bench_test.go
@@ -1,0 +1,72 @@
+//go:build !386
+
+package orderbench
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.viam.com/rdk/motionplan/armplanning"
+)
+
+// BenchmarkOrderReplay replays the whole captured order. It is the local equivalent of what the
+// Motion Order Benchmark workflow runs, and the number that matters is the reported order_ms rather
+// than the ns/op Go prints -- one iteration is a whole order, not a single operation.
+//
+//	go test ./motionplan/armplanning/orderbench -run xxx -bench OrderReplay -benchtime 1x
+//
+// To compare two revisions, use the CLI rather than benchstat: it builds the harness against both
+// libraries and joins plans by name.
+func BenchmarkOrderReplay(b *testing.B) {
+	benchmarkOrder(b, ModeWarm)
+}
+
+// BenchmarkOrderReplayCold plans each request in a fresh process, isolating the per-plan floor from
+// anything that amortises across the order. It forks once per plan, so it is much slower than the
+// warm replay.
+func BenchmarkOrderReplayCold(b *testing.B) {
+	benchmarkOrder(b, ModeCold)
+}
+
+func benchmarkOrder(b *testing.B, mode Mode) {
+	if armplanning.IsTooSmallForCache() {
+		b.Skip("machine is too small for the smart-seed cache; timings would not be comparable")
+	}
+
+	corpusDir, manifest, err := ResolveCorpusDir("", DefaultCorpus)
+	if err != nil {
+		// The corpus is a ~100MB artifact fetch. Skipping keeps `go test -bench .` usable on a
+		// machine that cannot reach the artifact store.
+		b.Skipf("corpus %q unavailable: %v", DefaultCorpus, err)
+	}
+	b.Logf("replaying %d plans from %s", len(manifest.Entries), corpusDir)
+
+	opts := Options{
+		CorpusDir:   corpusDir,
+		Manifest:    manifest,
+		Mode:        mode,
+		PlanTimeout: 60 * time.Second,
+	}
+
+	var last []Record
+	b.ResetTimer()
+	for b.Loop() {
+		last, err = Run(context.Background(), opts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+
+	var totalMS float64
+	var failures int
+	for _, stat := range Summarize(last) {
+		totalMS += stat.PlanMS
+		if stat.Failures > 0 {
+			failures++
+		}
+	}
+	b.ReportMetric(totalMS, "order_ms")
+	b.ReportMetric(float64(failures), "failed_plans")
+}


### PR DESCRIPTION
## Summary

The existing motion CI scores plan *quality* through the external `motion-testing` repo; nothing measures planner latency, and the in-tree armplanning benchmarks time single synthetic requests. That misses the regressions that actually happen: armplanning carries learned roadmaps, the smart-seed cache and a static-scene SDF registry between calls, so what a plan costs depends on which plans ran before it.

This adds `orderbench`, which replays a captured production order — 98 plans, in the order the robot planned them — and diffs latency and trajectory quality across two revisions.

> ⚠️ The new job fails on a regression but is **not** marked required. Planner timings on a shared runner are noisy, so a red mark should prompt reading the comment, not block a merge.

## Review guide

- Start with `compare.go` — the thresholds and what gates on them are the judgment calls worth arguing about.
- `replay.go` holds the controls that keep a cross-revision comparison honest: pinned `GOGC`, disabled on-disk roadmap cache, cold-vs-warm as a real fork.
- `.artifact/tree.json` (+398) and `corpora/cappuccina-5fb95a4c.json` (+986) are generated data — skim.

## Changes

- **orderbench**: `warm` replays the order in one process the way production runs; `cold` forks per plan to isolate preprocessing that never amortises. Only `PlanMotion` is timed.
- **orderbench/compare**: lists a plan at 1.25x, but fails a build only on 2.0x **and** ≥250 ms added, a 1.10x order total, or a newly failing plan. The absolute-time condition matters — a flat per-plan preprocessing cost reads as a fleet of 7x regressions on the cheapest plans, true as ratios and nearly irrelevant to the order.
- **corpus**: 98 payloads (107 MB) live in the artifact store; only the manifest is committed, pinning order, labels and content hashes, and every payload is verified before a run.
- **motion-order-benchmark.yml**: grafts the head harness onto the base checkout, so the comparison measures the library rather than the harness. Solver-attribution fields are read reflectively so the harness still builds against an older `PlanMeta`.

## Testing

- `go test ./motionplan/armplanning/orderbench` — ingest ordering, corpus drift detection, median summarisation across passes, gate verdicts.
- `go test -bench OrderReplay -benchtime 1x` replays the full order (~40 s).
- Validated against v1.5.0: reproduces the known regression at 2.33x order total, with six plans carrying +23.2 s. Two runs of the *same* build differ by 1.02x, which is where the thresholds came from.

<details>
<summary>Claude Code prompts used</summary>

- "Hi Claude, I would like to extand the performance testing we have for motion planning. I see we already have a CI check performing something similar. I would like to use a sequence of plans, ordered by the timestamp included in the filename, you can fetch them with `viam data export binary filter --destination ./order-export --tags 5fb95a4c-83f8-4e66-862d-52cbca842ed5 --timeout 120` How would we proceed to do that?"
- "You can run artifact push"
- "Let's set `fail_on_regression: true`, we will make this CI check not required. Then open a PR"

</details>
