### PR TITLE
RSDK-13395: downgrade invalid JPEG frame log to WARN

### DIFF
--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"image"
+	"image/jpeg"
 	"sync"
 	"time"
 
@@ -352,7 +353,14 @@ func (c *webcam) startBufferWorker() {
 				if err != nil {
 					c.buffer.release = nil
 					c.buffer.frame = nil
-					c.logger.Errorw("error reading frame", "error", err)
+
+					var jpegErr jpeg.FormatError
+					if errors.As(err, &jpegErr) {
+						c.logger.Warnw("dropped corrupt frame (usually benign, investigate only if continuous)", "error", err)
+					} else {
+						c.logger.Errorw("error reading frame", "error", err)
+					}
+
 					c.mu.Unlock()
 					continue
 				}

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -356,7 +356,7 @@ func (c *webcam) startBufferWorker() {
 
 					var jpegErr jpeg.FormatError
 					if errors.As(err, &jpegErr) {
-						c.logger.Warnw("dropped corrupt frame (usually benign, investigate only if continuous)", "error", err)
+						c.logger.Debugw("dropped corrupt frame (usually benign, investigate only if continuous)", "error", err)
 					} else {
 						c.logger.Errorw("error reading frame", "error", err)
 					}


### PR DESCRIPTION
this PR downgrades a specific log when a corrupt frame is read from a webcam (from ERROR to WARN). this error was clogging up the error logs when in reality this was only the result of a singular frame getting dropped (which happens sporadically seemingly as a result of the webcam hardware)

this only downgrades this specific set of logs to WARN and keeps other existing errors (such as "error reading frame" "no such device") as ERROR