### PR TITLE
Drop lint-go from the cache image to unbreak the nightly Docker build

### DIFF
--- a/etc/Dockerfile.cache
+++ b/etc/Dockerfile.cache
@@ -4,11 +4,9 @@ ARG BASE_TAG=amd64
 FROM $MAIN_TAG:$BASE_TAG as builder
 COPY --chown=1000:1000 ./ /tmp/rdk
 WORKDIR /tmp/rdk
-RUN --mount=type=secret,id=netrc,uid=1000,dst=/home/testbot/.netrc sudo -Hu testbot bash -lc 'if [ `dpkg --print-architecture` = armhf ]; then \
-        make build-go tool-install; \
-    else \
-        make build-go lint-go; \
-    fi'
+# `go mod download` first: `go build ./...` never fetches test-only deps, and the test jobs that
+# run in this image expect a warm module cache.
+RUN --mount=type=secret,id=netrc,uid=1000,dst=/home/testbot/.netrc sudo -Hu testbot bash -lc 'go mod download && make build-go tool-install'
 
 FROM $MAIN_TAG:$BASE_TAG
 COPY --from=builder --chown=1000:1000 /home/testbot/go /home/testbot/go


### PR DESCRIPTION
## Summary

The nightly Docker cache build has failed on every run since #6358 (2026-08-18), which made `make lint-go` a `mise run lint-go` wrapper. `etc/Dockerfile.cache` runs that target against `ghcr.io/viamrobotics/rdk-devenv`, which does not ship mise:

```
mise run lint-go
make: mise: No such file or directory
make: *** [Makefile:101: lint-go] Error 127
```

Only the amd64 and arm64 legs are affected — armhf builds `tool-install` instead and has stayed green. Unit tests run in `rdk-devenv:{amd64,arm64}-cache`, so those images are two weeks stale.

This image exists to warm the Go module cache, so it has no business linting. The builder step becomes `go mod download && make build-go tool-install` on every arch:

- **`lint-go` is gone.** It only ever ran here because the target used to declare `tool-install` as a prerequisite; that dependency was dropped in #5531, and after #6358 lint's only remaining contribution to the image was its `go mod tidy` — golangci-lint now lives under mise's install dir, which the final stage never copies.
- **`go mod download` replaces that `go mod tidy`.** On a `go 1.17`+ module it fetches the modules needed to build *and test* the main module, so the test-only deps `go build ./...` never touches stay in the cached GOPATH.
- **The arch conditional is collapsed.** Skipping lint on armhf was its only purpose, and armhf already ran exactly `make build-go tool-install`.

Net effect: amd64/arm64 end up with a superset of today's cache — the same module deps, plus the `tool-install` deps (gotestsum, gocov, actionlint, stringer) that those legs don't cache today even though `etc/test.sh` shells out to gotestsum.

## Testing

`docker buildx build --check` is clean and `go mod download` exits 0 against this `go.mod`. Not built end to end locally (the base image pull does not finish here) — the Docker workflow is nightly/dispatch-only, so please trigger it via `workflow_dispatch` before merging.

<details>
<summary>Claude Code prompts used</summary>

- "Hi Claude, we have seen quite a few seemingly flaky test errors in this repo recently. Can you fetch all the failed CI and CD failed test workflow from the last 48h and check if any of the test are flaky.
Build a table outlining which tests have been failing the most.
Then implement a fixfor the flakiness if it is a small enough change. If this requires a big refactor outline your proposed approach for me to review

Let me know if you have any question"
- "open a PR for what you implmented.
File a Jira ticket in the RSDK project with the Team set as Netcode.
Regarding \" Docker nightly, 3/3 failed\", can you make a PR against this repo?"
- "Regarding https://github.com/viamrobotics/rdk/pull/6411, can you list all the alternative options in the PR description?
Examples: \"Switching to make build-go tool-install on all arches\", maybe installing mise in the conan base image ..."
- "Hi Claude, can you take over this PR and apply this suggestion: https://github.com/viamrobotics/rdk/pull/6411#discussion_r3917493214?"
- "let;s add `go mod download`"
- "Then update the PR description"
- "update the PR description with what this change is actually doing and drop previous ideas and approaches"

</details>
