### PR TITLE
armplanning: harden collision_buffer_mm decode against zero values

### DIFF
--- a/motionplan/armplanning/api.go
+++ b/motionplan/armplanning/api.go
@@ -80,6 +80,10 @@ func (req *PlanRequest) validatePlanRequest() error {
 	if req.PlannerOptions == nil {
 		req.PlannerOptions = NewBasicPlannerOptions()
 	}
+	if req.PlannerOptions.CollisionBufferMM < 0 {
+		return errors.New("collision_buffer_mm can't be negative")
+	}
+	req.PlannerOptions.normalizeCollisionBuffer()
 
 	// If we have a start configuration, check for correctness. Reuse FrameSystemPoses compute function to provide error.
 	if len(req.StartState.structuredConfiguration) > 0 {
@@ -458,11 +462,17 @@ func ReadRequestAndResponseFromFile(fileName string) (*PlanRequest, motionplan.P
 	// We've removed world state from the plan request object. Instead forcing callers to merge
 	// world state transforms into the `FrameSystem` member itself. And world state obstacles are
 	// now passed in directly.
-	req := &PlanRequest{}
+	//
+	// PlannerOptions is pre-seeded with defaults so a saved options object that omits a field
+	// merges into the default rather than the type's zero value. A request captured before a
+	// field existed (or with the key stripped) must replay with the same effective options
+	// production would use - most acutely collision_buffer_mm, where a decoded 0 flips collision
+	// verdicts and can turn a milliseconds plan into a timeout.
+	req := &PlanRequest{PlannerOptions: NewBasicPlannerOptions()}
 	if _, hasWorldState := probe["world_state"]; hasWorldState {
 		// Legacy format, parse as a `PlanRequestWithWorldState` and have that "upgrade" to a modern
 		// `PlanRequest`.
-		legacy := &PlanRequestWithWorldState{}
+		legacy := &PlanRequestWithWorldState{PlannerOptions: NewBasicPlannerOptions()}
 		if err = json.Unmarshal(raw, legacy); err != nil {
 			return nil, nil, err
 		}

--- a/motionplan/armplanning/api.go
+++ b/motionplan/armplanning/api.go
@@ -80,10 +80,9 @@ func (req *PlanRequest) validatePlanRequest() error {
 	if req.PlannerOptions == nil {
 		req.PlannerOptions = NewBasicPlannerOptions()
 	}
-	if req.PlannerOptions.CollisionBufferMM < 0 {
-		return errors.New("collision_buffer_mm can't be negative")
+	if req.PlannerOptions.CollisionBufferMM <= 0 {
+		return errors.New("collision_buffer_mm has to be positive")
 	}
-	req.PlannerOptions.normalizeCollisionBuffer()
 
 	// If we have a start configuration, check for correctness. Reuse FrameSystemPoses compute function to provide error.
 	if len(req.StartState.structuredConfiguration) > 0 {

--- a/motionplan/armplanning/planner_options.go
+++ b/motionplan/armplanning/planner_options.go
@@ -153,8 +153,19 @@ func NewPlannerOptionsFromExtra(extra map[string]interface{}) (*PlannerOptions, 
 	if opt.CollisionBufferMM < 0 {
 		return nil, errors.New("collision_buffer_mm can't be negative")
 	}
+	opt.normalizeCollisionBuffer()
 
 	return opt, nil
+}
+
+// normalizeCollisionBuffer treats a zero collision buffer as the 1e-8 default.
+// A 0 only arises from decoding into a zero-valued struct or an explicit 0,
+// and exactly 0 flips collision verdicts for geometries modeled in contact,
+// turning millisecond plans into timeouts - so it is normalized, not honored.
+func (p *PlannerOptions) normalizeCollisionBuffer() {
+	if p.CollisionBufferMM == 0 {
+		p.CollisionBufferMM = defaultCollisionBufferMM
+	}
 }
 
 // GetGoalMetric creates the distance metric for the solver using the configured options.

--- a/motionplan/armplanning/planner_options.go
+++ b/motionplan/armplanning/planner_options.go
@@ -150,22 +150,11 @@ func NewPlannerOptionsFromExtra(extra map[string]interface{}) (*PlannerOptions, 
 		return nil, err
 	}
 
-	if opt.CollisionBufferMM < 0 {
-		return nil, errors.New("collision_buffer_mm can't be negative")
+	if opt.CollisionBufferMM <= 0 {
+		return nil, errors.New("collision_buffer_mm has to be positive")
 	}
-	opt.normalizeCollisionBuffer()
 
 	return opt, nil
-}
-
-// normalizeCollisionBuffer treats a zero collision buffer as the 1e-8 default.
-// A 0 only arises from decoding into a zero-valued struct or an explicit 0,
-// and exactly 0 flips collision verdicts for geometries modeled in contact,
-// turning millisecond plans into timeouts - so it is normalized, not honored.
-func (p *PlannerOptions) normalizeCollisionBuffer() {
-	if p.CollisionBufferMM == 0 {
-		p.CollisionBufferMM = defaultCollisionBufferMM
-	}
 }
 
 // GetGoalMetric creates the distance metric for the solver using the configured options.

--- a/motionplan/armplanning/planner_options_test.go
+++ b/motionplan/armplanning/planner_options_test.go
@@ -1,0 +1,103 @@
+package armplanning
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestNewPlannerOptionsFromExtraCollisionBuffer(t *testing.T) {
+	t.Run("absent key keeps the default", func(t *testing.T) {
+		opt, err := NewPlannerOptionsFromExtra(map[string]interface{}{"timeout": 30})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, opt.CollisionBufferMM, test.ShouldEqual, defaultCollisionBufferMM)
+	})
+
+	t.Run("explicit zero is normalized to the default", func(t *testing.T) {
+		opt, err := NewPlannerOptionsFromExtra(map[string]interface{}{"collision_buffer_mm": 0})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, opt.CollisionBufferMM, test.ShouldEqual, defaultCollisionBufferMM)
+	})
+
+	t.Run("positive value is honored", func(t *testing.T) {
+		opt, err := NewPlannerOptionsFromExtra(map[string]interface{}{"collision_buffer_mm": 2})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, opt.CollisionBufferMM, test.ShouldEqual, 2.0)
+	})
+
+	t.Run("negative value errors", func(t *testing.T) {
+		_, err := NewPlannerOptionsFromExtra(map[string]interface{}{"collision_buffer_mm": -1})
+		test.That(t, err, test.ShouldNotBeNil)
+	})
+}
+
+// TestReadRequestSeedsPlannerOptionDefaults pins that decoding a saved request
+// merges its planner_options into the defaults: a field absent from the JSON
+// must decode to its default, not the type's zero value. collision_buffer_mm
+// is the load-bearing case - a decoded 0 flips collision verdicts for
+// geometries modeled in contact.
+func TestReadRequestSeedsPlannerOptionDefaults(t *testing.T) {
+	read := func(t *testing.T, body string) *PlanRequest {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "req.json")
+		test.That(t, os.WriteFile(path, []byte(body), 0o600), test.ShouldBeNil)
+		req, err := ReadRequestFromFile(path)
+		test.That(t, err, test.ShouldBeNil)
+		return req
+	}
+
+	t.Run("options object without the buffer key", func(t *testing.T) {
+		req := read(t, `{"planner_options": {"timeout": 30}}`)
+		test.That(t, req.PlannerOptions.CollisionBufferMM, test.ShouldEqual, defaultCollisionBufferMM)
+		test.That(t, req.PlannerOptions.Timeout, test.ShouldEqual, 30.0)
+	})
+
+	t.Run("options object with the buffer key", func(t *testing.T) {
+		req := read(t, `{"planner_options": {"collision_buffer_mm": 2}}`)
+		test.That(t, req.PlannerOptions.CollisionBufferMM, test.ShouldEqual, 2.0)
+	})
+
+	t.Run("null options fall back to defaults", func(t *testing.T) {
+		req := read(t, `{"planner_options": null}`)
+		test.That(t, req.PlannerOptions.CollisionBufferMM, test.ShouldEqual, defaultCollisionBufferMM)
+	})
+
+	t.Run("absent options fall back to defaults", func(t *testing.T) {
+		req := read(t, `{}`)
+		test.That(t, req.PlannerOptions.CollisionBufferMM, test.ShouldEqual, defaultCollisionBufferMM)
+	})
+}
+
+// TestValidatePlanRequestCollisionBuffer pins the request-level backstop: a
+// request assembled with a zero buffer (however it was produced) plans with
+// the default, and a negative buffer is rejected.
+func TestValidatePlanRequestCollisionBuffer(t *testing.T) {
+	newReq := func(t *testing.T) *PlanRequest {
+		t.Helper()
+		req, err := readRequestFromBytes(wineAdjustJSON)
+		test.That(t, err, test.ShouldBeNil)
+		return req
+	}
+
+	t.Run("zero is normalized to the default", func(t *testing.T) {
+		req := newReq(t)
+		req.PlannerOptions.CollisionBufferMM = 0
+		test.That(t, req.validatePlanRequest(), test.ShouldBeNil)
+		test.That(t, req.PlannerOptions.CollisionBufferMM, test.ShouldEqual, defaultCollisionBufferMM)
+	})
+
+	t.Run("negative is rejected", func(t *testing.T) {
+		req := newReq(t)
+		req.PlannerOptions.CollisionBufferMM = -1
+		test.That(t, req.validatePlanRequest(), test.ShouldNotBeNil)
+	})
+
+	t.Run("positive is untouched", func(t *testing.T) {
+		req := newReq(t)
+		req.PlannerOptions.CollisionBufferMM = 2
+		test.That(t, req.validatePlanRequest(), test.ShouldBeNil)
+		test.That(t, req.PlannerOptions.CollisionBufferMM, test.ShouldEqual, 2.0)
+	})
+}

--- a/motionplan/armplanning/planner_options_test.go
+++ b/motionplan/armplanning/planner_options_test.go
@@ -15,10 +15,9 @@ func TestNewPlannerOptionsFromExtraCollisionBuffer(t *testing.T) {
 		test.That(t, opt.CollisionBufferMM, test.ShouldEqual, defaultCollisionBufferMM)
 	})
 
-	t.Run("explicit zero is normalized to the default", func(t *testing.T) {
-		opt, err := NewPlannerOptionsFromExtra(map[string]interface{}{"collision_buffer_mm": 0})
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, opt.CollisionBufferMM, test.ShouldEqual, defaultCollisionBufferMM)
+	t.Run("explicit zero errors", func(t *testing.T) {
+		_, err := NewPlannerOptionsFromExtra(map[string]interface{}{"collision_buffer_mm": 0})
+		test.That(t, err, test.ShouldNotBeNil)
 	})
 
 	t.Run("positive value is honored", func(t *testing.T) {
@@ -59,6 +58,13 @@ func TestReadRequestSeedsPlannerOptionDefaults(t *testing.T) {
 		test.That(t, req.PlannerOptions.CollisionBufferMM, test.ShouldEqual, 2.0)
 	})
 
+	t.Run("an explicit zero survives seeding", func(t *testing.T) {
+		// Seeding must not paper over a value the JSON actually states; the
+		// zero is caught later, by validatePlanRequest.
+		req := read(t, `{"planner_options": {"collision_buffer_mm": 0}}`)
+		test.That(t, req.PlannerOptions.CollisionBufferMM, test.ShouldEqual, 0.0)
+	})
+
 	t.Run("null options fall back to defaults", func(t *testing.T) {
 		req := read(t, `{"planner_options": null}`)
 		test.That(t, req.PlannerOptions.CollisionBufferMM, test.ShouldEqual, defaultCollisionBufferMM)
@@ -71,8 +77,9 @@ func TestReadRequestSeedsPlannerOptionDefaults(t *testing.T) {
 }
 
 // TestValidatePlanRequestCollisionBuffer pins the request-level backstop: a
-// request assembled with a zero buffer (however it was produced) plans with
-// the default, and a negative buffer is rejected.
+// non-positive buffer is rejected however the request was assembled. Exactly 0
+// flips collision verdicts for geometries modeled in contact, so it is refused
+// rather than planned at a value production never uses.
 func TestValidatePlanRequestCollisionBuffer(t *testing.T) {
 	newReq := func(t *testing.T) *PlanRequest {
 		t.Helper()
@@ -81,11 +88,10 @@ func TestValidatePlanRequestCollisionBuffer(t *testing.T) {
 		return req
 	}
 
-	t.Run("zero is normalized to the default", func(t *testing.T) {
+	t.Run("zero is rejected", func(t *testing.T) {
 		req := newReq(t)
 		req.PlannerOptions.CollisionBufferMM = 0
-		test.That(t, req.validatePlanRequest(), test.ShouldBeNil)
-		test.That(t, req.PlannerOptions.CollisionBufferMM, test.ShouldEqual, defaultCollisionBufferMM)
+		test.That(t, req.validatePlanRequest(), test.ShouldNotBeNil)
 	})
 
 	t.Run("negative is rejected", func(t *testing.T) {

--- a/motionplan/armplanning/posecloud_int_test.go
+++ b/motionplan/armplanning/posecloud_int_test.go
@@ -93,6 +93,10 @@ func TestPoseCloudPlanning(t *testing.T) {
 	// glass and lite6:wrist_link geometries: 90.09% }
 	test.That(t, errors.As(err, &ikErr), test.ShouldBeTrue)
 
+	// By using a larger defaultTimeout, IK will get more time than the typical one second.
+	relaxedOpts := NewBasicPlannerOptions()
+	relaxedOpts.Timeout = defaultTimeout + 1
+
 	// Plan for the same goal with a big leeway. IK finds a solution here due to the relaxed goal.
 	plan, _, err := PlanMotion(ctx, logger.Sublogger("cloud-planning-works"), &PlanRequest{
 		FrameSystem: fs,
@@ -111,10 +115,7 @@ func TestPoseCloudPlanning(t *testing.T) {
 			"lite6":   []referenceframe.Input{0, 0, 0, 0, 0, 0},
 			"gripper": []referenceframe.Input{25, 25},
 		}),
-		PlannerOptions: &PlannerOptions{
-			// By using a larger defaultTimeout, IK will get more time than the typical one second.
-			Timeout: defaultTimeout + 1,
-		},
+		PlannerOptions: relaxedOpts,
 	})
 	test.That(t, err, test.ShouldBeNil)
 

--- a/motionplan/armplanning/startup_profile.go
+++ b/motionplan/armplanning/startup_profile.go
@@ -57,7 +57,9 @@ func checkStartupPerf(logger logging.Logger) (time.Duration, error) {
 }
 
 func readRequestFromBytes(data []byte) (*PlanRequest, error) {
-	req := &PlanRequest{}
+	// Pre-seeded so options fields absent from the JSON decode to their
+	// defaults, not the type's zero values; see ReadRequestAndResponseFromFile.
+	req := &PlanRequest{PlannerOptions: NewBasicPlannerOptions()}
 	err := json.NewDecoder(bytes.NewReader(data)).Decode(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Treat a `collision_buffer_mm` of exactly 0 as unset and fall back to the 1e-8 default. A 0 flips collision verdicts for geometries modeled in contact, turning a ~100 ms plan into a >120 s timeout. Two paths produced one: replaying a saved request decoded into a zero-valued struct, and an explicit 0 in `extra` passed validation.

## Changes

- **api.go**: seed `PlannerOptions` with defaults before decoding a saved request, so an options object that merely omits a key merges into the default (modern and legacy `world_state` formats)
- **api.go**: `validatePlanRequest` normalizes 0 and rejects negatives — a backstop covering every `PlanMotion` call regardless of how the request was assembled
- **planner_options.go**: `NewPlannerOptionsFromExtra` applies the same normalization, so an explicit `collision_buffer_mm: 0` no longer slips past the negatives-only check
- **startup_profile.go**: the embedded startup-profile request decodes through seeded defaults too

Sub-epsilon buffers have no physical meaning — the default is 10 picometers — so 0 is normalized rather than honored; negatives remain an error.

## Testing

- `planner_options_test.go` (new): extra-path table (absent / 0 / positive / negative), file-decode table (options without the key, with the key, `null`, absent), and the `validatePlanRequest` backstop (0 normalized, negative rejected, positive untouched)
- `go test ./motionplan/armplanning/` passes; no non-test code in the repo sets a zero buffer

<details>
<summary>Claude Code prompts used</summary>

- "I would like you to investigate what we could do to fix or mitigate these performance issues. Check the code to see if we have missed something important that could explain the problem. Propose potential approaches and solution."
- "can you create a new PR addressing remedy #5: "Harden buffer decode: seed defaults on replay, clamp ≤ 0 to epsilon" ?"

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
