### PR TITLE
RSDK-14438: Avoid using `apt-cache` to sense Jetpack version

### DIFF
--- a/config/platform.go
+++ b/config/platform.go
@@ -15,6 +15,9 @@ import (
 
 var (
 	cudaRegex = regexp.MustCompile(`Cuda compilation tools, release (\d+)\.`)
+	// l4tCoreVersionRegex captures the L4T major from the nvidia-l4t-core package version,
+	// e.g. "36.4.4-20250616085344" -> "36".
+	l4tCoreVersionRegex = regexp.MustCompile(`^(\d+)\.`)
 	// l4tReleaseRegex captures the L4T (Jetson Linux) major release from the first line of
 	// /etc/nv_tegra_release, e.g. "# R36 (release), REVISION: 4.4, ..." -> "36".
 	l4tReleaseRegex    = regexp.MustCompile(`# R(\d+) `)
@@ -48,34 +51,66 @@ func readGPUTags(ctx context.Context, logger logging.Logger, tags []string) []st
 			logger.Error("error parsing `nvcc --version` output. Cuda-specific modules may not load")
 		}
 	}
-	tags = readJetpackTag(logger, tags)
+	tags = readJetpackTag(ctx, logger, tags)
 	return tags
 }
 
 // readJetpackTag adds a `jetpack:<major>` tag derived from the installed L4T (Jetson Linux)
