### PR TITLE
cmd-plan: add -fs-override to edit DoF limits across a whole replay

### DIFF
--- a/motionplan/armplanning/cmd-plan/cmd-plan.go
+++ b/motionplan/armplanning/cmd-plan/cmd-plan.go
@@ -7,6 +7,7 @@
 //	cmd-plan plan1.json plan2.json         # replay both exactly as recorded
 //	cmd-plan capture/                      # replay every .json in capture/, alphabetically
 //	cmd-plan -chain plan1.json plan2.json  # plan2 starts where plan1's plan ended
+//	cmd-plan -fs-override limits.json plan1.json plan2.json  # both against edited DoF limits
 //
 // Replaying as recorded asks whether each plan still solves on its own. Chaining asks whether the
 // robot could actually have run them back to back, which is the question when a captured sequence
@@ -79,8 +80,9 @@ type runOptions struct {
 
 // runner replays the sequence of plan requests named on the command line.
 type runner struct {
-	opts   *runOptions
-	logger logging.Logger
+	opts     *runOptions
+	override *frameSystemOverride
+	logger   logging.Logger
 	// mpLogger is what PlanMotion logs through; -quiet swaps it for a logger with no appenders.
 	mpLogger logging.Logger
 	mylog    *log.Logger
@@ -142,6 +144,8 @@ func realMain() error {
 	noViz := flag.Bool("no-viz", false, "skip rendering the plan; useful for benchmarking success rate and planning speed")
 	chain := flag.Bool("chain", false,
 		"plan each request from the configuration the previous plan ended in, rather than from its own recorded start state")
+	fsOverrideFile := flag.String("fs-override", "",
+		"json file of frame system overrides to apply to every request, e.g. tighter DoF limits. See override.go for the schema")
 
 	flag.Parse()
 
@@ -214,6 +218,14 @@ func realMain() error {
 		}, logger)
 	}
 
+	var override *frameSystemOverride
+	if *fsOverrideFile != "" {
+		var err error
+		if override, err = readFrameSystemOverride(*fsOverrideFile); err != nil {
+			return err
+		}
+	}
+
 	metricsExporter := perf.NewDevelopmentExporterWithOptions(perf.DevelopmentExporterOptions{
 		ReportingInterval: time.Second * 10,
 		TracesDisabled:    true,
@@ -248,6 +260,7 @@ func realMain() error {
 			noViz:                   *noViz,
 			chain:                   *chain,
 		},
+		override: override,
 		logger:   logger,
 		mpLogger: mpLogger,
 		mylog:    log.New(os.Stdout, "", 0),
@@ -374,7 +387,8 @@ func collectRequestFiles(args []string) ([]string, error) {
 }
 
 // loadRequest reads one request off disk and applies everything that is a property of the run
-// rather than of the recorded request: the pseudolinear constraints and the seed.
+// rather than of the recorded request: the pseudolinear constraints, the seed and the frame system
+// override.
 func (r *runner) loadRequest(file string) (*armplanning.PlanRequest, motionplan.Plan, error) {
 	r.logger.Infof("reading plan from %s", file)
 	req, origPlan, err := armplanning.ReadRequestAndResponseFromFile(file)
@@ -391,6 +405,13 @@ func (r *runner) loadRequest(file string) (*armplanning.PlanRequest, motionplan.
 		req.PlannerOptions.RandomSeed = r.opts.seed
 	}
 
+	if r.override != nil {
+		if err := r.override.apply(req.FrameSystem, r.logger); err != nil {
+			return nil, nil, fmt.Errorf("applying %s to %s: %w", r.override.source, file, err)
+		}
+	}
+
+	// Must run after the override, because the seed cache is built from the frame system's limits.
 	if err := armplanning.PrepSmartSeed(req.FrameSystem, r.logger); err != nil {
 		return nil, nil, err
 	}
@@ -689,9 +710,9 @@ func chainStartState(req *armplanning.PlanRequest, prevEnd referenceframe.FrameS
 
 		for i, limit := range frame.DoF() {
 			if inputs[i] < limit.Min || inputs[i] > limit.Max {
-				// Two requests captured against different limits can leave the robot parked
-				// outside the bounds of the one it lands in. The planner can still move it back
-				// inside, so say so and carry on.
+				// Tightening a limit with -fs-override, or two requests captured against
+				// different limits, can leave the robot parked outside the bounds it lands in.
+				// The planner can still move it back inside, so say so and carry on.
 				logger.Warnf("chain: frame %q joint %d carries over as %0.4f, outside its limit [%0.4f, %0.4f]",
 					name, i, inputs[i], limit.Min, limit.Max)
 			}

--- a/motionplan/armplanning/cmd-plan/override.go
+++ b/motionplan/armplanning/cmd-plan/override.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+
+	"go.viam.com/utils"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/referenceframe"
+)
+
+// frameSystemOverride is a set of edits applied to the frame system of every request in a run,
+// before planning. Recorded requests carry the frame system the robot had at capture time, so an
+// override is how you ask "what would these same plans do on hardware with different limits".
+//
+// The schema mirrors the builtin motion service's `input_range_override` config, so a limit worked
+// out here can be pasted straight into a robot config:
+//
+//	{
+//	  "input_range_override": {
+//	    "arm1": {
+//	      "0":                  {"min": -1.5707, "max": 1.5707},
+//	      "shoulder_lift_joint": {"min": -3.1415, "max": 3.1415, "max_velocity": 1.0}
+//	    }
+//	  }
+//	}
+type frameSystemOverride struct {
+	// InputRangeOverride is keyed by frame name, then by either a joint frame's name or its index
+	// among the model's moveable joints.
+	//
+	// Positions are in the planner's own units, radians for revolute joints and millimeters for
+	// prismatic ones, not the degrees a kinematics file uses. They replace what the model
+	// declared. Velocity and acceleration bounds only ever tighten it, so an override can slow a
+	// joint down but never speed it past what its model allows.
+	InputRangeOverride map[string]map[string]referenceframe.Limit `json:"input_range_override"`
+
+	// source is the file this was read from, for error messages.
+	source string
+}
+
+// readFrameSystemOverride reads an override file. Unknown keys are rejected rather than ignored,
+// because an override that silently does nothing looks exactly like a planner that ignored it.
+func readFrameSystemOverride(fileName string) (*frameSystemOverride, error) {
+	f, err := os.Open(filepath.Clean(fileName))
+	if err != nil {
+		return nil, err
+	}
+	defer utils.UncheckedErrorFunc(f.Close)
+
+	override := &frameSystemOverride{source: fileName}
+	decoder := json.NewDecoder(f)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(override); err != nil {
+		return nil, fmt.Errorf("could not read frame system override %s: %w", fileName, err)
+	}
+
+	if len(override.InputRangeOverride) == 0 {
+		return nil, fmt.Errorf("frame system override %s has no overrides in it", fileName)
+	}
+
+	return override, nil
+}
+
+// apply edits fs in place. The override is expected to hold for every request in a run, so a key
+// that matches nothing is an error rather than a warning.
+func (o *frameSystemOverride) apply(fs *referenceframe.FrameSystem, logger logging.Logger) error {
+	for frameName, mods := range o.InputRangeOverride {
+		frame := fs.Frame(frameName)
+		if frame == nil {
+			return fmt.Errorf("input_range_override names frame %q, which the frame system does not have. It has %v",
+				frameName, fs.FrameNames())
+		}
+
+		model, ok := frame.(*referenceframe.SimpleModel)
+		if !ok {
+			return fmt.Errorf("can only override the joints of a SimpleModel, and frame %q is a %T", frameName, frame)
+		}
+
+		// Keys may name a joint frame or give its index among the moveable frames, matching what
+		// `input_range_override` accepts in a robot config.
+		moveableNames := model.MoveableFrameNames()
+		resolved := make(map[string]referenceframe.Limit, len(mods))
+		for key, limit := range mods {
+			idx := slices.Index(moveableNames, key)
+			if idx < 0 {
+				keyAsIndex, err := strconv.Atoi(key)
+				if err != nil || keyAsIndex < 0 || keyAsIndex >= len(moveableNames) {
+					return fmt.Errorf("frame %q has no joint %q. Its moveable joints are %v", frameName, key, moveableNames)
+				}
+				idx = keyAsIndex
+			}
+			resolved[moveableNames[idx]] = limit
+		}
+
+		newModel, err := referenceframe.NewModelWithLimitOverrides(model, resolved)
+		if err != nil {
+			return err
+		}
+		if err := fs.ReplaceFrame(newModel); err != nil {
+			return err
+		}
+
+		for _, name := range slices.Sorted(maps.Keys(resolved)) {
+			logger.Infof("overrode limits of %s:%s to %s", frameName, name, describeLimit(resolved[name]))
+		}
+	}
+
+	return nil
+}
+
+// describeLimit renders a Limit for a log line. Its velocity and acceleration bounds are pointers,
+// so default formatting prints addresses.
+func describeLimit(limit referenceframe.Limit) string {
+	out := fmt.Sprintf("min %v max %v", limit.Min, limit.Max)
+	if limit.MaxVelocity != nil {
+		out += fmt.Sprintf(" max_velocity %v", *limit.MaxVelocity)
+	}
+	if limit.MaxAcceleration != nil {
+		out += fmt.Sprintf(" max_acceleration %v", *limit.MaxAcceleration)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

A recorded plan request carries the frame system the robot had when it was captured, so replaying one can only ask what *that* hardware would do. Answering "would these plans still solve if this joint were restricted" — the question when picking limits for a new cell, or reproducing a customer's tighter arm — meant hand-editing limits inside every request file.

`-fs-override` takes those edits as one file applied to every request in the run.

> Stacked on #6422. Review that one first; this PR's base is `cmd-plan-replay-sequence`, so its diff is only the 33 lines of wiring plus `override.go`.

## Changes

- **`override.go`**: schema mirrors the builtin motion service's `input_range_override` config, so a limit worked out here pastes straight into a robot config.
- **Reuses `referenceframe.NewModelWithLimitOverrides`** — the same call the motion service makes. Positions replace what the model declared; velocity and acceleration only tighten, per that function's existing contract.
- **Units are the planner's**: radians and millimeters, not the degrees a kinematics file uses. Called out in the type docs, since this is the easy way to get it wrong.
- **Fails loudly**: a key matching no frame or joint is an error, not a warning, and unknown JSON fields are rejected. An override that silently does nothing is indistinguishable from a planner ignoring it. Errors name what the frame system does have.

```json
{"input_range_override": {"sanding-ur5": {
  "0": {"min": -1.5707, "max": 1.5707},
  "wrist_3_joint": {"min": -3.1415, "max": 3.1415, "max_velocity": 1.0}}}}
```

Keys name a joint or give its index among the moveable joints, as the service config allows.

## Testing

No tests — `package main` debug CLI with no existing test file. Verified by running against `motionplan/armplanning/data/`:

- Confirmed the override reaches IK, not just the frame system: clamping `shoulder_pan_joint` to `[0, 0.1]` turns `orb-plan1` into "physically unreachable".
- Applied to every request in a 3-file chained run.
- Error paths: unknown frame, unknown joint, and a misspelled top-level JSON key each give an actionable message.
- A limit tightened below the recorded start state is accepted, matching the motion service's own behavior (`TestInputRangeOverrideAcceptsReturningInsideRange`); the chain warns instead of refusing.

<details>
<summary>Claude Code prompts used</summary>

- "Hi Claude, I would like to extend the `motionplan/armplanning/cmd-plan/cmd-plan.go` CLI to be able to take in not just a single plan request but also a sequence of plan requests. I would like the option to replay those plan requests in order as-is. I would like the option to replay those plan requests using the end state of one plan as the start state for the next plan request. I would like to be able to add an override to the frame system that applies to all the plan requests, for example changing the DoF limits. Can you help me with this? Let me know if you have any question"
- "can you split this into 2 stacked PRs? The first one has the change to plan multiple requests and possibly chain them. The second adds the frame system override capability"

</details>
