### PR TITLE
Remove sudo from license-check make command

### DIFF
--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -36,4 +36,4 @@ jobs:
 
     - name: Run license finder
       run: |
-        sudo -Hu testbot bash -lc 'make license-check'
+        make license-check


### PR DESCRIPTION
I missed that this was necessary in https://github.com/viamrobotics/rdk/pull/6445. This will fix the broken workflow in https://github.com/viamrobotics/rdk/pull/6426, which is failing because running the make command behind `sudo` is removing mise managed binaries from the path. I manually invoked the workflow on this branch to confirm it won't break while waiting for the next PR to be merged [here](https://github.com/viamrobotics/rdk/actions/runs/34482627831). Theoretically I could rebuild the PR stack to have this as the new base but don't see any reason to.