### PR TITLE
Exclude unchanged joint targets from primary motion chains

### DIFF
--- a/motionplan/armplanning/plan_manager.go
+++ b/motionplan/armplanning/plan_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"slices"
 	"time"
 
 	"go.viam.com/utils/trace"
@@ -137,6 +138,18 @@ func (pm *planManager) planToDirectJoints(
 	goalPoses, err := goal.ComputePoses(ctx, pm.pc.fs)
 	if err != nil {
 		return nil, err
+	}
+	// A full joint configuration also includes frames already at their target.
+	// Only changed joints should seed the primary motion chains; the planner can
+	// still move other frames if needed for collision avoidance.
+	movingGoals := referenceframe.FrameSystemPoses{}
+	for name, pose := range goalPoses {
+		if !slices.Equal(fullConfig.Get(name), start.Get(name)) {
+			movingGoals[name] = pose
+		}
+	}
+	if len(movingGoals) > 0 {
+		goalPoses = movingGoals
 	}
 
 	psc, err := NewPlanSegmentContext(ctx, pm.pc, start, goalPoses)

--- a/motionplan/armplanning/plan_manager_test.go
+++ b/motionplan/armplanning/plan_manager_test.go
@@ -1,0 +1,71 @@
+package armplanning
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/golang/geo/r3"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/referenceframe"
+	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/rdk/utils"
+)
+
+func TestJointGoalDetourKeepsUnchangedArmStill(t *testing.T) {
+	for _, moveBoth := range []bool{false, true} {
+		name := "one arm changes"
+		if moveBoth {
+			name = "both arms change"
+		}
+		t.Run(name, func(t *testing.T) { testJointGoalDetour(t, moveBoth) })
+	}
+}
+
+func testJointGoalDetour(t *testing.T, moveBoth bool) {
+	t.Helper()
+	fs, startJoints, goalJoints, req := nudgeBlockedScene(t)
+	idle, err := referenceframe.ParseModelJSONFile(utils.ResolveFile("components/arm/kinematics/xarm6.json"), "idle")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mount, err := referenceframe.NewStaticFrame("idle-mount", spatialmath.NewPoseFromPoint(r3.Vector{X: 2000}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = fs.AddFrame(mount, fs.World()); err != nil {
+		t.Fatal(err)
+	}
+	if err = fs.AddFrame(idle, mount); err != nil {
+		t.Fatal(err)
+	}
+	req.StartState = NewPlanState(nil, referenceframe.FrameSystemInputs{"arm": startJoints, "idle": startJoints})
+	idleGoal := startJoints
+	if moveBoth {
+		idleGoal = goalJoints
+	}
+	req.Goals = []*PlanState{NewPlanState(nil, referenceframe.FrameSystemInputs{"arm": goalJoints, "idle": idleGoal})}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	plan, _, err := PlanMotion(ctx, logging.NewTestLogger(t), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	trajectory := plan.Trajectory()
+	if len(trajectory) < 3 {
+		t.Fatalf("expected a detour around the post, got %d waypoints", len(trajectory))
+	}
+	for i, step := range trajectory {
+		if !moveBoth && !slices.Equal(step["idle"], startJoints) {
+			t.Fatalf("waypoint %d moves the unchanged arm: %v, want %v", i, step["idle"], startJoints)
+		}
+	}
+	if !slices.Equal(trajectory[len(trajectory)-1]["arm"], goalJoints) {
+		t.Fatal("acting arm did not reach its joint goal")
+	}
+	if !slices.Equal(trajectory[len(trajectory)-1]["idle"], idleGoal) {
+		t.Fatal("second arm did not reach its joint goal")
+	}
+}


### PR DESCRIPTION
A full joint-goal configuration can make an arm that is already at its target participate in the planner's primary detour search. A captured right-arm home request included the left arm's unchanged joints, but the resulting trajectory moved the left arm by 1.262286° before returning it to the same position.

Select primary motion chains from frames whose joint targets differ from the segment's starting joints. Keep the full target configuration for planning and execution, and retain the existing path for all-unchanged goals. The production change is 13 lines.

This does not lock other arms or serialize motion. Frames with unchanged targets remain available to the existing collision-avoidance fallback, and requests with changed targets for both arms still plan both. No API, configuration, collision-checking, or execution changes are introduced.

Validation:
- The regression reproduces unnecessary movement of an arm parked away from the obstacle on the original source, and passes with this change.
- A companion case verifies that both arms still reach their targets when both are requested to change.
- Offline replay of the captured home request produces zero left-arm excursion across eight waypoints, preserving every requested joint endpoint. The recorded trajectory had nine waypoints and 1.262286° left-arm excursion.
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run ./motionplan/armplanning` passes. `make lint-go` could not start because mise is not installed; this invokes the repo-pinned linter directly for the affected package.
- `go test -race -tags=no_skip ./motionplan/armplanning -skip '^TestDiagSceneKeyChurn$' -timeout 5m` passes (164.888s). The full `make test-go TEST_TARGET=./motionplan/armplanning` run was stopped after its 98-plan corpus diagnostic spent an extended period building collision distance fields; the stack trace was in SDF construction, outside the changed joint-goal code. That single diagnostic was excluded from the completed run.

No hardware deployment or physical validation has been performed. Captured robot scene data is not included in this PR. Manual security review found no new trust boundary; collision checks and the fallback planner remain in place. A dedicated security-review workflow was unavailable.
