### PR TITLE
bump github.com/chewxy/math32 to v1.11.2 for future riscv64 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -204,7 +204,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/chewxy/hm v1.0.0 // indirect
-	github.com/chewxy/math32 v1.0.8 // indirect
+	github.com/chewxy/math32 v1.11.2 // indirect
 	github.com/cli/browser v1.3.0 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -265,8 +265,8 @@ github.com/chenzhekl/goply v0.0.0-20190930133256-258c2381defd/go.mod h1:P2dOeu3S
 github.com/chewxy/hm v1.0.0 h1:zy/TSv3LV2nD3dwUEQL2VhXeoXbb9QkpmdRAVUFiA6k=
 github.com/chewxy/hm v1.0.0/go.mod h1:qg9YI4q6Fkj/whwHR1D+bOGeF7SniIP40VweVepLjg0=
 github.com/chewxy/math32 v1.0.0/go.mod h1:Miac6hA1ohdDUTagnvJy/q+aNnEk16qWUdb8ZVhvCN0=
-github.com/chewxy/math32 v1.0.8 h1:fU5E4Ec4Z+5RtRAi3TovSxUjQPkgRh+HbP7tKB2OFbM=
-github.com/chewxy/math32 v1.0.8/go.mod h1:dOB2rcuFrCn6UHrze36WSLVPKtzPMRAQvBvUwkSsLqs=
+github.com/chewxy/math32 v1.11.2 h1:IufN08Zwr1NKuWfY+4Tz55BcwKmyKKNdOP7KtumehnM=
+github.com/chewxy/math32 v1.11.2/go.mod h1:dOB2rcuFrCn6UHrze36WSLVPKtzPMRAQvBvUwkSsLqs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=


### PR DESCRIPTION
## What

Bumps the indirect dependency `github.com/chewxy/math32` from v1.0.8 to v1.11.2. No code changes; `go.mod` and `go.sum` only.

## Why

v1.0.8 does not build for `GOARCH=riscv64`, which blocks cross-compiling **any** module that links RDK for that target.

v1.11.2 includes fixes so riscv64 falls through to the pure-Go implementations.

## Scope of impact

math32 reaches RDK through `services/mlmodel` → `gorgonia.org/tensor` → `github.com/chewxy/math32`. It is a core dependency, so no build tag or model selection avoids it.

Because this is a `require` bump rather than a `replace`, it propagates to consumers through minimum version selection. Every module that links RDK picks up at least v1.11.2 without any change on their end. A `replace` would not work here, since Go ignores `replace` directives in dependency modules.

## Testing

| Check | Result |
| --- | --- |
| `GOOS=linux GOARCH=riscv64 go build ./services/mlmodel/...` before | fails, 5 × `missing function body` |
| `GOOS=linux GOARCH=riscv64 go build ./services/mlmodel/...` after | builds |
| `go build ./...` (linux/amd64) | passes |
| `go test ./services/mlmodel/...` | passes |
| `go mod tidy -diff` | clean |

Note that `go get` alone leaves the stale v1.0.8 lines in `go.sum` and fails `go mod tidy -diff`; this branch includes the `go mod tidy` pass.

## Notes

Found while cross-compiling `viam-modules/viamrtsp` for a Seeed reCamera (SG2002, RISC-V, musl). math32 was a blocker for modules using the RDK.
