### PR TITLE
RSDK-14135 cli: flaky test fix package timeout from the module-generate spinner holding a non-TTY console

### DIFF
--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -92,6 +92,23 @@ type addAppArgs struct {
 	DryRun  bool
 }
 
+// runWithSpinner runs action, which reports progress through the setTitle callback it is
+// handed. The live spinner is a full TUI: when stdin is not a terminal it grabs the console
+// itself (/dev/tty, or CONIN$ on Windows) and starts a read nothing ever answers, which on
+// Windows wedges the process at shutdown. So it is only used on a terminal, and only when
+// debug logging is off, since its redraws garble logged output. Otherwise titles are printed
+// to w and action runs directly.
+func runWithSpinner(w io.Writer, debug bool, action func(setTitle func(string))) error {
+	if debug || !isInteractive() {
+		action(func(title string) { printf(w, "%s", title) })
+		return nil
+	}
+
+	s := spinner.New()
+	s.Action(func() { action(func(title string) { s.Title(title) }) })
+	return s.Run()
+}
+
 // GenerateModuleAction runs the module generate cli and generates necessary module templates based on user input.
 func GenerateModuleAction(ctx context.Context, cmd *cli.Command, args generateModuleArgs) error {
 	c, err := newViamClient(ctx, cmd)
@@ -520,7 +537,6 @@ func (c *viamClient) generateModule(ctx context.Context, cmd *cli.Command, args 
 	}
 	populateAdditionalInfo(newModule)
 
-	var s *spinner.Spinner
 	var fatalError error
 	var registryURL string
 	nonFatalError := false
@@ -530,14 +546,7 @@ func (c *viamClient) generateModule(ctx context.Context, cmd *cli.Command, args 
 	}
 	globalArgs := *gArgs
 
-	// Avoid the live spinner when emitting debug logs; its redraws conflict with logged output.
-	logTitle := func(msg string) { printf(cmd.Root().Writer, "%s", msg) }
-	if isInteractive() && !globalArgs.Debug {
-		s = spinner.New()
-		logTitle = func(msg string) { s.Title(msg) }
-	}
-
-	action := func() {
+	action := func(logTitle func(string)) {
 		logTitle("Getting latest release...")
 		version, err := getLatestSDKTag(ctx, cmd, newModule.Language, globalArgs)
 		if err != nil {
@@ -588,14 +597,8 @@ func (c *viamClient) generateModule(ctx context.Context, cmd *cli.Command, args 
 		}
 	}
 
-	if s != nil {
-		s.Action(action)
-		err := s.Run()
-		if err != nil {
-			return err
-		}
-	} else {
-		action()
+	if err := runWithSpinner(cmd.Root().Writer, globalArgs.Debug, action); err != nil {
+		return err
 	}
 
 	if fatalError != nil {
@@ -696,10 +699,9 @@ func (c *viamClient) generateModuleAndApp(ctx context.Context, cmd *cli.Command,
 	}
 	globalArgs := *gArgs
 
-	s := spinner.New()
 	var fatalError error
-	action := func() {
-		s.Title("Generating webapp component file...")
+	action := func(logTitle func(string)) {
+		logTitle("Generating webapp component file...")
 		if err := addGoWebappFile(moduleDir, data); err != nil {
 			fatalError = errors.Wrap(err, "failed to generate webapp.go")
 			return
@@ -709,7 +711,7 @@ func (c *viamClient) generateModuleAndApp(ctx context.Context, cmd *cli.Command,
 			return
 		}
 
-		s.Title("Setting up app directories and static files...")
+		logTitle("Setting up app directories and static files...")
 		if err := addAppStaticFiles(moduleDir); err != nil {
 			fatalError = errors.Wrap(err, "failed to set up app files")
 			return
@@ -719,20 +721,15 @@ func (c *viamClient) generateModuleAndApp(ctx context.Context, cmd *cli.Command,
 			return
 		}
 
-		s.Title("Updating meta.json...")
+		logTitle("Updating meta.json...")
 		if err := addAppToManifest(filepath.Join(moduleDir, defaultManifestFilename), app, data); err != nil {
 			fatalError = errors.Wrap(err, "failed to update meta.json")
 			return
 		}
 	}
 
-	if globalArgs.Debug {
-		action()
-	} else {
-		s.Action(action)
-		if err := s.Run(); err != nil {
-			return err
-		}
+	if err := runWithSpinner(cmd.Root().Writer, globalArgs.Debug, action); err != nil {
+		return err
 	}
 
 	if fatalError != nil {
@@ -2213,10 +2210,9 @@ func AddModelAction(ctx context.Context, cmd *cli.Command, args addModelArgs) er
 		}
 	}
 
-	s := spinner.New()
 	var fatalError error
-	action := func() {
-		s.Title(fmt.Sprintf("Generating %s model stubs...", newModel.Language))
+	action := func(logTitle func(string)) {
+		logTitle(fmt.Sprintf("Generating %s model stubs...", newModel.Language))
 		switch newModel.Language {
 		case golang:
 			if err := addGolangModelFile(".", *newModel); err != nil {
@@ -2239,26 +2235,21 @@ func AddModelAction(ctx context.Context, cmd *cli.Command, args addModelArgs) er
 			}
 		}
 
-		s.Title("Generating model documentation...")
+		logTitle("Generating model documentation...")
 		if err := renderModelDocToDir(".", *newModel); err != nil {
 			fatalError = errors.Wrap(err, "failed to generate model documentation")
 			return
 		}
 
-		s.Title("Updating meta.json...")
+		logTitle("Updating meta.json...")
 		if err := addModelToManifest(defaultManifestFilename, *newModel); err != nil {
 			fatalError = errors.Wrap(err, "failed to update meta.json")
 			return
 		}
 	}
 
-	if globalArgs.Debug {
-		action()
-	} else {
-		s.Action(action)
-		if err := s.Run(); err != nil {
-			return err
-		}
+	if err := runWithSpinner(cmd.Root().Writer, globalArgs.Debug, action); err != nil {
+		return err
 	}
 
 	if fatalError != nil {
@@ -2548,10 +2539,9 @@ func AddAppAction(_ context.Context, cmd *cli.Command, args addAppArgs) error {
 		ConfigName:      "WebappConfig",
 	}
 
-	s := spinner.New()
 	var fatalError error
-	action := func() {
-		s.Title("Generating webapp component file...")
+	action := func(logTitle func(string)) {
+		logTitle("Generating webapp component file...")
 		if err := addGoWebappFile(".", data); err != nil {
 			fatalError = errors.Wrap(err, "failed to generate webapp.go")
 			return
@@ -2561,7 +2551,7 @@ func AddAppAction(_ context.Context, cmd *cli.Command, args addAppArgs) error {
 			return
 		}
 
-		s.Title("Setting up app directories and static files...")
+		logTitle("Setting up app directories and static files...")
 		if err := addAppStaticFiles("."); err != nil {
 			fatalError = errors.Wrap(err, "failed to set up app files")
 			return
@@ -2571,20 +2561,15 @@ func AddAppAction(_ context.Context, cmd *cli.Command, args addAppArgs) error {
 			return
 		}
 
-		s.Title("Updating meta.json...")
+		logTitle("Updating meta.json...")
 		if err := addAppToManifest(defaultManifestFilename, app, data); err != nil {
 			fatalError = errors.Wrap(err, "failed to update meta.json")
 			return
 		}
 	}
 
-	if globalArgs.Debug {
-		action()
-	} else {
-		s.Action(action)
-		if err := s.Run(); err != nil {
-			return err
-		}
+	if err := runWithSpinner(cmd.Root().Writer, globalArgs.Debug, action); err != nil {
+		return err
 	}
 
 	if fatalError != nil {

--- a/cli/module_generate_test.go
+++ b/cli/module_generate_test.go
@@ -1204,3 +1204,27 @@ func TestTransientGoFetchFailure(t *testing.T) {
 		})
 	}
 }
+
+func TestRunWithSpinner(t *testing.T) {
+	t.Parallel()
+
+	// `go test` hands the test binary /dev/null for stdin, so isInteractive() is false
+	// throughout: both cases below take the print-the-titles path, which is what CI runs.
+	for _, debug := range []bool{false, true} {
+		t.Run(fmt.Sprintf("debug=%t", debug), func(t *testing.T) {
+			t.Parallel()
+			out := &testWriter{}
+			cmd := buildTestCmd(out, &testWriter{}, nil)
+
+			ran := false
+			err := runWithSpinner(cmd.Root().Writer, debug, func(logTitle func(string)) {
+				logTitle("Doing the thing...")
+				ran = true
+			})
+
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, ran, test.ShouldBeTrue)
+			test.That(t, strings.Join(out.messages, ""), test.ShouldContainSubstring, "Doing the thing...")
+		})
+	}
+}


### PR DESCRIPTION
## What

Fixes the `cli` package timeout reported as RSDK-14135. The ticket is titled `TestTunnelE2ECLI`, but that test passed in the failing run (`--- PASS: TestTunnelE2ECLI (10.10s)`) — the alarm fired while `TestAddApp/AddAppAction_rejects_duplicate_app_name` was still running:

```
panic: test timed out after 10m0s
	running tests:
		TestAddApp (7m56s)
		TestAddApp/AddAppAction_rejects_duplicate_app_name (7m56s)

goroutine 3333 [semacquire, 7 minutes]:
internal/poll.(*FD).Close(...)
os.(*File).Close(...)
github.com/charmbracelet/bubbletea.(*Program).Run(...)
github.com/charmbracelet/huh/spinner.(*Spinner).Run(...)
go.viam.com/rdk/cli.AddAppAction(...)

goroutine 3338 [syscall, 7 minutes]:
syscall.ReadConsole(...)
github.com/muesli/cancelreader.(*fallbackCancelReader).Read(...)
github.com/charmbracelet/bubbletea.(*Program).readLoop(...)
```

Not related to #6442 (RSDK-14479), which fixes a genuine `TestTunnelE2ECLI` assertion failure from a released source port. A single wedged goroutine kills the whole test binary, and the timeout panic names whichever test the alarm happens to list.

## Root cause

The `huh` spinner is a bubbletea program, and bubbletea takes over the terminal. With `defaultInput`, if stdin is not a terminal it opens the console itself — `/dev/tty`, or `CONIN$` on Windows — and starts a read loop on it. On Windows that reader is `cancelreader`'s fallback, whose `Cancel` is documented as unreliable for console input, so the `defer f.Close()` in `Program.Run` blocks in `internal/poll.(*FD).Close` waiting for a `ReadConsole` that only returns when somebody presses a key. On CI nobody does.

`go test` never wires a terminal to the test binary (cmd/go leaves `Stdin` nil, so `os/exec` supplies `/dev/null`), so every spinner reached from a test takes that path. `generateModule` already guarded its spinner with `isInteractive()`, which is why `TestGenerateModuleAction` was unaffected; `generateModuleAndApp`, `AddModelAction` and `AddAppAction` did not.

`AddAppAction`'s duplicate-name guard has since moved above the spinner, so that particular subtest no longer reaches it — but every other path through these three actions still can, from tests and from any non-interactive CLI use (piped input, cron, CI).

## Fix

One `runWithSpinner(w, debug, action)` helper, used by all four call sites. It starts the TUI only when stdin is a terminal and debug logging is off, and otherwise prints the progress titles to the command writer and runs the action inline. `action` now receives its title-setter as an argument instead of closing over a `*spinner.Spinner`, which is what lets both modes share one body — this is the shape `generateModule` had already grown by hand, so that function loses code rather than gaining any.

## Testing

* `TestRunWithSpinner` covers both branches available under `go test`: the action runs, its titles reach the writer, and no TUI is started. A regression here fails as a 10-minute package timeout on Windows, so the assertion that matters is that this test returns at all.
* `go test ./cli/ -run 'TestAddApp|TestAddModel|TestRunWithSpinner' -count=1` — pass.
* Full `go test ./cli/` — pass except `TestGenerateModuleAction/test_generate_go_stubs`, which needs to download `go.viam.com/rdk` from the module proxy and cannot reach it from this sandbox.
* `golangci-lint run ./cli/...` and `golangci-lint fmt --diff ./cli/...` — clean.

No end-to-end `AddAppAction` success-path test: it routes through `runGoImports`, which shells out to `go install golang.org/x/tools/cmd/goimports@latest` when goimports is absent, and a network install is the wrong thing to add to a flaky-test fix.

Key: RSDK-14135

Co-authored by Claude agent for Jira.
