### PR TITLE
RSDK-14415 Support `user_permissions` in proto and JSON configs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -918,6 +918,54 @@ type AuthConfig struct {
 	Handlers           []AuthHandlerConfig `json:"handlers,omitempty"`
 	TLSAuthEntities    []string            `json:"tls_auth_entities,omitempty"`
 	ExternalAuthConfig *ExternalAuthConfig `json:"external_auth_config,omitempty"`
+	// UserPermissions represents the map of Users to Permissions for this machine.
+	UserPermissions []UserPermission `json:"user_permissions,omitempty"`
+}
+
+// The set of valid User types.
+const (
+	// UserTypeAPIKeyID identifies a user by the ID of the API key they authenticate with.
+	UserTypeAPIKeyID = "api-key-id"
+	// UserTypeAppUserID identifies a user by their Viam app user ID (a stable, non-PII
+	// identifier carried in the "app_user_id" auth metadata claim).
+	UserTypeAppUserID = "app-user-id"
+	// UserTypeDefault matches any authenticated user without a UserPermission of
+	// their own.
+	UserTypeDefault = "default"
+)
+
+// A UserPermission describes a User and the permissions granted to that user. If
+// no UserPermissions are configured, all users are unrestricted. If any are, users
+// are allowed only the methods their UserPermission (or the default user's, if
+// they have none) explicitly grants.
+type UserPermission struct {
+	// User is the User this UserPermission applies to. A User can only be listed
+	// in a single UserPermission for a set of UserPermissions.
+	User        User         `json:"user"`
+	Permissions []Permission `json:"permissions"`
+}
+
+// A User describes a single user that a UserPermission applies to.
+type User struct {
+	// Type is the type of user. Can be "api-key-id", "app-user-id", or "default".
+	Type string `json:"type"`
+	// ID is the API Key ID if Type is "api-key-id", the app user ID if Type is
+	// "app-user-id", and empty if Type is "default".
+	ID string `json:"id,omitempty"`
+}
+
+// A Permission grants a User the ability to invoke a set of methods on a set of
+// resources.
+type Permission struct {
+	// Resources are the names of the resources this permission applies to, e.g.
+	// ["cam1", "cam2", "cam3"]. The special string "_machine" refers to methods
+	// not associated with a single resource (e.g. RobotService methods and
+	// ListStreams).
+	Resources []string `json:"resources"`
+	// AllowedMethods is a list of fully qualified gRPC methods the user may invoke
+	// on the listed resources, e.g.
+	// ["/viam.component.camera.v1.CameraService/GetImages"].
+	AllowedMethods []string `json:"allowed_methods"`
 }
 
 // ExternalAuthConfig contains information needed to verify externally authenticated tokens.

--- a/config/proto_conversions.go
+++ b/config/proto_conversions.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang/geo/r3"
 	"github.com/pkg/errors"
+	"github.com/samber/lo"
 	packagespb "go.viam.com/api/app/packages/v1"
 	pb "go.viam.com/api/app/v1"
 	"go.viam.com/utils"
