### PR TITLE
Fix the two most frequent CI test flakes

### DIFF
--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -1335,15 +1335,65 @@ func generateGolangStubs(module modulegen.ModuleInputs) error {
 
 	// run go mod tidy
 	if module.Language == golang {
-		//nolint: noctx
-		tidyCmd := exec.Command("go", "mod", "tidy")
-		tidyCmd.Dir = module.ModuleName
-		if err := tidyCmd.Run(); err != nil {
-			return fmt.Errorf("failed to run go mod tidy: %w", err)
+		if out, err := runGoWithRetry(module.ModuleName, "mod", "tidy"); err != nil {
+			return fmt.Errorf("failed to run go mod tidy: %w\n%s", err, out)
 		}
 	}
 
 	return nil
+}
+
+// goFetchAttempts bounds how many times runGoWithRetry re-runs a `go` subcommand that
+// failed while talking to the module proxy or checksum database.
+const goFetchAttempts = 3
+
+// goFetchRetryDelay is the base backoff between attempts; attempt N waits N times this.
+const goFetchRetryDelay = 2 * time.Second
+
+// transientGoFetchMarkers are substrings the Go toolchain emits when proxy.golang.org or
+// sum.golang.org drops a request mid-flight. They say nothing about the module being
+// fetched, so the same command usually succeeds on a retry. Errors that describe the
+// module itself -- a bad version, a missing package, a checksum mismatch -- are absent
+// here on purpose, so a genuinely broken dependency still fails on the first attempt.
+var transientGoFetchMarkers = []string{
+	"INTERNAL_ERROR; received from peer",
+	"connection reset by peer",
+	"unexpected EOF",
+	"TLS handshake timeout",
+	"i/o timeout",
+	"502 Bad Gateway",
+	"503 Service Unavailable",
+	"504 Gateway Timeout",
+}
+
+// transientGoFetchFailure reports whether combined `go` output looks like a retryable
+// module-fetch failure rather than a real problem with the module graph.
+func transientGoFetchFailure(output []byte) bool {
+	out := string(output)
+	for _, marker := range transientGoFetchMarkers {
+		if strings.Contains(out, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// runGoWithRetry runs a `go` subcommand in dir, retrying transient module-proxy and
+// checksum-database failures. It returns the combined output of the final attempt so
+// callers can surface the toolchain's own diagnostics.
+func runGoWithRetry(dir string, args ...string) ([]byte, error) {
+	var out []byte
+	var err error
+	for attempt := 1; ; attempt++ {
+		//nolint: noctx
+		cmd := exec.Command(golang, args...)
+		cmd.Dir = dir
+		out, err = cmd.CombinedOutput()
+		if err == nil || attempt == goFetchAttempts || !transientGoFetchFailure(out) {
+			return out, err
+		}
+		time.Sleep(time.Duration(attempt) * goFetchRetryDelay)
+	}
 }
 
 // run goimports to remove unused imports and add necessary imports.
@@ -1362,10 +1412,8 @@ func runGoImports(moduleFile *os.File) error {
 	goImportsPath := filepath.Join(goPath, "bin", goImportsName)
 	if _, err := os.Stat(goImportsPath); os.IsNotExist(err) {
 		// installing goimports
-		//nolint: noctx
-		installCmd := exec.Command("go", "install", "golang.org/x/tools/cmd/goimports@latest")
-		if err := installCmd.Run(); err != nil {
-			return fmt.Errorf("failed to install goimports: %w", err)
+		if out, err := runGoWithRetry("", "install", "golang.org/x/tools/cmd/goimports@latest"); err != nil {
+			return fmt.Errorf("failed to install goimports: %w\n%s", err, out)
 		}
 	}
 

--- a/cli/module_generate_app_test.go
+++ b/cli/module_generate_app_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -51,28 +50,22 @@ func TestAppTemplateCompiles(t *testing.T) {
 	err = os.WriteFile(goModPath, goMod, 0o644)
 	test.That(t, err, test.ShouldBeNil)
 
-	//nolint: noctx
-	goGet := exec.Command("go", "get", "github.com/erh/vmodutils@latest")
-	goGet.Dir = appPath
-	goGetOut, err := goGet.CombinedOutput()
+	// The generated module resolves its dependencies from scratch, so every step below
+	// reaches the module proxy and checksum database. runGoWithRetry absorbs the
+	// intermittent stream resets those endpoints return.
+	goGetOut, err := runGoWithRetry(appPath, "get", "github.com/erh/vmodutils@latest")
 	if err != nil {
 		t.Fatalf("go get vmodutils failed: %v\n%s", err, goGetOut)
 	}
 
 	// Run go mod tidy to resolve dependencies
-	//nolint: noctx
-	tidy := exec.Command("go", "mod", "tidy")
-	tidy.Dir = appPath
-	tidyOut, err := tidy.CombinedOutput()
+	tidyOut, err := runGoWithRetry(appPath, "mod", "tidy")
 	if err != nil {
 		t.Fatalf("go mod tidy failed: %v\n%s", err, tidyOut)
 	}
 
 	// Verify the generated module.go compiles against current rdk
-	//nolint: noctx
-	build := exec.Command("go", "build", "./...")
-	build.Dir = appPath
-	buildOut, err := build.CombinedOutput()
+	buildOut, err := runGoWithRetry(appPath, "build", "./...")
 	if err != nil {
 		t.Fatalf("generated app module does not compile: %v\n%s", err, buildOut)
 	}

--- a/cli/module_generate_test.go
+++ b/cli/module_generate_test.go
@@ -1155,3 +1155,52 @@ func main() {
 		test.That(t, string(result), test.ShouldEqual, original)
 	})
 }
+
+func TestTransientGoFetchFailure(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		output   string
+		expected bool
+	}{
+		{
+			name: "sumdb stream reset",
+			output: "go: downloading go.viam.com/utils v0.10.1\n" +
+				"go: go.viam.com/utils@v0.10.1: verifying go.mod: go.viam.com/utils@v0.10.1/go.mod: " +
+				"reading https://sum.golang.org/tile/8/0/x227/599: stream error: stream ID 3637; " +
+				"INTERNAL_ERROR; received from peer\n",
+			expected: true,
+		},
+		{
+			name:     "proxy gateway error",
+			output:   "go: module lookup disabled: 502 Bad Gateway\n",
+			expected: true,
+		},
+		{
+			name:     "checksum mismatch is not transient",
+			output:   "go: github.com/foo/bar@v1.0.0: checksum mismatch\n\tSECURITY ERROR\n",
+			expected: false,
+		},
+		{
+			name:     "unknown revision is not transient",
+			output:   "go: github.com/foo/bar@v9.9.9: invalid version: unknown revision v9.9.9\n",
+			expected: false,
+		},
+		{
+			name:     "compile error is not transient",
+			output:   "# go.viam.com/rdk/grpc\n./auth_identity.go:69:21: entity.AuthMetadata undefined\n",
+			expected: false,
+		},
+		{
+			name:     "empty output",
+			output:   "",
+			expected: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			test.That(t, transientGoFetchFailure([]byte(tc.output)), test.ShouldEqual, tc.expected)
+		})
+	}
+}

--- a/robot/framesystem/framesystem_test.go
+++ b/robot/framesystem/framesystem_test.go
@@ -23,6 +23,9 @@ func TestEmptyConfigFrameService(t *testing.T) {
 	ctx := context.Background()
 	r, err := robotimpl.New(ctx, &config.Config{}, nil, logger)
 	test.That(t, err, test.ShouldBeNil)
+	// Closing the robot joins its web module-server goroutines. Leaving them running
+	// races the test logger against test completion.
+	defer r.Close(ctx)
 	fsCfg, err := r.FrameSystemConfig(ctx)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, fsCfg.Parts, test.ShouldHaveLength, 0)

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -596,6 +596,11 @@ func TestNavSetUpFromFaultyConfig(t *testing.T) {
 		test.That(t, cfg.Ensure(false, logger), test.ShouldBeNil)
 		myRobot, err := robotimpl.New(ctx, cfg, nil, logger)
 		test.That(t, err, test.ShouldBeNil)
+		// Registered rather than deferred so the robot is still closed when an
+		// assertion below fails: a robot left running keeps goroutines that log
+		// through the test logger after the test has completed, which the race
+		// detector reports against whichever test runs next.
+		t.Cleanup(func() { test.That(t, myRobot.Close(ctx), test.ShouldBeNil) })
 		_, err = navigation.FromProvider(myRobot, "test_navigation")
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, tc.expectedError)


### PR DESCRIPTION
## Summary

Six CI jobs were re-run and then passed in the last week. Four of the six failed on the same thing: `sum.golang.org` resetting the HTTP/2 stream while the CLI module-generation tests resolve a freshly generated module's dependency graph. The second recurring flake is a data race — two tests build a local robot and never close it, so its web module-server goroutine logs through the test logger after the test function has returned, racing `testing.tRunner`'s completion write.

## Changes

- **cli/module_generate.go**: `runGoWithRetry` retries a `go` subcommand up to 3× on transport-level proxy/checksum-DB failures only — checksum mismatches, unknown revisions and compile errors still fail on the first attempt. It also returns combined output, so `go mod tidy` failures stop reporting a bare `exit status 1`.
- **robot/framesystem, services/navigation/builtin**: close the leaked robots. These were the only two sites in the tree constructing a local robot without closing it.

## Testing

- `TestTransientGoFetchFailure` covers the retry predicate in both directions.
- `go test -race` green on both robot packages; full `cli` package plus `TestAppTemplateCompiles` and `TestGenerateModuleAction` end to end; `golangci-lint run` clean.

<details>
<summary>Claude Code prompts used</summary>

- "Hi Claude, we have seen quite a few seemingly flaky test errors in this repo recently. Can you fetch all the failed CI and CD failed test workflow from the last 48h and check if any of the test are flaky.
Build a table outlining which tests have been failing the most.
Then implement a fixfor the flakiness if it is a small enough change. If this requires a big refactor outline your proposed approach for me to review

Let me know if you have any question"
- "open a PR for what you implmented.
File a Jira ticket in the RSDK project with the Team set as Netcode.
Regarding \" Docker nightly, 3/3 failed\", can you make a PR against this repo?"

</details>
