### PR TITLE
RSDK-14503 retry pip install when generating python stubs: flaky test fix TestGenerateModuleAction/test_generate_stubs

### DIFF
--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -2123,6 +2123,9 @@ func TestTunnelE2ECLI(t *testing.T) {
 	destPort, destListener, err := goutils.ReserveRandomPort()
 	test.That(t, err, test.ShouldBeNil)
 	destListenerAddr := net.JoinHostPort("localhost", strconv.Itoa(destPort))
+	defer func() {
+		test.That(t, destListener.Close(), test.ShouldBeNil)
+	}()
 
 	sourcePort, err := goutils.TryReserveRandomPort()
 	test.That(t, err, test.ShouldBeNil)
@@ -2132,38 +2135,26 @@ func TestTunnelE2ECLI(t *testing.T) {
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 
-	// Ensure context is always cancelled and goroutines always drain, even when
-	// an assertion fails mid-test. destListener must be closed before wg.Wait to
-	// unblock a potentially pending Accept() in the echo goroutine.
-	defer func() {
-		ctxCancel()
-		destListener.Close()
-		wg.Wait()
-	}()
-
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 
 		logger.Infof("Listening on %s for tunnel message", destListenerAddr)
 		conn, err := destListener.Accept()
-		if ctx.Err() != nil {
-			// Test is shutting down; do not assert on a cancelled listener.
-			return
-		}
 		test.That(t, err, test.ShouldBeNil)
 		defer func() {
 			test.That(t, conn.Close(), test.ShouldBeNil)
 		}()
 
-		buf := make([]byte, len(tunnelMsg))
-		_, err = io.ReadFull(conn, buf)
+		bytes := make([]byte, 1024)
+		n, err := conn.Read(bytes)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, string(buf), test.ShouldEqual, tunnelMsg)
+		test.That(t, n, test.ShouldEqual, len(tunnelMsg))
+		test.That(t, string(bytes), test.ShouldContainSubstring, tunnelMsg)
 		logger.Info("Received expected tunnel message at", destListenerAddr)
 
 		// Write the same message back.
-		n, err := conn.Write([]byte(tunnelMsg))
+		n, err = conn.Write([]byte(tunnelMsg))
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, n, test.ShouldEqual, len(tunnelMsg))
 	}()
@@ -2220,20 +2211,19 @@ func TestTunnelE2ECLI(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, n, test.ShouldEqual, len(tunnelMsg))
 
-	// Expect `tunnelMsg` to be written back. Use io.ReadFull so we read exactly
-	// len(tunnelMsg) bytes; a plain conn.Read on a TCP stream may return more or
-	// fewer bytes depending on how the kernel coalesces segments.
-	echoBuf := make([]byte, len(tunnelMsg))
-	_, err = io.ReadFull(conn, echoBuf)
+	// Expect `tunnelMsg` to be written back.
+	bytes := make([]byte, 1024)
+	n, err = conn.Read(bytes)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, string(echoBuf), test.ShouldEqual, tunnelMsg)
+	test.That(t, n, test.ShouldEqual, len(tunnelMsg))
+	test.That(t, string(bytes), test.ShouldContainSubstring, tunnelMsg)
 
 	// Cancel test's context once message has made it all the way across and has been echoed
 	// back. This stops the RunServer goroutine and the tunnel itself.
-	// ctxCancel and wg.Wait are also deferred above so cleanup still happens if
-	// an assertion above fails.
 	ctxCancel()
 	test.That(t, stopServer(), test.ShouldBeNil)
+
+	wg.Wait()
 }
 
 // fakeTunnelLister is a tunnelLister test double. Before `reloadAfter` ListTunnels

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -2123,9 +2123,6 @@ func TestTunnelE2ECLI(t *testing.T) {
 	destPort, destListener, err := goutils.ReserveRandomPort()
 	test.That(t, err, test.ShouldBeNil)
 	destListenerAddr := net.JoinHostPort("localhost", strconv.Itoa(destPort))
-	defer func() {
-		test.That(t, destListener.Close(), test.ShouldBeNil)
-	}()
 
 	sourcePort, err := goutils.TryReserveRandomPort()
 	test.That(t, err, test.ShouldBeNil)
@@ -2135,26 +2132,38 @@ func TestTunnelE2ECLI(t *testing.T) {
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 
+	// Ensure context is always cancelled and goroutines always drain, even when
+	// an assertion fails mid-test. destListener must be closed before wg.Wait to
+	// unblock a potentially pending Accept() in the echo goroutine.
+	defer func() {
+		ctxCancel()
+		destListener.Close()
+		wg.Wait()
+	}()
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 
 		logger.Infof("Listening on %s for tunnel message", destListenerAddr)
 		conn, err := destListener.Accept()
+		if ctx.Err() != nil {
+			// Test is shutting down; do not assert on a cancelled listener.
+			return
+		}
 		test.That(t, err, test.ShouldBeNil)
 		defer func() {
 			test.That(t, conn.Close(), test.ShouldBeNil)
 		}()
 
-		bytes := make([]byte, 1024)
-		n, err := conn.Read(bytes)
+		buf := make([]byte, len(tunnelMsg))
+		_, err = io.ReadFull(conn, buf)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, n, test.ShouldEqual, len(tunnelMsg))
-		test.That(t, string(bytes), test.ShouldContainSubstring, tunnelMsg)
+		test.That(t, string(buf), test.ShouldEqual, tunnelMsg)
 		logger.Info("Received expected tunnel message at", destListenerAddr)
 
 		// Write the same message back.
-		n, err = conn.Write([]byte(tunnelMsg))
+		n, err := conn.Write([]byte(tunnelMsg))
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, n, test.ShouldEqual, len(tunnelMsg))
 	}()
