### PR TITLE
RSDK-13572: webcams reconnect when plugged into different port on darwin

### DIFF
--- a/components/camera/videosource/query.go
+++ b/components/camera/videosource/query.go
@@ -106,7 +106,7 @@ func findReaderAndDriver(
 			searchPath = filepath.Base(path)
 		}
 
-		reader, driver, err := getReaderAndDriver(searchPath, constraints, logger)
+		reader, driver, err := getReaderAndDriver(labelFilter(searchPath, true), searchPath, constraints, logger)
 		if err != nil {
 			return nil, nil, "", err
 		}
@@ -114,7 +114,7 @@ func findReaderAndDriver(
 	}
 
 	// Handle "any" path
-	reader, driver, err := getReaderAndDriver("", constraints, logger)
+	reader, driver, err := getReaderAndDriver(nil, "", constraints, logger)
 	if err != nil {
 		return nil, nil, "", errors.Wrap(err, "found no webcams")
 	}
@@ -128,20 +128,37 @@ func findReaderAndDriver(
 	return reader, driver, path, nil
 }
 
-// GetNamedVideoSource attempts to find a device (not a screen) by the given name.
-// If name is empty, it finds any device.
-func getReaderAndDriver(
+// findReaderAndDriverByName finds a video device whose driver Name matches the given name and returns an image
+// reader, the driver instance, and the driver's label (the value the config treats as a video path).
+//
+// The driver Name is the OS-reported device name (e.g. "HD Pro Webcam C920"). Unlike the label, it does not
+// change when a device is replugged into a different port, so it is used to recover a camera whose label is gone.
+// When several devices share a name, the first one that is available and not already in use is chosen.
+func findReaderAndDriverByName(
+	conf *WebcamConfig,
 	name string,
+	logger logging.Logger,
+) (video.Reader, driver.Driver, string, error) {
+	constraints := makeConstraints(conf, logger)
+
+	reader, driver, err := getReaderAndDriver(nameFilter(name), name, constraints, logger)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	labels := strings.Split(driver.Info().Label, mediadevicescamera.LabelSeparator)
+	return reader, driver, labels[0], nil
+}
+
+// getReaderAndDriver attempts to find a device (not a screen) matching the given filter.
+// If filter is nil, it finds any device. target is the identifier being searched for and is only used in
+// error messages.
+func getReaderAndDriver(
+	filter driver.FilterFn,
+	target string,
 	constraints mediadevices.MediaStreamConstraints,
 	logger logging.Logger,
 ) (video.Reader, driver.Driver, error) {
-	var ptr *string
-	if name == "" {
-		ptr = nil
-	} else {
-		ptr = &name
-	}
-	d, selectedMedia, err := getUserVideoDriver(constraints, ptr, logger)
+	d, selectedMedia, err := getUserVideoDriver(constraints, filter, target, logger)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -170,14 +187,15 @@ func getReaderAndDriver(
 
 func getUserVideoDriver(
 	constraints mediadevices.MediaStreamConstraints,
-	label *string,
+	filter driver.FilterFn,
+	target string,
 	logger logging.Logger,
 ) (driver.Driver, prop.Media, error) {
 	var videoConstraints mediadevices.MediaTrackConstraints
 	if constraints.Video != nil {
 		constraints.Video(&videoConstraints)
 	}
-	return selectVideo(videoConstraints, label, logger)
+	return selectVideo(videoConstraints, filter, target, logger)
 }
 
 func openDriver(d driver.Driver) error {
@@ -220,16 +238,27 @@ func labelFilter(target string, useSep bool) driver.FilterFn {
 	})
 }
 
+// nameFilter matches drivers whose Name equals target. Like labels, names may pack several values separated by
+// LabelSeparator (linux uses "name;busInfo"), so each component is compared individually.
+func nameFilter(target string) driver.FilterFn {
+	return driver.FilterFn(func(d driver.Driver) bool {
+		names := strings.Split(d.Info().Name, mediadevicescamera.LabelSeparator)
+		for _, name := range names {
+			if name == target {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 func selectVideo(
 	constraints mediadevices.MediaTrackConstraints,
-	label *string,
+	filter driver.FilterFn,
+	target string,
 	logger logging.Logger,
 ) (driver.Driver, prop.Media, error) {
-	labelStr := ""
-	if label != nil {
-		labelStr = *label
-	}
-	return selectBestDriver(getVideoFilterBase(), getVideoFilter(label), labelStr, constraints, logger)
+	return selectBestDriver(getVideoFilterBase(), getVideoFilter(filter), target, constraints, logger)
 }
 
 func getVideoFilterBase() driver.FilterFn {
@@ -238,10 +267,11 @@ func getVideoFilterBase() driver.FilterFn {
 	return driver.FilterAnd(typeFilter, notScreenFilter)
 }
 
-func getVideoFilter(label *string) driver.FilterFn {
+// getVideoFilter combines the base video filter with an optional device-specific filter.
+func getVideoFilter(specific driver.FilterFn) driver.FilterFn {
 	filter := getVideoFilterBase()
-	if label != nil {
-		filter = driver.FilterAnd(filter, labelFilter(*label, true))
+	if specific != nil {
+		filter = driver.FilterAnd(filter, specific)
 	}
 	return filter
 }

--- a/components/camera/videosource/query.go
+++ b/components/camera/videosource/query.go
@@ -106,7 +106,7 @@ func findReaderAndDriver(
 			searchPath = filepath.Base(path)
 		}
 
-		reader, driver, err := getReaderAndDriver(labelFilter(searchPath, true), searchPath, constraints, logger)
+		reader, driver, err := getReaderAndDriver(labelFilter(searchPath, true, false), searchPath, constraints, logger)
 		if err != nil {
 			return nil, nil, "", err
 		}
@@ -141,7 +141,7 @@ func findReaderAndDriverByName(
 ) (video.Reader, driver.Driver, string, error) {
 	constraints := makeConstraints(conf, logger)
 
-	reader, driver, err := getReaderAndDriver(nameFilter(name), name, constraints, logger)
+	reader, driver, err := getReaderAndDriver(labelFilter(name, true, true), name, constraints, logger)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -223,28 +223,19 @@ func newReaderFromDriver(
 	return recorder.VideoRecord(mediaProp)
 }
 
-func labelFilter(target string, useSep bool) driver.FilterFn {
+// labelFilter matches drivers whose Label equals target, or whose Name equals target when isName is set.
+func labelFilter(target string, useSep, isName bool) driver.FilterFn {
 	return driver.FilterFn(func(d driver.Driver) bool {
-		if !useSep {
-			return d.Info().Label == target
+		value := d.Info().Label
+		if isName {
+			value = d.Info().Name
 		}
-		labels := strings.Split(d.Info().Label, mediadevicescamera.LabelSeparator)
+		if !useSep {
+			return value == target
+		}
+		labels := strings.Split(value, mediadevicescamera.LabelSeparator)
 		for _, label := range labels {
 			if label == target {
-				return true
-			}
-		}
-		return false
-	})
-}
-
-// nameFilter matches drivers whose Name equals target. Like labels, names may pack several values separated by
-// LabelSeparator (linux uses "name;busInfo"), so each component is compared individually.
-func nameFilter(target string) driver.FilterFn {
-	return driver.FilterFn(func(d driver.Driver) bool {
-		names := strings.Split(d.Info().Name, mediadevicescamera.LabelSeparator)
-		for _, name := range names {
-			if name == target {
 				return true
 			}
 		}

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -96,6 +96,8 @@ type webcam struct {
 	// This is returned to us as a label in mediadevices but our config
 	// treats it as a video path.
 	targetPath string
+	// targetName is the OS-reported name of the driver behind targetPath
+	targetName string
 	conf       WebcamConfig
 
 	closed       bool // set by Close method
@@ -167,6 +169,7 @@ func NewWebcam(
 	if c.targetPath == "" {
 		c.targetPath = label
 	}
+	c.targetName = driver.Info().Name
 	c.logger = c.logger.WithFields("camera_name", c.Name().ShortName(), "camera_label", c.targetPath)
 
 	// only set once we're good
@@ -255,6 +258,7 @@ func (c *webcam) startMonitorWorker() {
 						oldRelease := c.buffer.release
 						conf := c.conf
 						targetPath := c.targetPath
+						targetName := c.targetName
 
 						c.driver = nil
 						c.reader = nil
@@ -277,6 +281,14 @@ func (c *webcam) startMonitorWorker() {
 
 						// Try to find and reconnect to camera outside lock (heavy I/O)
 						reader, driver, label, err := findReaderAndDriver(&conf, targetPath, c.logger)
+						reconnectedByName := false
+						if err != nil && targetName != "" {
+							// The label may have changed, fall back to the device name
+							c.logger.Debugw("failed to reconnect camera by path; retrying by name",
+								"error", err, "name", targetName)
+							reader, driver, label, err = findReaderAndDriverByName(&conf, targetName, c.logger)
+							reconnectedByName = err == nil
+						}
 						if err != nil {
 							c.logger.Debugw("failed to reconnect camera", "error", err)
 							continue
@@ -288,6 +300,10 @@ func (c *webcam) startMonitorWorker() {
 						c.driver = driver
 						c.disconnected = false
 						if c.targetPath == "" {
+							c.targetPath = label
+						}
+						if reconnectedByName && label != c.targetPath {
+							c.logger.Infow("camera reconnected under a new path", "old_path", c.targetPath, "new_path", label)
 							c.targetPath = label
 						}
 						c.logger = c.logger.WithFields("camera_name", c.Name().ShortName(), "camera_label", c.targetPath)


### PR DESCRIPTION
This PR makes it so webcams reconnect automatically when they are unplugged and replugged into a different port (previously was not the case on darwin).

previously the loop would try and reconnect to the same path that was found upon initial connection. However on darwin this path depends on the USB port (whereas on linux it does not) so the reconnect loop will always fail if the webcam is replugged into a different port than it was originally.  

This PR adds a fallback check on darwin to reconnect based on the webcam name if the original method based on the path fails. 

NOTE: the webcam name is not a unique identifier. So for example if there was an additional webcam plugged in (unused) there is a chance when you replug into a different port it would connect to the unused one instead.  As of now I'm not sure how to work around this because there is no other way to uniquely identify the webcam through mediadevices.