-// release, if this is a Jetson.
-func readJetpackTag(logger logging.Logger, tags []string) []string {
-	body, err := os.ReadFile("/etc/nv_tegra_release")
-	if err != nil {
-		if !os.IsNotExist(err) {
-			logger.Errorw("can't read /etc/nv_tegra_release, jetpack modules may not load", "err", err)
-		}
-		// not a Jetson (file absent), or unreadable: no jetpack tag.
+// release, if this is a Jetson. NVIDIA recommends reading the version from the installed
+// nvidia-l4t-core package (this is what the jetson-inference install scripts do), so we try that
+// first and fall back to /etc/nv_tegra_release, which the L4T BSP writes, when the package query
+// is unavailable.
+func readJetpackTag(ctx context.Context, logger logging.Logger, tags []string) []string {
+	l4tMajor := l4tMajorFromCorePackage(ctx)
+	if l4tMajor == "" {
+		l4tMajor = l4tMajorFromReleaseFile(logger)
+	}
+	if l4tMajor == "" {
+		// not a Jetson, or couldn't determine the release: no jetpack tag.
 		return tags
 	}
-	match := l4tReleaseRegex.FindSubmatch(body)
-	if match == nil {
-		logger.Warnw("could not parse L4T release from /etc/nv_tegra_release; jetpack tag not set",
-			"contents", string(body))
-		return tags
-	}
-	l4tMajor := string(match[1])
 	jetpack, ok := l4tToJetpack[l4tMajor]
 	if !ok {
 		logger.Warnw("unrecognized L4T major release; jetpack tag not set", "l4t_major", l4tMajor)
 		return tags
 	}
 	return append(tags, "jetpack:"+jetpack)
+}
+
+// l4tMajorFromCorePackage returns the installed L4T major version from the nvidia-l4t-core dpkg
+// package (e.g. "36" from "36.4.4-20250616085344"), or "" if it can't be determined.
+func l4tMajorFromCorePackage(ctx context.Context) string {
+	if _, err := exec.LookPath("dpkg-query"); err != nil {
+		return ""
+	}
+	out, err := exec.CommandContext(ctx, "dpkg-query", "--showformat=${Version}", "--show", "nvidia-l4t-core").Output()
+	if err != nil {
+		// a non-zero exit usually means the package isn't installed (i.e. not a Jetson).
+		return ""
+	}
+	if match := l4tCoreVersionRegex.FindSubmatch(out); match != nil {
+		return string(match[1])
+	}
+	return ""
+}
+
+// l4tMajorFromReleaseFile returns the L4T major version from /etc/nv_tegra_release (e.g. "36"
+// from "# R36 (release), ..."), or "" if the file is missing or unparseable.
+func l4tMajorFromReleaseFile(logger logging.Logger) string {
+	body, err := os.ReadFile("/etc/nv_tegra_release")
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logger.Errorw("can't read /etc/nv_tegra_release, jetpack modules may not load", "err", err)
+		}
+		// not a Jetson (file absent), or unreadable.
+		return ""
+	}
+	if match := l4tReleaseRegex.FindSubmatch(body); match != nil {
+		return string(match[1])
+	}
+	logger.Warnw("could not parse L4T release from /etc/nv_tegra_release; jetpack tag not set",
+		"contents", string(body))
+	return ""
 }
 
 type piModel struct {

--- a/config/platform.go
+++ b/config/platform.go
@@ -14,12 +14,26 @@ import (
 )
 
 var (
-	cudaRegex            = regexp.MustCompile(`Cuda compilation tools, release (\d+)\.`)
-	aptCacheVersionRegex = regexp.MustCompile(`\nVersion: (\d+)\D`)
-	piModelRegex         = regexp.MustCompile(`Raspberry Pi\s?(Compute Module)?\s?(\d\w*)?\s?(\w+)?\s?(Model (.+))? Rev`)
-	darwinVersionRegex   = regexp.MustCompile(`(\d+)\.`)
-	savedPlatformTags    []string
+	cudaRegex = regexp.MustCompile(`Cuda compilation tools, release (\d+)\.`)
+	// l4tReleaseRegex captures the L4T (Jetson Linux) major release from the first line of
+	// /etc/nv_tegra_release, e.g. "# R36 (release), REVISION: 4.4, ..." -> "36".
+	l4tReleaseRegex    = regexp.MustCompile(`# R(\d+) `)
+	piModelRegex       = regexp.MustCompile(`Raspberry Pi\s?(Compute Module)?\s?(\d\w*)?\s?(\w+)?\s?(Model (.+))? Rev`)
+	darwinVersionRegex = regexp.MustCompile(`(\d+)\.`)
+	savedPlatformTags  []string
 )
+
+// l4tToJetpack maps an L4T (Jetson Linux) major release to its JetPack major version.
+// R32->JetPack 4, R34/R35->JetPack 5, R36->JetPack 6, R38/R39->JetPack 7 (see
+// https://developer.nvidia.com/embedded/jetson-linux-archive).
+var l4tToJetpack = map[string]string{
+	"32": "4",
+	"34": "5",
+	"35": "5",
+	"36": "6",
+	"38": "7",
+	"39": "7",
+}
 
 // helper to read platform tags for GPU-related system libraries.
 func readGPUTags(ctx context.Context, logger logging.Logger, tags []string) []string {
@@ -34,16 +48,34 @@ func readGPUTags(ctx context.Context, logger logging.Logger, tags []string) []st
 			logger.Error("error parsing `nvcc --version` output. Cuda-specific modules may not load")
 		}
 	}
-	if _, err := exec.LookPath("apt-cache"); err == nil {
-		out, err := exec.CommandContext(ctx, "apt-cache", "show", "nvidia-jetpack").Output()
-		// note: the error case here will usually mean 'package missing', we don't analyze it.
-		if err == nil {
-			if match := aptCacheVersionRegex.FindSubmatch(out); match != nil {
-				tags = append(tags, "jetpack:"+string(match[1]))
-			}
-		}
-	}
+	tags = readJetpackTag(logger, tags)
 	return tags
