### PR TITLE
RSDK-13572: webcams reconnect when plugged into different port on darwin

### DIFF
--- a/components/camera/videosource/query.go
+++ b/components/camera/videosource/query.go
@@ -106,7 +106,7 @@ func findReaderAndDriver(
 			searchPath = filepath.Base(path)
 		}
 
-		reader, driver, err := getReaderAndDriver(searchPath, constraints, logger)
+		reader, driver, err := getReaderAndDriver(labelFilter(searchPath, true), searchPath, constraints, logger)
 		if err != nil {
 			return nil, nil, "", err
 		}
@@ -114,7 +114,7 @@ func findReaderAndDriver(
 	}
 
 	// Handle "any" path
-	reader, driver, err := getReaderAndDriver("", constraints, logger)
+	reader, driver, err := getReaderAndDriver(nil, "", constraints, logger)
 	if err != nil {
 		return nil, nil, "", errors.Wrap(err, "found no webcams")
 	}
@@ -128,20 +128,37 @@ func findReaderAndDriver(
 	return reader, driver, path, nil
 }
 
-// GetNamedVideoSource attempts to find a device (not a screen) by the given name.
-// If name is empty, it finds any device.
-func getReaderAndDriver(
+// findReaderAndDriverByName finds a video device whose driver Name matches the given name and returns an image
+// reader, the driver instance, and the driver's label (the value the config treats as a video path).
+//
+// The driver Name is the OS-reported device name (e.g. "HD Pro Webcam C920"). Unlike the label, it does not
+// change when a device is replugged into a different port, so it is used to recover a camera whose label is gone.
+// When several devices share a name, the first one that is available and not already in use is chosen.
+func findReaderAndDriverByName(
+	conf *WebcamConfig,
 	name string,
+	logger logging.Logger,
+) (video.Reader, driver.Driver, string, error) {
+	constraints := makeConstraints(conf, logger)
+
+	reader, driver, err := getReaderAndDriver(nameFilter(name), name, constraints, logger)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	labels := strings.Split(driver.Info().Label, mediadevicescamera.LabelSeparator)
+	return reader, driver, labels[0], nil
+}
+
+// getReaderAndDriver attempts to find a device (not a screen) matching the given filter.
+// If filter is nil, it finds any device. target is the identifier being searched for and is only used in
+// error messages.
+func getReaderAndDriver(
+	filter driver.FilterFn,
+	target string,
 	constraints mediadevices.MediaStreamConstraints,
 	logger logging.Logger,
 ) (video.Reader, driver.Driver, error) {
-	var ptr *string
-	if name == "" {
-		ptr = nil
-	} else {
-		ptr = &name
-	}
-	d, selectedMedia, err := getUserVideoDriver(constraints, ptr, logger)
+	d, selectedMedia, err := getUserVideoDriver(constraints, filter, target, logger)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -170,14 +187,15 @@ func getReaderAndDriver(
 
 func getUserVideoDriver(
 	constraints mediadevices.MediaStreamConstraints,
-	label *string,
+	filter driver.FilterFn,
+	target string,
 	logger logging.Logger,
 ) (driver.Driver, prop.Media, error) {
 	var videoConstraints mediadevices.MediaTrackConstraints
 	if constraints.Video != nil {
 		constraints.Video(&videoConstraints)
 	}
-	return selectVideo(videoConstraints, label, logger)
+	return selectVideo(videoConstraints, filter, target, logger)
 }
 
 func openDriver(d driver.Driver) error {
@@ -220,16 +238,27 @@ func labelFilter(target string, useSep bool) driver.FilterFn {
 	})
 }
 
+// nameFilter matches drivers whose Name equals target. Like labels, names may pack several values separated by
+// LabelSeparator (linux uses "name;busInfo"), so each component is compared individually.
+func nameFilter(target string) driver.FilterFn {
+	return driver.FilterFn(func(d driver.Driver) bool {
+		names := strings.Split(d.Info().Name, mediadevicescamera.LabelSeparator)
+		for _, name := range names {
+			if name == target {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 func selectVideo(
 	constraints mediadevices.MediaTrackConstraints,
-	label *string,
+	filter driver.FilterFn,
+	target string,
 	logger logging.Logger,
 ) (driver.Driver, prop.Media, error) {
-	labelStr := ""
-	if label != nil {
-		labelStr = *label
-	}
-	return selectBestDriver(getVideoFilterBase(), getVideoFilter(label), labelStr, constraints, logger)
+	return selectBestDriver(getVideoFilterBase(), getVideoFilter(filter), target, constraints, logger)
 }
 
 func getVideoFilterBase() driver.FilterFn {
@@ -238,10 +267,11 @@ func getVideoFilterBase() driver.FilterFn {
 	return driver.FilterAnd(typeFilter, notScreenFilter)
 }
 
-func getVideoFilter(label *string) driver.FilterFn {
+// getVideoFilter combines the base video filter with an optional device-specific filter.
+func getVideoFilter(specific driver.FilterFn) driver.FilterFn {
 	filter := getVideoFilterBase()
-	if label != nil {
-		filter = driver.FilterAnd(filter, labelFilter(*label, true))
+	if specific != nil {
+		filter = driver.FilterAnd(filter, specific)
 	}
 	return filter
 }

--- a/components/camera/videosource/query.go
+++ b/components/camera/videosource/query.go
@@ -106,7 +106,7 @@ func findReaderAndDriver(
 			searchPath = filepath.Base(path)
 		}
 
-		reader, driver, err := getReaderAndDriver(labelFilter(searchPath, true), searchPath, constraints, logger)
+		reader, driver, err := getReaderAndDriver(labelFilter(searchPath, true, false), searchPath, constraints, logger)
 		if err != nil {
 			return nil, nil, "", err
 		}
@@ -141,7 +141,7 @@ func findReaderAndDriverByName(
 ) (video.Reader, driver.Driver, string, error) {
 	constraints := makeConstraints(conf, logger)
 
-	reader, driver, err := getReaderAndDriver(nameFilter(name), name, constraints, logger)
+	reader, driver, err := getReaderAndDriver(labelFilter(name, true, true), name, constraints, logger)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -223,28 +223,19 @@ func newReaderFromDriver(
 	return recorder.VideoRecord(mediaProp)
 }
 
-func labelFilter(target string, useSep bool) driver.FilterFn {
+// labelFilter matches drivers whose Label equals target, or whose Name equals target when isName is set.
+func labelFilter(target string, useSep, isName bool) driver.FilterFn {
 	return driver.FilterFn(func(d driver.Driver) bool {
-		if !useSep {
-			return d.Info().Label == target
+		value := d.Info().Label
+		if isName {
+			value = d.Info().Name
 		}
-		labels := strings.Split(d.Info().Label, mediadevicescamera.LabelSeparator)
+		if !useSep {
+			return value == target
+		}
+		labels := strings.Split(value, mediadevicescamera.LabelSeparator)
 		for _, label := range labels {
 			if label == target {
-				return true
-			}
-		}
-		return false
-	})
-}
-
-// nameFilter matches drivers whose Name equals target. Like labels, names may pack several values separated by
-// LabelSeparator (linux uses "name;busInfo"), so each component is compared individually.
-func nameFilter(target string) driver.FilterFn {
-	return driver.FilterFn(func(d driver.Driver) bool {
-		names := strings.Split(d.Info().Name, mediadevicescamera.LabelSeparator)
-		for _, name := range names {
-			if name == target {
 				return true
 			}
 		}

--- a/components/camera/videosource/query.go
+++ b/components/camera/videosource/query.go
@@ -128,12 +128,7 @@ func findReaderAndDriver(
 	return reader, driver, path, nil
 }
 
-// findReaderAndDriverByName finds a video device whose driver Name matches the given name and returns an image
-// reader, the driver instance, and the driver's label (the value the config treats as a video path).
-//
-// The driver Name is the OS-reported device name (e.g. "HD Pro Webcam C920"). Unlike the label, it does not
-// change when a device is replugged into a different port, so it is used to recover a camera whose label is gone.
-// When several devices share a name, the first one that is available and not already in use is chosen.
+// findReaderAndDriverByName finds a video device whose driver Name matches the given name. The driver Name is the OS-reported device name
 func findReaderAndDriverByName(
 	conf *WebcamConfig,
 	name string,
@@ -141,7 +136,7 @@ func findReaderAndDriverByName(
 ) (video.Reader, driver.Driver, string, error) {
 	constraints := makeConstraints(conf, logger)
 
-	reader, driver, err := getReaderAndDriver(labelFilter(name, true, true), name, constraints, logger)
+	reader, driver, err := getReaderAndDriver(labelFilter(name, false, true), name, constraints, logger)
 	if err != nil {
 		return nil, nil, "", err
 	}

--- a/components/camera/videosource/query.go
+++ b/components/camera/videosource/query.go
@@ -128,39 +128,20 @@ func findReaderAndDriver(
 	return reader, driver, path, nil
 }
 
-// pathsWithName returns the path of every registered video device whose driver Name matches name
-func pathsWithName(name string) map[string]struct{} {
-	drivers := driver.GetManager().Query(getVideoFilter(labelFilter(name, false, true)))
-	paths := make(map[string]struct{}, len(drivers))
-	for _, d := range drivers {
-		paths[strings.Split(d.Info().Label, mediadevicescamera.LabelSeparator)[0]] = struct{}{}
-	}
-	return paths
-}
+// findReaderAndDriverByName finds a video device whose driver Name matches the given name. The driver Name is the OS-reported device name
+func findReaderAndDriverByName(
+	conf *WebcamConfig,
+	name string,
+	logger logging.Logger,
+) (video.Reader, driver.Driver, string, error) {
+	constraints := makeConstraints(conf, logger)
 
-// isPathRegistered reports whether a video device with the given path is already registered
-func isPathRegistered(path string) bool {
-	drivers := driver.GetManager().Query(getVideoFilter(labelFilter(filepath.Base(path), true, false)))
-	return len(drivers) > 0
-}
-
-// findNewPathByName returns the path of the single registered video device whose driver Name matches name and whose
-// path is not in knownPaths
-func findNewPathByName(name string, knownPaths map[string]struct{}) (string, error) {
-	var candidates []string
-	for path := range pathsWithName(name) {
-		if _, known := knownPaths[path]; !known {
-			candidates = append(candidates, path)
-		}
+	reader, driver, err := getReaderAndDriver(labelFilter(name, false, true), name, constraints, logger)
+	if err != nil {
+		return nil, nil, "", err
 	}
-	switch len(candidates) {
-	case 0:
-		return "", errors.Errorf("no new device with name '%s'", name)
-	case 1:
-		return candidates[0], nil
-	default:
-		return "", errors.Errorf("multiple new devices share name '%s'", name)
-	}
+	labels := strings.Split(driver.Info().Label, mediadevicescamera.LabelSeparator)
+	return reader, driver, labels[0], nil
 }
 
 // getReaderAndDriver attempts to find a device (not a screen) matching the given filter.
@@ -286,7 +267,7 @@ func getVideoFilter(specific driver.FilterFn) driver.FilterFn {
 func selectBestDriver(
 	baseFilter driver.FilterFn,
 	filter driver.FilterFn,
-	target string,
+	label string,
 	constraints mediadevices.MediaTrackConstraints,
 	logger logging.Logger,
 ) (driver.Driver, prop.Media, error) {
@@ -308,8 +289,8 @@ func selectBestDriver(
 
 	driverProperties := queryDriverProperties(filter, logger)
 	if len(driverProperties) == 0 {
-		msg := fmt.Sprintf("no queryable drivers for video path: '%s'", target)
-		if target != "" {
+		msg := fmt.Sprintf("no queryable drivers for video path: '%s'", label)
+		if label != "" {
 			msg += "; check if the device is available or already in use (busy)"
 		}
 		return nil, prop.Media{}, errors.New(msg)

--- a/components/camera/videosource/query.go
+++ b/components/camera/videosource/query.go
@@ -139,7 +139,7 @@ func findReaderAndDriverByName(
 	matches := driver.GetManager().Query(getVideoFilter(nameFilter))
 	if len(matches) != 1 {
 		return nil, nil, "", errors.Errorf(
-			"cannot reconnect by name: expected exactly one device named '%s', found %d", name, len(matches))
+			"cannot reconnect by name: multiple webcams with identical hardware names")
 	}
 
 	constraints := makeConstraints(conf, logger)

--- a/components/camera/videosource/query.go
+++ b/components/camera/videosource/query.go
@@ -128,20 +128,39 @@ func findReaderAndDriver(
 	return reader, driver, path, nil
 }
 
-// findReaderAndDriverByName finds a video device whose driver Name matches the given name. The driver Name is the OS-reported device name
-func findReaderAndDriverByName(
-	conf *WebcamConfig,
-	name string,
-	logger logging.Logger,
-) (video.Reader, driver.Driver, string, error) {
-	constraints := makeConstraints(conf, logger)
-
-	reader, driver, err := getReaderAndDriver(labelFilter(name, false, true), name, constraints, logger)
-	if err != nil {
-		return nil, nil, "", err
+// pathsWithName returns the path of every registered video device whose driver Name matches name
+func pathsWithName(name string) map[string]struct{} {
+	drivers := driver.GetManager().Query(getVideoFilter(labelFilter(name, false, true)))
+	paths := make(map[string]struct{}, len(drivers))
+	for _, d := range drivers {
+		paths[strings.Split(d.Info().Label, mediadevicescamera.LabelSeparator)[0]] = struct{}{}
 	}
-	labels := strings.Split(driver.Info().Label, mediadevicescamera.LabelSeparator)
-	return reader, driver, labels[0], nil
+	return paths
+}
+
+// isPathRegistered reports whether a video device with the given path is already registered
+func isPathRegistered(path string) bool {
+	drivers := driver.GetManager().Query(getVideoFilter(labelFilter(filepath.Base(path), true, false)))
+	return len(drivers) > 0
+}
+
+// findNewPathByName returns the path of the single registered video device whose driver Name matches name and whose
+// path is not in knownPaths
+func findNewPathByName(name string, knownPaths map[string]struct{}) (string, error) {
+	var candidates []string
+	for path := range pathsWithName(name) {
+		if _, known := knownPaths[path]; !known {
+			candidates = append(candidates, path)
+		}
+	}
+	switch len(candidates) {
+	case 0:
+		return "", errors.Errorf("no new device with name '%s'", name)
+	case 1:
+		return candidates[0], nil
+	default:
+		return "", errors.Errorf("multiple new devices share name '%s'", name)
+	}
 }
 
 // getReaderAndDriver attempts to find a device (not a screen) matching the given filter.
@@ -267,7 +286,7 @@ func getVideoFilter(specific driver.FilterFn) driver.FilterFn {
 func selectBestDriver(
 	baseFilter driver.FilterFn,
 	filter driver.FilterFn,
-	label string,
+	target string,
 	constraints mediadevices.MediaTrackConstraints,
 	logger logging.Logger,
 ) (driver.Driver, prop.Media, error) {
@@ -289,8 +308,8 @@ func selectBestDriver(
 
 	driverProperties := queryDriverProperties(filter, logger)
 	if len(driverProperties) == 0 {
-		msg := fmt.Sprintf("no queryable drivers for video path: '%s'", label)
-		if label != "" {
+		msg := fmt.Sprintf("no queryable drivers for video path: '%s'", target)
+		if target != "" {
 			msg += "; check if the device is available or already in use (busy)"
 		}
 		return nil, prop.Media{}, errors.New(msg)

--- a/components/camera/videosource/query.go
+++ b/components/camera/videosource/query.go
@@ -135,21 +135,25 @@ func findReaderAndDriverByName(
 	name string,
 	logger logging.Logger,
 ) (video.Reader, driver.Driver, string, error) {
-	nameFilter := labelFilter(name, false, true)
-	matches := driver.GetManager().Query(getVideoFilter(nameFilter))
-	if len(matches) != 1 {
+	if countDevicesWithName(name) != 1 {
 		return nil, nil, "", errors.Errorf(
 			"cannot reconnect by name: multiple webcams with identical hardware names")
 	}
 
 	constraints := makeConstraints(conf, logger)
 
-	reader, driver, err := getReaderAndDriver(nameFilter, name, constraints, logger)
+	reader, driver, err := getReaderAndDriver(labelFilter(name, false, true), name, constraints, logger)
 	if err != nil {
 		return nil, nil, "", err
 	}
 	labels := strings.Split(driver.Info().Label, mediadevicescamera.LabelSeparator)
 	return reader, driver, labels[0], nil
+}
+
+// countDevicesWithName returns how many registered video devices have the given driver Name.
+// It only scans the in-memory driver registry and performs no device I/O.
+func countDevicesWithName(name string) int {
+	return len(driver.GetManager().Query(getVideoFilter(labelFilter(name, false, true))))
 }
 
 // getReaderAndDriver attempts to find a device (not a screen) matching the given filter.

--- a/components/camera/videosource/query.go
+++ b/components/camera/videosource/query.go
@@ -128,15 +128,26 @@ func findReaderAndDriver(
 	return reader, driver, path, nil
 }
 
-// findReaderAndDriverByName finds a video device whose driver Name matches the given name. The driver Name is the OS-reported device name
+// findReaderAndDriverByName finds a video device whose driver Name matches the given name. The driver Name is the OS-reported device name.
+//
+// It only proceeds when exactly one registered device has that Name. Identical cameras share a Name and cannot be
+// told apart by it, so rather than guess (and risk attaching to the wrong device or stealing another webcam's
+// device), the fallback is refused until the ambiguity is gone.
 func findReaderAndDriverByName(
 	conf *WebcamConfig,
 	name string,
 	logger logging.Logger,
 ) (video.Reader, driver.Driver, string, error) {
+	nameFilter := labelFilter(name, false, true)
+	matches := driver.GetManager().Query(getVideoFilter(nameFilter))
+	if len(matches) != 1 {
+		return nil, nil, "", errors.Errorf(
+			"cannot reconnect by name: expected exactly one device named '%s', found %d", name, len(matches))
+	}
+
 	constraints := makeConstraints(conf, logger)
 
-	reader, driver, err := getReaderAndDriver(labelFilter(name, false, true), name, constraints, logger)
+	reader, driver, err := getReaderAndDriver(nameFilter, name, constraints, logger)
 	if err != nil {
 		return nil, nil, "", err
 	}

--- a/components/camera/videosource/query.go
+++ b/components/camera/videosource/query.go
@@ -129,10 +129,7 @@ func findReaderAndDriver(
 }
 
 // findReaderAndDriverByName finds a video device whose driver Name matches the given name. The driver Name is the OS-reported device name.
-//
-// It only proceeds when exactly one registered device has that Name. Identical cameras share a Name and cannot be
-// told apart by it, so rather than guess (and risk attaching to the wrong device or stealing another webcam's
-// device), the fallback is refused until the ambiguity is gone.
+// It only proceeds when exactly one registered device has that Name to prevent ambiguity
 func findReaderAndDriverByName(
 	conf *WebcamConfig,
 	name string,

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"image"
+	"runtime"
 	"sync"
 	"time"
 
@@ -282,8 +283,9 @@ func (c *webcam) startMonitorWorker() {
 						// Try to find and reconnect to camera outside lock (heavy I/O)
 						reader, driver, label, err := findReaderAndDriver(&conf, targetPath, c.logger)
 						reconnectedByName := false
-						if err != nil && targetName != "" {
-							// The label may have changed, fall back to the device name
+
+						// On darwin, label changes when webcam port is switched so fall back to device name
+						if err != nil && targetName != "" && runtime.GOOS == "darwin" {
 							c.logger.Debugw("failed to reconnect camera by path; retrying by name",
 								"error", err, "name", targetName)
 							reader, driver, label, err = findReaderAndDriverByName(&conf, targetName, c.logger)

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -96,6 +96,8 @@ type webcam struct {
 	// This is returned to us as a label in mediadevices but our config
 	// treats it as a video path.
 	targetPath string
+	// targetName is the OS-reported name of the driver behind targetPath
+	targetName string
 	conf       WebcamConfig
 
 	closed       bool // set by Close method
@@ -167,6 +169,7 @@ func NewWebcam(
 	if c.targetPath == "" {
 		c.targetPath = label
 	}
+	c.targetName = driver.Info().Name
 	c.logger = c.logger.WithFields("camera_name", c.Name().ShortName(), "camera_label", c.targetPath)
 
 	// only set once we're good
@@ -255,6 +258,7 @@ func (c *webcam) startMonitorWorker() {
 						oldRelease := c.buffer.release
 						conf := c.conf
 						targetPath := c.targetPath
+						targetName := c.targetName
 
 						c.driver = nil
 						c.reader = nil
@@ -277,6 +281,14 @@ func (c *webcam) startMonitorWorker() {
 
 						// Try to find and reconnect to camera outside lock (heavy I/O)
 						reader, driver, label, err := findReaderAndDriver(&conf, targetPath, c.logger)
+						reconnectedByName := false
+						if err != nil && targetName != "" {
+							// The label may have changed, fall back to the device name
+							c.logger.Debugw("failed to reconnect camera by path; retrying by name",
+								"error", err, "name", targetName)
+							reader, driver, label, err = findReaderAndDriverByName(&conf, targetName, c.logger)
+							reconnectedByName = err == nil
+						}
 						if err != nil {
 							c.logger.Debugw("failed to reconnect camera", "error", err)
 							continue
@@ -288,6 +300,10 @@ func (c *webcam) startMonitorWorker() {
 						c.driver = driver
 						c.disconnected = false
 						if c.targetPath == "" {
+							c.targetPath = label
+						}
+						if reconnectedByName && label != c.targetPath {
+							c.logger.Infow("camera reconnected under a new path", "old_path", c.targetPath, "new_path", label)
 							c.targetPath = label
 						}
 						c.logger = c.logger.WithFields("camera_name", c.Name().ShortName(), "camera_label", c.targetPath)

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -248,6 +248,7 @@ func (c *webcam) startMonitorWorker() {
 						c.mu.Lock()
 						c.sawOtherSameName = true
 						c.mu.Unlock()
+						logger.Warnw("another device shares this camera's hardware name; reconnecting by name is disabled", "name", targetName)
 					}
 					continue
 				}

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -99,7 +99,11 @@ type webcam struct {
 	targetPath string
 	// targetName is the OS-reported name of the driver behind targetPath
 	targetName string
-	conf       WebcamConfig
+	// sawOtherSameName is set once another registered device has shared targetName while this camera was
+	// connected. Identical cameras cannot be told apart by Name, so once set the name-based reconnect fallback
+	// is disabled for the life of this instance rather than risk attaching to the wrong device.
+	sawOtherSameName bool
+	conf             WebcamConfig
 
 	closed       bool // set by Close method
 	disconnected bool // set by monitor worker
@@ -230,6 +234,8 @@ func (c *webcam) startMonitorWorker() {
 				c.mu.Lock()
 				logger := c.logger
 				driver := c.driver
+				targetName := c.targetName
+				sawOtherSameName := c.sawOtherSameName
 				c.mu.Unlock()
 
 				ok, err := isCameraConnected(driver)
@@ -238,6 +244,11 @@ func (c *webcam) startMonitorWorker() {
 					continue
 				}
 				if ok {
+					if runtime.GOOS == "darwin" && !sawOtherSameName && targetName != "" && countDevicesWithName(targetName) > 1 {
+						c.mu.Lock()
+						c.sawOtherSameName = true
+						c.mu.Unlock()
+					}
 					continue
 				}
 
@@ -260,6 +271,7 @@ func (c *webcam) startMonitorWorker() {
 						conf := c.conf
 						targetPath := c.targetPath
 						targetName := c.targetName
+						sawOtherSameName := c.sawOtherSameName
 
 						c.driver = nil
 						c.reader = nil
@@ -285,7 +297,7 @@ func (c *webcam) startMonitorWorker() {
 						reconnectedByName := false
 
 						// On darwin, label changes when webcam port is switched so fall back to device name
-						if err != nil && targetName != "" && runtime.GOOS == "darwin" {
+						if err != nil && targetName != "" && runtime.GOOS == "darwin" && !sawOtherSameName {
 							c.logger.Debugw("failed to reconnect camera by path; retrying by name",
 								"error", err, "name", targetName)
 							reader, driver, label, err = findReaderAndDriverByName(&conf, targetName, c.logger)

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -159,7 +159,7 @@ func NewWebcam(
 	c.cameraModel = camera.NewPinholeModelWithBrownConradyDistortion(nativeConf.CameraParameters, nativeConf.DistortionParameters)
 
 	c.targetPath = nativeConf.Path
-	reader, driver, path, err := findReaderAndDriver(nativeConf, c.targetPath, c.logger)
+	reader, driver, label, err := findReaderAndDriver(nativeConf, c.targetPath, c.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find camera: %w", err)
 	}
@@ -168,7 +168,7 @@ func NewWebcam(
 	c.driver = driver
 	c.disconnected = false
 	if c.targetPath == "" {
-		c.targetPath = path
+		c.targetPath = label
 	}
 	c.targetName = driver.Info().Name
 	c.logger = c.logger.WithFields("camera_name", c.Name().ShortName(), "camera_label", c.targetPath)
@@ -243,14 +243,7 @@ func (c *webcam) startMonitorWorker() {
 
 				c.mu.Lock()
 				c.disconnected = true
-				targetName := c.targetName
 				c.mu.Unlock()
-
-				// A device Name cannot tell identical cameras apart, so record which same-Name paths already exist:
-				var knownPaths map[string]struct{}
-				if runtime.GOOS == "darwin" && targetName != "" {
-					knownPaths = pathsWithName(targetName)
-				}
 
 				logger.Error("camera no longer connected; reconnecting")
 			reconnectLoop:
@@ -266,6 +259,7 @@ func (c *webcam) startMonitorWorker() {
 						oldRelease := c.buffer.release
 						conf := c.conf
 						targetPath := c.targetPath
+						targetName := c.targetName
 
 						c.driver = nil
 						c.reader = nil
@@ -287,20 +281,14 @@ func (c *webcam) startMonitorWorker() {
 						}
 
 						// Try to find and reconnect to camera outside lock (heavy I/O)
-						reader, driver, path, err := findReaderAndDriver(&conf, targetPath, c.logger)
+						reader, driver, label, err := findReaderAndDriver(&conf, targetPath, c.logger)
 						reconnectedByName := false
 
-						// On darwin, path changes when webcam port is switched so fall back to device name if old path is gone
-						if err != nil && runtime.GOOS == "darwin" && targetName != "" && !isPathRegistered(targetPath) {
-							newPath, nameErr := findNewPathByName(targetName, knownPaths)
-							if nameErr != nil {
-								c.logger.Debugw("failed to reconnect camera by path or name",
-									"path_error", err, "name_error", nameErr)
-								continue
-							}
-							c.logger.Debugw("failed to reconnect camera by path; retrying under new path found by name",
-								"error", err, "name", targetName, "new_path", newPath)
-							reader, driver, path, err = findReaderAndDriver(&conf, newPath, c.logger)
+						// On darwin, label changes when webcam port is switched so fall back to device name
+						if err != nil && targetName != "" && runtime.GOOS == "darwin" {
+							c.logger.Debugw("failed to reconnect camera by path; retrying by name",
+								"error", err, "name", targetName)
+							reader, driver, label, err = findReaderAndDriverByName(&conf, targetName, c.logger)
 							reconnectedByName = err == nil
 						}
 						if err != nil {
@@ -314,11 +302,11 @@ func (c *webcam) startMonitorWorker() {
 						c.driver = driver
 						c.disconnected = false
 						if c.targetPath == "" {
-							c.targetPath = path
+							c.targetPath = label
 						}
-						if reconnectedByName && path != c.targetPath {
-							c.logger.Infow("camera reconnected under a new path", "old_path", c.targetPath, "new_path", path)
-							c.targetPath = path
+						if reconnectedByName && label != c.targetPath {
+							c.logger.Infow("camera reconnected under a new path", "old_path", c.targetPath, "new_path", label)
+							c.targetPath = label
 						}
 						c.logger = c.logger.WithFields("camera_name", c.Name().ShortName(), "camera_label", c.targetPath)
 

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -159,7 +159,7 @@ func NewWebcam(
 	c.cameraModel = camera.NewPinholeModelWithBrownConradyDistortion(nativeConf.CameraParameters, nativeConf.DistortionParameters)
 
 	c.targetPath = nativeConf.Path
-	reader, driver, label, err := findReaderAndDriver(nativeConf, c.targetPath, c.logger)
+	reader, driver, path, err := findReaderAndDriver(nativeConf, c.targetPath, c.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find camera: %w", err)
 	}
@@ -168,7 +168,7 @@ func NewWebcam(
 	c.driver = driver
 	c.disconnected = false
 	if c.targetPath == "" {
-		c.targetPath = label
+		c.targetPath = path
 	}
 	c.targetName = driver.Info().Name
 	c.logger = c.logger.WithFields("camera_name", c.Name().ShortName(), "camera_label", c.targetPath)
@@ -243,7 +243,14 @@ func (c *webcam) startMonitorWorker() {
 
 				c.mu.Lock()
 				c.disconnected = true
+				targetName := c.targetName
 				c.mu.Unlock()
+
+				// A device Name cannot tell identical cameras apart, so record which same-Name paths already exist:
+				var knownPaths map[string]struct{}
+				if runtime.GOOS == "darwin" && targetName != "" {
+					knownPaths = pathsWithName(targetName)
+				}
 
 				logger.Error("camera no longer connected; reconnecting")
 			reconnectLoop:
@@ -259,7 +266,6 @@ func (c *webcam) startMonitorWorker() {
 						oldRelease := c.buffer.release
 						conf := c.conf
 						targetPath := c.targetPath
-						targetName := c.targetName
 
 						c.driver = nil
 						c.reader = nil
@@ -281,14 +287,20 @@ func (c *webcam) startMonitorWorker() {
 						}
 
 						// Try to find and reconnect to camera outside lock (heavy I/O)
-						reader, driver, label, err := findReaderAndDriver(&conf, targetPath, c.logger)
+						reader, driver, path, err := findReaderAndDriver(&conf, targetPath, c.logger)
 						reconnectedByName := false
 
-						// On darwin, label changes when webcam port is switched so fall back to device name
-						if err != nil && targetName != "" && runtime.GOOS == "darwin" {
-							c.logger.Debugw("failed to reconnect camera by path; retrying by name",
-								"error", err, "name", targetName)
-							reader, driver, label, err = findReaderAndDriverByName(&conf, targetName, c.logger)
+						// On darwin, path changes when webcam port is switched so fall back to device name if old path is gone
+						if err != nil && runtime.GOOS == "darwin" && targetName != "" && !isPathRegistered(targetPath) {
+							newPath, nameErr := findNewPathByName(targetName, knownPaths)
+							if nameErr != nil {
+								c.logger.Debugw("failed to reconnect camera by path or name",
+									"path_error", err, "name_error", nameErr)
+								continue
+							}
+							c.logger.Debugw("failed to reconnect camera by path; retrying under new path found by name",
+								"error", err, "name", targetName, "new_path", newPath)
+							reader, driver, path, err = findReaderAndDriver(&conf, newPath, c.logger)
 							reconnectedByName = err == nil
 						}
 						if err != nil {
@@ -302,11 +314,11 @@ func (c *webcam) startMonitorWorker() {
 						c.driver = driver
 						c.disconnected = false
 						if c.targetPath == "" {
-							c.targetPath = label
+							c.targetPath = path
 						}
-						if reconnectedByName && label != c.targetPath {
-							c.logger.Infow("camera reconnected under a new path", "old_path", c.targetPath, "new_path", label)
-							c.targetPath = label
+						if reconnectedByName && path != c.targetPath {
+							c.logger.Infow("camera reconnected under a new path", "old_path", c.targetPath, "new_path", path)
+							c.targetPath = path
 						}
 						c.logger = c.logger.WithFields("camera_name", c.Name().ShortName(), "camera_label", c.targetPath)
 

--- a/components/camera/videosource/webcam_reconnect_test.go
+++ b/components/camera/videosource/webcam_reconnect_test.go
@@ -1,0 +1,223 @@
+//go:build darwin
+
+// Note: reconnecting by name is only needed on darwin
+
+package videosource
+
+import (
+	"context"
+	"image"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pion/mediadevices/pkg/driver"
+	"github.com/pion/mediadevices/pkg/driver/availability"
+	"github.com/pion/mediadevices/pkg/frame"
+	"github.com/pion/mediadevices/pkg/io/video"
+	"github.com/pion/mediadevices/pkg/prop"
+	"go.viam.com/test"
+	goutils "go.viam.com/utils"
+	"go.viam.com/utils/testutils"
+
+	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+)
+
+// fakeCamera is a mediadevices video adapter whose availability the test controls. Reporting
+// availability.ErrNoDevice is what the real darwin driver does once a device is unplugged, so flipping
+// available to false is how a test simulates a hot unplug.
+type fakeCamera struct {
+	available atomic.Bool
+}
+
+func newFakeCamera(available bool) *fakeCamera {
+	f := &fakeCamera{}
+	f.available.Store(available)
+	return f
+}
+
+func (f *fakeCamera) Open() error  { return nil }
+func (f *fakeCamera) Close() error { return nil }
+
+func (f *fakeCamera) Properties() []prop.Media {
+	return []prop.Media{{Video: prop.Video{Width: 640, Height: 480, FrameRate: 30, FrameFormat: frame.FormatI420}}}
+}
+
+func (f *fakeCamera) VideoRecord(p prop.Media) (video.Reader, error) {
+	img := image.NewRGBA(image.Rect(0, 0, p.Width, p.Height))
+	return video.ReaderFunc(func() (image.Image, func(), error) {
+		return img, func() {}, nil
+	}), nil
+}
+
+func (f *fakeCamera) IsAvailable() (bool, error) {
+	if !f.available.Load() {
+		return false, availability.ErrNoDevice
+	}
+	return true, nil
+}
+
+// registerFakeCamera registers a fakeCamera in the global mediadevices driver manager under the given Label
+// and Name and returns both the fake and the registered driver. The registration is removed when the test ends.
+// Labels must not contain path separators so that findReaderAndDriver's filepath.Base leaves them unchanged.
+func registerFakeCamera(t *testing.T, label, name string, available bool) (*fakeCamera, driver.Driver) {
+	t.Helper()
+	fake := newFakeCamera(available)
+	manager := driver.GetManager()
+	err := manager.Register(fake, driver.Info{Label: label, Name: name, DeviceType: driver.Camera})
+	test.That(t, err, test.ShouldBeNil)
+
+	drivers := manager.Query(labelFilter(label, false, false))
+	test.That(t, drivers, test.ShouldHaveLength, 1)
+	d := drivers[0]
+
+	t.Cleanup(func() {
+		if d.Status() != driver.StateClosed {
+			test.That(t, d.Close(), test.ShouldBeNil)
+		}
+		manager.Delete(d.ID())
+	})
+	return fake, d
+}
+
+// The monitor worker ticks every 500ms; three ticks is long enough to be sure a reconnect that was going to
+// happen would have happened.
+const monitorSettleTime = 1500 * time.Millisecond
+
+// newTestWebcam opens the given registered driver and wires it into a webcam with only the monitor worker
+// running. It bypasses NewWebcam because that starts the AVFoundation observer, which is not available in a
+// test process and is not what these tests exercise.
+func newTestWebcam(t *testing.T, d driver.Driver) *webcam {
+	t.Helper()
+	logger := logging.NewTestLogger(t)
+	label := d.Info().Label
+	conf := WebcamConfig{Path: label, FrameRate: defaultFrameRate}
+
+	reader, opened, err := getReaderAndDriver(labelFilter(label, true, false), label, makeConstraints(&conf, logger), logger)
+	test.That(t, err, test.ShouldBeNil)
+
+	c := &webcam{
+		Named:      resource.NewName(camera.API, "test-webcam").AsNamed(),
+		logger:     logger,
+		workers:    goutils.NewBackgroundStoppableWorkers(),
+		buffer:     newWebcamBuffer(),
+		reader:     reader,
+		driver:     opened,
+		targetPath: label,
+		targetName: d.Info().Name,
+		conf:       conf,
+	}
+	t.Cleanup(func() {
+		test.That(t, c.Close(context.Background()), test.ShouldBeNil)
+	})
+	c.startMonitorWorker()
+	return c
+}
+
+type webcamSnapshot struct {
+	disconnected     bool
+	sawOtherSameName bool
+	targetPath       string
+	driverLabel      string
+}
+
+func snapshot(c *webcam) webcamSnapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	s := webcamSnapshot{
+		disconnected:     c.disconnected,
+		sawOtherSameName: c.sawOtherSameName,
+		targetPath:       c.targetPath,
+	}
+	if c.driver != nil {
+		s.driverLabel = c.driver.Info().Label
+	}
+	return s
+}
+
+// unplug mimics what the darwin observer does when a device disappears: the device stops reporting as
+// available and its registration is removed from the driver manager.
+func unplug(fake *fakeCamera, d driver.Driver) {
+	fake.available.Store(false)
+	driver.GetManager().Delete(d.ID())
+}
+
+func waitForDisconnect(t *testing.T, c *webcam) {
+	t.Helper()
+	testutils.WaitForAssertion(t, func(tb testing.TB) {
+		test.That(tb, snapshot(c).disconnected, test.ShouldBeTrue)
+	})
+}
+
+func waitForReconnect(t *testing.T, c *webcam, wantLabel string) {
+	t.Helper()
+	testutils.WaitForAssertion(t, func(tb testing.TB) {
+		s := snapshot(c)
+		test.That(tb, s.disconnected, test.ShouldBeFalse)
+		test.That(tb, s.targetPath, test.ShouldEqual, wantLabel)
+		test.That(tb, s.driverLabel, test.ShouldEqual, wantLabel)
+	})
+}
+
+func TestMonitorReconnectsByNameWhenPathChanges(t *testing.T) {
+	fakeA, a := registerFakeCamera(t, "rdk-test-replug-a", "rdk-test-replug-cam", true)
+	c := newTestWebcam(t, a)
+
+	unplug(fakeA, a)
+	waitForDisconnect(t, c)
+
+	// The same camera comes back under a new UID, as happens when it is plugged into a different port.
+	registerFakeCamera(t, "rdk-test-replug-a2", "rdk-test-replug-cam", true)
+	waitForReconnect(t, c, "rdk-test-replug-a2")
+}
+
+func TestMonitorSkipsNameFallbackAfterSeeingDuplicate(t *testing.T) {
+	fakeA, a := registerFakeCamera(t, "rdk-test-dup-a", "rdk-test-dup-cam", true)
+	_, b := registerFakeCamera(t, "rdk-test-dup-b", "rdk-test-dup-cam", true)
+	c := newTestWebcam(t, a)
+
+	testutils.WaitForAssertion(t, func(tb testing.TB) {
+		test.That(tb, snapshot(c).sawOtherSameName, test.ShouldBeTrue)
+	})
+
+	// Removing the duplicate must not re-enable the fallback.
+	driver.GetManager().Delete(b.ID())
+	unplug(fakeA, a)
+	waitForDisconnect(t, c)
+
+	registerFakeCamera(t, "rdk-test-dup-a2", "rdk-test-dup-cam", true)
+	time.Sleep(monitorSettleTime)
+	s := snapshot(c)
+	test.That(t, s.disconnected, test.ShouldBeTrue)
+	test.That(t, s.driverLabel, test.ShouldEqual, "")
+
+	// Reconnecting by the original path is unaffected by the flag.
+	registerFakeCamera(t, "rdk-test-dup-a", "rdk-test-dup-cam", true)
+	waitForReconnect(t, c, "rdk-test-dup-a")
+}
+
+func TestMonitorRefusesNameFallbackWhenMultipleAppear(t *testing.T) {
+	fakeA, a := registerFakeCamera(t, "rdk-test-multi-a", "rdk-test-multi-cam", true)
+	c := newTestWebcam(t, a)
+
+	unplug(fakeA, a)
+	waitForDisconnect(t, c)
+
+	// Both candidates are registered unavailable first so that a monitor tick landing between the two
+	// registrations cannot open the lone candidate; they are only made available once both exist.
+	fakeA2, _ := registerFakeCamera(t, "rdk-test-multi-a2", "rdk-test-multi-cam", false)
+	fakeA3, a3 := registerFakeCamera(t, "rdk-test-multi-a3", "rdk-test-multi-cam", false)
+	fakeA2.available.Store(true)
+	fakeA3.available.Store(true)
+
+	time.Sleep(monitorSettleTime)
+	s := snapshot(c)
+	test.That(t, s.disconnected, test.ShouldBeTrue)
+	test.That(t, s.driverLabel, test.ShouldEqual, "")
+
+	// Once only one candidate remains the fallback proceeds, since no duplicate was ever seen while connected.
+	driver.GetManager().Delete(a3.ID())
+	waitForReconnect(t, c, "rdk-test-multi-a2")
+}


### PR DESCRIPTION
This PR makes it so webcams reconnect automatically when they are unplugged and replugged into a different port (previously was not the case on darwin).

previously the webcam reconnect loop would try and reconnect to the same path that was found upon initial connection. However on darwin this path depends on the USB port (whereas on linux it does not) so the reconnect loop will always fail if the webcam is replugged into a different port than it was originally.

This PR adds a fallback check on darwin to reconnect based on the webcam name if the original method based on the path fails.

NOTE: the webcam name is not a unique identifier. So for example if there was an additional unused webcam plugged in, there is a chance that when you replug into a different port it would connect to the unused one instead. As of now I'm not sure how to work around this, because there is no other way to uniquely identify the webcam through mediadevices that I'm aware of