@@ -709,6 +710,7 @@ func AuthConfigToProto(auth *AuthConfig) (*pb.AuthConfig, error) {
 	proto := pb.AuthConfig{
 		Handlers:        handlers,
 		TlsAuthEntities: auth.TLSAuthEntities,
+		UserPermissions: lo.Map(auth.UserPermissions, userPermissionToProto),
 	}
 
 	if auth.ExternalAuthConfig != nil {
@@ -735,6 +737,7 @@ func AuthConfigFromProto(proto *pb.AuthConfig, _ logging.Logger) (*AuthConfig, e
 	auth := AuthConfig{
 		Handlers:        handlers,
 		TLSAuthEntities: proto.GetTlsAuthEntities(),
+		UserPermissions: lo.Map(proto.GetUserPermissions(), userPermissionFromProto),
 	}
 
 	if proto.ExternalAuthConfig != nil {
@@ -744,6 +747,38 @@ func AuthConfigFromProto(proto *pb.AuthConfig, _ logging.Logger) (*AuthConfig, e
 	}
 
 	return &auth, nil
+}
+
+// userPermissionToProto converts UserPermission to the proto equivalent.
+func userPermissionToProto(up UserPermission, _ int) *pb.UserPermission {
+	return &pb.UserPermission{
+		User: &pb.User{
+			Type: up.User.Type,
+			Id:   up.User.ID,
+		},
+		Permissions: lo.Map(up.Permissions, func(perm Permission, _ int) *pb.Permission {
+			return &pb.Permission{
+				Resources:      perm.Resources,
+				AllowedMethods: perm.AllowedMethods,
+			}
+		}),
+	}
+}
+
+// userPermissionFromProto creates UserPermission from the proto equivalent.
+func userPermissionFromProto(proto *pb.UserPermission, _ int) UserPermission {
+	return UserPermission{
+		User: User{
+			Type: proto.GetUser().GetType(),
+			ID:   proto.GetUser().GetId(),
+		},
+		Permissions: lo.Map(proto.GetPermissions(), func(perm *pb.Permission, _ int) Permission {
+			return Permission{
+				Resources:      perm.GetResources(),
+				AllowedMethods: perm.GetAllowedMethods(),
+			}
+		}),
+	}
 }
 
 // CloudConfigToProto converts Cloud to the proto equivalent.

--- a/config/proto_conversions_test.go
+++ b/config/proto_conversions_test.go
@@ -784,6 +784,67 @@ func TestAuthConfigToProto(t *testing.T) {
 		validateAuthConfig(t, *out, testAuthConfig)
 	})
 
+	t.Run("user permissions", func(t *testing.T) {
+		authConfig := AuthConfig{
+			UserPermissions: []UserPermission{
+				{
+					User: User{Type: UserTypeAPIKeyID, ID: "c6f77790-5405-488a-9c9c-9612402fb9b0"},
+					Permissions: []Permission{
+						{
+							Resources:      []string{"_machine"},
+							AllowedMethods: []string{"/viam.robot.v1.RobotService/ResourceNames"},
+						},
+						{
+							Resources: []string{"cam1", "cam2"},
+							AllowedMethods: []string{
+								"/viam.component.camera.v1.CameraService/GetImages",
+								"/proto.stream.v1.StreamService/AddStream",
+							},
+						},
+					},
+				},
+				{
+					User: User{Type: UserTypeAppUserID, ID: "a1b2c3d4-0000-4000-8000-000000000001"},
+					Permissions: []Permission{
+						{
+							Resources:      []string{"sensor1"},
+							AllowedMethods: []string{"/viam.component.sensor.v1.SensorService/GetReadings"},
+						},
+					},
+				},
+				{
+					User: User{Type: UserTypeDefault},
+					Permissions: []Permission{
+						{
+							Resources:      []string{"_machine"},
+							AllowedMethods: []string{"/viam.robot.v1.RobotService/GetMachineStatus"},
+						},
+					},
+				},
+			},
+		}
+
+		proto, err := AuthConfigToProto(&authConfig)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, proto.GetUserPermissions(), test.ShouldHaveLength, 3)
+		test.That(t, proto.GetUserPermissions()[0].GetUser().GetType(), test.ShouldEqual, UserTypeAPIKeyID)
+		test.That(t, proto.GetUserPermissions()[2].GetUser().GetId(), test.ShouldBeEmpty)
+
+		out, err := AuthConfigFromProto(proto, logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, out.UserPermissions, test.ShouldResemble, authConfig.UserPermissions)
+	})
+
+	t.Run("no user permissions", func(t *testing.T) {
+		proto, err := AuthConfigToProto(&AuthConfig{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, proto.GetUserPermissions(), test.ShouldBeEmpty)
+
+		out, err := AuthConfigFromProto(proto, logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, out.UserPermissions, test.ShouldBeEmpty)
+	})
+
 	t.Run("external auth config", func(t *testing.T) {
 		keyset := jwk.NewSet()
 		privKeyForWebAuth, err := rsa.GenerateKey(rand.Reader, 4096)


### PR DESCRIPTION
RSDK-14415

## What

Supports `user_permissions` in proto and JSON conversion. Adds `UserPermission`, `User`, and `Permission` structs to config.

## Why

Per [the scope](https://docs.google.com/document/d/1QyY2NAqZm74uaP66V35l52Sf5qSrN0Z5meGWpEQgF_U/edit?usp=sharing). We can separate this commit out from the actual [enforcement](https://github.com/viamrobotics/rdk/pull/6269) of `user_permissions` so that the rollout is smoother (app needs the proto conversion logic).

