### PR TITLE
CLAUDE.md: add comment style and upstream-bug conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,3 +18,5 @@ This repository is `go.viam.com/rdk` and ships three primary surfaces:
 
 - Verify changes with `make lint-go` and `make test-go`. The `rdk-devenv` container has Go tooling pre-installed; locally, run `make tool-install` first.
 - Generated protobuf (`*.pb.go`), build files (`Makefile`, `*.make`), `go.sum`, and workflow files are deny-listed in `.claude/settings.ci.json`. Update `go.sum` via `go mod tidy`.
+- Default to no inline code comments; godoc comments on exported symbols are expected. Add terse inline one-liners only when the WHY (not the WHAT) is non-obvious.
+- Do NOT bandaid over upstream bugs or platform gaps in any dependency — raise them immediately with a severity (critical / high / medium / low).


### PR DESCRIPTION
Adds two rules to the Conventions section of `CLAUDE.md`.

## Motivation
Two issues I frequently come across in Claude written code:
- Too many comments - PRs are regularly put up and merged with unhelpful comments
- Claude is an expert at bandaiding over bugs - I have several examples in spatial math