### PR TITLE
Add armplanning.ClearRoadmapCache

### DIFF
--- a/motionplan/armplanning/roadmap.go
+++ b/motionplan/armplanning/roadmap.go
@@ -64,13 +64,10 @@ const (
 // roadmapRegistry caches structures per key for the life of the process.
 var roadmapRegistry sync.Map // string -> *roadmap
 
-// ClearRoadmapCache discards every learned roadmap: the sampled structures, harvested
-// corridors, per-scene edge verdicts and memoized smoothed trajectories. Call it between
-// planning requests that must not share learned state - resetting a long-lived process, or
-// measuring a cold start the way a freshly started viam-server would plan. A plan already in
-// flight keeps the roadmap it holds. Roadmaps persisted to disk (MOTION_ROADMAP_CACHE_DIR)
-// are not deleted and will be reloaded on next use; leave that variable unset for a fully
-// cold start.
+// ClearRoadmapCache discards all learned roadmap data. Call this between planning requests
+// that must not share learned state, such as when measuring a cold start. A plan already in
+// flight keeps the roadmap it holds, and roadmaps persisted to disk (MOTION_ROADMAP_CACHE_DIR)
+// are reloaded on next use.
 func ClearRoadmapCache() {
 	roadmapRegistry.Clear()
 }

--- a/motionplan/armplanning/roadmap.go
+++ b/motionplan/armplanning/roadmap.go
@@ -64,6 +64,17 @@ const (
 // roadmapRegistry caches structures per key for the life of the process.
 var roadmapRegistry sync.Map // string -> *roadmap
 
+// ClearRoadmapCache discards every learned roadmap: the sampled structures, harvested
+// corridors, per-scene edge verdicts and memoized smoothed trajectories. Call it between
+// planning requests that must not share learned state - resetting a long-lived process, or
+// measuring a cold start the way a freshly started viam-server would plan. A plan already in
+// flight keeps the roadmap it holds. Roadmaps persisted to disk (MOTION_ROADMAP_CACHE_DIR)
+// are not deleted and will be reloaded on next use; leave that variable unset for a fully
+// cold start.
+func ClearRoadmapCache() {
+	roadmapRegistry.Clear()
+}
+
 type roadmap struct {
 	frames []string // moving chain frames with DoF, sorted; defines flat layout
 	dims   []int    // DoF per frame

--- a/motionplan/armplanning/roadmap_cache_test.go
+++ b/motionplan/armplanning/roadmap_cache_test.go
@@ -1,0 +1,18 @@
+package armplanning
+
+import (
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestClearRoadmapCache(t *testing.T) {
+	rm := &roadmap{key: "clear-test-key", frames: []string{"arm"}}
+	rm.built.Store(true)
+	roadmapRegistry.Store(rm.key, rm)
+
+	ClearRoadmapCache()
+
+	_, ok := roadmapRegistry.Load(rm.key)
+	test.That(t, ok, test.ShouldBeFalse)
+}


### PR DESCRIPTION
## Summary

The learned-roadmap registry lives for the life of the process with no public reset: `ClearSeedCache` drops the smart-seed cache and `MOTION_ROADMAP_CACHE_DIR` controls the on-disk cache, but nothing can drop the in-process learned roadmaps — the sampled structures, harvested corridors, per-scene edge verdicts and memoized smoothed trajectories. `motion-testing`'s ordered-sequence benchmark needs exactly that to measure a genuine cold start before each replayed sequence; today it can only rely on each sequence being the first user of its frame system in the process, which silently stops holding the moment two sequences share one.

`ClearRoadmapCache` is the one-call reset, mirroring `ClearSeedCache`. A plan already in flight keeps the roadmap it holds; disk-persisted roadmaps are not deleted and reload on next use.

## Testing

- `go test ./motionplan/armplanning -run TestClearRoadmapCache` — stores a registry entry, asserts the clear removes it.

<details>
<summary>Claude Code prompts used</summary>

- "I would like to capture data on the first pass of the sequence and use those metrics as cold start metrics. The following passes will be used to compute the metrics on a warm cache. We should also clear the roadmpa cache before the start of each sequence"
- "can you upgrade the rdk dep? Then check if it gives us a way to clear the roadmap cache"
- "let's commit the dependency upgrade. Please draft a PR in rdk for `armplanning.ClearRoadmapCache()`"

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)