### PR TITLE
RSDK-14133 cli: flaky test fix TestAddApp/AddAppAction_rejects_duplicate_app_name

### DIFF
--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1489,12 +1489,7 @@ func TestShellFileCopy(t *testing.T) {
 
 		t.Run("single file relative", func(t *testing.T) {
 			tempDir := t.TempDir()
-			cwd, err := os.Getwd()
-			test.That(t, err, test.ShouldBeNil)
-			//nolint: usetesting
-			t.Cleanup(func() { os.Chdir(cwd) })
-			//nolint: usetesting
-			test.That(t, os.Chdir(tempDir), test.ShouldBeNil)
+			t.Chdir(tempDir)
 
 			args := []string{fmt.Sprintf("machine:%s", tfs.SingleFileNested), "foo"}
 			cCtx, viamClient, _, _ := setupWithRunningPart(
@@ -1848,15 +1843,7 @@ func TestShellGetFTDC(t *testing.T) {
 
 		t.Run("download to cwd", func(t *testing.T) {
 			tempDir := t.TempDir()
-			originalWd, err := os.Getwd()
-			test.That(t, err, test.ShouldBeNil)
-			//nolint: usetesting
-			err = os.Chdir(tempDir)
-			test.That(t, err, test.ShouldBeNil)
-			t.Cleanup(func() {
-				//nolint: usetesting
-				os.Chdir(originalWd)
-			})
+			t.Chdir(tempDir)
 
 			testDownload(t, "")
 		})

--- a/cli/module_build_test.go
+++ b/cli/module_build_test.go
@@ -470,21 +470,9 @@ func TestModuleGetPlatformsForModule(t *testing.T) {
 	test.That(t, platforms, test.ShouldResemble, []string{"linux/amd64", "linux/arm64"})
 }
 
-// testChdir is os.Chdir scoped to a test.
-// Necessary because Getwd() fails if run on a deleted path.
-func testChdir(t *testing.T, dest string) {
-	t.Helper()
-	orig, err := os.Getwd()
-	test.That(t, err, test.ShouldBeNil)
-	//nolint: usetesting
-	os.Chdir(dest)
-	//nolint: usetesting
-	t.Cleanup(func() { os.Chdir(orig) })
-}
-
 func TestLocalBuild(t *testing.T) {
 	testDir := t.TempDir()
-	testChdir(t, testDir)
+	t.Chdir(testDir)
 
 	setupScriptCmd, setupFile, setupContent := "./setup.sh", "setup.sh", "echo setup step msg"
 	buildCmd, buildFile, buildContent := "make build", "Makefile", "make build:\n\techo build step msg"

--- a/cli/module_generate_app_test.go
+++ b/cli/module_generate_app_test.go
@@ -26,7 +26,7 @@ func TestAppTemplateCompiles(t *testing.T) {
 	globalArgs := *gArgs
 
 	testDir := t.TempDir()
-	testChdir(t, testDir)
+	t.Chdir(testDir)
 	appPath := filepath.Join(testDir, testData.ModuleName)
 
 	// Generate the app

--- a/cli/module_generate_test.go
+++ b/cli/module_generate_test.go
@@ -27,13 +27,11 @@ import (
 
 func TestAddModel(t *testing.T) {
 	// NOTE: do not mark this top-level test t.Parallel(). Some subtests call
-	// testChdir, which mutates the process-wide CWD. Marking a subtest
-	// non-parallel only serializes it against its siblings; if this parent ran
-	// in parallel with TestAddApp (which also chdirs), their CWD mutations would
-	// race, breaking relative-path lookups (meta.json) and, on Windows, breaking
-	// t.TempDir() cleanup ("the process cannot access the file because it is
-	// being used by another process"). Keeping the parent sequential serializes
-	// all CWD-mutating tests against each other.
+	// t.Chdir, which mutates the process-wide CWD; marking a subtest non-parallel
+	// only serializes it against its siblings, so if this parent ran in parallel
+	// with TestAddApp (which also chdirs) their CWD mutations would race, breaking
+	// relative-path lookups (meta.json). t.Chdir panics if this test or any
+	// ancestor is parallel, so that mistake fails loudly rather than flaking.
 	baseModule := modulegen.ModuleInputs{
 		ModuleName:            "my-module",
 		Visibility:            moduleVisibilityPrivate,
@@ -416,10 +414,10 @@ file(READ "${CMAKE_CURRENT_SOURCE_DIR}/meta.json" _META_JSON)
 	})
 
 	t.Run("AddModelAction dry run", func(t *testing.T) {
-		// No t.Parallel(): calls testChdir which mutates process-wide CWD,
+		// No t.Parallel(): calls t.Chdir which mutates process-wide CWD,
 		// which races with parallel subtests that call go install / use relative paths.
 		dir := t.TempDir()
-		testChdir(t, dir)
+		t.Chdir(dir)
 
 		// Write .viam-gen-info so the action can read module context
 		data, err := json.Marshal(baseModule)
@@ -453,8 +451,8 @@ file(READ "${CMAKE_CURRENT_SOURCE_DIR}/meta.json" _META_JSON)
 }
 
 func TestGenerateModuleAction(t *testing.T) {
-	// No t.Parallel(): subtests use relative paths that depend on CWD (set by testChdir),
-	// so this test must run sequentially to avoid races with TestAddModel's testChdir calls.
+	// No t.Parallel(): subtests use relative paths that depend on CWD (set by t.Chdir),
+	// so this test must run sequentially to avoid races with TestAddModel's t.Chdir calls.
 	testModule := modulegen.ModuleInputs{
 		ModuleName:       "my-module",
 		Visibility:       moduleVisibilityPrivate,
@@ -485,7 +483,7 @@ func TestGenerateModuleAction(t *testing.T) {
 	globalArgs := *gArgs
 
 	testDir := t.TempDir()
-	testChdir(t, testDir)
+	t.Chdir(testDir)
 	modulePath := filepath.Join(testDir, testModule.ModuleName)
 
 	t.Run("test setting up module directory", func(t *testing.T) {
@@ -844,7 +842,7 @@ func TestCreatePythonVenv(t *testing.T) {
 
 func TestAddApp(t *testing.T) {
 	// NOTE: do not mark this top-level test t.Parallel(). Some subtests call
-	// testChdir, which mutates the process-wide CWD, and would race with the
+	// t.Chdir, which mutates the process-wide CWD, and would race with the
 	// CWD-mutating subtests in TestAddModel if both parents ran in parallel.
 	// See the note on TestAddModel for details.
 
@@ -1024,9 +1022,9 @@ func main() {
 	})
 
 	t.Run("AddAppAction dry run", func(t *testing.T) {
-		// No t.Parallel(): calls testChdir which mutates process-wide CWD.
+		// No t.Parallel(): calls t.Chdir which mutates process-wide CWD.
 		dir := t.TempDir()
-		testChdir(t, dir)
+		t.Chdir(dir)
 
 		data, err := json.Marshal(baseGenInfo)
 		test.That(t, err, test.ShouldBeNil)
@@ -1061,7 +1059,7 @@ func main() {
 		test.That(t, os.WriteFile(filepath.Join(dir, ".viam-gen-info"), data, 0o600), test.ShouldBeNil)
 
 		// Temporarily point CWD so readViamGenInfo(".")  resolves correctly.
-		// We can't use testChdir here (parallel), so call readViamGenInfo directly.
+		// We can't use t.Chdir here (parallel), so call readViamGenInfo directly.
 		info, err := readViamGenInfo(dir)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, info.Language, test.ShouldEqual, "python")
@@ -1075,9 +1073,9 @@ func main() {
 	})
 
 	t.Run("AddAppAction rejects duplicate app name", func(t *testing.T) {
-		// No t.Parallel(): calls testChdir which mutates process-wide CWD.
+		// No t.Parallel(): calls t.Chdir which mutates process-wide CWD.
 		dir := t.TempDir()
-		testChdir(t, dir)
+		t.Chdir(dir)
 
 		data, err := json.Marshal(baseGenInfo)
 		test.That(t, err, test.ShouldBeNil)

--- a/cli/xacro_test.go
+++ b/cli/xacro_test.go
@@ -402,11 +402,7 @@ func TestValidateOutputWritable(t *testing.T) {
 
 	t.Run("path in current directory", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		originalDir, _ := os.Getwd()
-		//nolint: usetesting
-		defer os.Chdir(originalDir)
-		//nolint: usetesting
-		os.Chdir(tmpDir)
+		t.Chdir(tmpDir)
 
 		err := validateOutputWritable("output.urdf")
 		test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
## Problem

`TestAddApp/AddAppAction_rejects_duplicate_app_name` intermittently failed with:

```
Expected: 'failed to read meta.json: cannot find meta.json: open meta.json: no such file or directory'
to contain substring 'already exists' (but it didn't)!
```

The subtest chdirs into a temp dir, writes `.viam-gen-info` and then `meta.json` **relative to the process CWD**, and finally calls `AddAppAction`, which resolves both paths relative to the CWD as well.

When the failure was reported, both `TestAddModel` and `TestAddApp` were top-level `t.Parallel()` tests whose "non-parallel" subtests each called `testChdir`. Marking a subtest non-parallel only serializes it against its siblings, so the two parents ran concurrently and their process-wide `os.Chdir` calls interleaved. If the CWD flipped to the other test's directory in the window after its `.viam-gen-info` was written but before its `meta.json` was, `AddAppAction` found `.viam-gen-info` but no manifest — exactly the observed error.

The parents were later made sequential, but the invariant ("a test that chdirs must not be parallel, and neither may any ancestor") was enforced only by comments, and `testChdir` called `os.Chdir` with the error dropped, so a failed chdir surfaced later as a confusing unrelated failure.

## Fix

Replace the `testChdir` helper with the stdlib `t.Chdir`:

- It panics if the test **or any ancestor** is parallel, so re-adding `t.Parallel()` to `TestAddModel`/`TestAddApp` (or to a chdir-ing subtest) fails loudly instead of flaking.
- It restores the previous CWD from a held directory handle during cleanup and fails the test if the chdir itself fails.

The remaining raw `os.Chdir` sites in the package (`client_test.go`, `xacro_test.go`) are converted as well; all of them are in sequential tests, and this removes their `//nolint: usetesting` suppressions so the `usetesting` linter keeps new direct `os.Chdir` calls out of the package. Comments were updated to describe the now machine-enforced invariant.

## Testing

No new test: the previously flaking assertions in `TestAddApp`/`TestAddModel`/`TestGenerateModuleAction` are the coverage. Behavior is unchanged for passing runs — the tests still chdir into a temp dir — but the failure mode is now impossible to reintroduce silently (panic from `t.Chdir` + lint enforcement).

Key: RSDK-14133

Co-authored by Claude agent for Jira.