+}
+
+// readJetpackTag adds a `jetpack:<major>` tag derived from the installed L4T (Jetson Linux)
+// release, if this is a Jetson.
+func readJetpackTag(logger logging.Logger, tags []string) []string {
+	body, err := os.ReadFile("/etc/nv_tegra_release")
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logger.Errorw("can't read /etc/nv_tegra_release, jetpack modules may not load", "err", err)
+		}
+		// not a Jetson (file absent), or unreadable: no jetpack tag.
+		return tags
+	}
+	match := l4tReleaseRegex.FindSubmatch(body)
+	if match == nil {
+		logger.Warnw("could not parse L4T release from /etc/nv_tegra_release; jetpack tag not set",
+			"contents", string(body))
+		return tags
+	}
+	l4tMajor := string(match[1])
+	jetpack, ok := l4tToJetpack[l4tMajor]
+	if !ok {
+		logger.Warnw("unrecognized L4T major release; jetpack tag not set", "l4t_major", l4tMajor)
+		return tags
+	}
+	return append(tags, "jetpack:"+jetpack)
 }
 
 type piModel struct {

--- a/config/platform_test.go
+++ b/config/platform_test.go
@@ -38,33 +38,42 @@ Build cuda_11.5.r11.5/compiler.30672275_0
 		test.That(t, string(match[1]), test.ShouldResemble, "11")
 	})
 
