### PR TITLE
streaming: end the arm stream before the final runway drains, not after

### DIFF
--- a/services/motion/builtin/streaming/arm_stream_test.go
+++ b/services/motion/builtin/streaming/arm_stream_test.go
@@ -33,12 +33,37 @@ func newFakeStreamingArm() (*inject.Arm, *fakeStreamRecorder) {
 		responses chan<- arm.Response,
 		extra map[string]interface{},
 	) error {
+		// Honor the interface contract: return only once the trajectory is done, not
+		// when the input stream closes. Playback is simulated against a wall clock
+		// anchored at the first batch; after the input stream closes, wait out
+		// whatever trajectory time remains (or bail on ctx cancellation, like a real
+		// driver interrupting a move).
+		var started time.Time
+		var lastPointTime time.Duration
 		for batch := range batches {
+			if started.IsZero() {
+				started = time.Now()
+			}
 			rec.mu.Lock()
 			rec.batches = append(rec.batches, batch)
 			rec.mu.Unlock()
+			if len(batch) > 0 {
+				lastPointTime = batch[len(batch)-1].Time
+			}
 		}
-		return nil
+		if started.IsZero() {
+			return nil
+		}
+		remaining := lastPointTime - time.Since(started)
+		if remaining <= 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(remaining):
+			return nil
+		}
 	}
 	return inj, rec
 }

--- a/services/motion/builtin/streaming/coordinator.go
+++ b/services/motion/builtin/streaming/coordinator.go
@@ -56,6 +56,7 @@ func Run(
 			return
 		}
 		// On success, close first to signal that the RPC can finish.
+		// This blocks until the arm reports that it has completed executing the stream.
 		err = as.close()
 		cancel()
 	}()
@@ -89,7 +90,7 @@ func Run(
 						return fmt.Errorf("sample (lastJointPositions=%v): %w", ts.lastJointPositions, err)
 					}
 					if len(pvats) == 0 {
-						return waitOutRunway(ctx, as)
+						return nil
 					}
 					if err := as.send(ctx, pvats); err != nil {
 						return err
@@ -129,13 +130,4 @@ func (s *armStream) topUp(ctx context.Context, ts *trajexSession, targetRunway t
 		return nil
 	}
 	return s.send(ctx, pvats)
-}
-
-func waitOutRunway(ctx context.Context, as *armStream) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-time.After(as.currentEstimatedRunwayInArm()):
-		return nil
-	}
 }

--- a/services/motion/builtin/streaming/coordinator.go
+++ b/services/motion/builtin/streaming/coordinator.go
@@ -15,8 +15,7 @@ import (
 
 // Run executes a streaming session through one trajex session and one arm stream RPC.
 // If jpCh is closed, it samples everything out of the trajex session and sends it to the
-// arm, then waits for the arm to have finished executing before returning, including for the
-// runway estimate to reach zero.
+// arm, then waits for the arm to have finished executing before returning.
 //
 // --- An important note on backpressure --
 //


### PR DESCRIPTION
Before, RDK was waiting out its open-loop arm-side runway estimate before closing the MoveThroughJointPositionsStreamed gRPC stream to the arm.

So, the arm was completing the last point in the stream and often not hearing "stream close" until several milliseconds later. In the UR module's case, it needed to hear "stream close" within 2 ms, causing the arm to report an error in executing the stream.

This PR removes waiting out the open-loop runway estimate, and instead utilizes the fact that closing the gRPC stream itself blocks until the arm returns (after having executed the last point in the stream).