### PR TITLE
RSDK-14354: Export rdk disk-space check for viam-agent

### DIFF
--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -555,7 +555,7 @@ func (m *cloudManager) downloadFileWithChecksum(
 			}
 		}
 		required := remaining + diskusage.MinFreeBytes
-		if _, err := checkDiskSpace(m.logger, downloadPath, "package download", required,
+		if _, err := CheckDiskSpace(m.logger, downloadPath, "package download", required,
 			"content_size", rutils.FormatBytes(uint64(resp.ContentLength))); err != nil {
 			return "", "", err
 		}

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -556,7 +556,7 @@ func (m *cloudManager) downloadFileWithChecksum(
 		}
 		required := remaining + diskusage.MinFreeBytes
 		if _, err := diskusage.CheckDiskSpace(m.logger, downloadPath, "package download", required,
-			"content_size", rutils.FormatBytes(uint64(resp.ContentLength))); err != nil {
+			diskSpaceBlockingEnabled(), "content_size", rutils.FormatBytes(uint64(resp.ContentLength))); err != nil {
 			return "", "", err
 		}
 	}

--- a/robot/packages/cloud_package_manager.go
+++ b/robot/packages/cloud_package_manager.go
@@ -555,7 +555,7 @@ func (m *cloudManager) downloadFileWithChecksum(
 			}
 		}
 		required := remaining + diskusage.MinFreeBytes