-	t.Run("apt-cache", func(t *testing.T) {
-		jp5 := `Package: nvidia-jetpack
-Version: 5.1.1-b56
-Architecture: arm64
-Maintainer: NVIDIA Corporation
-Installed-Size: 194
-Depends: nvidia-jetpack-runtime (= 5.1.1-b56), nvidia-jetpack-dev (= 5.1.1-b56)
-Homepage: http://developer.nvidia.com/jetson
-Priority: standard
-Section: metapackages`
-		match := aptCacheVersionRegex.FindSubmatch([]byte(jp5))
+	t.Run("l4t-release", func(t *testing.T) {
+		// The L4T major is parsed from the first line of /etc/nv_tegra_release and mapped to
+		// the JetPack major. This sample is verbatim from a JetPack 6 Jetson Orin Nano.
+		jp6 := "# R36 (release), REVISION: 4.4, GCID: 41062509, BOARD: generic, EABI: aarch64, DATE: Mon Jun 16 16:07:13 UTC 2025\n" +
+			"# KERNEL_VARIANT: oot\nTARGET_USERSPACE_LIB_DIR=nvidia\n"
+		match := l4tReleaseRegex.FindSubmatch([]byte(jp6))
 		test.That(t, match, test.ShouldNotBeNil)
-		test.That(t, string(match[1]), test.ShouldResemble, "5")
+		test.That(t, l4tToJetpack[string(match[1])], test.ShouldEqual, "6")
 
-		jp6 := `Package: nvidia-jetpack
-Source: nvidia-jetpack (6.1)
-Version: 6.1+b123
-Architecture: arm64
-Maintainer: NVIDIA Corporation
-Installed-Size: 194
-Depends: nvidia-jetpack-runtime (= 6.1+b123), nvidia-jetpack-dev (= 6.1+b123)
-Homepage: http://developer.nvidia.com/jetson
-Priority: standard
-Section: metapackages`
-		match = aptCacheVersionRegex.FindSubmatch([]byte(jp6))
+		// JetPack 5 (L4T R35) and JetPack 4 (L4T R32).
+		match = l4tReleaseRegex.FindSubmatch([]byte("# R35 (release), REVISION: 4.1, GCID: 12345, BOARD: generic\n"))
 		test.That(t, match, test.ShouldNotBeNil)
-		test.That(t, string(match[1]), test.ShouldResemble, "6")
+		test.That(t, l4tToJetpack[string(match[1])], test.ShouldEqual, "5")
+
+		match = l4tReleaseRegex.FindSubmatch([]byte("# R32 (release), REVISION: 7.1\n"))
+		test.That(t, match, test.ShouldNotBeNil)
+		test.That(t, l4tToJetpack[string(match[1])], test.ShouldEqual, "4")
+
+		// JetPack 7 spans two L4T majors: R38 (JetPack 7.0/7.1) and R39 (JetPack 7.2).
+		match = l4tReleaseRegex.FindSubmatch([]byte("# R38 (release), REVISION: 2.0, GCID: 67890, BOARD: generic\n"))
+		test.That(t, match, test.ShouldNotBeNil)
+		test.That(t, l4tToJetpack[string(match[1])], test.ShouldEqual, "7")
+
+		match = l4tReleaseRegex.FindSubmatch([]byte("# R39 (release), REVISION: 2.1, GCID: 13579, BOARD: generic\n"))
+		test.That(t, match, test.ShouldNotBeNil)
+		test.That(t, l4tToJetpack[string(match[1])], test.ShouldEqual, "7")
+
+		// A future/unknown L4T major parses but has no mapping (so no tag is emitted).
+		match = l4tReleaseRegex.FindSubmatch([]byte("# R40 (release), REVISION: 0.0\n"))
+		test.That(t, match, test.ShouldNotBeNil)
+		_, ok := l4tToJetpack[string(match[1])]
+		test.That(t, ok, test.ShouldBeFalse)
+
+		// Non-Jetson / unparseable contents must not match.
+		test.That(t, l4tReleaseRegex.FindSubmatch([]byte("")), test.ShouldBeNil)
+		test.That(t, l4tReleaseRegex.FindSubmatch([]byte("not an nv_tegra_release file\n")), test.ShouldBeNil)
 	})
 
 	t.Run("pi", func(t *testing.T) {

--- a/config/platform_test.go
+++ b/config/platform_test.go
@@ -76,6 +76,27 @@ Build cuda_11.5.r11.5/compiler.30672275_0
 		test.That(t, l4tReleaseRegex.FindSubmatch([]byte("not an nv_tegra_release file\n")), test.ShouldBeNil)
 	})
 
+	t.Run("l4t-core-package", func(t *testing.T) {
+		// The primary source: `dpkg-query --showformat='${Version}' --show nvidia-l4t-core`. The
+		// L4T major is the leading component of the package version and maps to the JetPack major.
+		// This sample is verbatim from a JetPack 6 Jetson Orin Nano.
+		match := l4tCoreVersionRegex.FindSubmatch([]byte("36.4.3-20250107174145"))
+		test.That(t, match, test.ShouldNotBeNil)
+		test.That(t, l4tToJetpack[string(match[1])], test.ShouldEqual, "6")
+
+		match = l4tCoreVersionRegex.FindSubmatch([]byte("35.4.1-20230801124926"))
+		test.That(t, match, test.ShouldNotBeNil)
+		test.That(t, l4tToJetpack[string(match[1])], test.ShouldEqual, "5")
+
+		match = l4tCoreVersionRegex.FindSubmatch([]byte("32.7.1-20220219090432"))
+		test.That(t, match, test.ShouldNotBeNil)
+		test.That(t, l4tToJetpack[string(match[1])], test.ShouldEqual, "4")
+
+		// Empty output (package not installed / not a Jetson) must not match.
+		test.That(t, l4tCoreVersionRegex.FindSubmatch([]byte("")), test.ShouldBeNil)
+		test.That(t, l4tCoreVersionRegex.FindSubmatch([]byte("dpkg-query: no packages found matching nvidia-l4t-core")), test.ShouldBeNil)
+	})
+
 	t.Run("pi", func(t *testing.T) {
 		type Pair struct {
 			a string


### PR DESCRIPTION
RSDK-14438

## What

Uses `dpkg-query --show nvidia-l4t-core` and `/etc/nv_tegra_release` to report the `jetpack` platform tag instead of `apt-cache show nvidia-jetpack`.

## Why

`apt-cache show nvidia-jetpack` can show the `nvidia-jetpack` versions that `apt` is aware of, not necessarily the one that's installed. `nvidia-jetpack` also does not _need_ to be installed for its listed L4T libraries to be. The libraries are in the image that's flashed onto Jetson devices. The correct value to check is the Jetson release number under `dpkg-query --show nvidia-l4t-core` or `/etc/nv_tegra_release`.

We were reporting `jetpack:6` platform tags for any machine that was aware of `nvidia-jetpack` v6 existing in the apt cache. So, module deployment for https://github.com/viam-modules/viam-mlmodelservice-triton happened to work on actual Jetpack 6 devices but notably failed when the apt cache got cleared (disk got too full).

## Testing

Added some unit tests. Also verified that this correctly finds Jetpack 6 as the running version on an actual user's Jetson Orin Nano device.

cc @alejandromijares 