### PR TITLE
Use github actions instead of docker images for go caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,11 +236,11 @@ jobs:
       matrix:
         include:
           - arch: ubuntu-16-core
-            image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
+            image: ghcr.io/viamrobotics/rdk-devenv:amd64
             platform: linux/amd64
             platform_name: linux-amd64
           - arch: ubuntu-arm-16-core
-            image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
+            image: ghcr.io/viamrobotics/rdk-devenv:arm64
             platform: linux/arm64
             platform_name: linux-arm64
     runs-on: ${{ matrix.arch }}
@@ -286,6 +286,10 @@ jobs:
         if: needs.check-changes.outputs.skip_module == 'true'
         run: echo "SKIP_MODULE=true" >> $GITHUB_ENV
 
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
       - name: Run go unit tests
         env:
           # The devenv images have the C++ runtime the prebuilt trajex archives
@@ -329,14 +333,24 @@ jobs:
       - name: Install toolchain
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
+
+      # Use this action to run golangci-lint and skip it in the following make
+      # invocation. Using this action gives us convenient caching behavior that
+      # significantly speeds up lint times.
+      - name: golangci-lint
+        # golangci/golangci-lint-action@9.3.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a
+        with:
+          install-mode: 'none' # already installed by mise
+          cache-invalidation-interval: 1 # days
 
       - name: Verify no uncommitted changes from "make build-go lint-go generate-go"
         run: |
           git init && git add .
-          LINT_DRY_RUN=1 make build-go lint-go generate-go
+          LINT_DRY_RUN=1 LINT_SKIP_GOLANGCI_LINT=1 make build-go lint-go generate-go
           GEN_DIFF=$(git status -s)
           if [ -n "$GEN_DIFF" ]; then
               echo '"make build-go lint-go generate-go" resulted in the following untracked changes:' 1>&2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -337,20 +337,26 @@ jobs:
         with:
           go-version-file: go.mod
 
-      # Use this action to run golangci-lint and skip it in the following make
-      # invocation. Using this action gives us convenient caching behavior that
-      # significantly speeds up lint times.
+      # Use this action just to save and restore the golangci-lint cache. The
+      # binary is actually installed by mise in the previous step and executed
+      # as part of a make/mise target in the following step. The weird looking
+      # combination of `install-only` and `install-mode` does still let the
+      # caching parts of the action run. We should probably verify if that's
+      # still the case if we ever change this version because there's a good
+      # chance the current behavior was not intentional on the part of the
+      # authors.
       - name: golangci-lint
         # golangci/golangci-lint-action@9.3.0
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a
         with:
           install-mode: 'none' # already installed by mise
+          install-only: true
           cache-invalidation-interval: 1 # days
 
       - name: Verify no uncommitted changes from "make build-go lint-go generate-go"
         run: |
           git init && git add .
-          LINT_DRY_RUN=1 LINT_SKIP_GOLANGCI_LINT=1 make build-go lint-go generate-go
+          LINT_DRY_RUN=1 make build-go lint-go generate-go
           GEN_DIFF=$(git status -s)
           if [ -n "$GEN_DIFF" ]; then
               echo '"make build-go lint-go generate-go" resulted in the following untracked changes:' 1>&2

--- a/mise.toml
+++ b/mise.toml
@@ -8,15 +8,12 @@ alias = "lint"
 description = 'Lint and format go code'
 usage = '''
 flag "-n --dry-run" default=#false env="LINT_DRY_RUN" help="Print diffs rather than automatically applying fixes"
-flag "--skip-golangci-lint" default=#false env="LINT_SKIP_GOLANGCI_LINT" help="Skip commands that use the golangci-lint binary"
 '''
 run = '''
 set -x
 go mod tidy{% if usage.dry_run %} -diff{% endif %}|| result=$?
-{% if not usage.skip_golangci_lint %}
 golangci-lint run{% if env.CI %} -v{% endif %}{% if not usage.dry_run %} --fix{% endif %} || result=$?
 golangci-lint fmt{% if env.CI %} -v{% endif %}{% if usage.dry_run %} --diff{% endif %} || result=$?
-{% endif %}
 ./etc/lint_register_apis.sh || result=$?
 exit ${result:-0}
 '''

--- a/mise.toml
+++ b/mise.toml
@@ -8,12 +8,15 @@ alias = "lint"
 description = 'Lint and format go code'
 usage = '''
 flag "-n --dry-run" default=#false env="LINT_DRY_RUN" help="Print diffs rather than automatically applying fixes"
+flag "--skip-golangci-lint" default=#false env="LINT_SKIP_GOLANGCI_LINT" help="Skip commands that use the golangci-lint binary"
 '''
 run = '''
 set -x
 go mod tidy{% if usage.dry_run %} -diff{% endif %}|| result=$?
+{% if not usage.skip_golangci_lint %}
 golangci-lint run{% if env.CI %} -v{% endif %}{% if not usage.dry_run %} --fix{% endif %} || result=$?
 golangci-lint fmt{% if env.CI %} -v{% endif %}{% if usage.dry_run %} --diff{% endif %} || result=$?
+{% endif %}
 ./etc/lint_register_apis.sh || result=$?
 exit ${result:-0}
 '''


### PR DESCRIPTION
Currently we run a nightly job that bakes the caches from building + linting* rdk into a docker image that is then consumed by some other CI jobs. This PR removes that image from the lint and test CI jobs in favor of using actions that cache the same data via github's caching service. There are still other jobs that will need to be updated before we can fully remove the caching docker image but this is a significant first step.

* [Run w/ cold cache][cold]
* [Run w/ warm cache][warm]

\* As of a recent change this image does not include the `golangci-lint` cache but that was an unintentional change that I don't think is worth fixing if we're gonna replace the cache image anyway.

[cold]: https://github.com/viamrobotics/rdk/actions/runs/33767563499
[warm]: https://github.com/viamrobotics/rdk/actions/runs/33769326710