### PR TITLE
RSDK-14134 Test Failure: go.viam.com/rdk/cli.TestAddModel/AddModelAction_dry_run: flaky test fix use t.Chdir for CWD-mutating CLI tests

### DIFF
--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1489,12 +1489,7 @@ func TestShellFileCopy(t *testing.T) {
 
 		t.Run("single file relative", func(t *testing.T) {
 			tempDir := t.TempDir()
-			cwd, err := os.Getwd()
-			test.That(t, err, test.ShouldBeNil)
-			//nolint: usetesting
-			t.Cleanup(func() { os.Chdir(cwd) })
-			//nolint: usetesting
-			test.That(t, os.Chdir(tempDir), test.ShouldBeNil)
+			t.Chdir(tempDir)
 
 			args := []string{fmt.Sprintf("machine:%s", tfs.SingleFileNested), "foo"}
 			cCtx, viamClient, _, _ := setupWithRunningPart(
@@ -1847,16 +1842,7 @@ func TestShellGetFTDC(t *testing.T) {
 		}
 
 		t.Run("download to cwd", func(t *testing.T) {
-			tempDir := t.TempDir()
-			originalWd, err := os.Getwd()
-			test.That(t, err, test.ShouldBeNil)
-			//nolint: usetesting
-			err = os.Chdir(tempDir)
-			test.That(t, err, test.ShouldBeNil)
-			t.Cleanup(func() {
-				//nolint: usetesting
-				os.Chdir(originalWd)
-			})
+			t.Chdir(t.TempDir())
 
 			testDownload(t, "")
 		})

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -470,21 +470,9 @@ func TestModuleGetPlatformsForModule(t *testing.T) {
 	test.That(t, platforms, test.ShouldResemble, []string{"linux/amd64", "linux/arm64"})
 }
 
-// testChdir is os.Chdir scoped to a test.
-// Necessary because Getwd() fails if run on a deleted path.
-func testChdir(t *testing.T, dest string) {
-	t.Helper()
-	orig, err := os.Getwd()
-	test.That(t, err, test.ShouldBeNil)
-	//nolint: usetesting
-	os.Chdir(dest)
-	//nolint: usetesting
-	t.Cleanup(func() { os.Chdir(orig) })
-}
-
 func TestLocalBuild(t *testing.T) {
 	testDir := t.TempDir()
-	testChdir(t, testDir)
+	t.Chdir(testDir)
 
 	setupScriptCmd, setupFile, setupContent := "./setup.sh", "setup.sh", "echo setup step msg"
 	buildCmd, buildFile, buildContent := "make build", "Makefile", "make build:\n\techo build step msg"

--- a/cli/module_generate_app_test.go
+++ b/cli/module_generate_app_test.go
@@ -26,7 +26,7 @@ func TestAppTemplateCompiles(t *testing.T) {
 	globalArgs := *gArgs
 
 	testDir := t.TempDir()
-	testChdir(t, testDir)
+	t.Chdir(testDir)
 	appPath := filepath.Join(testDir, testData.ModuleName)
 
 	// Generate the app

--- a/cli/module_generate_test.go
+++ b/cli/module_generate_test.go
@@ -27,13 +27,14 @@ import (
 
 func TestAddModel(t *testing.T) {
 	// NOTE: do not mark this top-level test t.Parallel(). Some subtests call
-	// testChdir, which mutates the process-wide CWD. Marking a subtest
+	// t.Chdir, which mutates the process-wide CWD. Marking a subtest
 	// non-parallel only serializes it against its siblings; if this parent ran
 	// in parallel with TestAddApp (which also chdirs), their CWD mutations would
-	// race, breaking relative-path lookups (meta.json) and, on Windows, breaking
-	// t.TempDir() cleanup ("the process cannot access the file because it is
-	// being used by another process"). Keeping the parent sequential serializes
-	// all CWD-mutating tests against each other.
+	// race, breaking relative-path lookups (meta.json, .viam-gen-info) and, on
+	// Windows, breaking t.TempDir() cleanup ("the process cannot access the file
+	// because it is being used by another process"). Keeping the parent
+	// sequential serializes all CWD-mutating tests against each other; t.Chdir
+	// enforces that by panicking if this test or any ancestor is parallel.
 	baseModule := modulegen.ModuleInputs{
 		ModuleName:            "my-module",
 		Visibility:            moduleVisibilityPrivate,
@@ -416,10 +417,10 @@ file(READ "${CMAKE_CURRENT_SOURCE_DIR}/meta.json" _META_JSON)
 	})
 
 	t.Run("AddModelAction dry run", func(t *testing.T) {
-		// No t.Parallel(): calls testChdir which mutates process-wide CWD,
+		// No t.Parallel(): calls t.Chdir which mutates process-wide CWD,
 		// which races with parallel subtests that call go install / use relative paths.
 		dir := t.TempDir()
-		testChdir(t, dir)
+		t.Chdir(dir)
 
 		// Write .viam-gen-info so the action can read module context
 		data, err := json.Marshal(baseModule)
@@ -449,12 +450,19 @@ file(READ "${CMAKE_CURRENT_SOURCE_DIR}/meta.json" _META_JSON)
 		err = AddModelAction(context.Background(), cCtx, args)
 		// dry-run returns nil without touching files
 		test.That(t, err, test.ShouldBeNil)
+		result, err := loadManifest(defaultManifestFilename)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(result.Models), test.ShouldEqual, 0)
+		_, err = os.Stat("second_model.go")
+		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+		_, err = os.Stat("my-org_my-module_second-model.md")
+		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
 	})
 }
 
 func TestGenerateModuleAction(t *testing.T) {
-	// No t.Parallel(): subtests use relative paths that depend on CWD (set by testChdir),
-	// so this test must run sequentially to avoid races with TestAddModel's testChdir calls.
+	// No t.Parallel(): subtests use relative paths that depend on CWD (set by t.Chdir),
+	// so this test must run sequentially to avoid races with TestAddModel's t.Chdir calls.
 	testModule := modulegen.ModuleInputs{
 		ModuleName:       "my-module",
 		Visibility:       moduleVisibilityPrivate,
@@ -485,7 +493,7 @@ func TestGenerateModuleAction(t *testing.T) {
 	globalArgs := *gArgs
 
 	testDir := t.TempDir()
-	testChdir(t, testDir)
+	t.Chdir(testDir)
 	modulePath := filepath.Join(testDir, testModule.ModuleName)
 
 	t.Run("test setting up module directory", func(t *testing.T) {
@@ -844,7 +852,7 @@ func TestCreatePythonVenv(t *testing.T) {
 
 func TestAddApp(t *testing.T) {
 	// NOTE: do not mark this top-level test t.Parallel(). Some subtests call
-	// testChdir, which mutates the process-wide CWD, and would race with the
+	// t.Chdir, which mutates the process-wide CWD, and would race with the
 	// CWD-mutating subtests in TestAddModel if both parents ran in parallel.
 	// See the note on TestAddModel for details.
 
@@ -1024,9 +1032,9 @@ func main() {
 	})
 
 	t.Run("AddAppAction dry run", func(t *testing.T) {
-		// No t.Parallel(): calls testChdir which mutates process-wide CWD.
+		// No t.Parallel(): calls t.Chdir which mutates process-wide CWD.
 		dir := t.TempDir()
-		testChdir(t, dir)
+		t.Chdir(dir)
 
 		data, err := json.Marshal(baseGenInfo)
 		test.That(t, err, test.ShouldBeNil)
@@ -1061,7 +1069,7 @@ func main() {
 		test.That(t, os.WriteFile(filepath.Join(dir, ".viam-gen-info"), data, 0o600), test.ShouldBeNil)
 
 		// Temporarily point CWD so readViamGenInfo(".")  resolves correctly.
-		// We can't use testChdir here (parallel), so call readViamGenInfo directly.
+		// We can't use t.Chdir here (parallel), so call readViamGenInfo directly.
 		info, err := readViamGenInfo(dir)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, info.Language, test.ShouldEqual, "python")
@@ -1075,9 +1083,9 @@ func main() {
 	})
 
 	t.Run("AddAppAction rejects duplicate app name", func(t *testing.T) {
-		// No t.Parallel(): calls testChdir which mutates process-wide CWD.
+		// No t.Parallel(): calls t.Chdir which mutates process-wide CWD.
 		dir := t.TempDir()
-		testChdir(t, dir)
+		t.Chdir(dir)
 
 		data, err := json.Marshal(baseGenInfo)
 		test.That(t, err, test.ShouldBeNil)

--- a/cli/xacro_test.go
+++ b/cli/xacro_test.go
@@ -401,12 +401,7 @@ func TestValidateOutputWritable(t *testing.T) {
 	})
 
 	t.Run("path in current directory", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		originalDir, _ := os.Getwd()
-		//nolint: usetesting
-		defer os.Chdir(originalDir)
-		//nolint: usetesting
-		os.Chdir(tmpDir)
+		t.Chdir(t.TempDir())
 
 		err := validateOutputWritable("output.urdf")
 		test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
## What happened

`TestAddModel/AddModelAction_dry_run` failed with:

```
module_generate_test.go:444: Expected: nil
    Actual:   '.viam-gen-info not found; run this command from within a module directory created with `viam module generate`'
```

`test.That` is fatal, so this was the *first* failing assertion in the subtest: the
`os.WriteFile(".viam-gen-info", ...)` a few lines above had succeeded, yet
`AddModelAction`'s `readViamGenInfo(".")` could not find the file moments later. The
process CWD changed in between.

The reported line number (444) pins the failure to the June 16–18 commit range, where
`TestAddModel` was still a `t.Parallel()` top-level test. Its serial
`"AddModelAction dry run"` subtest chdir'd into its own `t.TempDir()` and used relative
paths, while `TestAddApp` — also `t.Parallel()` and also chdir-ing — ran concurrently.
Marking a subtest non-parallel only serializes it against its *siblings*, so the two
parents' CWD mutations interleaved and relative lookups resolved against the wrong
directory.

## Why it can silently come back

`t.Parallel()` was removed from both parents (#6141), so main is currently safe — but the
only thing enforcing that is a comment. The homegrown `testChdir` helper called
`os.Chdir` and **discarded the error**, so re-adding `t.Parallel()` to any of these
parents reintroduces the race with no signal beyond an occasional CI flake.

## The fix

Replace `testChdir` with the standard library's `testing.T.Chdir` at every CWD-mutating
site in the `cli` test package:

* it **panics** (`testing: test using t.Setenv or t.Chdir can not use t.Parallel`) when the
  test or any ancestor is parallel — the exact regression that caused this flake now fails
  deterministically on the first run instead of racing;
* it fails the test when the `chdir` itself fails, instead of silently continuing with the
  old CWD (which is how a successful write and a failing read ended up in the same test);
* it restores the previous directory from a held directory fd, and its cleanup is
  registered after `t.TempDir()`'s, so LIFO ordering still restores the CWD before the temp
  dir is removed (this is what the old helper's "Getwd() fails on a deleted path" comment
  was working around);
* it lets the `//nolint: usetesting` suppressions go away, so the linter now rejects new
  raw `os.Chdir` calls in these tests.

I verified both properties (cleanup ordering under a serial parent, and the panic when a
parent is parallel) with a standalone probe test replicating `TestAddModel`'s shape.

While here, the dry-run subtest now asserts what its comment already claimed — that the
dry run leaves `meta.json` and the module tree untouched — rather than only checking the
returned error.

## Notes

Scope is limited to the `cli` package, where the reported flake lives. Other packages use
the same `os.Chdir` pattern, but each test binary has its own process CWD, so those races
are independent and out of scope here.

The sandbox for this session cannot download the Go 1.25.10 toolchain required by `go.mod`
(`storage.googleapis.com` is not in the network allowlist), so `make test-go` / `make
lint-go` could not be executed locally; the changes are `gofmt`-clean and are a mechanical
swap to a standard-library test API. CI on this PR is the real check.

Key: RSDK-14134

Co-authored by Claude agent for Jira.