@@ -2211,19 +2220,20 @@ func TestTunnelE2ECLI(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, n, test.ShouldEqual, len(tunnelMsg))
 
-	// Expect `tunnelMsg` to be written back.
-	bytes := make([]byte, 1024)
-	n, err = conn.Read(bytes)
+	// Expect `tunnelMsg` to be written back. Use io.ReadFull so we read exactly
+	// len(tunnelMsg) bytes; a plain conn.Read on a TCP stream may return more or
+	// fewer bytes depending on how the kernel coalesces segments.
+	echoBuf := make([]byte, len(tunnelMsg))
+	_, err = io.ReadFull(conn, echoBuf)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, n, test.ShouldEqual, len(tunnelMsg))
-	test.That(t, string(bytes), test.ShouldContainSubstring, tunnelMsg)
+	test.That(t, string(echoBuf), test.ShouldEqual, tunnelMsg)
 
 	// Cancel test's context once message has made it all the way across and has been echoed
 	// back. This stops the RunServer goroutine and the tunnel itself.
+	// ctxCancel and wg.Wait are also deferred above so cleanup still happens if
+	// an assertion above fails.
 	ctxCancel()
 	test.That(t, stopServer(), test.ShouldBeNil)
-
-	wg.Wait()
 }
 
 // fakeTunnelLister is a tunnelLister test double. Before `reloadAfter` ListTunnels

--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -1535,6 +1535,17 @@ func errorWithStderr(err error, stderr string) error {
 	return err
 }
 
+// errorWithCommandStderr augments the error of a command run with (*exec.Cmd).Output with
+// the stderr that Output captured, so a failing subprocess reports why it failed rather
+// than only "exit status 1".
+func errorWithCommandStderr(err error) error {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return errorWithStderr(err, string(exitErr.Stderr))
+	}
+	return err
+}
+
 func generatePythonStubs(module modulegen.ModuleInputs) error {
 	venvName := ".venv"
 	pythonCmd := findPythonCommand()
@@ -1560,7 +1571,7 @@ func generatePythonStubs(module modulegen.ModuleInputs) error {
 		module.ResourceSubtype, module.Namespace, module.ModuleName, module.ModelName)
 	out, err := cmd.Output()
 	if err != nil {
-		return errors.Wrap(err, "cannot generate python stubs -- generator script encountered an error")
+		return errors.Wrap(errorWithCommandStderr(err), "cannot generate python stubs -- generator script encountered an error")
 	}
 
 	resourcePath := filepath.Join(module.ModuleName, "src", "models", fmt.Sprintf("%s.py", module.ModelSnake))
@@ -1921,11 +1932,7 @@ func addPythonModelFiles(module modulegen.ModuleInputs) error {
 		module.ResourceSubtype, module.Namespace, module.ModuleName, module.ModelName)
 	out, err := stubCmd.Output()
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
-			return fmt.Errorf("generator script encountered an error:\n%s", strings.TrimSpace(string(exitErr.Stderr)))
-		}
-		return errors.Wrap(err, "generator script encountered an error")
+		return errors.Wrap(errorWithCommandStderr(err), "generator script encountered an error")
 	}
 
 	resourcePath := filepath.Join("src", "models", fmt.Sprintf("%s.py", module.ModelSnake))

--- a/cli/module_generate/scripts/generate_stubs.py
+++ b/cli/module_generate/scripts/generate_stubs.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 from importlib import import_module
 from typing import List, Set, Union
 
@@ -298,15 +299,33 @@ class {3}({4}, EasyResource):
     return resource_file
 
 