-		if _, err := CheckDiskSpace(m.logger, downloadPath, "package download", required,
+		if _, err := diskusage.CheckDiskSpace(m.logger, downloadPath, "package download", required,
 			"content_size", rutils.FormatBytes(uint64(resp.ContentLength))); err != nil {
 			return "", "", err
 		}

--- a/robot/packages/cloud_package_manager_test.go
+++ b/robot/packages/cloud_package_manager_test.go
@@ -405,18 +405,18 @@ func TestCloud(t *testing.T) {
 		defer utils.UncheckedErrorFunc(func() error { return pm.Close(context.Background()) })
 
 		t.Setenv(rutils.ViamEnableDiskSpaceBlockEnvVar, "true")
-		orig := enoughFreeSpace
+		orig := diskusage.EnoughFreeSpaceFunc
 		// Report low only for the unpack step, identified by its target dir: the download pre-filter
 		// checks the ".download" archive path, while unpackFile extracts into a "*.tmp" dir. Keying
 		// on the call site (rather than the byte count each guard happens to pass) keeps this from
 		// breaking if the guards' required-bytes math changes.
-		enoughFreeSpace = func(path string, _ uint64) (bool, uint64, error) {
+		diskusage.EnoughFreeSpaceFunc = func(path string, _ uint64) (bool, uint64, error) {
 			if strings.Contains(path, ".tmp") {
 				return false, 5, nil // unpack guard: report low
 			}
 			return true, 1 << 40, nil // download pre-filter: plenty
 		}
-		t.Cleanup(func() { enoughFreeSpace = orig })
+		t.Cleanup(func() { diskusage.EnoughFreeSpaceFunc = orig })
 
 		input := config.PackageConfig{Name: "some-name-1", Package: "org1/test-model", Version: "v1", Type: "ml_model"}
 		fakeServer.StorePackage(input)
@@ -434,7 +434,7 @@ func TestCloud(t *testing.T) {
 		test.That(t, statusFile.Status, test.ShouldNotEqual, syncStatusFailed)
 
 		// Restore free space and sync the same version again: it should re-download and succeed.
-		enoughFreeSpace = orig
+		diskusage.EnoughFreeSpaceFunc = orig
 		err = pm.Sync(ctx, []config.PackageConfig{input}, []config.Module{})
 		test.That(t, err, test.ShouldBeNil)
 
@@ -732,13 +732,13 @@ func TestDownloadFileWithChecksum(t *testing.T) {
 		// Refused before any file is written, and the pre-filter sizes the requirement as
 		// Content-Length plus the MinFreeBytes floor.
 		t.Setenv(rutils.ViamEnableDiskSpaceBlockEnvVar, "true")
-		orig := enoughFreeSpace
+		orig := diskusage.EnoughFreeSpaceFunc
 		var gotRequired uint64
-		enoughFreeSpace = func(_ string, minBytes uint64) (bool, uint64, error) {
+		diskusage.EnoughFreeSpaceFunc = func(_ string, minBytes uint64) (bool, uint64, error) {
 			gotRequired = minBytes
 			return false, 5, nil
 		}
-		t.Cleanup(func() { enoughFreeSpace = orig })
+		t.Cleanup(func() { diskusage.EnoughFreeSpaceFunc = orig })
 
 		dest := filepath.Join(packagesDir, "download-lowspace")
 		_, _, err := pm.downloadFileWithChecksum(t.Context(), server.URL+"/download-lowspace", dest, "download-lowspace")
@@ -757,13 +757,13 @@ func TestDownloadFileWithChecksum(t *testing.T) {
 		// assert the requirement without exercising resume, and confirm the partial is left intact for
 		// a later retry.
 		t.Setenv(rutils.ViamEnableDiskSpaceBlockEnvVar, "true")
-		orig := enoughFreeSpace
+		orig := diskusage.EnoughFreeSpaceFunc
 		var gotRequired uint64
-		enoughFreeSpace = func(_ string, minBytes uint64) (bool, uint64, error) {
+		diskusage.EnoughFreeSpaceFunc = func(_ string, minBytes uint64) (bool, uint64, error) {
 			gotRequired = minBytes
 			return false, 5, nil
 		}
-		t.Cleanup(func() { enoughFreeSpace = orig })
+		t.Cleanup(func() { diskusage.EnoughFreeSpaceFunc = orig })
 
 		dest := filepath.Join(packagesDir, "download-partial")
 		const partial = 7
@@ -783,11 +783,11 @@ func TestDownloadFileWithChecksum(t *testing.T) {
 
 	t.Run("proceeds when low on space but blocking is disabled (log-only default)", func(t *testing.T) {
 		// With blocking disabled (the default), low space is logged but the download proceeds.
-		orig := enoughFreeSpace
-		enoughFreeSpace = func(_ string, minBytes uint64) (bool, uint64, error) {
+		orig := diskusage.EnoughFreeSpaceFunc
+		diskusage.EnoughFreeSpaceFunc = func(_ string, minBytes uint64) (bool, uint64, error) {
 			return false, 5, nil
 		}
-		t.Cleanup(func() { enoughFreeSpace = orig })
+		t.Cleanup(func() { diskusage.EnoughFreeSpaceFunc = orig })
 
 		dest := filepath.Join(packagesDir, "download-lowspace-logonly")
 		_, _, err := pm.downloadFileWithChecksum(t.Context(), server.URL+"/download-lowspace-logonly", dest, "download-lowspace-logonly")

--- a/robot/packages/local_package_manager.go
+++ b/robot/packages/local_package_manager.go
@@ -110,7 +110,8 @@ func (m *localManager) fileCopyHelper(ctx context.Context, path, dstPath string)
 	if info, statErr := os.Stat(path); statErr == nil && info.Mode().IsRegular() {
 		required = uint64(info.Size()) + diskusage.MinFreeBytes
 	}
-	if _, err := diskusage.CheckDiskSpace(m.logger, dstPath, fmt.Sprintf("local package %q", filepath.Base(path)), required); err != nil {
+	if _, err := diskusage.CheckDiskSpace(m.logger, dstPath, fmt.Sprintf("local package %q", filepath.Base(path)),
+		required, diskSpaceBlockingEnabled()); err != nil {
 		return "", "", err
 	}
 

--- a/robot/packages/local_package_manager.go
+++ b/robot/packages/local_package_manager.go
@@ -110,7 +110,7 @@ func (m *localManager) fileCopyHelper(ctx context.Context, path, dstPath string)
 	if info, statErr := os.Stat(path); statErr == nil && info.Mode().IsRegular() {
 		required = uint64(info.Size()) + diskusage.MinFreeBytes
 	}
-	if _, err := CheckDiskSpace(m.logger, dstPath, fmt.Sprintf("local package %q", filepath.Base(path)), required); err != nil {
+	if _, err := diskusage.CheckDiskSpace(m.logger, dstPath, fmt.Sprintf("local package %q", filepath.Base(path)), required); err != nil {
 		return "", "", err
 	}
 

--- a/robot/packages/local_package_manager.go
+++ b/robot/packages/local_package_manager.go
@@ -110,7 +110,7 @@ func (m *localManager) fileCopyHelper(ctx context.Context, path, dstPath string)
 	if info, statErr := os.Stat(path); statErr == nil && info.Mode().IsRegular() {
 		required = uint64(info.Size()) + diskusage.MinFreeBytes
 	}
-	if _, err := checkDiskSpace(m.logger, dstPath, fmt.Sprintf("local package %q", filepath.Base(path)), required); err != nil {
+	if _, err := CheckDiskSpace(m.logger, dstPath, fmt.Sprintf("local package %q", filepath.Base(path)), required); err != nil {
 		return "", "", err
 	}
 

--- a/robot/packages/local_package_manager_test.go
+++ b/robot/packages/local_package_manager_test.go
@@ -108,11 +108,11 @@ func TestLocalManagerUtils(t *testing.T) {
 		size := int64(diskusage.MinFreeBytes) + 4242
 		test.That(t, os.WriteFile(src, make([]byte, size), 0o600), test.ShouldBeNil)
 
-		orig := enoughFreeSpace
-		t.Cleanup(func() { enoughFreeSpace = orig })
+		orig := diskusage.EnoughFreeSpaceFunc
+		t.Cleanup(func() { diskusage.EnoughFreeSpaceFunc = orig })
 
 		var gotRequired uint64
-		enoughFreeSpace = func(_ string, minBytes uint64) (bool, uint64, error) {
+		diskusage.EnoughFreeSpaceFunc = func(_ string, minBytes uint64) (bool, uint64, error) {
 			gotRequired = minBytes
 			return false, 5, nil
 		}
@@ -142,9 +142,9 @@ func TestLocalManagerUtils(t *testing.T) {
 		// unpackFile checks free space incrementally as it extracts and aborts when low and
 		// blocking is on. The seeded counter fires the check before the first file, so even this
 		// tiny tarball exercises it.
-		orig := enoughFreeSpace
-		t.Cleanup(func() { enoughFreeSpace = orig })
-		enoughFreeSpace = func(_ string, _ uint64) (bool, uint64, error) {
+		orig := diskusage.EnoughFreeSpaceFunc
+		t.Cleanup(func() { diskusage.EnoughFreeSpaceFunc = orig })
+		diskusage.EnoughFreeSpaceFunc = func(_ string, _ uint64) (bool, uint64, error) {
 			return false, 5, nil // always low
 		}
 
@@ -156,7 +156,7 @@ func TestLocalManagerUtils(t *testing.T) {
 			test.That(t, err.Error(), test.ShouldContainSubstring, "not enough free disk space")
 			// installPackage relies on errors.Is to avoid mislabeling this as a corrupt-archive
 			// "try a different version" failure, so the sentinel must propagate.
-			test.That(t, errors.Is(err, errInsufficientDiskSpace), test.ShouldBeTrue)
+			test.That(t, errors.Is(err, diskusage.ErrInsufficientDiskSpace), test.ShouldBeTrue)
 		})
 
 		t.Run("proceeds when low but blocking disabled (log-only default)", func(t *testing.T) {
@@ -176,7 +176,7 @@ func TestLocalManagerUtils(t *testing.T) {
 			tarPath := writeSingleFileTarGz(t, "big-member", fileSize)
 
 			var gotRequired uint64
-			enoughFreeSpace = func(_ string, minBytes uint64) (bool, uint64, error) {
+			diskusage.EnoughFreeSpaceFunc = func(_ string, minBytes uint64) (bool, uint64, error) {
 				gotRequired = minBytes
 				return false, 5, nil
 			}
@@ -184,7 +184,7 @@ func TestLocalManagerUtils(t *testing.T) {
 
 			err := unpackFile(context.Background(), logging.NewTestLogger(t), tarPath, t.TempDir())
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, errors.Is(err, errInsufficientDiskSpace), test.ShouldBeTrue)
+			test.That(t, errors.Is(err, diskusage.ErrInsufficientDiskSpace), test.ShouldBeTrue)
 			test.That(t, gotRequired, test.ShouldEqual, uint64(fileSize)+diskusage.MinFreeBytes)
 		})
 	})

--- a/robot/packages/utils.go
+++ b/robot/packages/utils.go
@@ -36,7 +36,7 @@ const maxPartialAge = 72 * time.Hour
 // having to actually fill a disk.
 var enoughFreeSpace = diskusage.EnoughFreeSpace
 
-// errInsufficientDiskSpace is returned by checkDiskSpace when blocking is on and the volume is
+// errInsufficientDiskSpace is returned by CheckDiskSpace when blocking is on and the volume is
 // low. Callers use errors.Is to tell a disk-space refusal from other failures (e.g. a corrupt
 // archive) and surface an accurate message.
 var errInsufficientDiskSpace = errors.New("not enough free disk space")
@@ -57,13 +57,13 @@ func diskSpaceBlockingEnabled() bool {
 	return rutils.GetenvBool(rutils.ViamEnableDiskSpaceBlockEnvVar, false)
 }
 
-// checkDiskSpace checks whether the volume holding path has required bytes free. It returns
+// CheckDiskSpace checks whether the volume holding path has required bytes free. It returns
 // low=true whenever space is low. When blocking is enabled via ViamEnableDiskSpaceBlockEnvVar it
-// returns an error refusing the op (the caller logs it, so checkDiskSpace stays quiet to avoid
+// returns an error refusing the op (the caller logs it, so CheckDiskSpace stays quiet to avoid
 // double-logging the same reason every cycle); otherwise it logs a warning and returns nil so the
 // op proceeds (log-only). A failed check is logged and treated as "proceed" so a broken statfs
 // never blocks installs. desc names the op in logs/errors; extraFields extend the warning.
-func checkDiskSpace(logger logging.Logger, path, desc string, required uint64, extraFields ...any) (low bool, err error) {
+func CheckDiskSpace(logger logging.Logger, path, desc string, required uint64, extraFields ...any) (low bool, err error) {
 	enough, available, err := enoughFreeSpace(path, required)
 	if err != nil {
 		logger.Warnw("could not check free disk space; proceeding",
@@ -333,7 +333,7 @@ func unpackFile(ctx context.Context, logger logging.Logger, fromFile, toDir stri
 			if !loggedLowSpace && bytesSinceDiskCheck >= unpackDiskCheckInterval {
 				bytesSinceDiskCheck = 0
 				required := diskusage.MinFreeBytes + uint64(header.Size)
-				low, err := checkDiskSpace(logger, toDir, "unpacking package", required)
+				low, err := CheckDiskSpace(logger, toDir, "unpacking package", required)
 				if err != nil {
 					return err
 				}

--- a/robot/packages/utils.go
+++ b/robot/packages/utils.go
@@ -31,65 +31,13 @@ const partialsDirName = "part"
 // cleanup partial downloads that were started this long ago
 const maxPartialAge = 72 * time.Hour
 
-// enoughFreeSpace reports whether the volume holding path has at least minBytes
-// available. It is a package var so tests can inject a low-space result without
-// having to actually fill a disk.
-var enoughFreeSpace = diskusage.EnoughFreeSpace
-
-// errInsufficientDiskSpace is returned by CheckDiskSpace when blocking is on and the volume is
-// low. Callers use errors.Is to tell a disk-space refusal from other failures (e.g. a corrupt
-// archive) and surface an accurate message.
-var errInsufficientDiskSpace = errors.New("not enough free disk space")
-
 // isTransientDiskSpaceError reports whether err is a low-space failure that should be retried
 // rather than marked syncStatusFailed. Two paths reach here: blocking mode refuses the op up front
-// with errInsufficientDiskSpace, and log-only mode proceeds past the warning but then the write
+// with diskusage.ErrInsufficientDiskSpace, and log-only mode proceeds past the warning but then the write
 // genuinely exhausts the disk (a raw syscall.ENOSPC wrapped by os/io). Both are the same transient
 // condition, so treat them alike so the next sync retries once space frees.
 func isTransientDiskSpaceError(err error) bool {
-	return errors.Is(err, errInsufficientDiskSpace) || errors.Is(err, syscall.ENOSPC)
-}
-
-// diskSpaceBlockingEnabled reports whether low-space conditions should refuse the operation
-// (download, local copy, or unpack). Default (unset) is false: low-space is logged but the
-// operation proceeds (log-only). See rutils.ViamEnableDiskSpaceBlockEnvVar.
-func diskSpaceBlockingEnabled() bool {
-	return rutils.GetenvBool(rutils.ViamEnableDiskSpaceBlockEnvVar, false)
-}
-
-// CheckDiskSpace checks whether the volume holding path has required bytes free. It returns
-// low=true whenever space is low. When blocking is enabled via ViamEnableDiskSpaceBlockEnvVar it
-// returns an error refusing the op (the caller logs it, so CheckDiskSpace stays quiet to avoid
-// double-logging the same reason every cycle); otherwise it logs a warning and returns nil so the
-// op proceeds (log-only). A failed check is logged and treated as "proceed" so a broken statfs
-// never blocks installs. desc names the op in logs/errors; extraFields extend the warning.
-func CheckDiskSpace(logger logging.Logger, path, desc string, required uint64, extraFields ...any) (low bool, err error) {
-	enough, available, err := enoughFreeSpace(path, required)
-	if err != nil {
-		logger.Warnw("could not check free disk space; proceeding",
-			append([]any{"desc", desc, "path", path, "error", err}, extraFields...)...)
-		return false, nil
-	}
-	if enough {
-		return false, nil
-	}
-	if !diskSpaceBlockingEnabled() {
-		// Log-only: the op proceeds and returns no error, so this warning is the only signal
-		// that space is low.
-		logger.Warnw("not enough free disk space",
-			append([]any{
-				"desc", desc, "path", path,
-				"available", rutils.FormatBytes(available),
-				"required", rutils.FormatBytes(required),
-				"blocking", false,
-			}, extraFields...)...)
-		return true, nil
-	}
-	// Blocking: don't warn here — the returned error carries the same detail and is logged by the
-	// caller (cloud_package_manager.go and local_package_manager.go both log the install error),
-	// so warning too would double-log the same reason every sync cycle.
-	return true, fmt.Errorf("%w for %s: %s available, %s required",
-		errInsufficientDiskSpace, desc, rutils.FormatBytes(available), rutils.FormatBytes(required))
+	return errors.Is(err, diskusage.ErrInsufficientDiskSpace) || errors.Is(err, syscall.ENOSPC)
 }
 
 // create a partials folder for this URL and return a destination path for the file.
@@ -333,7 +281,7 @@ func unpackFile(ctx context.Context, logger logging.Logger, fromFile, toDir stri
 			if !loggedLowSpace && bytesSinceDiskCheck >= unpackDiskCheckInterval {
 				bytesSinceDiskCheck = 0
 				required := diskusage.MinFreeBytes + uint64(header.Size)
-				low, err := CheckDiskSpace(logger, toDir, "unpacking package", required)
+				low, err := diskusage.CheckDiskSpace(logger, toDir, "unpacking package", required)
 				if err != nil {
 					return err
 				}

--- a/robot/packages/utils.go
+++ b/robot/packages/utils.go
@@ -31,6 +31,14 @@ const partialsDirName = "part"
 // cleanup partial downloads that were started this long ago
 const maxPartialAge = 72 * time.Hour
 
+// diskSpaceBlockingEnabled reports whether viam-server should refuse an operation (download,
+// local copy, or unpack) when space is low. Default (unset) is false: low space is logged but the
+// operation proceeds (log-only). CheckDiskSpace takes this as an argument so each caller sets its
+// own policy; viam-server's comes from the environment.
+func diskSpaceBlockingEnabled() bool {
+	return rutils.GetenvBool(rutils.ViamEnableDiskSpaceBlockEnvVar, false)
+}
+
 // isTransientDiskSpaceError reports whether err is a low-space failure that should be retried
 // rather than marked syncStatusFailed. Two paths reach here: blocking mode refuses the op up front
 // with diskusage.ErrInsufficientDiskSpace, and log-only mode proceeds past the warning but then the write
@@ -281,7 +289,7 @@ func unpackFile(ctx context.Context, logger logging.Logger, fromFile, toDir stri
 			if !loggedLowSpace && bytesSinceDiskCheck >= unpackDiskCheckInterval {
 				bytesSinceDiskCheck = 0
 				required := diskusage.MinFreeBytes + uint64(header.Size)
-				low, err := diskusage.CheckDiskSpace(logger, toDir, "unpacking package", required)
+				low, err := diskusage.CheckDiskSpace(logger, toDir, "unpacking package", required, diskSpaceBlockingEnabled())
 				if err != nil {
 					return err
 				}

--- a/utils/diskusage/disk_usage_shared.go
+++ b/utils/diskusage/disk_usage_shared.go
@@ -123,8 +123,10 @@ func CheckDiskSpace(logger logging.Logger, path, desc string, required uint64, b
 		ErrInsufficientDiskSpace, desc, utils.FormatBytes(available), utils.FormatBytes(required))
 }
 
-// nearestExistingDir walks up from path until it finds an existing directory,
-// returning that ancestor. Non-directories are skipped
+// nearestExistingDir walks up from path until it finds an existing directory, returning that
+// ancestor. It skips non-directories because Statfs reads the whole volume either way, and on
+// Windows GetDiskFreeSpaceExW rejects a file path outright. If no ancestor exists (e.g. an empty
+// path), it returns path unchanged and lets the subsequent Statfs surface the error.
 func nearestExistingDir(path string) string {
 	for path != "" {
 		if info, err := os.Stat(path); err == nil && info.IsDir() {

--- a/utils/diskusage/disk_usage_shared.go
+++ b/utils/diskusage/disk_usage_shared.go
@@ -1,10 +1,12 @@
 package diskusage
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/utils"
 )
 
@@ -76,9 +78,60 @@ func EnoughFreeSpace(path string, minBytes uint64) (enough bool, available uint6
 	return usage.AvailableBytes >= minBytes, usage.AvailableBytes, nil
 }
 
-// nearestExistingDir walks up from path until it finds something that exists,
-// returning that ancestor. If no ancestor exists (e.g. an empty path), it returns
-// path unchanged and lets the subsequent Statfs surface the error.
+// ErrInsufficientDiskSpace is returned by CheckDiskSpace when blocking is on and the volume is
+// low. Callers use errors.Is to tell a disk-space refusal from other failures (e.g. a corrupt
+// archive) and surface an accurate message.
+var ErrInsufficientDiskSpace = errors.New("not enough free disk space")
+
+// EnoughFreeSpace reports whether the volume holding path has at least minBytes
+// available. It is a package var so tests can inject a low-space result without
+// having to actually fill a disk.
+var EnoughFreeSpaceFunc = EnoughFreeSpace
+
+// blockingEnabled reports whether low-space conditions should refuse the operation (download,
+// local copy, or unpack). Default (unset) is false: low-space is logged but the operation
+// proceeds (log-only). See utils.ViamEnableDiskSpaceBlockEnvVar.
+func blockingEnabled() bool {
+	return utils.GetenvBool(utils.ViamEnableDiskSpaceBlockEnvVar, false)
+}
+
+// CheckDiskSpace checks whether the volume holding path has required bytes free. It returns
+// low=true whenever space is low. When blocking is enabled via ViamEnableDiskSpaceBlockEnvVar it
+// returns an error refusing the op (the caller logs it, so CheckDiskSpace stays quiet to avoid
+// double-logging the same reason every cycle); otherwise it logs a warning and returns nil so the
+// op proceeds (log-only). A failed check is logged and treated as "proceed" so a broken statfs
+// never blocks installs. desc names the op in logs/errors; extraFields extend the warning.
+func CheckDiskSpace(logger logging.Logger, path, desc string, required uint64, extraFields ...any) (low bool, err error) {
+	enough, available, err := EnoughFreeSpaceFunc(path, required)
+	if err != nil {
+		logger.Warnw("could not check free disk space; proceeding",
+			append([]any{"desc", desc, "path", path, "error", err}, extraFields...)...)
+		return false, nil
+	}
+	if enough {
+		return false, nil
+	}
+	if !blockingEnabled() {
+		// Log-only: the op proceeds and returns no error, so this warning is the only signal
+		// that space is low.
+		logger.Warnw("not enough free disk space",
+			append([]any{
+				"desc", desc, "path", path,
+				"available", utils.FormatBytes(available),
+				"required", utils.FormatBytes(required),
+				"blocking", false,
+			}, extraFields...)...)
+		return true, nil
+	}
+	// Blocking: don't warn here — the returned error carries the same detail and is logged by the
+	// caller (cloud_package_manager.go and local_package_manager.go both log the install error),
+	// so warning too would double-log the same reason every sync cycle.
+	return true, fmt.Errorf("%w for %s: %s available, %s required",
+		ErrInsufficientDiskSpace, desc, utils.FormatBytes(available), utils.FormatBytes(required))
+}
+
+// nearestExistingDir walks up from path until it finds an existing directory,
+// returning that ancestor. Non-directories are skipped
 func nearestExistingDir(path string) string {
 	for path != "" {
 		if info, err := os.Stat(path); err == nil && info.IsDir() {

--- a/utils/diskusage/disk_usage_shared.go
+++ b/utils/diskusage/disk_usage_shared.go
@@ -83,9 +83,8 @@ func EnoughFreeSpace(path string, minBytes uint64) (enough bool, available uint6
 // archive) and surface an accurate message.
 var ErrInsufficientDiskSpace = errors.New("not enough free disk space")
 
-// EnoughFreeSpace reports whether the volume holding path has at least minBytes
-// available. It is a package var so tests can inject a low-space result without
-// having to actually fill a disk.
+// EnoughFreeSpaceFunc is the probe CheckDiskSpace uses to measure free space. It is a package
+// var so tests can inject a low-space result without having to actually fill a disk.
 var EnoughFreeSpaceFunc = EnoughFreeSpace
 
 // blockingEnabled reports whether low-space conditions should refuse the operation (download,

--- a/utils/diskusage/disk_usage_shared.go
+++ b/utils/diskusage/disk_usage_shared.go
@@ -10,10 +10,10 @@ import (
 	"go.viam.com/rdk/utils"
 )
 
-// MinFreeBytes is the floor of free space viam-server tries to keep on volumes it writes to
+// MinFreeBytes is the floor of free space callers try to keep on volumes they write to
 // (downloads, local copies, unpacking). Falling below it always logs a warning, and refuses the
-// install only when VIAM_ENABLE_DISK_SPACE_BLOCK is set (otherwise log-only). Also a trigger for
-// the background monitor; see IsLow.
+// operation only when the caller asks CheckDiskSpace to block (otherwise log-only). Also a
+// trigger for the background monitor; see IsLow.
 const MinFreeBytes uint64 = 10 * mb
 
 // MaxUsedFraction is the utilization (0.0-1.0) at or above which the monitor flags a volume as
@@ -87,20 +87,14 @@ var ErrInsufficientDiskSpace = errors.New("not enough free disk space")
 // var so tests can inject a low-space result without having to actually fill a disk.
 var EnoughFreeSpaceFunc = EnoughFreeSpace
 
-// blockingEnabled reports whether low-space conditions should refuse the operation (download,
-// local copy, or unpack). Default (unset) is false: low-space is logged but the operation
-// proceeds (log-only). See utils.ViamEnableDiskSpaceBlockEnvVar.
-func blockingEnabled() bool {
-	return utils.GetenvBool(utils.ViamEnableDiskSpaceBlockEnvVar, false)
-}
-
 // CheckDiskSpace checks whether the volume holding path has required bytes free. It returns
-// low=true whenever space is low. When blocking is enabled via ViamEnableDiskSpaceBlockEnvVar it
-// returns an error refusing the op (the caller logs it, so CheckDiskSpace stays quiet to avoid
-// double-logging the same reason every cycle); otherwise it logs a warning and returns nil so the
-// op proceeds (log-only). A failed check is logged and treated as "proceed" so a broken statfs
-// never blocks installs. desc names the op in logs/errors; extraFields extend the warning.
-func CheckDiskSpace(logger logging.Logger, path, desc string, required uint64, extraFields ...any) (low bool, err error) {
+// low=true whenever space is low. When blocking is true it returns an error refusing the op (the
+// caller logs it, so CheckDiskSpace stays quiet to avoid double-logging the same reason every
+// cycle); otherwise it logs a warning and returns nil so the op proceeds (log-only). Blocking is
+// the caller's policy: viam-server reads utils.ViamEnableDiskSpaceBlockEnvVar, viam-agent reads
+// its own config. A failed check is logged and treated as "proceed" so a broken statfs never
+// blocks installs. desc names the op in logs/errors; extraFields extend the warning.
+func CheckDiskSpace(logger logging.Logger, path, desc string, required uint64, blocking bool, extraFields ...any) (low bool, err error) {
 	enough, available, err := EnoughFreeSpaceFunc(path, required)
 	if err != nil {
 		logger.Warnw("could not check free disk space; proceeding",
@@ -110,7 +104,7 @@ func CheckDiskSpace(logger logging.Logger, path, desc string, required uint64, e
 	if enough {
 		return false, nil
 	}
-	if !blockingEnabled() {
+	if !blocking {
 		// Log-only: the op proceeds and returns no error, so this warning is the only signal
 		// that space is low.
 		logger.Warnw("not enough free disk space",

--- a/utils/diskusage/disk_usage_shared.go
+++ b/utils/diskusage/disk_usage_shared.go
@@ -53,7 +53,7 @@ func IsLowOnSpace(path string) (usage DiskUsage, low bool, err error) {
 func (du DiskUsage) IsLow() bool {
 	// A zero total size is a pseudo-fs (procfs/sysfs) or garbage statfs result, not a real volume
 	// we can assess — treat it as not-low rather than warning every interval. (Mirrors
-	// checkDiskSpace, which proceeds on an outright statfs error.)
+	// CheckDiskSpace, which proceeds on an outright statfs error.)
 	if du.SizeBytes == 0 {
 		return false
 	}
@@ -69,7 +69,7 @@ func EnoughFreeSpace(path string, minBytes uint64) (enough bool, available uint6
 		return false, 0, err
 	}
 	// Don't refuse an install on a pseudo-fs/garbage (zero total size) result; let ENOSPC be the
-	// backstop, consistent with how checkDiskSpace handles a statfs error.
+	// backstop, consistent with how CheckDiskSpace handles a statfs error.
 	if usage.SizeBytes == 0 {
 		return true, usage.AvailableBytes, nil
 	}
@@ -81,7 +81,7 @@ func EnoughFreeSpace(path string, minBytes uint64) (enough bool, available uint6
 // path unchanged and lets the subsequent Statfs surface the error.
 func nearestExistingDir(path string) string {
 	for path != "" {
-		if _, err := os.Stat(path); err == nil {
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
 			return path
 		}
 		parent := filepath.Dir(path)

--- a/utils/diskusage/disk_usage_test.go
+++ b/utils/diskusage/disk_usage_test.go
@@ -2,6 +2,7 @@ package diskusage
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -124,4 +125,20 @@ func TestCheckDiskSpace(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, low, test.ShouldBeFalse)
 	test.That(t, logs.FilterMessage("could not check free disk space; proceeding").Len(), test.ShouldEqual, 1)
+}
+
+func TestNearestExistingDir(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a-file")
+	test.That(t, os.WriteFile(file, []byte("x"), 0o600), test.ShouldBeNil)
+
+	// A file resolves to its parent. Statfs reads the whole volume either way, so Linux would
+	// accept the file path, but Windows GetDiskFreeSpaceExW rejects it.
+	test.That(t, nearestExistingDir(file), test.ShouldEqual, dir)
+	// An existing directory is already the answer, so don't climb to its parent.
+	test.That(t, nearestExistingDir(dir), test.ShouldEqual, dir)
+	// A path that does not exist yet resolves to its nearest existing ancestor.
+	test.That(t, nearestExistingDir(filepath.Join(dir, "no", "such", "path")), test.ShouldEqual, dir)
+	// No ancestor exists: return path unchanged and let the caller's Statfs surface the error.
+	test.That(t, nearestExistingDir(""), test.ShouldEqual, "")
 }

--- a/utils/diskusage/disk_usage_test.go
+++ b/utils/diskusage/disk_usage_test.go
@@ -1,10 +1,13 @@
 package diskusage
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
 	"go.viam.com/test"
+
+	"go.viam.com/rdk/logging"
 )
 
 func TestEnoughFreeSpace(t *testing.T) {
@@ -105,4 +108,20 @@ func TestDiskUsage(t *testing.T) {
 			test.That(t, tc.du.String(), test.ShouldResemble, tc.exp)
 		}
 	})
+}
+
+func TestCheckDiskSpace(t *testing.T) {
+	// Cover the one path the robot/packages guard tests don't: a probe that errors must proceed
+	// even with blocking on, so a broken statfs never refuses an install.
+	orig := EnoughFreeSpaceFunc
+	EnoughFreeSpaceFunc = func(string, uint64) (bool, uint64, error) {
+		return false, 0, errors.New("statfs failed")
+	}
+	t.Cleanup(func() { EnoughFreeSpaceFunc = orig })
+
+	logger, logs := logging.NewObservedTestLogger(t)
+	low, err := CheckDiskSpace(logger, t.TempDir(), "test op", 1<<20, true)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, low, test.ShouldBeFalse)
+	test.That(t, logs.FilterMessage("could not check free disk space; proceeding").Len(), test.ShouldEqual, 1)
 }


### PR DESCRIPTION
Export the package disk-space check for use by viam-agent ([agent disk space monitor](https://github.com/viamrobotics/agent/pull/293)) and resolve file paths to their containing directories.

