### PR TITLE
Set up test and license check workflows for future mise integration

### DIFF
--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -12,6 +12,9 @@ jobs:
       image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
       options: --platform linux/amd64
     timeout-minutes: 30
+    env:
+      MISE_GO_SET_GOROOT: false
+      MISE_AUTO_INSTALL: false
 
     steps:
     - name: Check out code
@@ -25,6 +28,11 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pullrequest-trusted.yml).
         allow-unsafe-pr-checkout: true
+
+    # Nothing this action installs is currently used, but it has to be merged
+    # to main for CI on the next PR in the stack to pass.
+    - name: Install toolchain
+      uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518
 
     - name: Run license finder
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -324,6 +324,8 @@ jobs:
     container:
       image: ${{ matrix.image }}
       options: --platform ${{ matrix.platform }}
+    env:
+      MISE_GO_SET_GOROOT: false
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
This PR installs mise and sets some related environment variables in the lint and license_finder CI workflows. As of now this doesn't change anything except maybe waste a bit of time during the license_finder run, but merging it to `main` will allow future PRs in this stack that expect mise to be installed to pass CI