+def install_requirements(packages: List[str], attempts: int = 3) -> None:
+    """Install the packages this script imports.
+
+    PyPI drops requests often enough that a single failed install regularly
+    fails module generation, so retry with a backoff and, when the last attempt
+    fails, raise with pip's own output instead of a bare exit status.
+    """
+    for attempt in range(1, attempts + 1):
+        res = subprocess.run(
+            [sys.executable, "-m", "pip", "install"] + packages,
+            capture_output=True,
+            text=True,
+        )
+        if res.returncode == 0:
+            return
+        if attempt == attempts:
+            output = res.stderr.strip() or res.stdout.strip()
+            raise Exception(
+                "Could not install requirements to generate python stubs:\n" + output
+            )
+        time.sleep(attempt * 2)
+
+
 if __name__ == "__main__":
     packages = ["viam-sdk", "typing-extensions", "ruff", "python-slugify"]
     if sys.argv[2] == "mlmodel":
         packages.append("numpy")
-    install_res = subprocess.run(
-        [sys.executable, "-m", "pip", "install"] + packages,
-        capture_output=True,
-    )
-    if install_res.returncode != 0:
-        raise Exception("Could not install requirements to generate python stubs")
+    install_requirements(packages)
     result = main(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
     print(result)

--- a/cli/module_generate_test.go
+++ b/cli/module_generate_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -839,6 +840,32 @@ func TestCreatePythonVenv(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		_, statErr := os.Stat(venvDir)
 		test.That(t, os.IsNotExist(statErr), test.ShouldBeTrue)
+	})
+}
+
+func TestErrorWithCommandStderr(t *testing.T) {
+	t.Run("surfaces the stderr captured by (*exec.Cmd).Output", func(t *testing.T) {
+		t.Parallel()
+		exitErr := &exec.ExitError{
+			ProcessState: &os.ProcessState{},
+			Stderr:       []byte("\nCould not install requirements to generate python stubs:\nERROR: no matching distribution\n"),
+		}
+		err := errorWithCommandStderr(exitErr)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "Could not install requirements to generate python stubs")
+		test.That(t, err.Error(), test.ShouldContainSubstring, "ERROR: no matching distribution")
+	})
+
+	t.Run("returns the original error when the command produced no stderr", func(t *testing.T) {
+		t.Parallel()
+		exitErr := &exec.ExitError{ProcessState: &os.ProcessState{}}
+		test.That(t, errorWithCommandStderr(exitErr), test.ShouldEqual, exitErr)
+	})
+
+	t.Run("returns the original error when the command never ran", func(t *testing.T) {
+		t.Parallel()
+		base := errors.New("exec: \"python3\": executable file not found in $PATH")
+		test.That(t, errorWithCommandStderr(base), test.ShouldEqual, base)
 	})
 }
 


### PR DESCRIPTION
## Problem

`TestGenerateModuleAction/test_generate_stubs` intermittently fails with:

```
Expected: nil
Actual:   'cannot generate python stubs -- generator script encountered an error: exit status 1'
```

`generatePythonStubs` runs `cli/module_generate/scripts/generate_stubs.py` in a fresh venv, and the first thing that script does is `pip install viam-sdk typing-extensions ruff python-slugify` from PyPI. That network step is the only non-deterministic part of the subtest: a single dropped or 5xx'd request makes pip exit non-zero, the script raises, and generation fails.

The failure was also undiagnosable. The script raised a bare `Exception("Could not install requirements to generate python stubs")` with pip's output discarded, and the Go caller used `cmd.Output()` without ever reading the captured stderr — so the only thing that ever reached CI was `exit status 1`.

## Fix

- `generate_stubs.py`: install the requirements through a new `install_requirements` helper that retries the install up to 3 times with a backoff and, when the last attempt fails, raises with pip's own stderr/stdout.
- `module_generate.go`: add `errorWithCommandStderr`, which pulls the stderr that `(*exec.Cmd).Output` captured off the `*exec.ExitError` and appends it to the error (reusing the existing `errorWithStderr`). `generatePythonStubs` now uses it, so a real generator failure reports the python traceback and pip output instead of an exit status. `addPythonModelFiles` had an inline version of the same logic and now shares the helper.

This mirrors the treatment the Go stub path already got in #6410 (`runGoWithRetry`) and the venv creation path (`createPythonVenv`).

## Testing

- Added `TestErrorWithCommandStderr` covering stderr surfacing, an exit error with no stderr, and an error from a command that never started.
- Verified the retry/backoff and error-reporting behavior of `install_requirements` locally by driving it with a stubbed `subprocess.run` (succeeds on a later attempt without raising; raises with pip's output after exhausting attempts).

Key: RSDK-14503

Co-authored by Claude agent for Jira.