### PR TITLE
spatialmath: gate mesh negative-cache reuse on the querying buffer

### DIFF
--- a/spatialmath/mesh.go
+++ b/spatialmath/mesh.go
@@ -116,6 +116,11 @@ type meshState struct {
 	// is *negCacheEntry which carries the original key components so we can
 	// verify on lookup — hash collisions are rare but treated as cache misses
 	// (the cached entry is overwritten by the next BVH walk anyway).
+	//
+	// The buffer is deliberately NOT part of the key: an entry stores the
+	// measured separation, so one entry serves every buffer. Reuse is gated at
+	// lookup on that separation exceeding the querying buffer — a pair cleared
+	// at 1e-8 is still a collision at 3mm, and must re-walk.
 	negCache sync.Map // uint64 -> *negCacheEntry
 
 	// distAnchors generalizes negCache from "same world poses" to "nearby
@@ -847,7 +852,14 @@ func (m *Mesh) collidesWithMesh(other *Mesh, collisionBufferMM float64) (bool, f
 		if v, ok := m.state.negCache.Load(negKey); ok {
 			e := v.(*negCacheEntry)
 			if negCacheEntryMatches(e, other.state, m.pose, other.pose) {
-				return false, math.Sqrt(e.minDistSq), nil
+				// The entry records the measured separation, not a verdict: only a
+				// separation strictly greater than the *current* buffer proves no
+				// collision. An entry stored under a smaller buffer says nothing
+				// about a larger one, so fall through to the walk rather than reuse
+				// it. Mirrors the distAnchors gate above.
+				if d := math.Sqrt(e.minDistSq); d > collisionBufferMM {
+					return false, d, nil
+				}
 			}
 		}
 	}

--- a/spatialmath/mesh_test.go
+++ b/spatialmath/mesh_test.go
@@ -739,3 +739,68 @@ func TestLazyBVHConstruction(t *testing.T) {
 		test.That(t, transformed.bvh, test.ShouldEqual, originalBVH)
 	})
 }
+
+// TestNegCacheRespectsCollisionBuffer pins the invariant that a cached "no
+// collision" verdict is reusable only for buffers below the separation it
+// measured. A pair cleared at a tight buffer is still a collision at a wider
+// one; reusing the cached verdict there silently drops real collisions —
+// including the start-state collisions the motion planner relies on to build
+// its allowed-collision list, whose absence then surfaces mid-plan as a
+// violation between two geometries that never move relative to each other.
+func TestNegCacheRespectsCollisionBuffer(t *testing.T) {
+	const gap = 1.5 // mm of clear space between the two meshes
+
+	// Two parallel single-triangle meshes, gap apart along X.
+	newPair := func() (*Mesh, *Mesh) {
+		tri := func(x float64) *Triangle {
+			return NewTriangle(
+				r3.Vector{X: x, Y: 0, Z: 0},
+				r3.Vector{X: x, Y: 10, Z: 0},
+				r3.Vector{X: x, Y: 0, Z: 10},
+			)
+		}
+		a := NewMesh(NewZeroPose(), []*Triangle{tri(0)}, "a")
+		b := NewMesh(NewZeroPose(), []*Triangle{tri(gap)}, "b")
+		return a, b
+	}
+
+	t.Run("wide buffer collides on a cold cache", func(t *testing.T) {
+		a, b := newPair()
+		collides, _, err := a.CollidesWith(b, gap*2)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	t.Run("wide buffer still collides after a tight-buffer check", func(t *testing.T) {
+		a, b := newPair()
+
+		collides, _, err := a.CollidesWith(b, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeFalse)
+
+		// Same pair at the same poses, wider buffer. The verdict cached by the
+		// call above measured gap of clearance, which does not clear gap*2.
+		collides, _, err = a.CollidesWith(b, gap*2)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeTrue)
+	})
+
+	// Guards against "fixing" the above by disabling the cache outright: an
+	// entry must still be stored, and a repeat query at the same buffer must
+	// still be served from it.
+	t.Run("cache still serves a repeat query at the same buffer", func(t *testing.T) {
+		a, b := newPair()
+
+		collides, _, err := a.CollidesWith(b, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeFalse)
+
+		_, cached := a.state.negCache.Load(negCacheKey(b.state, a.pose, b.pose))
+		test.That(t, cached, test.ShouldBeTrue)
+
+		collides, dist, err := a.CollidesWith(b, defaultCollisionBufferMM)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, collides, test.ShouldBeFalse)
+		test.That(t, dist, test.ShouldAlmostEqual, gap)
+	})
+}


### PR DESCRIPTION
## Summary

The mesh negative cache serves a stored "no collision" verdict on any later query at the same poses, without comparing the entry's measured separation to the *current* collision buffer. An entry written at the 1e-8 default clears the same pair for a 2 mm-buffer query even when the measured separation is under 2 mm — a silently dropped collision. It bites whenever one mesh instance is queried under different buffers, e.g. a live server whose frame-system geometry outlives requests while plans alternate buffer settings. The adjacent `distAnchors` path already has this gate; `negCache` was missing it.

The fix reuses an entry only when its measured separation exceeds the querying buffer, falling through to the BVH walk otherwise. The buffer deliberately stays out of the key: one entry serves every buffer below its measured separation.

## Testing

- `TestNegCacheRespectsCollisionBuffer` pins the invariant: a wide-buffer query collides cold, still collides after a tight-buffer check cached the pair, and a repeat query at the same buffer is still served from the cache (guarding against fixing this by disabling the cache).

<details>
<summary>Claude Code prompts used</summary>

- "I would like you to investigate what we could do to fix or mitigate these performance issues. Check the code to see if we have missed something important that could explain the problem. Propose potential approaches and solution."
- "Can you create a draft PR for each of the changes recommended in the remedy section for which we already have a worktree?"

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
