### PR TITLE
RSDK-14479 cli: flaky test fix TestTunnelE2ECLI short read plus listener closed

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -4189,9 +4189,15 @@ func tunnelTraffic(ctx context.Context, cmd *cli.Command, robotClient *client.Ro
 	//nolint: noctx
 	li, err := net.Listen("tcp", net.JoinHostPort("localhost", strconv.Itoa(local)))
 	if err != nil {
-		return fmt.Errorf("failed to create listener %w", err)
+		return fmt.Errorf("failed to create listener: %w", err)
 	}
 	infof(cmd.Root().Writer, "tunneling connections from local port %v to destination port %v on machine part...", local, dest)
+	return serveTunnel(ctx, cmd, robotClient, li, dest)
+}
+
+// serveTunnel tunnels every connection accepted on li to dest on the machine part. It
+// takes ownership of li and closes it once ctx is done.
+func serveTunnel(ctx context.Context, cmd *cli.Command, robotClient *client.RobotClient, li net.Listener, dest int) error {
 	go func() {
 		// Once the context has errored, close the listener so the loop below will exit from
 		// `Accept`ing new connections.
@@ -4225,7 +4231,7 @@ func tunnelTraffic(ctx context.Context, cmd *cli.Command, robotClient *client.Ro
 	wg.Wait()
 
 	// nilerr is needed because Go wants us to return the ctx.Err() from the loop above, but
-	// any ctx.Err() from that loop should just halt tunnelTraffic without error.
+	// any ctx.Err() from that loop should just halt serveTunnel without error.
 	return nil //nolint:nilerr
 }
 

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -33,7 +33,6 @@ import (
 	goutils "go.viam.com/utils"
 	"go.viam.com/utils/protoutils"
 	"go.viam.com/utils/rpc"
-	"go.viam.com/utils/testutils"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -2127,9 +2126,13 @@ func TestTunnelE2ECLI(t *testing.T) {
 		test.That(t, destListener.Close(), test.ShouldBeNil)
 	}()
 
-	sourcePort, err := goutils.TryReserveRandomPort()
+	// Bind the source listener here and hand it to serveTunnel (which closes it once ctx is
+	// done). Reserving a port with TryReserveRandomPort and letting the tunnel bind it later
+	// leaves a window for another server to claim the port; the test would then silently
+	// talk to that server instead of the tunnel (RSDK-14479).
+	sourcePort, sourceListener, err := goutils.ReserveRandomPort()
 	test.That(t, err, test.ShouldBeNil)
-	sourceListenerAddr := net.JoinHostPort("localhost", strconv.Itoa(sourcePort))
+	sourceListenerAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(sourcePort))
 
 	logger := logging.NewTestLogger(t)
 	ctx, ctxCancel := context.WithCancel(context.Background())
@@ -2192,18 +2195,14 @@ func TestTunnelE2ECLI(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		tunnelTraffic(ctx, cCtx, rc, sourcePort, destPort)
+		test.That(t, serveTunnel(ctx, cCtx, rc, sourceListener, destPort), test.ShouldBeNil)
 	}()
 
-	// Write `tunnelMsg` to CLI tunneler over TCP from this test process. Retry until
-	// tunnelTraffic's listener is bound.
-	var conn net.Conn
-	testutils.WaitForAssertion(t, func(tb testing.TB) {
-		var dialErr error
-		//nolint: noctx
-		conn, dialErr = net.Dial("tcp", sourceListenerAddr)
-		test.That(tb, dialErr, test.ShouldBeNil)
-	})
+	// Write `tunnelMsg` to CLI tunneler over TCP from this test process. The listener is
+	// already bound, so no dial retry is needed.
+	//nolint: noctx
+	conn, err := net.Dial("tcp", sourceListenerAddr)
+	test.That(t, err, test.ShouldBeNil)
 	defer func() {
 		test.That(t, conn.Close(), test.ShouldBeNil)
 	}()
@@ -2224,6 +2223,23 @@ func TestTunnelE2ECLI(t *testing.T) {
 	test.That(t, stopServer(), test.ShouldBeNil)
 
 	wg.Wait()
+}
+
+func TestTunnelTrafficLocalPortInUse(t *testing.T) {
+	t.Parallel()
+	// A local port that something else already owns must surface as an error instead of
+	// leaving the caller tunneling traffic into whatever is listening there (RSDK-14479).
+	port, li, err := goutils.ReserveRandomPort()
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, li.Close(), test.ShouldBeNil)
+	}()
+
+	//nolint:dogsled
+	cCtx, _, _, _ := setup(nil, nil, nil, nil, "token")
+	err = tunnelTraffic(context.Background(), cCtx, nil, port, port)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "failed to create listener")
 }
 
 // fakeTunnelLister is a tunnelLister test double. Before `reloadAfter` ListTunnels

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -2229,11 +2229,17 @@ func TestTunnelTrafficLocalPortInUse(t *testing.T) {
 	t.Parallel()
 	// A local port that something else already owns must surface as an error instead of
 	// leaving the caller tunneling traffic into whatever is listening there (RSDK-14479).
-	port, li, err := goutils.ReserveRandomPort()
+	//
+	// Listen on "localhost" explicitly so the address matches what tunnelTraffic binds
+	// (net.Listen("tcp", "localhost:PORT")). Using ReserveRandomPort (which binds to
+	// 0.0.0.0) does not conflict on dual-stack macOS/Windows where localhost resolves
+	// to the IPv6 loopback.
+	li, err := net.Listen("tcp", "localhost:0")
 	test.That(t, err, test.ShouldBeNil)
 	defer func() {
 		test.That(t, li.Close(), test.ShouldBeNil)
 	}()
+	port := li.Addr().(*net.TCPAddr).Port
 
 	//nolint:dogsled
 	cCtx, _, _, _ := setup(nil, nil, nil, nil, "token")


### PR DESCRIPTION
## What

Fixes flake #2 from RSDK-14479: `TestTunnelE2ECLI` intermittently read 15 bytes for the 13-byte `"Hello, World!"` message at `cli/client_test.go:2218`, while the destination listener goroutine had never accepted a connection and failed at teardown with `accept tcp [::]:33341: use of closed network connection`.

Flake #1 (`TestModularOptionalDependencyOnRemote`) is out of scope here — it is covered by #6414.

## Root cause

The test reserved its source port with `goutils.TryReserveRandomPort()`, which **closes** the listener before returning, and then let `tunnelTraffic` bind that port number later. Between those two points the port is free, so another server can claim it — most plausibly the in-process viam-server started immediately afterwards by `serverutils.TryStartServerAndConnect`, which reserves its own port the same racy way out of the same ephemeral pool.

When that happened, `tunnelTraffic`'s bind either failed (its error was discarded by the test goroutine) or landed on a different address of the dual-stack `localhost`, and the test dialed the impostor instead of the tunnel. That explains both symptoms exactly:

* The 15 bytes are a gRPC server's HTTP/2 `SETTINGS` frame — a 9-byte frame header plus one 6-byte `MAX_FRAME_SIZE` setting. Verified against a bare `grpc.NewServer()`:

  ```
  n=15 err=<nil> bytes=00 00 06 04 00 00 00 00 00 00 05 00 00 40 00
  ```

* Nothing was ever tunnelled, so `destListener.Accept()` stayed blocked until the deferred `Close` ran at teardown.

## Reproducer

Standing a `grpc.Server` on the released `sourcePort` before `tunnelTraffic` runs reproduces the CI failure verbatim on the unpatched test:

```
client_test.go:2226: Expected: '13'
    Actual:   '15'
    (Should be equal)
client_test.go:2152: Expected: nil
    Actual:   'accept tcp 0.0.0.0:39849: use of closed network connection'
```

With the change applied, that same racing bind is rejected with `bind: address already in use` — the port is held for the whole test, so the race is no longer reachable.

## Fix

* Split the accept/serve loop out of `tunnelTraffic` into `serveTunnel`, which takes a caller-provided `net.Listener`. `tunnelTraffic` keeps binding `localhost:<local port>` for the two production call sites, so CLI behaviour is unchanged.
* `TestTunnelE2ECLI` now binds the source listener up front with `goutils.ReserveRandomPort()` and hands it to `serveTunnel`. The port stays reserved for the whole test, and dialing it directly also removes the `localhost` dual-stack resolution ambiguity and the `WaitForAssertion` dial-retry loop (the suspected connection leak, since it only closed the last conn it opened). This mirrors how the sibling `TestTunnelE2E` in `web/server/entrypoint_test.go` is structured.
* The test no longer discards `serveTunnel`'s error, so a future bind/serve failure fails loudly rather than silently redirecting the test at another server.
* Added `TestTunnelTrafficLocalPortInUse` covering the bind-failure path the E2E test used to swallow, and added the missing colon to `tunnelTraffic`'s "failed to create listener" error.

## Testing

* `go test ./cli/ -run TestTunnel -count=40` — pass
* `go test ./cli/ -run TestTunnel -count=25 -race` — pass
* `golangci-lint run ./cli/...` and `golangci-lint fmt --diff ./cli/...` — clean
* `go build ./...` — clean

Key: RSDK-14479

Co-authored by Claude agent for Jira.