### PR TITLE
mpserver: add "Render Executed Plan" to the plan detail page

### DIFF
--- a/motionplan/armplanning/mpserver/server.go
+++ b/motionplan/armplanning/mpserver/server.go
@@ -193,6 +193,9 @@ var detailTmpl = template.Must(template.New("detail").Parse(`<!DOCTYPE html>
 &nbsp;<label>Seed: <input id="seed" type="number" step="1" value="0" style="width:6ch; padding:4px 8px; border:1px solid black;"></label>
 &nbsp;<button onclick="runPlanning()">Do Motion Planning</button>
 &nbsp;<button onclick="renderState()">Render Start State</button>
+{{if .ExecutedPlanSteps}}
+&nbsp;<button onclick="renderExecutedPlan()">Render Executed Plan ({{.ExecutedPlanSteps}} steps)</button>
+{{end}}
 <div id="result"></div>
 
 <h2>Start Inputs</h2>
@@ -275,6 +278,15 @@ function renderState() {
 }
 
 renderState();
+
+// renderExecutedPlan replays the plan recorded in the file alongside the request — the trajectory
+// that actually ran — instead of one computed now. The button only exists for files that carry
+// one, so a 404 here means the file changed underneath the page.
+function renderExecutedPlan() {
+  fetch('/render-executed-plan?file=' + encodeURIComponent('{{.File}}'))
+    .then(r => { if (!r.ok) r.text().then(msg => alert('Render error: ' + msg)); })
+    .catch(err => alert('Render error: ' + err));
+}
 
 // ---- goal pose editing ----
 
@@ -909,6 +921,9 @@ type detailData struct {
 	StartInputs    []frameInputs
 	Goals          []goalDetail
 	Constraints    *detailConstraints // nil when no linear/orientation constraints are present
+	// ExecutedPlanSteps is the trajectory length of the plan recorded in the file alongside the
+	// request, or 0 for a request-only file. It gates the "Render Executed Plan" button.
+	ExecutedPlanSteps int
 }
 
 type ikInspectData struct {
@@ -1533,6 +1548,20 @@ func visualizeLinearTrajectory(ctx context.Context, req *armplanning.PlanRequest
 	return nil
 }
 
+// executedTrajectory returns the recorded plan's trajectory as visualizer-ready configurations,
+// or nil when the file carried no plan alongside its request.
+func executedTrajectory(plan motionplan.Plan) []*referenceframe.LinearInputs {
+	if plan == nil {
+		return nil
+	}
+	traj := plan.Trajectory()
+	steps := make([]*referenceframe.LinearInputs, len(traj))
+	for idx, step := range traj {
+		steps[idx] = step.ToLinearInputs()
+	}
+	return steps
+}
+
 func planTrajectoryToStrings(plan motionplan.Plan) []map[string][]string {
 	traj := plan.Trajectory()
 	result := make([]map[string][]string, len(traj))
@@ -1565,10 +1594,14 @@ func handleDetail(logger logging.Logger) http.HandlerFunc {
 			http.Error(w, "missing file parameter", http.StatusBadRequest)
 			return
 		}
-		req, err := armplanning.ReadRequestFromFile(filepath.Join(rdkRoot, file))
+		req, executed, err := armplanning.ReadRequestAndResponseFromFile(filepath.Join(rdkRoot, file))
 		if err != nil {
 			http.Error(w, fmt.Sprintf("reading plan file: %v", err), http.StatusInternalServerError)
 			return
+		}
+		executedSteps := 0
+		if executed != nil {
+			executedSteps = len(executed.Trajectory())
 		}
 		overridesParam := r.URL.Query().Get("overrides")
 		overrides, err := decodeOverrides(overridesParam)
@@ -1600,12 +1633,13 @@ func handleDetail(logger logging.Logger) http.HandlerFunc {
 			}
 		}
 		data := detailData{
-			File:           file,
-			OverridesParam: overridesParam,
-			Frames:         buildFrameInfo(req.FrameSystem),
-			StartInputs:    startConfig,
-			Goals:          goals,
-			Constraints:    buildDetailConstraints(req.Constraints),
+			File:              file,
+			OverridesParam:    overridesParam,
+			Frames:            buildFrameInfo(req.FrameSystem),
+			StartInputs:       startConfig,
+			Goals:             goals,
+			Constraints:       buildDetailConstraints(req.Constraints),
+			ExecutedPlanSteps: executedSteps,
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		if err := detailTmpl.Execute(w, data); err != nil {
@@ -2073,6 +2107,34 @@ func handleRenderPlan(logger logging.Logger) http.HandlerFunc {
 	}
 }
 
+// handleRenderExecutedPlan replays the plan recorded in the file alongside the request — the
+// trajectory that actually ran — instead of one computed now. Goal-pose overrides are deliberately
+// not applied: the recorded trajectory belongs to the recorded goals, so re-aiming the goals would
+// leave the animation and the goal arrows describing two different motions.
+func handleRenderExecutedPlan(logger logging.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		file := r.URL.Query().Get("file")
+		if file == "" {
+			http.Error(w, "missing file parameter", http.StatusBadRequest)
+			return
+		}
+		req, executed, err := armplanning.ReadRequestAndResponseFromFile(filepath.Join(rdkRoot, file))
+		if err != nil {
+			http.Error(w, fmt.Sprintf("reading plan file: %v", err), http.StatusInternalServerError)
+			return
+		}
+		steps := executedTrajectory(executed)
+		if len(steps) == 0 {
+			http.Error(w, "plan file has no executed plan recorded alongside the request", http.StatusNotFound)
+			return
+		}
+		ctx := beginRender()
+		if err := visualizeLinearTrajectory(ctx, req, steps); err != nil {
+			logger.Warnf("visualization failed (motion-tools server may not be running): %v", err)
+		}
+	}
+}
+
 // handlePlanDownload serves the plan request (with any in-progress overrides applied) as a
 // downloadable JSON file, in the same format ReadRequestFromFile expects back.
 func handlePlanDownload(logger logging.Logger) http.HandlerFunc {
@@ -2183,6 +2245,7 @@ func RunServer() error {
 	http.HandleFunc("/plan/run", handlePlanRun(logger))
 	http.HandleFunc("/plan/download", handlePlanDownload(logger))
 	http.HandleFunc("/render-plan", handleRenderPlan(logger))
+	http.HandleFunc("/render-executed-plan", handleRenderExecutedPlan(logger))
 	http.HandleFunc("/render-start", handleRenderStart(logger))
 	http.HandleFunc("/render-solution", handleRenderSolution(logger))
 	http.HandleFunc("/render-shadows", handleRenderShadows(logger))


### PR DESCRIPTION
## Summary

Plan request files can carry the plan that actually ran as a second JSON object after the request, but the mpserver detail page could only compute a fresh plan or draw the start state — that recorded trajectory was never visible. Adds a "Render Executed Plan" button that replays it through the existing trajectory animation path, labeled with its step count. It only renders for files that carry a plan, so request-only pages are unchanged.

Goal-pose overrides are deliberately not applied — the recorded trajectory belongs to the recorded goals, so re-aiming one would leave the animation and the goal arrows describing different motions.

## Testing

No automated tests: the fixtures are gitignored `mplans/` files, so a test would only skip in CI. Verified against a running `cmd-plan -mp`:

<img width="1092" height="229" alt="image" src="https://github.com/user-attachments/assets/3e20b927-b45c-43ad-bfd2-4f1919b0eec4" />


- 52-step file shows `Render Executed Plan (52 steps)`; the render returns 200 and animates in the visualizer with no draw errors
- request-only file shows no button, and `/render-executed-plan` returns 404
- missing `file` param returns 400

<details>
<summary>Claude Code prompts used</summary>

- "Hi Claude, we have a motion planning CLI we run with `go run motionplan/armplanning/cmd-plan/cmd-plan.go`. When providing the `-mp` flag it starts a server which allows to inspect motion plans. I would like to add a feature to this server. It currently allows to "Do Motion Planning" and "Render Start State" for a given plan request, I would like to add a "Render Executed Plan" for plan request files which also include the plan that was executed.\n\n  Could you help me with that?\n  Let me know if you have any question"
- "I stopped the other server. Can you start this version? You may need to symlink the mplans directory"
- "I don't see the button, where on the page is it supposed to be ?"
- "this is good. Commit, push, and open a PR"

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
