### PR TITLE
Bump golangci-lint to 2.13.2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -150,16 +150,6 @@ linters:
       - linters:
           - lll
         path: /doc.go$
-      # RSDK-14539: reads GetRobotPartLogsRequest.ErrorsOnly.
-      - linters:
-          - staticcheck
-        text: SA1019
-        path: ^cli/client\.go$
-      # RSDK-14540: read CloudConfig.LocationSecret and ReadyRequest.ParentAddress.
-      - linters:
-          - staticcheck
-        text: SA1019
-        path: ^(config/proto_conversions|module/modmanager/module)\.go$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -71,6 +71,15 @@ linters:
       excludes:
         - G104
         - G115
+        # Rules introduced after gosec 2.25, not yet triaged.
+        - G117
+        - G118
+        - G122
+        - G124
+        - G703
+        - G704
+        - G705
+        - G710
     govet:
       disable:
         - fieldalignment
@@ -142,6 +151,7 @@ linters:
           - lll
         path: /doc.go$
 issues:
+  max-issues-per-linter: 0
   max-same-issues: 0
 formatters:
   enable:
@@ -154,8 +164,7 @@ formatters:
         - default
         - prefix(go.viam.com/rdk)
     gofumpt:
-      extra:
-        group-params: true
+      extra-rules: true
   exclusions:
     generated: lax
     paths:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -150,6 +150,16 @@ linters:
       - linters:
           - lll
         path: /doc.go$
+      # RSDK-14539: reads GetRobotPartLogsRequest.ErrorsOnly.
+      - linters:
+          - staticcheck
+        text: SA1019
+        path: ^cli/client\.go$
+      # RSDK-14540: read CloudConfig.LocationSecret and ReadyRequest.ParentAddress.
+      - linters:
+          - staticcheck
+        text: SA1019
+        path: ^(config/proto_conversions|module/modmanager/module)\.go$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,7 +27,7 @@ linters:
     - gocritic
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan
@@ -76,6 +76,7 @@ linters:
         - fieldalignment
         - shadow
         - composites
+        - inline
       enable-all: true
     lll:
       line-length: 140
@@ -153,7 +154,8 @@ formatters:
         - default
         - prefix(go.viam.com/rdk)
     gofumpt:
-      extra-rules: true
+      extra:
+        group-params: true
   exclusions:
     generated: lax
     paths:

--- a/app/app_client.go
+++ b/app/app_client.go
@@ -2782,7 +2782,8 @@ func (c *AppClient) CreateKey(
 	var authorizations []*pb.Authorization
 	for _, keyAuthorization := range keyAuthorizations {
 		authorization := createAuthorization(
-			orgID, "", "api-key", keyAuthorization.role, keyAuthorization.resourceType, keyAuthorization.resourceID)
+			orgID, "", "api-key", keyAuthorization.role, keyAuthorization.resourceType, keyAuthorization.resourceID,
+		)
 		authorizations = append(authorizations, authorization)
 	}
 

--- a/app/data_client_test.go
+++ b/app/data_client_test.go
@@ -533,7 +533,8 @@ func TestDataClient(t *testing.T) {
 		resp, err := client.BinaryDataByFilter(
 			context.Background(), includeBinary, &DataByFilterOptions{
 				&filter, limit, last, dataRequest.SortOrder, countOnly, includeInternalData,
-			})
+			},
+		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp.BinaryData[0], test.ShouldResemble, &binaryData)
 		test.That(t, resp.Count, test.ShouldEqual, count)
@@ -787,7 +788,8 @@ func TestDataClient(t *testing.T) {
 		}
 		resp, err := client.AddBoundingBoxToImageByID(
 			context.Background(), binaryDataID, bboxLabel, annotations.Bboxes[0].XMinNormalized,
-			annotations.Bboxes[0].YMinNormalized, annotations.Bboxes[0].XMaxNormalized, annotations.Bboxes[0].YMaxNormalized)
+			annotations.Bboxes[0].YMinNormalized, annotations.Bboxes[0].XMaxNormalized, annotations.Bboxes[0].YMaxNormalized,
+		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, resp, test.ShouldResemble, annotations.Bboxes[0].ID)
 	})

--- a/app/data_client_test.go
+++ b/app/data_client_test.go
@@ -249,6 +249,7 @@ func captureMetadataToProto(metadata CaptureMetadata) *pb.CaptureMetadata {
 
 func binaryMetadataToProto(binaryMetadata *BinaryMetadata) *pb.BinaryMetadata {
 	return &pb.BinaryMetadata{
+		//nolint:staticcheck
 		Id:              binaryMetadata.ID,
 		BinaryDataId:    binaryMetadata.BinaryDataID,
 		CaptureMetadata: captureMetadataToProto(binaryMetadata.CaptureMetadata),

--- a/cli/app.go
+++ b/cli/app.go
@@ -3151,7 +3151,8 @@ Example changing multiple fields:
     --config '{"schedule":"0 0 * * *","method":"DoCommand","command":{"action":"reset"}}'`,
 							UsageText: createUsageText(
 								"machines part update-job",
-								[]string{generalFlagPart, generalFlagName, generalFlagConfig}, true, false),
+								[]string{generalFlagPart, generalFlagName, generalFlagConfig}, true, false,
+							),
 							Flags: append(commonPartFlags, []cli.Flag{
 								&cli.StringFlag{
 									Name:     generalFlagName,
@@ -3248,7 +3249,8 @@ Copy multiple files from the machine to a local destination with recursion and k
 								"machines part cp",
 								[]string{generalFlagPart},
 								true, false,
-								"<source i.e. [machine:]files>... <target i.e. [machine:]files>"),
+								"<source i.e. [machine:]files>... <target i.e. [machine:]files>",
+							),
 							Flags: append(commonPartFlags, []cli.Flag{
 								&cli.BoolFlag{
 									Name:    cpFlagRecursive,
@@ -3282,7 +3284,8 @@ Note: There is no progress meter while copying is in progress.
 								"machines part get-ftdc",
 								[]string{generalFlagPart},
 								true, false,
-								"[target]"),
+								"[target]",
+							),
 							Flags: lo.Flatten([][]cli.Flag{
 								commonPartFlags,
 								commonPathFlags,

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -867,19 +867,27 @@ func (a *authFlow) loadOIDiscoveryEndpoint(ctx context.Context) (*openIDDiscover
 	return &resp, nil
 }
 
-func openbrowser(url string) error {
-	var err error
+func openbrowser(rawURL string) error {
+	// The OS openers below hand any scheme to its registered handler, so a non-web
+	// scheme here would launch an arbitrary local application.
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return errors.Wrap(err, "cannot open malformed URL")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return errors.Errorf("refusing to open URL with scheme %q", parsed.Scheme)
+	}
 
 	switch runtime.GOOS {
 	case "linux":
-		//nolint: noctx
-		err = exec.Command("xdg-open", url).Start()
+		//nolint: gosec,noctx
+		err = exec.Command("xdg-open", rawURL).Start()
 	case osWindows:
-		//nolint: noctx
-		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+		//nolint: gosec,noctx
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", rawURL).Start()
 	case "darwin":
-		//nolint: noctx
-		err = exec.Command("open", url).Start()
+		//nolint: gosec,noctx
+		err = exec.Command("open", rawURL).Start()
 	default:
 		err = errors.New("unsupported platform")
 	}

--- a/cli/client.go
+++ b/cli/client.go
@@ -5791,7 +5791,7 @@ func (c *viamClient) robotPartLogs(ctx context.Context, orgStr, locStr, robotStr
 	for {
 		resp, err := c.client.GetRobotPartLogs(ctx, &apppb.GetRobotPartLogsRequest{
 			Id:         part.Id,
-			ErrorsOnly: errorsOnly,
+			ErrorsOnly: errorsOnly, //nolint:staticcheck // RSDK-14539
 			PageToken:  &pageToken,
 			Start:      start,
 			End:        end,

--- a/cli/client.go
+++ b/cli/client.go
@@ -2380,7 +2380,8 @@ func validateTriggerConfig(w io.Writer, config, triggerConfig map[string]any) er
 	if !ok || !validType {
 		return fmt.Errorf(
 			"trigger event type must be one of: part_online, part_offline, "+
-				"part_data_ingested, conditional_data_ingested, conditional_logs_ingested; got %q", eventTypeRaw)
+				"part_data_ingested, conditional_data_ingested, conditional_logs_ingested; got %q", eventTypeRaw,
+		)
 	}
 
 	// warn about unknown event keys
@@ -4007,7 +4008,8 @@ func MachinesPartRunAction(ctx context.Context, cmd *cli.Command, args machinesP
 	if args.Component != "" {
 		// Connect to the robot to get resource information
 		dialCtx, fqdn, rpcOpts, err := viamClient.prepareDial(
-			ctx, args.Organization, args.Location, args.Machine, args.Part, globalArgs.Debug)
+			ctx, args.Organization, args.Location, args.Machine, args.Part, globalArgs.Debug,
+		)
 		if err != nil {
 			return err
 		}
@@ -5431,7 +5433,8 @@ func newViamClientInner(ctx context.Context, cmd *cli.Command, disableBrowserOpe
 		warningf(
 			cmd.Root().ErrWriter,
 			"you are trying to log into localhost with a TLS connection."+
-				" This will likely result in a hang; please try logging in to http localhost instead")
+				" This will likely result in a hang; please try logging in to http localhost instead",
+		)
 	}
 
 	if err = conf.checkUpdate(cmd); err != nil {
@@ -5948,7 +5951,8 @@ func (c *viamClient) runRobotPartCommand(
 			grpcurl.Format("json"),
 			descSource,
 			strings.NewReader(data),
-			options)
+			options,
+		)
 		if err != nil {
 			return false, err
 		}

--- a/cli/client.go
+++ b/cli/client.go
@@ -5185,6 +5185,7 @@ func installedDebVersion() (*semver.Version, error) {
 
 // dpkgQueryOwnerFunc runs `dpkg -S <path>`; overridable in tests.
 var dpkgQueryOwnerFunc = func(path string) (string, error) {
+	//nolint:gosec
 	out, err := exec.Command("dpkg", "-S", path).Output()
 	return string(out), err
 }

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1781,7 +1781,8 @@ func TestShellFileCopy(t *testing.T) {
 
 			args := []string{fmt.Sprintf("machine:%s", tfs.SingleFileNested), tempDir}
 			cCtx, viamClient, _, _ := setupWithRunningPart(
-				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+				t, asc, nil, nil, partFlags, "token", partFqdn, args...,
+			)
 			test.That(t,
 				viamClient.machinesPartCopyFilesAction(context.Background(), cCtx, parseStructFromCtx[machinesPartCopyFilesArgs](cCtx), logger),
 				test.ShouldBeNil)
@@ -1797,7 +1798,8 @@ func TestShellFileCopy(t *testing.T) {
 
 			args := []string{fmt.Sprintf("machine:%s", tfs.SingleFileNested), "foo"}
 			cCtx, viamClient, _, _ := setupWithRunningPart(
-				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+				t, asc, nil, nil, partFlags, "token", partFqdn, args...,
+			)
 			test.That(t,
 				viamClient.machinesPartCopyFilesAction(context.Background(), cCtx, parseStructFromCtx[machinesPartCopyFilesArgs](cCtx), logger),
 				test.ShouldBeNil)
@@ -1814,7 +1816,8 @@ func TestShellFileCopy(t *testing.T) {
 
 			t.Log("without recursion set")
 			cCtx, viamClient, _, _ := setupWithRunningPart(
-				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+				t, asc, nil, nil, partFlags, "token", partFqdn, args...,
+			)
 			err := viamClient.machinesPartCopyFilesAction(context.Background(), cCtx, parseStructFromCtx[machinesPartCopyFilesArgs](cCtx), logger)
 			test.That(t, errors.Is(err, errDirectoryCopyRequestNoRecursion), test.ShouldBeTrue)
 			_, err = os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
@@ -1825,7 +1828,8 @@ func TestShellFileCopy(t *testing.T) {
 			maps.Copy(partFlagsCopy, partFlags)
 			partFlagsCopy["recursive"] = true
 			cCtx, viamClient, _, _ = setupWithRunningPart(
-				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
+				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...,
+			)
 			test.That(t,
 				viamClient.machinesPartCopyFilesAction(context.Background(), cCtx, parseStructFromCtx[machinesPartCopyFilesArgs](cCtx), logger),
 				test.ShouldBeNil)
@@ -1844,7 +1848,8 @@ func TestShellFileCopy(t *testing.T) {
 			maps.Copy(partFlagsCopy, partFlags)
 			partFlagsCopy["recursive"] = true
 			cCtx, viamClient, _, _ := setupWithRunningPart(
-				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
+				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...,
+			)
 			test.That(t,
 				viamClient.machinesPartCopyFilesAction(context.Background(), cCtx, parseStructFromCtx[machinesPartCopyFilesArgs](cCtx), logger),
 				test.ShouldBeNil)
@@ -1880,7 +1885,8 @@ func TestShellFileCopy(t *testing.T) {
 					partFlagsCopy["recursive"] = true
 					partFlagsCopy["preserve"] = preserve
 					cCtx, viamClient, _, _ := setupWithRunningPart(
-						t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
+						t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...,
+					)
 					test.That(t,
 						viamClient.machinesPartCopyFilesAction(context.Background(), cCtx, parseStructFromCtx[machinesPartCopyFilesArgs](cCtx), logger),
 						test.ShouldBeNil)
@@ -1908,7 +1914,8 @@ func TestShellFileCopy(t *testing.T) {
 
 			args := []string{tfs.SingleFileNested, fmt.Sprintf("machine:%s", tempDir)}
 			cCtx, viamClient, _, _ := setupWithRunningPart(
-				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+				t, asc, nil, nil, partFlags, "token", partFqdn, args...,
+			)
 			test.That(t,
 				viamClient.machinesPartCopyFilesAction(context.Background(), cCtx, parseStructFromCtx[machinesPartCopyFilesArgs](cCtx), logger),
 				test.ShouldBeNil)
@@ -1926,7 +1933,8 @@ func TestShellFileCopy(t *testing.T) {
 			defer os.Remove(randomPath)
 			args := []string{tfs.SingleFileNested, fmt.Sprintf("machine:%s", randomName)}
 			cCtx, viamClient, _, _ := setupWithRunningPart(
-				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+				t, asc, nil, nil, partFlags, "token", partFqdn, args...,
+			)
 			test.That(t,
 				viamClient.machinesPartCopyFilesAction(context.Background(), cCtx, parseStructFromCtx[machinesPartCopyFilesArgs](cCtx), logger),
 				test.ShouldBeNil)
@@ -1943,7 +1951,8 @@ func TestShellFileCopy(t *testing.T) {
 
 			t.Log("without recursion set")
 			cCtx, viamClient, _, _ := setupWithRunningPart(
-				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+				t, asc, nil, nil, partFlags, "token", partFqdn, args...,
+			)
 			err := viamClient.machinesPartCopyFilesAction(context.Background(), cCtx, parseStructFromCtx[machinesPartCopyFilesArgs](cCtx), logger)
 			test.That(t, errors.Is(err, errDirectoryCopyRequestNoRecursion), test.ShouldBeTrue)
 			_, err = os.ReadFile(filepath.Join(tempDir, filepath.Base(tfs.SingleFileNested)))
@@ -1954,7 +1963,8 @@ func TestShellFileCopy(t *testing.T) {
 			maps.Copy(partFlagsCopy, partFlags)
 			partFlagsCopy["recursive"] = true
 			cCtx, viamClient, _, _ = setupWithRunningPart(
-				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
+				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...,
+			)
 			test.That(t,
 				viamClient.machinesPartCopyFilesAction(context.Background(), cCtx, parseStructFromCtx[machinesPartCopyFilesArgs](cCtx), logger),
 				test.ShouldBeNil)
@@ -1973,7 +1983,8 @@ func TestShellFileCopy(t *testing.T) {
 			maps.Copy(partFlagsCopy, partFlags)
 			partFlagsCopy["recursive"] = true
 			cCtx, viamClient, _, _ := setupWithRunningPart(
-				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
+				t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...,
+			)
 			test.That(t,
 				viamClient.machinesPartCopyFilesAction(context.Background(), cCtx, parseStructFromCtx[machinesPartCopyFilesArgs](cCtx), logger),
 				test.ShouldBeNil)
@@ -2009,7 +2020,8 @@ func TestShellFileCopy(t *testing.T) {
 					partFlagsCopy["recursive"] = true
 					partFlagsCopy["preserve"] = preserve
 					cCtx, viamClient, _, _ := setupWithRunningPart(
-						t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...)
+						t, asc, nil, nil, partFlagsCopy, "token", partFqdn, args...,
+					)
 					test.That(t,
 						viamClient.machinesPartCopyFilesAction(context.Background(), cCtx, parseStructFromCtx[machinesPartCopyFilesArgs](cCtx), logger),
 						test.ShouldBeNil)
@@ -2098,7 +2110,8 @@ func TestShellGetFTDC(t *testing.T) {
 
 		args := []string{tempDir}
 		cCtx, viamClient, _, _ := setupWithRunningPart(
-			t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+			t, asc, nil, nil, partFlags, "token", partFqdn, args...,
+		)
 		test.That(t,
 			viamClient.machinesPartGetFTDCAction(context.Background(), cCtx, parseStructFromCtx[machinesPartGetFTDCArgs](cCtx), true, logger),
 			test.ShouldNotBeNil)
@@ -2132,7 +2145,8 @@ func TestShellGetFTDC(t *testing.T) {
 				targetPath = "."
 			}
 			cCtx, viamClient, _, _ := setupWithRunningPart(
-				t, asc, nil, nil, partFlags, "token", partFqdn, args...)
+				t, asc, nil, nil, partFlags, "token", partFqdn, args...,
+			)
 			test.That(t,
 				viamClient.machinesPartGetFTDCAction(context.Background(), cCtx, parseStructFromCtx[machinesPartGetFTDCArgs](cCtx), true, logger),
 				test.ShouldBeNil)
@@ -2178,7 +2192,8 @@ func TestShellGetFTDC(t *testing.T) {
 
 		targetPath := t.TempDir()
 		cCtx, viamClient, _, _ := setupWithRunningPart(
-			t, asc, nil, nil, partFlags, "token", partFqdn, targetPath)
+			t, asc, nil, nil, partFlags, "token", partFqdn, targetPath,
+		)
 		test.That(t,
 			viamClient.machinesPartGetFTDCAction(context.Background(), cCtx, parseStructFromCtx[machinesPartGetFTDCArgs](cCtx), true, logger),
 			test.ShouldBeNil)

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -339,7 +339,8 @@ func TestDataSourceTypeToProto(t *testing.T) {
 		_, err := dataSourceTypeToProto(pipelineSinkDataSourceType, pipelineDataSourceTypes)
 		test.That(t, err, test.ShouldBeError, fmt.Errorf(
 			"invalid data source type: %q. Supported values: %v",
-			pipelineSinkDataSourceType, pipelineDataSourceTypes))
+			pipelineSinkDataSourceType, pipelineDataSourceTypes,
+		))
 	})
 
 	t.Run("rejects unknown and empty names", func(t *testing.T) {
@@ -347,7 +348,8 @@ func TestDataSourceTypeToProto(t *testing.T) {
 			_, err := dataSourceTypeToProto(name, tabularDataByMQLDataSourceTypes)
 			test.That(t, err, test.ShouldBeError, fmt.Errorf(
 				"invalid data source type: %q. Supported values: %v",
-				name, tabularDataByMQLDataSourceTypes))
+				name, tabularDataByMQLDataSourceTypes,
+			))
 		}
 	})
 }

--- a/cli/data_test.go
+++ b/cli/data_test.go
@@ -23,6 +23,7 @@ import (
 
 func TestFilenameForDownload(t *testing.T) {
 	const expectedUTC = "1970-01-01T00_00_00Z"
+	//nolint:staticcheck
 	noFilename := filenameForDownload(&datapb.BinaryMetadata{Id: "my-id"})
 	test.That(t, noFilename, test.ShouldEqual, expectedUTC+"_my-id")
 
@@ -56,6 +57,7 @@ func TestDownloadBinarySkipsExisting(t *testing.T) {
 	// newMeta returns a fresh metadata object per call, matching real gRPC
 	// unmarshaling (downloadBinary mutates metadata.FileName in place).
 	newMeta := func(id string) *datapb.BinaryMetadata {
+		//nolint:staticcheck
 		return &datapb.BinaryMetadata{Id: id, FileName: fileNames[id], FileExt: ".jpg"}
 	}
 

--- a/cli/ml_inference.go
+++ b/cli/ml_inference.go
@@ -37,7 +37,8 @@ func MLInferenceInferAction(ctx context.Context, cmd *cli.Command, args mlInfere
 	_, err = client.mlRunInference(
 		ctx,
 		args.OrgID, args.BinaryDataID,
-		args.ModelOrgID, args.ModelName, args.ModelVersion)
+		args.ModelOrgID, args.ModelName, args.ModelVersion,
+	)
 	if err != nil {
 		return err
 	}

--- a/cli/ml_training.go
+++ b/cli/ml_training.go
@@ -69,7 +69,8 @@ func MLSubmitCustomTrainingJob(ctx context.Context, cmd *cli.Command, args mlSub
 
 	trainingJobID, err := client.mlSubmitCustomTrainingJob(
 		args.DatasetID, args.ScriptName, args.Version, args.OrgID,
-		args.ModelName, args.ModelVersion, args.ContainerVersion, args.Args)
+		args.ModelName, args.ModelVersion, args.ContainerVersion, args.Args,
+	)
 	if err != nil {
 		return err
 	}
@@ -124,7 +125,8 @@ func MLSubmitCustomTrainingJobWithUpload(ctx context.Context, cmd *cli.Command, 
 		registryItemID)
 	trainingJobID, err := client.mlSubmitCustomTrainingJob(
 		args.DatasetID, registryItemID, resp.Version, args.ModelOrgID,
-		args.ModelName, args.ModelVersion, args.ContainerVersion, args.Args)
+		args.ModelName, args.ModelVersion, args.ContainerVersion, args.Args,
+	)
 	if err != nil {
 		return err
 	}
@@ -161,7 +163,8 @@ func MLListContainers(ctx context.Context, cmd *cli.Command, args mlListContaine
 		return err
 	}
 	supportedContainers, err := client.mlTrainingClient.ListSupportedContainers(
-		context.Background(), &mltrainingpb.ListSupportedContainersRequest{})
+		context.Background(), &mltrainingpb.ListSupportedContainersRequest{},
+	)
 	if err != nil {
 		return err
 	}
@@ -195,7 +198,8 @@ func MLSubmitTrainingJob(ctx context.Context, cmd *cli.Command, args mlSubmitTra
 	}
 	trainingJobID, err := client.mlSubmitTrainingJob(
 		args.DatasetID, args.ModelOrgID, args.ModelName, args.ModelVersion, args.ModelType,
-		args.ModelFramework, args.ModelLabels)
+		args.ModelFramework, args.ModelLabels,
+	)
 	if err != nil {
 		return err
 	}
@@ -371,7 +375,8 @@ func DataCancelTrainingJob(ctx context.Context, cmd *cli.Command, args dataCance
 // dataCancelTrainingJob cancels a training job with the given ID.
 func (c *viamClient) dataCancelTrainingJob(trainingJobID string) error {
 	if _, err := c.mlTrainingClient.CancelTrainingJob(
-		context.Background(), &mltrainingpb.CancelTrainingJobRequest{Id: trainingJobID}); err != nil {
+		context.Background(), &mltrainingpb.CancelTrainingJobRequest{Id: trainingJobID},
+	); err != nil {
 		return err
 	}
 	return nil

--- a/cli/module_build.go
+++ b/cli/module_build.go
@@ -107,7 +107,8 @@ func parseGitHubRepo(repoURL string) (owner, repo string, ok bool, err error) {
 	// github url but missing owner/repo: the cloud build will definitely fail, so hard-fail early
 	if len(parts) < 2 || parts[1] == "" {
 		return "", "", false, fmt.Errorf(
-			"meta.json url %q is missing the repo path (expected https://github.com/<owner>/<repo>)", repoURL)
+			"meta.json url %q is missing the repo path (expected https://github.com/<owner>/<repo>)", repoURL,
+		)
 	}
 	return parts[0], strings.TrimSuffix(parts[1], ".git"), true, nil
 }
@@ -1101,7 +1102,8 @@ func (c *viamClient) moduleBuildStartFromSource(
 	}
 	if manifest.Build == nil || manifest.Build.Build == "" {
 		return "", errors.New(
-			"your meta.json cannot have an empty build step. See 'viam module build --help' for more information")
+			"your meta.json cannot have an empty build step. See 'viam module build --help' for more information",
+		)
 	}
 
 	moduleID, err := parseModuleID(manifest.ModuleID)
@@ -1782,7 +1784,8 @@ func reloadModuleActionInner(
 	}
 	var newPart *apppb.RobotPart
 	newPart, needsRestart, err = configureModule(
-		ctx, cmd, vc, manifest, part.Part, args.Local, cloudBuild, reloadUser(vc.conf), args.Annotation, reloadTime.Unix(), dest)
+		ctx, cmd, vc, manifest, part.Part, args.Local, cloudBuild, reloadUser(vc.conf), args.Annotation, reloadTime.Unix(), dest,
+	)
 	// if the module has been configured, the cached response we have may no longer accurately reflect
 	// the update, so we set the updated `part.Part`
 	if newPart != nil {

--- a/cli/module_generate.go
+++ b/cli/module_generate.go
@@ -1385,7 +1385,7 @@ func runGoWithRetry(dir string, args ...string) ([]byte, error) {
 	var out []byte
 	var err error
 	for attempt := 1; ; attempt++ {
-		//nolint: noctx
+		//nolint: gosec,noctx
 		cmd := exec.Command(golang, args...)
 		cmd.Dir = dir
 		out, err = cmd.CombinedOutput()
@@ -1512,7 +1512,7 @@ func createPythonVenv(pythonCmd, venvName string) error {
 	const maxAttempts = 3
 	var err error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		//nolint: noctx
+		//nolint: gosec,noctx
 		cmd := exec.Command(pythonCmd, "-m", "venv", venvName)
 		var stderr bytes.Buffer
 		cmd.Stderr = &stderr

--- a/cli/module_generate/modulegen/inputs.go
+++ b/cli/module_generate/modulegen/inputs.go
@@ -125,7 +125,8 @@ func (inputs *ModuleInputs) CheckResourceAndSetType() error {
 	}
 	if inputs.ResourceSubtype == "generic" {
 		return errors.New(
-			"resource subtype 'generic' cannot be differentiated; please specify either 'generic-service' or 'generic-component'")
+			"resource subtype 'generic' cannot be differentiated; please specify either 'generic-service' or 'generic-component'",
+		)
 	}
 	for _, resource := range Resources {
 		splitResource := strings.Split(resource, " ")

--- a/cli/module_registry.go
+++ b/cli/module_registry.go
@@ -358,7 +358,8 @@ func UploadModuleAction(ctx context.Context, cmd *cli.Command, args uploadModule
 		if err := validateModuleFile(ctx, client, cmd, moduleID, tarballPath, versionArg, platformArg, moduleUploadPath); err != nil {
 			return fmt.Errorf(
 				"error validating module: %w. For more details, please visit: https://docs.viam.com/cli/reference/#module ",
-				err)
+				err,
+			)
 		}
 	}
 
@@ -627,13 +628,15 @@ func validateModuleFile(
 			if info.IsDir() {
 				return errors.Errorf(
 					"the module archive contains a directory at the entrypoint %q instead of an executable file",
-					entrypoint)
+					entrypoint,
+				)
 			}
 
 			if info.Mode().Perm()&0o100 == 0 {
 				return errors.Errorf(
 					"the module archive contains a file at the entrypoint %q, but that file is not marked as executable",
-					entrypoint)
+					entrypoint,
+				)
 			}
 			// executable file at entrypoint. validation succeeded.
 			// continue looping to find symlinks

--- a/cli/module_reload.go
+++ b/cli/module_reload.go
@@ -53,7 +53,8 @@ func configureModule(
 			return err
 		}
 		cfgJSON, needsRestart, err = mutateModuleConfig(
-			cmd, cfgJSON, *manifest, local, cloudReload, reloadUser, annotation, reloadUnixTS, remoteDest)
+			cmd, cfgJSON, *manifest, local, cloudReload, reloadUser, annotation, reloadUnixTS, remoteDest,
+		)
 		if err != nil {
 			return err
 		}

--- a/cli/traces_test.go
+++ b/cli/traces_test.go
@@ -77,7 +77,8 @@ func TestTraceGetRemote(t *testing.T) {
 		})
 
 		cCtx, viamClient, _, _ := setupWithRunningPart(
-			t, asc, nil, nil, testPartFlags, "token", partFqdn)
+			t, asc, nil, nil, testPartFlags, "token", partFqdn,
+		)
 		test.That(t,
 			viamClient.tracesGetRemoteAction(context.Background(), cCtx, parseStructFromCtx[traceGetRemoteArgs](cCtx), output, true, true, logger),
 			test.ShouldNotBeNil)
@@ -111,7 +112,8 @@ func TestTraceGetRemote(t *testing.T) {
 			output := t.TempDir()
 
 			cCtx, viamClient, _, _ := setupWithRunningPart(
-				t, asc, nil, nil, testFlags, "token", partFqdn)
+				t, asc, nil, nil, testFlags, "token", partFqdn,
+			)
 			test.That(t,
 				viamClient.tracesGetRemoteAction(context.Background(), cCtx, parseStructFromCtx[traceGetRemoteArgs](cCtx), output, false, true, logger),
 				test.ShouldBeNil)
@@ -125,7 +127,8 @@ func TestTraceGetRemote(t *testing.T) {
 			output := t.TempDir()
 
 			cCtx, viamClient, _, _ := setupWithRunningPart(
-				t, asc, nil, nil, testFlags, "token", partFqdn)
+				t, asc, nil, nil, testFlags, "token", partFqdn,
+			)
 			test.That(t,
 				viamClient.tracesGetRemoteAction(context.Background(), cCtx, parseStructFromCtx[traceGetRemoteArgs](cCtx), output, true, true, logger),
 				test.ShouldBeNil)
@@ -146,7 +149,8 @@ func TestTraceGetRemote(t *testing.T) {
 
 			defaultTracesPath = originalTracePath
 			cCtx, viamClient, _, _ := setupWithRunningPart(
-				t, asc, nil, nil, testFlags, "token", partFqdn)
+				t, asc, nil, nil, testFlags, "token", partFqdn,
+			)
 			flagArgs := parseStructFromCtx[traceGetRemoteArgs](cCtx)
 
 			// checking default traces path -> not found

--- a/components/arm/server.go
+++ b/components/arm/server.go
@@ -347,7 +347,8 @@ func (s *serviceServer) GetGeometries(ctx context.Context, req *commonpb.GetGeom
 				return nil, err
 			}
 			return &commonpb.GetGeometriesResponse{Geometries: referenceframe.NewGeometriesToProto(
-				gifs.Geometries())}, nil
+				gifs.Geometries(),
+			)}, nil
 		}
 		return nil, err
 	}

--- a/components/audioin/client_test.go
+++ b/components/audioin/client_test.go
@@ -28,7 +28,8 @@ func setupAudioInService(t *testing.T, injectAudioIn *inject.AudioIn) (net.Liste
 	test.That(t, err, test.ShouldBeNil)
 
 	audioInSvc, err := resource.NewAPIResourceCollection(
-		audioin.API, map[resource.Name]audioin.AudioIn{audioin.Named(testAudioInName): injectAudioIn})
+		audioin.API, map[resource.Name]audioin.AudioIn{audioin.Named(testAudioInName): injectAudioIn},
+	)
 	test.That(t, err, test.ShouldBeNil)
 	resourceAPI, ok, err := resource.LookupAPIRegistration[audioin.AudioIn](audioin.API)
 	test.That(t, err, test.ShouldBeNil)

--- a/components/audioin/fake/fake.go
+++ b/components/audioin/fake/fake.go
@@ -20,7 +20,8 @@ func init() {
 	resource.RegisterComponent(
 		audioin.API,
 		resource.DefaultModelFamily.WithModel("fake"),
-		resource.Registration[audioin.AudioIn, *Config]{Constructor: NewAudioIn})
+		resource.Registration[audioin.AudioIn, *Config]{Constructor: NewAudioIn},
+	)
 }
 
 const (

--- a/components/audioout/client_test.go
+++ b/components/audioout/client_test.go
@@ -27,7 +27,8 @@ func setupAudioOutService(t *testing.T, injectAudioOut *inject.AudioOut) (net.Li
 	test.That(t, err, test.ShouldBeNil)
 
 	audioOutSvc, err := resource.NewAPIResourceCollection(
-		audioout.API, map[resource.Name]audioout.AudioOut{audioout.Named(testAudioOutName): injectAudioOut})
+		audioout.API, map[resource.Name]audioout.AudioOut{audioout.Named(testAudioOutName): injectAudioOut},
+	)
 	test.That(t, err, test.ShouldBeNil)
 	resourceAPI, ok, err := resource.LookupAPIRegistration[audioout.AudioOut](audioout.API)
 	test.That(t, err, test.ShouldBeNil)

--- a/components/audioout/fake/fake.go
+++ b/components/audioout/fake/fake.go
@@ -17,7 +17,8 @@ func init() {
 	resource.RegisterComponent(
 		audioout.API,
 		resource.DefaultModelFamily.WithModel("fake"),
-		resource.Registration[audioout.AudioOut, resource.NoNativeConfig]{Constructor: NewAudioOut})
+		resource.Registration[audioout.AudioOut, resource.NoNativeConfig]{Constructor: NewAudioOut},
+	)
 }
 
 // AudioOut is a fake AudioOut that simulates audio playback.

--- a/components/base/client_test.go
+++ b/components/base/client_test.go
@@ -167,7 +167,8 @@ func TestClient(t *testing.T) {
 				context.Background(),
 				angleDeg,
 				degsPerSec,
-				map[string]interface{}{"foo": "bar"})
+				map[string]interface{}{"foo": "bar"},
+			)
 			test.That(t, err, test.ShouldBeNil)
 			expectedArgs := []interface{}{angleDeg, degsPerSec, expectedExtra}
 			test.That(t, argsReceived["Spin"], test.ShouldResemble, expectedArgs)

--- a/components/base/sensorcontrolled/movestraight.go
+++ b/components/base/sensorcontrolled/movestraight.go
@@ -169,7 +169,7 @@ func (sb *sensorBase) calcHeadingControl(ctx context.Context, initHeading float6
 	}
 
 	headingErr := initHeading - currHeading
-	headingErrWrapped := headingErr - (math.Floor((headingErr+180.)/(2*180.)))*2*180. // [-180;180)
+	headingErrWrapped := headingErr - math.Floor((headingErr+180.)/(2*180.))*2*180. // [-180;180)
 
 	return headingErrWrapped * headingGain, nil
 }

--- a/components/base/sensorcontrolled/sensorcontrolled.go
+++ b/components/base/sensorcontrolled/sensorcontrolled.go
@@ -96,7 +96,8 @@ func init() {
 	resource.RegisterComponent(
 		base.API,
 		model,
-		resource.Registration[base.Base, *Config]{Constructor: createSensorBase})
+		resource.Registration[base.Base, *Config]{Constructor: createSensorBase},
+	)
 }
 
 func createSensorBase(

--- a/components/base/sensorcontrolled/sensorcontrolled_test.go
+++ b/components/base/sensorcontrolled/sensorcontrolled_test.go
@@ -73,7 +73,7 @@ func createDependencies(t *testing.T) resource.Dependencies {
 }
 
 func addBaseDependency(deps resource.Dependencies) resource.Dependencies {
-	deps[base.Named(("test_base"))] = &inject.Base{
+	deps[base.Named("test_base")] = &inject.Base{
 		DoFunc: testutils.EchoFunc,
 		MoveStraightFunc: func(ctx context.Context, distanceMm int, mmPerSec float64, extra map[string]interface{}) error {
 			return nil
@@ -438,7 +438,7 @@ func TestSensorBaseDoCommand(t *testing.T) {
 	expectedPID := control.PIDConfig{P: 0.1, I: 2.0, D: 0.0}
 	sb.tunedVals = &[]control.PIDConfig{expectedPID, {}}
 	expectedeMap := make(map[string]interface{})
-	expectedeMap["get_tuned_pid"] = (expectedPID.String())
+	expectedeMap["get_tuned_pid"] = expectedPID.String()
 
 	req := make(map[string]interface{})
 	req["get_tuned_pid"] = true

--- a/components/base/wheeled/wheeled_base.go
+++ b/components/base/wheeled/wheeled_base.go
@@ -165,7 +165,7 @@ func (wb *wheeledBase) reconfigure(ctx context.Context, deps resource.Dependenci
 					return newMotors, rdkutils.NewBuildTimeoutError(wb.Name().String(), wb.logger)
 				default:
 				}
-				if (curr)[i].Name().String() != (fromConfig)[i] {
+				if curr[i].Name().String() != fromConfig[i] {
 					for _, name := range fromConfig {
 						m, err := motor.FromProvider(deps, name)
 						if err != nil {

--- a/components/board/esp32/board.go
+++ b/components/board/esp32/board.go
@@ -50,7 +50,8 @@ func init() {
 		espModel,
 		resource.Registration[board.Board, *Config]{
 			Constructor: newEsp32Board,
-		})
+		},
+	)
 }
 
 // Validate for esp32 will always return an unsupported error.

--- a/components/board/fake/board.go
+++ b/components/board/fake/board.go
@@ -72,7 +72,8 @@ func init() {
 			) (board.Board, error) {
 				return NewBoard(ctx, cfg, logger)
 			},
-		})
+		},
+	)
 }
 
 // NewBoard returns a new fake board.

--- a/components/board/genericlinux/board.go
+++ b/components/board/genericlinux/board.go
@@ -40,7 +40,8 @@ func RegisterBoard(modelName string, gpioMappings map[string]GPIOBoardMapping) {
 			) (board.Board, error) {
 				return NewBoard(ctx, conf, ConstPinDefs(gpioMappings), logger)
 			},
-		})
+		},
+	)
 }
 
 // NewBoard is the constructor for a Board.
@@ -255,7 +256,8 @@ func findNewDigIntConfig(
 		logger.Debugf(
 			"Keeping digital interrupt on pin %s even though it's not explicitly mentioned "+
 				"in the new board config",
-			interrupt.config.Pin)
+			interrupt.config.Pin,
+		)
 		return &interrupt.config
 	}
 	return nil

--- a/components/board/genericlinux/board_nonlinux.go
+++ b/components/board/genericlinux/board_nonlinux.go
@@ -29,7 +29,8 @@ func RegisterBoard(modelName string, gpioMappings map[string]GPIOBoardMapping) {
 			) (board.Board, error) {
 				return nil, errors.New("linux boards are not supported on non-linux OSes")
 			},
-		})
+		},
+	)
 }
 
 // GetGPIOBoardMappings attempts to find a compatible GPIOBoardMapping for the given board.

--- a/components/board/genericlinux/data.go
+++ b/components/board/genericlinux/data.go
@@ -116,7 +116,8 @@ func getPwmChipDefs(pinDefs []PinDefinition, logger logging.Logger) (map[string]
 			symlink, err := os.Readlink(filepath.Join(sysfsDir, file.Name()))
 			if err != nil {
 				logger.Errorw(
-					"file is not symlink", "file", file.Name(), "err:", err)
+					"file is not symlink", "file", file.Name(), "err:", err,
+				)
 				continue
 			}
 
@@ -160,7 +161,8 @@ func getBoardMapping(pinDefs []PinDefinition, pwmChipsInfo map[string]pwmChipDat
 				pwmChipInfo = dummyPwmInfo
 			} else {
 				logger.Errorw(
-					"cannot find expected hardware PWM chip, continuing without it", "pin", pinDef.Name)
+					"cannot find expected hardware PWM chip, continuing without it", "pin", pinDef.Name,
+				)
 				pwmChipInfo = dummyPwmInfo
 			}
 		}

--- a/components/board/genericlinux/digital_interrupts.go
+++ b/components/board/genericlinux/digital_interrupts.go
@@ -41,7 +41,8 @@ func newDigitalInterrupt(
 	defer utils.UncheckedErrorFunc(chip.Close)
 
 	line, err := chip.OpenLineWithEvents(
-		uint32(pinMapping.GPIO), gpio.Input, gpio.BothEdges, "viam-interrupt")
+		uint32(pinMapping.GPIO), gpio.Input, gpio.BothEdges, "viam-interrupt",
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/components/button/client_test.go
+++ b/components/button/client_test.go
@@ -49,7 +49,8 @@ func TestClient(t *testing.T) {
 
 	buttonSvc, err := resource.NewAPIResourceCollection(
 		button.API,
-		map[resource.Name]button.Button{button.Named(testButtonName): injectButton, button.Named(failButtonName): injectButton2})
+		map[resource.Name]button.Button{button.Named(testButtonName): injectButton, button.Named(failButtonName): injectButton2},
+	)
 	test.That(t, err, test.ShouldBeNil)
 	resourceAPI, ok, err := resource.LookupAPIRegistration[button.Button](button.API)
 	test.That(t, err, test.ShouldBeNil)

--- a/components/camera/camera_test.go
+++ b/components/camera/camera_test.go
@@ -41,7 +41,8 @@ type simpleSource struct {
 
 func (s *simpleSource) Read(ctx context.Context) (image.Image, func(), error) {
 	img, err := rimage.NewDepthMapFromFile(
-		context.Background(), artifact.MustPath(s.filePath+".dat.gz"))
+		context.Background(), artifact.MustPath(s.filePath+".dat.gz"),
+	)
 	return img, func() {}, err
 }
 
@@ -55,7 +56,8 @@ type simpleSourceWithPCD struct {
 
 func (s *simpleSourceWithPCD) Read(ctx context.Context) (image.Image, func(), error) {
 	img, err := rimage.NewDepthMapFromFile(
-		context.Background(), artifact.MustPath(s.filePath+".dat.gz"))
+		context.Background(), artifact.MustPath(s.filePath+".dat.gz"),
+	)
 	return img, func() {}, err
 }
 
@@ -136,7 +138,7 @@ func TestNewCamera(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	props, err = cam2.Properties(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, *(props.IntrinsicParams), test.ShouldResemble, *intrinsics1)
+	test.That(t, *props.IntrinsicParams, test.ShouldResemble, *intrinsics1)
 
 	// camera with camera parameters inherited  from other camera
 	cam2props, err := cam2.Properties(context.Background())
@@ -150,7 +152,7 @@ func TestNewCamera(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	cam3props, err := cam3.Properties(context.Background())
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, *(cam3props.IntrinsicParams), test.ShouldResemble, *(cam2props.IntrinsicParams))
+	test.That(t, *cam3props.IntrinsicParams, test.ShouldResemble, *cam2props.IntrinsicParams)
 
 	// camera with different camera parameters, will not inherit
 	cam4, err := camera.NewVideoSourceFromReader(
@@ -163,7 +165,7 @@ func TestNewCamera(t *testing.T) {
 	cam4props, err := cam4.Properties(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, cam4props.IntrinsicParams, test.ShouldNotBeNil)
-	test.That(t, *(cam4props.IntrinsicParams), test.ShouldNotResemble, *(cam2props.IntrinsicParams))
+	test.That(t, *cam4props.IntrinsicParams, test.ShouldNotResemble, *cam2props.IntrinsicParams)
 }
 
 type cloudSource struct {

--- a/components/camera/fake/image_file.go
+++ b/components/camera/fake/image_file.go
@@ -92,7 +92,8 @@ func (c fileSourceConfig) Validate(path string) ([]string, []string, error) {
 		if c.CameraParameters.Width < 0 || c.CameraParameters.Height < 0 {
 			return nil, nil, fmt.Errorf(
 				"got illegal negative dimensions for width_px and height_px (%d, %d) fields set in intrinsic_parameters for image_file camera",
-				c.CameraParameters.Height, c.CameraParameters.Width)
+				c.CameraParameters.Height, c.CameraParameters.Width,
+			)
 		}
 	}
 

--- a/components/camera/ffmpeg/ffmpeg.go
+++ b/components/camera/ffmpeg/ffmpeg.go
@@ -45,7 +45,8 @@ func (cfg *Config) Validate(path string) ([]string, []string, error) {
 		if cfg.CameraParameters.Height < 0 || cfg.CameraParameters.Width < 0 {
 			return nil, nil, fmt.Errorf(
 				"got illegal negative dimensions for width_px and height_px (%d, %d) fields set in intrinsic_parameters for ffmpeg camera",
-				cfg.CameraParameters.Width, cfg.CameraParameters.Height)
+				cfg.CameraParameters.Width, cfg.CameraParameters.Height,
+			)
 		}
 	}
 	return []string{}, nil, nil

--- a/components/camera/replaypcd/replaypcd_utils_test.go
+++ b/components/camera/replaypcd/replaypcd_utils_test.go
@@ -76,7 +76,7 @@ func (mDServer *mockDataServiceServer) BinaryDataByFilter(ctx context.Context, r
 		binaryData := datapb.BinaryData{
 			Binary: data,
 			Metadata: &datapb.BinaryMetadata{
-				Id:            fmt.Sprintf(datasetDirectory, newFileNum),
+				BinaryDataId:  fmt.Sprintf(datasetDirectory, newFileNum),
 				TimeRequested: timeReq,
 				TimeReceived:  timeRec,
 				CaptureMetadata: &datapb.CaptureMetadata{
@@ -102,7 +102,7 @@ func (mDServer *mockDataServiceServer) BinaryDataByFilter(ctx context.Context, r
 
 			binaryData := datapb.BinaryData{
 				Metadata: &datapb.BinaryMetadata{
-					Id:            fmt.Sprintf(datasetDirectory, newFileNum+i),
+					BinaryDataId:  fmt.Sprintf(datasetDirectory, newFileNum+i),
 					TimeRequested: timeReq,
 					TimeReceived:  timeRec,
 					CaptureMetadata: &datapb.CaptureMetadata{

--- a/components/camera/transformpipeline/mods.go
+++ b/components/camera/transformpipeline/mods.go
@@ -73,7 +73,7 @@ func (rs *rotateSource) Read(ctx context.Context) (image.Image, func(), error) {
 	case camera.ColorStream, camera.UnspecifiedStream:
 		// imaging.Rotate rotates an image counter-clockwise but our rotate function rotates in the
 		// clockwise direction. The angle is negated here for consistency.
-		return imaging.Rotate(orig, -(rs.angle), color.Black), release, nil
+		return imaging.Rotate(orig, -rs.angle, color.Black), release, nil
 	case camera.DepthStream:
 		dm, err := rimage.ConvertImageToDepthMap(ctx, orig)
 		if err != nil {

--- a/components/camera/transformpipeline/mods_test.go
+++ b/components/camera/transformpipeline/mods_test.go
@@ -26,7 +26,8 @@ func TestCrop(t *testing.T) {
 	img, err := rimage.NewImageFromFile(artifact.MustPath("rimage/board1_small.png"))
 	test.That(t, err, test.ShouldBeNil)
 	dm, err := rimage.NewDepthMapFromFile(
-		context.Background(), artifact.MustPath("rimage/board1_gray_small.png"))
+		context.Background(), artifact.MustPath("rimage/board1_gray_small.png"),
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	// test depth source
@@ -201,7 +202,8 @@ func TestResizeColor(t *testing.T) {
 
 func TestResizeDepth(t *testing.T) {
 	img, err := rimage.NewDepthMapFromFile(
-		context.Background(), artifact.MustPath("rimage/board1_gray_small.png"))
+		context.Background(), artifact.MustPath("rimage/board1_gray_small.png"),
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	am := utils.AttributeMap{
@@ -414,7 +416,8 @@ func TestRotateColorSource(t *testing.T) {
 
 func TestRotateDepthSource(t *testing.T) {
 	pc, err := rimage.NewDepthMapFromFile(
-		context.Background(), artifact.MustPath("rimage/board1_gray_small.png"))
+		context.Background(), artifact.MustPath("rimage/board1_gray_small.png"),
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	source, err := camera.NewVideoSourceFromReader(context.Background(), &fake.StaticSource{DepthImg: pc}, nil, camera.UnspecifiedStream)
@@ -626,7 +629,8 @@ func BenchmarkColorRotate(b *testing.B) {
 
 func BenchmarkDepthRotate(b *testing.B) {
 	img, err := rimage.NewDepthMapFromFile(
-		context.Background(), artifact.MustPath("rimage/board1.dat.gz"))
+		context.Background(), artifact.MustPath("rimage/board1.dat.gz"),
+	)
 	test.That(b, err, test.ShouldBeNil)
 
 	source := gostream.NewVideoSource(&fake.StaticSource{DepthImg: img}, prop.Video{})

--- a/components/camera/transformpipeline/pipeline.go
+++ b/components/camera/transformpipeline/pipeline.go
@@ -62,7 +62,8 @@ func init() {
 				}
 				return src, nil
 			},
-		})
+		},
+	)
 }
 
 // transformConfig specifies a stream and list of transforms to apply on images/pointclouds coming from a source camera.

--- a/components/camera/videosource/query.go
+++ b/components/camera/videosource/query.go
@@ -286,7 +286,8 @@ func selectBestDriver(
 		logger.Debugw(
 			"considering driver",
 			"label", d.Info().Label,
-			"priority", priority)
+			"priority", priority,
+		)
 		for _, p := range props {
 			fitnessDist, ok := constraints.MediaConstraints.FitnessDistance(p)
 			if !ok {
@@ -299,7 +300,8 @@ func selectBestDriver(
 				"label", d.Info().Label,
 				"props", p,
 				"distance", fitnessDist,
-				"distance_with_priority", fitnessDistWithPriority)
+				"distance_with_priority", fitnessDistWithPriority,
+			)
 			if fitnessDistWithPriority < minFitnessDist {
 				minFitnessDist = fitnessDistWithPriority
 				bestDriver = d
@@ -319,7 +321,8 @@ func selectBestDriver(
 				"frame format, etc. "+
 				"Use the find-webcams discovery service to find valid constraints for your device. "+
 				"Devices tried: %s",
-			strings.Join(labels, ", "))
+			strings.Join(labels, ", "),
+		)
 	}
 
 	logger.Debugw("winning driver", "label", bestDriver.Info().Label, "props", bestProp)

--- a/components/camera/videosource/webcam.go
+++ b/components/camera/videosource/webcam.go
@@ -46,7 +46,8 @@ func init() {
 		ModelWebcam,
 		resource.Registration[camera.Camera, *WebcamConfig]{
 			Constructor: NewWebcam,
-		})
+		},
+	)
 }
 
 // WebcamConfig is the native config attribute struct for webcams.
@@ -65,12 +66,14 @@ func (c WebcamConfig) Validate(path string) ([]string, []string, error) {
 	if c.Width < 0 || c.Height < 0 {
 		return nil, nil, fmt.Errorf(
 			"got illegal negative dimensions for width_px and height_px (%d, %d) fields set for webcam camera",
-			c.Width, c.Height)
+			c.Width, c.Height,
+		)
 	}
 	if c.FrameRate < 0 {
 		return nil, nil, fmt.Errorf(
 			"got illegal negative frame rate (%.2f) field set for webcam camera",
-			c.FrameRate)
+			c.FrameRate,
+		)
 	}
 
 	return []string{}, nil, nil
@@ -393,7 +396,8 @@ func (c *webcam) Images(_ context.Context, _ []string, _ map[string]interface{})
 				c.lastResWarnTime = time.Now()
 				c.logger.Warnf(
 					"requested width and height (%dx%d) do not match actual webcam resolution (%dx%d); using actual resolution",
-					c.conf.Width, c.conf.Height, img.Bounds().Dx(), img.Bounds().Dy())
+					c.conf.Width, c.conf.Height, img.Bounds().Dx(), img.Bounds().Dy(),
+				)
 			}
 		}
 	}

--- a/components/encoder/client_test.go
+++ b/components/encoder/client_test.go
@@ -112,7 +112,8 @@ func TestClient(t *testing.T) {
 		pos, positionType, err := workingEncoderClient.Position(
 			context.Background(),
 			encoder.PositionTypeUnspecified,
-			map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}})
+			map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}},
+		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pos, test.ShouldEqual, 42.0)
 		test.That(t, positionType, test.ShouldEqual, pb.PositionType_POSITION_TYPE_UNSPECIFIED)

--- a/components/encoder/errors.go
+++ b/components/encoder/errors.go
@@ -13,7 +13,8 @@ func NewPositionTypeUnsupportedError(positionType PositionType) error {
 func NewEncodedMotorPositionTypeUnsupportedError(props Properties) error {
 	if props.AngleDegreesSupported {
 		return errors.New(
-			"encoder position type is Angle Degrees, need an encoder that supports Ticks")
+			"encoder position type is Angle Degrees, need an encoder that supports Ticks",
+		)
 	}
 	return errors.New("need an encoder that supports Ticks")
 }

--- a/components/encoder/incremental/incremental_encoder.go
+++ b/components/encoder/incremental/incremental_encoder.go
@@ -25,7 +25,8 @@ func init() {
 		incrModel,
 		resource.Registration[encoder.Encoder, *Config]{
 			Constructor: NewIncrementalEncoder,
-		})
+		},
+	)
 }
 
 // Encoder keeps track of a motor position using a rotary incremental encoder.

--- a/components/encoder/single/single_encoder.go
+++ b/components/encoder/single/single_encoder.go
@@ -51,7 +51,8 @@ func init() {
 		singleModel,
 		resource.Registration[encoder.Encoder, *Config]{
 			Constructor: NewSingleEncoder,
-		})
+		},
+	)
 }
 
 // DirectionAware lets you ask what direction something is moving. Only used for Encoder for now, unclear future.

--- a/components/gantry/server.go
+++ b/components/gantry/server.go
@@ -165,7 +165,8 @@ func (s *serviceServer) GetGeometries(ctx context.Context, req *commonpb.GetGeom
 				return nil, err
 			}
 			return &commonpb.GetGeometriesResponse{Geometries: referenceframe.NewGeometriesToProto(
-				gifs.Geometries())}, nil
+				gifs.Geometries(),
+			)}, nil
 		}
 		return nil, err
 	}

--- a/components/generic/fake/generic.go
+++ b/components/generic/fake/generic.go
@@ -20,7 +20,8 @@ func init() {
 			logger logging.Logger,
 		) (resource.Resource, error) {
 			return newGeneric(conf.ResourceName(), logger), nil
-		}})
+		}},
+	)
 }
 
 func newGeneric(name resource.Name, logger logging.Logger) resource.Resource {

--- a/components/gripper/client_test.go
+++ b/components/gripper/client_test.go
@@ -81,7 +81,8 @@ func TestClient(t *testing.T) {
 
 	gripperSvc, err := resource.NewAPIResourceCollection(
 		gripper.API,
-		map[resource.Name]gripper.Gripper{gripper.Named(testGripperName): injectGripper, gripper.Named(failGripperName): injectGripper2})
+		map[resource.Name]gripper.Gripper{gripper.Named(testGripperName): injectGripper, gripper.Named(failGripperName): injectGripper2},
+	)
 	test.That(t, err, test.ShouldBeNil)
 	resourceAPI, ok, err := resource.LookupAPIRegistration[gripper.Gripper](gripper.API)
 	test.That(t, err, test.ShouldBeNil)

--- a/components/input/gpio/gpio_test.go
+++ b/components/input/gpio/gpio_test.go
@@ -336,7 +336,7 @@ func TestGPIOInput(t *testing.T) {
 		defer teardown(t, s)
 		testutils.WaitForAssertion(t, func(tb testing.TB) {
 			tb.Helper()
-			state, err := (s.dev).Events(s.ctx, map[string]interface{}{})
+			state, err := s.dev.Events(s.ctx, map[string]interface{}{})
 			test.That(tb, err, test.ShouldBeNil)
 			test.That(tb, state["ButtonNorth"].Value, test.ShouldEqual, 0)
 			test.That(tb, state["ButtonNorth"].Event, test.ShouldEqual, input.Connect)

--- a/components/motor/client_test.go
+++ b/components/motor/client_test.go
@@ -162,7 +162,8 @@ func TestClient(t *testing.T) {
 
 		isOn, powerPct, err := workingMotorClient.IsPowered(
 			context.Background(),
-			map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}})
+			map[string]interface{}{"foo": "bar", "baz": []interface{}{1., 2., 3.}},
+		)
 		test.That(t, isOn, test.ShouldBeTrue)
 		test.That(t, powerPct, test.ShouldEqual, 42.0)
 		test.That(t, err, test.ShouldBeNil)

--- a/components/motor/gpio/encoded.go
+++ b/components/motor/gpio/encoded.go
@@ -81,7 +81,8 @@ func newEncodedMotor(
 
 	// TODO DOCS-1524: link to docs that explain control parameters
 	em.logger.Warn(
-		"recommended: for more accurate motor control, configure 'control_parameters' in the motor config")
+		"recommended: for more accurate motor control, configure 'control_parameters' in the motor config",
+	)
 
 	if em.rampRate < 0 {
 		return nil, fmt.Errorf("ramp rate can not be a negative number but is %v", em.rampRate)
@@ -185,7 +186,8 @@ func (m *EncodedMotor) makeAdjustments(ctx context.Context, goalRPM, goalPos, di
 			m.logger.Warnf(
 				"%v motor running at too low an rpm [%v] for stable motion:"+
 					"trying to run at %v rpm, check if stalled or try increasing the motor's rpm",
-				m.Name().Name, currentRPM, goalRPM)
+				m.Name().Name, currentRPM, goalRPM,
+			)
 			zeroRPMTracker = 0
 		}
 

--- a/components/motor/gpiostepper/gpiostepper.go
+++ b/components/motor/gpiostepper/gpiostepper.go
@@ -368,7 +368,8 @@ func (m *gpioStepper) SetPower(ctx context.Context, powerPct float64, extra map[
 		return errors.Errorf(
 			"if you want to set the power, set 'stepper_delay_usec' in the motor config at "+
 				"the minimum time delay between pulses for your stepper motor (%s)",
-			m.Name().Name)
+			m.Name().Name,
+		)
 	}
 
 	m.opMgr.CancelRunning(ctx)

--- a/components/motor/gpiostepper/gpiostepper_test.go
+++ b/components/motor/gpiostepper/gpiostepper_test.go
@@ -726,7 +726,7 @@ func TestRunning(t *testing.T) {
 
 		// Very high RPM should be clamped by minDelay
 		freq = s.rpmToFreqHz(100000)
-		test.That(t, freq, test.ShouldEqual, uint(math.Round(1.0/(30e-6))))
+		test.That(t, freq, test.ShouldEqual, uint(math.Round(1.0/30e-6)))
 
 		// Very low RPM clamps to 1 Hz
 		freq = s.rpmToFreqHz(0.001)

--- a/components/movementsensor/fake/movementsensor.go
+++ b/components/movementsensor/fake/movementsensor.go
@@ -24,7 +24,8 @@ func init() {
 	resource.RegisterComponent(
 		movementsensor.API,
 		model,
-		resource.Registration[movementsensor.MovementSensor, *Config]{Constructor: NewMovementSensor})
+		resource.Registration[movementsensor.MovementSensor, *Config]{Constructor: NewMovementSensor},
+	)
 }
 
 // NewMovementSensor makes a new fake movement sensor.

--- a/components/movementsensor/merged/merged.go
+++ b/components/movementsensor/merged/merged.go
@@ -63,7 +63,8 @@ func init() {
 		movementsensor.API, model,
 		resource.Registration[movementsensor.MovementSensor, *Config]{
 			Constructor: newMergedModel,
-		})
+		},
+	)
 }
 
 func newMergedModel(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger) (
@@ -149,42 +150,48 @@ func (m *merged) reconfigure(ctx context.Context, deps resource.Dependencies, co
 
 	m.ori, err = firstGoodSensorWithProperties(
 		deps, newConf.Orientation, m.logger,
-		&movementsensor.Properties{OrientationSupported: true}, "orientation")
+		&movementsensor.Properties{OrientationSupported: true}, "orientation",
+	)
 	if err != nil {
 		return err
 	}
 
 	m.pos, err = firstGoodSensorWithProperties(
 		deps, newConf.Position, m.logger,
-		&movementsensor.Properties{PositionSupported: true}, "position")
+		&movementsensor.Properties{PositionSupported: true}, "position",
+	)
 	if err != nil {
 		return err
 	}
 
 	m.compass, err = firstGoodSensorWithProperties(
 		deps, newConf.CompassHeading, m.logger,
-		&movementsensor.Properties{CompassHeadingSupported: true}, "compass_heading")
+		&movementsensor.Properties{CompassHeadingSupported: true}, "compass_heading",
+	)
 	if err != nil {
 		return err
 	}
 
 	m.linVel, err = firstGoodSensorWithProperties(
 		deps, newConf.LinearVelocity, m.logger,
-		&movementsensor.Properties{LinearVelocitySupported: true}, "linear_velocity")
+		&movementsensor.Properties{LinearVelocitySupported: true}, "linear_velocity",
+	)
 	if err != nil {
 		return err
 	}
 
 	m.angVel, err = firstGoodSensorWithProperties(
 		deps, newConf.AngularVelocity, m.logger,
-		&movementsensor.Properties{AngularVelocitySupported: true}, "angular_velocity")
+		&movementsensor.Properties{AngularVelocitySupported: true}, "angular_velocity",
+	)
 	if err != nil {
 		return err
 	}
 
 	m.linAcc, err = firstGoodSensorWithProperties(
 		deps, newConf.LinearAcceleration, m.logger,
-		&movementsensor.Properties{LinearAccelerationSupported: true}, "linear_acceleration")
+		&movementsensor.Properties{LinearAccelerationSupported: true}, "linear_acceleration",
+	)
 	if err != nil {
 		return err
 	}

--- a/components/movementsensor/merged/merged_test.go
+++ b/components/movementsensor/merged/merged_test.go
@@ -141,7 +141,8 @@ func TestValidate(t *testing.T) {
 	// doesn't pass validate
 	conf := setUpCfg(
 		emptySensors, emptySensors /*pos*/, emptySensors, /*compass*/
-		emptySensors /*linvel*/, emptySensors /*angvel*/, emptySensors /*linacc*/)
+		emptySensors /*linvel*/, emptySensors /*angvel*/, emptySensors, /*linacc*/
+	)
 	implicits, _, err := conf.Validate("somepath", movementsensor.API.Type.Name)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, implicits, test.ShouldBeNil)
@@ -149,14 +150,16 @@ func TestValidate(t *testing.T) {
 	// doesn't pass configuration
 	conf = setUpCfg(
 		oriSensors, emptySensors /*pos*/, emptySensors, /*compass*/
-		linvelSensors, emptySensors /*angvel*/, emptySensors /*linacc*/)
+		linvelSensors, emptySensors /*angvel*/, emptySensors, /*linacc*/
+	)
 	implicits, _, err = conf.Validate("somepath", movementsensor.API.Type.Name)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, implicits, test.ShouldResemble, append(oriSensors, linvelSensors...))
 
 	conf = setUpCfg(
 		/*ori*/ emptySensors, emptySensors /*pos*/, emptySensors, /*comapss*/
-		linvelSensors /*linval*/, angvelSensors /*angvel*/, emptySensors /*linacc*/)
+		linvelSensors /*linval*/, angvelSensors /*angvel*/, emptySensors, /*linacc*/
+	)
 	implicits, _, err = conf.Validate("somepath", movementsensor.API.Type.Name)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, implicits, test.ShouldResemble, append(linvelSensors, angvelSensors...))
@@ -169,7 +172,8 @@ func TestCreation(t *testing.T) {
 	// doesn't pass configuration
 	conf := setUpCfg(
 		oriSensors, emptySensors /*pos*/, emptySensors, /*compass*/
-		linvelSensors, emptySensors /*angvel*/, emptySensors /*linacc*/)
+		linvelSensors, emptySensors /*angvel*/, emptySensors, /*linacc*/
+	)
 
 	depmap := map[string]movementsensor.Properties{
 		linvelSensors[0]: emptyProps,                       // empty
@@ -186,7 +190,8 @@ func TestCreation(t *testing.T) {
 	// first time passing configuration with two merged sensors
 	conf = setUpCfg(
 		/*ori*/ emptySensors, emptySensors /*pos*/, emptySensors, /*comapss*/
-		linvelSensors /*linval*/, angvelSensors /*angvel*/, emptySensors /*linacc*/)
+		linvelSensors /*linval*/, angvelSensors /*angvel*/, emptySensors, /*linacc*/
+	)
 
 	depmap = map[string]movementsensor.Properties{
 		linvelSensors[0]: linvelProps,

--- a/components/movementsensor/replay/replay.go
+++ b/components/movementsensor/replay/replay.go
@@ -227,7 +227,8 @@ func (replay *replayMovementSensor) Position(ctx context.Context, extra map[stri
 	}
 	return geo.NewPoint(
 			coordStruct.GetStructValue().GetFields()["latitude"].GetNumberValue(),
-			coordStruct.GetStructValue().GetFields()["longitude"].GetNumberValue()),
+			coordStruct.GetStructValue().GetFields()["longitude"].GetNumberValue(),
+		),
 		altitude.GetNumberValue(), nil
 }
 

--- a/components/movementsensor/replay/replay_test.go
+++ b/components/movementsensor/replay/replay_test.go
@@ -110,7 +110,8 @@ var (
 
 	errPropertiesFailedToInitializeTest = errors.Wrap(
 		errors.Wrap(context.DeadlineExceeded, errPropertiesFailedToInitialize.Error()),
-		errMessageNoDataAvailable)
+		errMessageNoDataAvailable,
+	)
 )
 
 func TestNewReplayMovementSensor(t *testing.T) {

--- a/components/movementsensor/utils_test.go
+++ b/components/movementsensor/utils_test.go
@@ -96,7 +96,7 @@ func TestPositionLogic(t *testing.T) {
 func TestPMTKFunctions(t *testing.T) {
 	var (
 		expectedValue    = ([]uint8{36, 80, 77, 84, 75, 50, 50, 48, 44, 49, 48, 48, 48, 42, 31})
-		testValue        = ([]byte("PMTK220,1000"))
+		testValue        = []byte("PMTK220,1000")
 		expectedChecksum = 31
 	)
 	test.That(t, PMTKChecksum(testValue), test.ShouldEqual, expectedChecksum)

--- a/components/movementsensor/wheeledodometry/wheeledodometry.go
+++ b/components/movementsensor/wheeledodometry/wheeledodometry.go
@@ -86,7 +86,8 @@ func init() {
 	resource.RegisterComponent(
 		movementsensor.API,
 		Model,
-		resource.Registration[movementsensor.MovementSensor, *Config]{Constructor: newWheeledOdometry})
+		resource.Registration[movementsensor.MovementSensor, *Config]{Constructor: newWheeledOdometry},
+	)
 }
 
 // Validate ensures all parts of the config are valid.

--- a/components/posetracker/client_test.go
+++ b/components/posetracker/client_test.go
@@ -104,7 +104,8 @@ func TestClient(t *testing.T) {
 
 	t.Run("client tests for working pose tracker", func(t *testing.T) {
 		bodyToPoseInFrame, err := workingPTClient.Poses(
-			context.Background(), []string{zeroPoseBody, nonZeroPoseBody}, map[string]interface{}{"foo": "Poses"})
+			context.Background(), []string{zeroPoseBody, nonZeroPoseBody}, map[string]interface{}{"foo": "Poses"},
+		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, extraOptions, test.ShouldResemble, map[string]interface{}{"foo": "Poses"})
 

--- a/components/powersensor/fake/powersensor.go
+++ b/components/powersensor/fake/powersensor.go
@@ -22,7 +22,8 @@ func init() {
 		model,
 		resource.Registration[powersensor.PowerSensor, *Config]{
 			Constructor: newFakePowerSensorModel,
-		})
+		},
+	)
 }
 
 func newFakePowerSensorModel(_ context.Context, _ resource.Dependencies, conf resource.Config, logger logging.Logger,

--- a/components/sensor/fake/sensor.go
+++ b/components/sensor/fake/sensor.go
@@ -21,7 +21,8 @@ func init() {
 			logger logging.Logger,
 		) (sensor.Sensor, error) {
 			return newSensor(conf.ResourceName(), logger), nil
-		}})
+		}},
+	)
 }
 
 func newSensor(name resource.Name, logger logging.Logger) sensor.Sensor {

--- a/components/servo/fake/servo.go
+++ b/components/servo/fake/servo.go
@@ -22,7 +22,8 @@ func init() {
 					logger: logger,
 				}, nil
 			},
-		})
+		},
+	)
 }
 
 // A Servo allows setting and reading a single angle.

--- a/components/servo/gpio/servo.go
+++ b/components/servo/gpio/servo.go
@@ -191,7 +191,8 @@ func (s *servoGPIO) reconfigure(ctx context.Context, deps resource.Dependencies,
 	if newConf.Frequency != nil {
 		if *newConf.Frequency > maxFreqHz || *newConf.Frequency < minFreqHz {
 			return errors.Errorf(
-				"PWM frequencies should not be above %dHz or below %dHz, have %dHz", maxFreqHz, minFreqHz, newConf.Frequency)
+				"PWM frequencies should not be above %dHz or below %dHz, have %dHz", maxFreqHz, minFreqHz, newConf.Frequency,
+			)
 		}
 
 		s.frequency = *newConf.Frequency

--- a/components/switch/client_test.go
+++ b/components/switch/client_test.go
@@ -79,7 +79,8 @@ func TestClient(t *testing.T) {
 			toggleswitch.Named(testSwitchName):     injectSwitch,
 			toggleswitch.Named(failSwitchName):     injectSwitch2,
 			toggleswitch.Named(mismatchSwitchName): injectSwitch3,
-		})
+		},
+	)
 	test.That(t, err, test.ShouldBeNil)
 	resourceAPI, ok, err := resource.LookupAPIRegistration[toggleswitch.Switch](toggleswitch.API)
 	test.That(t, err, test.ShouldBeNil)

--- a/config/proto_conversions.go
+++ b/config/proto_conversions.go
@@ -162,7 +162,8 @@ func ComponentConfigFromProto(protoConf *pb.ComponentConfig, logger logging.Logg
 			// Don't fail configuration due to a malformed log level.
 			level = logging.INFO
 			logger.Warnw(
-				"Invalid log level.", "name", protoConf.GetName(), "log_level", protoConf.GetLogConfiguration().Level, "error", err)
+				"Invalid log level.", "name", protoConf.GetName(), "log_level", protoConf.GetLogConfiguration().Level, "error", err,
+			)
 		}
 		logConfig = &resource.LogConfig{Level: level}
 	}
@@ -253,7 +254,8 @@ func ServiceConfigFromProto(protoConf *pb.ServiceConfig, logger logging.Logger) 
 			// Don't fail configuration due to a malformed log level.
 			level = logging.INFO
 			logger.Warnw(
-				"Invalid log level.", "name", protoConf.GetName(), "log_level", protoConf.GetLogConfiguration().Level, "error", err)
+				"Invalid log level.", "name", protoConf.GetName(), "log_level", protoConf.GetLogConfiguration().Level, "error", err,
+			)
 		}
 		logConfig = &resource.LogConfig{Level: level}
 	}

--- a/config/proto_conversions.go
+++ b/config/proto_conversions.go
@@ -793,7 +793,7 @@ func CloudConfigToProto(cloud *Cloud) (*pb.CloudConfig, error) {
 	return &pb.CloudConfig{
 		Id:                cloud.ID,
 		Secret:            cloud.Secret,
-		LocationSecret:    cloud.LocationSecret,
+		LocationSecret:    cloud.LocationSecret, //nolint:staticcheck // RSDK-14540
 		LocationSecrets:   locationSecrets,
 		ManagedBy:         cloud.ManagedBy,
 		Fqdn:              cloud.FQDN,

--- a/config/watcher_test.go
+++ b/config/watcher_test.go
@@ -279,7 +279,8 @@ func TestNewWatcherCloud(t *testing.T) {
 	storeConfigInServer(confToReturn)
 
 	appConn, err := grpc.NewAppConn(
-		context.Background(), confToReturn.Cloud.AppAddress, confToReturn.Cloud.ID, confToReturn.Cloud.GetCloudCredsDialOpt(), logger)
+		context.Background(), confToReturn.Cloud.AppAddress, confToReturn.Cloud.ID, confToReturn.Cloud.GetCloudCredsDialOpt(), logger,
+	)
 	test.That(t, err, test.ShouldBeNil)
 	defer appConn.Close()
 	watcher, err := config.NewWatcher(context.Background(), &config.Config{Cloud: newCloudConf()}, logger, appConn)

--- a/control/control_loop.go
+++ b/control/control_loop.go
@@ -61,7 +61,7 @@ func createLoop(logger logging.Logger, cfg Config, m Controllable) (*Loop, error
 	if l.cfg.Frequency == 0.0 || l.cfg.Frequency > 200 {
 		return nil, errors.New("loop frequency shouldn't be 0 or above 200Hz")
 	}
-	l.dt = time.Duration(float64(time.Second) * (1.0 / (l.cfg.Frequency)))
+	l.dt = time.Duration(float64(time.Second) * (1.0 / l.cfg.Frequency))
 	for _, bcfg := range cfg.Blocks {
 		blk, err := l.createBlock(bcfg, logger)
 		if err != nil {

--- a/control/derivative_test.go
+++ b/control/derivative_test.go
@@ -108,7 +108,7 @@ func TestDerivativeNext(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		if i > 5 {
 			test.That(t, out[0].GetSignalValueAt(0), test.ShouldAlmostEqual,
-				-math.Sin((time.Duration(i * tenMs).Seconds())), 0.01)
+				-math.Sin(time.Duration(i*tenMs).Seconds()), 0.01)
 		}
 	}
 	cfg = BlockConfig{
@@ -127,7 +127,7 @@ func TestDerivativeNext(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		if i > 5 {
 			test.That(t, out[0].GetSignalValueAt(0), test.ShouldAlmostEqual,
-				math.Cos((time.Duration(i * tenMs).Seconds())), 0.01)
+				math.Cos(time.Duration(i*tenMs).Seconds()), 0.01)
 		}
 	}
 	cfg = BlockConfig{
@@ -142,7 +142,7 @@ func TestDerivativeNext(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	sin = nil
 	for i := int64(0); i < iter; i++ {
-		sin = append(sin, math.Sin(2*math.Pi*(time.Duration(i*tenMs).Seconds())))
+		sin = append(sin, math.Sin(2*math.Pi*time.Duration(i*tenMs).Seconds()))
 	}
 	for i := int64(0); i < iter; i++ {
 		sig.SetSignalValueAt(0, sin[i])
@@ -150,7 +150,7 @@ func TestDerivativeNext(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		if i > 5 {
 			test.That(t, out[0].GetSignalValueAt(0), test.ShouldAlmostEqual,
-				2*math.Pi*math.Cos(2*math.Pi*(time.Duration(i*tenMs).Seconds())), 0.01)
+				2*math.Pi*math.Cos(2*math.Pi*time.Duration(i*tenMs).Seconds()), 0.01)
 		}
 	}
 }

--- a/control/encoder_speed.go
+++ b/control/encoder_speed.go
@@ -32,7 +32,7 @@ func (b *encoderToRPM) Next(ctx context.Context, x []*Signal, dt time.Duration) 
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	currEncCount := int(x[0].GetSignalValueAt(0))
-	b.y[0].SetSignalValueAt(0, (float64(currEncCount-b.prevEncCount)/float64(b.ticksPerRevolution))*60.0/(dt.Seconds()))
+	b.y[0].SetSignalValueAt(0, (float64(currEncCount-b.prevEncCount)/float64(b.ticksPerRevolution))*60.0/dt.Seconds())
 	b.prevEncCount = currEncCount
 	return b.y, true
 }

--- a/control/fir_filters.go
+++ b/control/fir_filters.go
@@ -52,7 +52,7 @@ type firSinc struct {
 
 func (f *firSinc) calculateCoefficients() error {
 	wc := 2.0 * f.cutOffFreq / f.smpFreq
-	n1 := (0.5) * (float64(f.order) - 1)
+	n1 := 0.5 * (float64(f.order) - 1)
 	for i := 0; i < f.order; i++ {
 		if float64(i)-n1 == 0 {
 			f.coeffs[i] = wc
@@ -112,7 +112,7 @@ func (f *firWindowedSinc) calculateKernel() error {
 		if i-hs == 0 {
 			f.kernel[i] = math.Pi * wc
 		} else {
-			f.kernel[i] = math.Sin(math.Pi*wc*(float64(i-hs))) / float64(i-hs)
+			f.kernel[i] = math.Sin(math.Pi*wc*float64(i-hs)) / float64(i-hs)
 		}
 		f.kernel[i] *= (0.54 - 0.46*math.Cos(math.Pi*float64(i/f.kernelSize)))
 		acc += f.kernel[i]

--- a/control/iir_filters.go
+++ b/control/iir_filters.go
@@ -29,8 +29,8 @@ func calculateBiquadCoefficient(fc float64, p, n int, rp float64, hp bool) ([]fl
 
 	if rp > 0 {
 		scale := math.Sqrt(math.Pow(100.0/(100.0-rp), 2) - 1)
-		vx := (1.0 / float64(n)) * math.Log((1.0/scale)+math.Sqrt((math.Pow(1.0/scale, 2))+1))
-		kx := (1.0 / float64(n)) * math.Log((1.0/scale)+math.Sqrt((math.Pow(1.0/scale, 2))-1))
+		vx := (1.0 / float64(n)) * math.Log((1.0/scale)+math.Sqrt(math.Pow(1.0/scale, 2)+1))
+		kx := (1.0 / float64(n)) * math.Log((1.0/scale)+math.Sqrt(math.Pow(1.0/scale, 2)-1))
 		kx = (math.Exp(kx) + math.Exp(-kx)) * 0.5
 		realP = realP * ((math.Exp(vx) - math.Exp(-vx)) * 0.5) / kx
 		imagP = imagP * ((math.Exp(vx) + math.Exp(-vx)) * 0.5) / kx
@@ -39,9 +39,9 @@ func calculateBiquadCoefficient(fc float64, p, n int, rp float64, hp bool) ([]fl
 	Wc := math.Pi * fc
 	squaredMod := math.Pow(realP, 2) + math.Pow(imagP, 2)
 	d := 4 - 4*realP*T + squaredMod*math.Pow(T, 2)
-	x0 := (math.Pow(T, 2)) / d
-	x1 := 2 * (math.Pow(T, 2)) / d
-	x2 := (math.Pow(T, 2)) / d
+	x0 := math.Pow(T, 2) / d
+	x1 := 2 * math.Pow(T, 2) / d
+	x2 := math.Pow(T, 2) / d
 	y1 := (8 - 2*squaredMod*math.Pow(T, 2)) / d
 	y2 := (-4 - 4*realP*T - squaredMod*math.Pow(T, 2)) / d
 	var k float64

--- a/control/pid.go
+++ b/control/pid.go
@@ -389,7 +389,8 @@ func (p *pidTuner) computeCohenCoonsGains(stepPwr float64) error {
 	if tau == 0 || tauD == 0 || K == 0 {
 		return errors.Errorf(
 			"PID auto-tuning could not characterize the step response using method %s (tau %v, deadtime %v, gain %v)",
-			p.tuneMethod, tau, tauD, K)
+			p.tuneMethod, tau, tauD, K,
+		)
 	}
 	r := tauD / tau
 	if p.tuneMethod == tuneMethodCohenCoonsPID {
@@ -426,7 +427,7 @@ func (p *pidTuner) pidTunerStep(pv float64, logger logging.Logger) (float64, boo
 		return p.out, false
 	case step:
 		p.vF = l2*math.Pow(pv-p.xF, 2.0) + (1-l1)*p.vF
-		p.dF = l3*(math.Pow(pv-p.pPv, 2.0)) + (1-l3)*p.dF
+		p.dF = l3*math.Pow(pv-p.pPv, 2.0) + (1-l3)*p.dF
 		p.xF = l1*pv + (1-l1)*p.xF
 		r := (2 - l1) * p.vF / p.dF
 		p.pPv = pv

--- a/control/setup_control.go
+++ b/control/setup_control.go
@@ -236,7 +236,8 @@ func (p *PIDLoop) createControlLoopConfig(pidVals []PIDConfig, componentName str
 	}
 	if p.Options.PositionControlUsingTrapz && p.Options.SensorFeedback2DVelocityControl {
 		p.logger.Warn(
-			"PositionControlUsingTrapz and SensorFeedback2DVelocityControl are not yet supported in the same control loop")
+			"PositionControlUsingTrapz and SensorFeedback2DVelocityControl are not yet supported in the same control loop",
+		)
 	}
 
 	p.basicControlConfig(componentName, pidVals[0], controllableType)

--- a/data/capture_file.go
+++ b/data/capture_file.go
@@ -116,7 +116,8 @@ func ReadCaptureFile(f *os.File) (*CaptureFile, error) {
 // NewCaptureFile creates a new *CaptureFile with the specified md in the specified directory.
 func NewCaptureFile(dir string, md *v1.DataCaptureMetadata) (*CaptureFile, error) {
 	fileName := CaptureFilePathWithReplacedReservedChars(
-		filepath.Join(dir, getFileTimestampName()) + InProgressCaptureFileExt)
+		filepath.Join(dir, getFileTimestampName()) + InProgressCaptureFileExt,
+	)
 	//nolint:gosec
 	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {

--- a/data/collector.go
+++ b/data/collector.go
@@ -373,7 +373,7 @@ func (c *collector) logCaptureErrs() {
 			if errors.As(err, &failedToReadError) {
 				c.logger.Warn(err)
 			} else {
-				c.logger.Error((err))
+				c.logger.Error(err)
 			}
 			c.lastLoggedErrors[err.Error()] = now
 		}

--- a/etc/analyzecoverage/main.go
+++ b/etc/analyzecoverage/main.go
@@ -105,7 +105,8 @@ func mainWithArgs(ctx context.Context, _ []string, logger logging.Logger) error 
 	var closestPastResultsErr error
 	if isPullRequest {
 		closestPastResults, closestPastResultsErr = findClosestMergeBaseResults(
-			ctx, coll, branchName, gitSHA, baseRef, baseSha)
+			ctx, coll, branchName, gitSHA, baseRef, baseSha,
+		)
 	}
 
 	createdAt := time.Now()
@@ -301,7 +302,8 @@ func generateMarkdownOutput(
 		"**Summary** | **%.0f%%** (%d / %d)",
 		results.summary.LineCoveragePct,
 		results.summary.LinesCovered,
-		results.summary.LinesTotal))
+		results.summary.LinesTotal,
+	))
 	if canDelta {
 		builder.WriteString(fmt.Sprintf(" | %s", getDelta(results.summary, closestPastResults.results.summary)))
 	}
@@ -630,7 +632,8 @@ func findClosestMergeBaseResults(
 		if i != 0 {
 			mergeBaseErr = fmt.Errorf(
 				"merge base coverage results not available, comparing against closest %s~%d=(%s) instead",
-				possibleMergeBaseRoot, i, mergeBase)
+				possibleMergeBaseRoot, i, mergeBase,
+			)
 		}
 		break
 	}
@@ -642,7 +645,8 @@ func findClosestMergeBaseResults(
 			mergeBase = baseSha
 			mergeBaseErr = fmt.Errorf(
 				"merge base coverage results not available, using HEAD(%s)=%s as no other closest candidate was found",
-				baseRef, baseSha)
+				baseRef, baseSha,
+			)
 		} else {
 			return nil, errors.New("failed to find any suitable merge base to compare against")
 		}

--- a/etc/analyzecoverage/main.go
+++ b/etc/analyzecoverage/main.go
@@ -590,7 +590,7 @@ func findClosestMergeBaseResults(
 	}
 
 	// look back for results
-	//nolint: noctx
+	//nolint: gosec,noctx
 	cmd := exec.Command("git", "merge-base", branchSha, baseSha)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/etc/analyzetests/main.go
+++ b/etc/analyzetests/main.go
@@ -37,7 +37,7 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI))
 	if err != nil {

--- a/etc/subsystem_manifest/main.go
+++ b/etc/subsystem_manifest/main.go
@@ -109,7 +109,7 @@ func getViamServerMetadata(path, resourcesOutputFileName string) (*viamServerMet
 		//nolint:errcheck
 		defer os.Remove(resourcesOutputFileName)
 
-		//nolint: noctx
+		//nolint: gosec,noctx
 		command := exec.Command(path, "--dump-resources", resourcesOutputFileName)
 		if err := command.Run(); err != nil {
 			return nil, err

--- a/examples/customresources/demos/rtppassthrough/myrtppassthrough.go
+++ b/examples/customresources/demos/rtppassthrough/myrtppassthrough.go
@@ -17,7 +17,8 @@ func main() {
 	resource.RegisterComponent(
 		camera.API,
 		model,
-		resource.Registration[camera.Camera, *fake.Config]{Constructor: newFakeCamera})
+		resource.Registration[camera.Camera, *fake.Config]{Constructor: newFakeCamera},
+	)
 	module.ModularMain(resource.APIModel{camera.API, model})
 }
 

--- a/examples/customresources/models/mydiscovery/mydiscovery.go
+++ b/examples/customresources/models/mydiscovery/mydiscovery.go
@@ -25,7 +25,8 @@ func init() {
 			logger logging.Logger,
 		) (discovery.Service, error) {
 			return newDiscovery(conf.ResourceName(), logger), nil
-		}})
+		}},
+	)
 }
 
 func newDiscovery(name resource.Name, logger logging.Logger) discovery.Service {

--- a/gostream/query.go
+++ b/gostream/query.go
@@ -378,7 +378,8 @@ func selectBestDriver(
 		logger.Debugw(
 			"considering driver",
 			"label", d.Info().Label,
-			"priority", priority)
+			"priority", priority,
+		)
 		for _, p := range props {
 			fitnessDist, ok := constraints.MediaConstraints.FitnessDistance(p)
 			if !ok {
@@ -391,7 +392,8 @@ func selectBestDriver(
 				"label", d.Info().Label,
 				"props", p,
 				"distance", fitnessDist,
-				"distance_with_priority", fitnessDistWithPriority)
+				"distance_with_priority", fitnessDistWithPriority,
+			)
 			if fitnessDistWithPriority < minFitnessDist {
 				minFitnessDist = fitnessDistWithPriority
 				bestDriver = d

--- a/gostream/stream_test.go
+++ b/gostream/stream_test.go
@@ -54,7 +54,7 @@ func stream(ctx context.Context, b *testing.B, s VideoStream) {
 const SecondNs = 1000000000.0 // second in nanoseconds
 
 func incrementAverage(avgOld, valNew, sizeNew float64) float64 {
-	avgNew := (avgOld) + (valNew-avgOld)/sizeNew
+	avgNew := avgOld + (valNew-avgOld)/sizeNew
 	return avgNew
 }
 

--- a/logging/impl.go
+++ b/logging/impl.go
@@ -368,7 +368,8 @@ func (imp *impl) Write(entry *LogEntry) {
 				suppressedEntry := *entry
 				suppressedEntry.Message = fmt.Sprintf(
 					"Message logged %d times; suppressing for rest of window (%v): %s",
-					noisyMessageCountThreshold, noisyMessageWindowDuration, entry.Message)
+					noisyMessageCountThreshold, noisyMessageWindowDuration, entry.Message,
+				)
 
 				imp.testHelper()
 				for _, appender := range imp.getAppenders() {

--- a/logging/impl_test.go
+++ b/logging/impl_test.go
@@ -604,7 +604,8 @@ func TestLoggingDeduplication(t *testing.T) {
 		assertLogMatches(t, notStdout,
 			fmt.Sprintf(
 				`2023-10-30T13:19:45.806Z	INFO	impl	logging/impl_test.go:132	identical message	{"%s":"bar","key":"value"}`,
-				ignoredLogFieldKey))
+				ignoredLogFieldKey,
+			))
 	}
 	loggerWith.Info(identicalMsg) // not output due to being noisy; emits suppression notice
 	assertLogMatches(t, notStdout,

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 min_version = '2026.8.16'
 
 [tools]
-golangci-lint = "2.9.0"
+golangci-lint = "2.13.2"
 
 [tasks.lint-go]
 alias = "lint"

--- a/module/modmanager/manager.go
+++ b/module/modmanager/manager.go
@@ -242,7 +242,8 @@ func (mgr *Manager) Add(ctx context.Context, confs ...config.Module) error {
 		confs = newConfs
 		mgr.logger.CWarnw(
 			ctx, "Running in an untrusted environment; will only add some modules", "modules",
-			confs)
+			confs,
+		)
 	}
 
 	var (
@@ -373,7 +374,8 @@ func (mgr *Manager) startModule(ctx context.Context, mod *module) error {
 	}
 
 	cleanup := rutils.SlowLogger(
-		ctx, "Waiting for module to complete startup and registration", "module", mod.cfg.Name, mod.logger)
+		ctx, "Waiting for module to complete startup and registration", "module", mod.cfg.Name, mod.logger,
+	)
 	defer cleanup()
 
 	var moduleRestartCtx context.Context
@@ -502,7 +504,8 @@ func (mgr *Manager) closeModule(mod *module, reason string) error {
 	}
 
 	cleanup := rutils.SlowLogger(
-		context.Background(), "Waiting for module to complete shutdown", "module", mod.cfg.Name, mod.logger)
+		context.Background(), "Waiting for module to complete shutdown", "module", mod.cfg.Name, mod.logger,
+	)
 	defer cleanup()
 
 	// Remove all resources associated with the module. Only allow 20s across all removals.
@@ -996,7 +999,8 @@ func (mgr *Manager) attemptRestart(ctx context.Context, mod *module) error {
 	// executable we were given for initial module addition.
 
 	cleanup := rutils.SlowLogger(
-		ctx, "Waiting for module to complete restart and re-registration", "module", mod.cfg.Name, mod.logger)
+		ctx, "Waiting for module to complete restart and re-registration", "module", mod.cfg.Name, mod.logger,
+	)
 	defer cleanup()
 
 	// There is a potential race here where the process starts but then crashes,

--- a/module/modmanager/module.go
+++ b/module/modmanager/module.go
@@ -138,7 +138,7 @@ func (m *module) checkReady(ctx context.Context, parentAddr string) error {
 	}
 
 	req := &pb.ReadyRequest{
-		ParentAddress:    legacyParentAddr,
+		ParentAddress:    legacyParentAddr, //nolint:staticcheck // RSDK-14540
 		RawParentAddress: parentAddr,
 	}
 

--- a/module/modmanager/module.go
+++ b/module/modmanager/module.go
@@ -246,7 +246,8 @@ func (m *module) startProcess(
 		// append a random alpha string to the module name while creating a socket address to avoid conflicts
 		// with old versions of the module.
 		if m.addr, err = modlib.CreateSocketAddress(
-			filepath.Dir(parentAddr), fmt.Sprintf("%s-%s", m.cfg.Name, utils.RandomAlphaString(5))); err != nil {
+			filepath.Dir(parentAddr), fmt.Sprintf("%s-%s", m.cfg.Name, utils.RandomAlphaString(5)),
+		); err != nil {
 			return err
 		}
 	}

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -512,7 +512,7 @@ func TestAttributeConversion(t *testing.T) {
 			Model: modelWithReconfigure.String(),
 		}
 
-		return &testHarness{
+		th := &testHarness{
 			m:                    m,
 			mockConf:             mockConf,
 			mockReconfigConf:     mockReconfigConf,
@@ -523,13 +523,15 @@ func TestAttributeConversion(t *testing.T) {
 			reconfigDeps1:        &reconfigDeps1,
 			reconfigDeps2:        &reconfigDeps2,
 			modelWithReconfigure: modelWithReconfigure,
-		}, func() {
+		}
+		teardown := func() {
 			resource.Deregister(shell.API, model)
 			resource.Deregister(shell.API, modelWithReconfigure)
 			test.That(t, conn.Close(), test.ShouldBeNil)
 			m.Close(ctx)
 			test.That(t, myRobot.Close(ctx), test.ShouldBeNil)
 		}
+		return th, teardown
 	}
 
 	t.Run("non-reconfigurable creation", func(t *testing.T) {

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -513,23 +513,23 @@ func TestAttributeConversion(t *testing.T) {
 		}
 
 		return &testHarness{
-				m:                    m,
-				mockConf:             mockConf,
-				mockReconfigConf:     mockReconfigConf,
-				createConf1:          &createConf1,
-				reconfigConf1:        &reconfigConf1,
-				reconfigConf2:        &reconfigConf2,
-				createDeps1:          &createDeps1,
-				reconfigDeps1:        &reconfigDeps1,
-				reconfigDeps2:        &reconfigDeps2,
-				modelWithReconfigure: modelWithReconfigure,
-			}, func() {
-				resource.Deregister(shell.API, model)
-				resource.Deregister(shell.API, modelWithReconfigure)
-				test.That(t, conn.Close(), test.ShouldBeNil)
-				m.Close(ctx)
-				test.That(t, myRobot.Close(ctx), test.ShouldBeNil)
-			}
+			m:                    m,
+			mockConf:             mockConf,
+			mockReconfigConf:     mockReconfigConf,
+			createConf1:          &createConf1,
+			reconfigConf1:        &reconfigConf1,
+			reconfigConf2:        &reconfigConf2,
+			createDeps1:          &createDeps1,
+			reconfigDeps1:        &reconfigDeps1,
+			reconfigDeps2:        &reconfigDeps2,
+			modelWithReconfigure: modelWithReconfigure,
+		}, func() {
+			resource.Deregister(shell.API, model)
+			resource.Deregister(shell.API, modelWithReconfigure)
+			test.That(t, conn.Close(), test.ShouldBeNil)
+			m.Close(ctx)
+			test.That(t, myRobot.Close(ctx), test.ShouldBeNil)
+		}
 	}
 
 	t.Run("non-reconfigurable creation", func(t *testing.T) {

--- a/module/resources.go
+++ b/module/resources.go
@@ -445,7 +445,8 @@ func (m *Module) cascadeRebuildDependentsOf(ctx context.Context, newResName reso
 			m.logger.Warnw(
 				"detected mutual-optional dependency cycle: one of these resources will always hold a closed handle to the other "+
 					"after reconstruction. Remove the optional dependency from one side to break the cycle.",
-				"resource", newResName.String(), "dependent", args.conf.Name)
+				"resource", newResName.String(), "dependent", args.conf.Name,
+			)
 			newDependents = append(newDependents, args)
 			continue
 		}
@@ -470,7 +471,8 @@ func (m *Module) cascadeRebuildDependentsOf(ctx context.Context, newResName reso
 
 func (m *Module) removeResource(ctx context.Context, resName resource.Name) error {
 	slowWatcher, slowWatcherCancel := utils.SlowGoroutineWatcher(
-		30*time.Second, fmt.Sprintf("module resource %q is taking a while to remove", resName), m.logger)
+		30*time.Second, fmt.Sprintf("module resource %q is taking a while to remove", resName), m.logger,
+	)
 	defer func() {
 		slowWatcherCancel()
 		<-slowWatcher

--- a/module/testmodule/main.go
+++ b/module/testmodule/main.go
@@ -56,7 +56,8 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 		helperModel,
 		resource.Registration[resource.Resource, resource.NoNativeConfig]{
 			Constructor: newHelper,
-		})
+		},
+	)
 	err = myMod.AddModelFromRegistry(ctx, generic.API, helperModel)
 	if err != nil {
 		return err
@@ -65,7 +66,8 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 	resource.RegisterService(
 		genericservice.API,
 		otherModel,
-		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newOther})
+		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newOther},
+	)
 	err = myMod.AddModelFromRegistry(ctx, genericservice.API, otherModel)
 	if err != nil {
 		return err
@@ -74,7 +76,8 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 	resource.RegisterComponent(
 		motor.API,
 		testMotorModel,
-		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newTestMotor})
+		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newTestMotor},
+	)
 	err = myMod.AddModelFromRegistry(ctx, motor.API, testMotorModel)
 	if err != nil {
 		return err
@@ -83,7 +86,8 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 	resource.RegisterComponent(
 		generic.API,
 		testSlowModel,
-		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newSlow})
+		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newSlow},
+	)
 	err = myMod.AddModelFromRegistry(ctx, generic.API, testSlowModel)
 	if err != nil {
 		return err
@@ -92,7 +96,8 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 	resource.RegisterComponent(
 		generic.API,
 		testFSDependentModel,
-		resource.Registration[resource.Resource, *fsDepConfig]{Constructor: newFSDependent})
+		resource.Registration[resource.Resource, *fsDepConfig]{Constructor: newFSDependent},
+	)
 	err = myMod.AddModelFromRegistry(ctx, generic.API, testFSDependentModel)
 	if err != nil {
 		return err
@@ -101,7 +106,8 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 	resource.RegisterComponent(
 		sensor.API,
 		testSensorDependentModel,
-		resource.Registration[resource.Resource, *sensorDepConfig]{Constructor: newSensorDependent})
+		resource.Registration[resource.Resource, *sensorDepConfig]{Constructor: newSensorDependent},
+	)
 	err = myMod.AddModelFromRegistry(ctx, sensor.API, testSensorDependentModel)
 	if err != nil {
 		return err

--- a/module/testmodule2/main.go
+++ b/module/testmodule2/main.go
@@ -45,7 +45,8 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 	resource.RegisterComponent(
 		generic.API,
 		helperModel,
-		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newHelper})
+		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newHelper},
+	)
 	err = myMod.AddModelFromRegistry(ctx, generic.API, helperModel)
 	if err != nil {
 		return err
@@ -54,7 +55,8 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 	resource.RegisterComponent(
 		motor.API,
 		testMotorModel,
-		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newTestMotor})
+		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newTestMotor},
+	)
 	err = myMod.AddModelFromRegistry(ctx, motor.API, testMotorModel)
 	if err != nil {
 		return err
@@ -63,7 +65,8 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) err
 	resource.RegisterComponent(
 		sensor.API,
 		testSensorDependentModel,
-		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newSensorDependent})
+		resource.Registration[resource.Resource, resource.NoNativeConfig]{Constructor: newSensorDependent},
+	)
 	err = myMod.AddModelFromRegistry(ctx, sensor.API, testSensorDependentModel)
 	if err != nil {
 		return err

--- a/module/version_reconfigure_test.go
+++ b/module/version_reconfigure_test.go
@@ -64,7 +64,8 @@ func TestValidationFailureDuringReconfiguration(t *testing.T) {
 
 	// Assert that there were no validation or component building errors
 	test.That(t, logs.FilterMessageSnippet(
-		"Modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
+		"Modular config validation error found in resource: generic1",
+	).Len(), test.ShouldEqual, 0)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 
 	// Read the config, swap to the v2 build, and overwrite the config, triggering a
@@ -129,7 +130,8 @@ func TestVersionBumpWithNewImplicitDeps(t *testing.T) {
 
 	// Assert that there were no validation or component building errors
 	test.That(t, logs.FilterMessageSnippet(
-		"Modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
+		"Modular config validation error found in resource: generic1",
+	).Len(), test.ShouldEqual, 0)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 
 	// Swap in the v3 build. Version 3 requires `generic1` to have a `motor` in its
@@ -202,7 +204,8 @@ func TestVersionBumpWithNewImplicitDepsWithoutConfigChange(t *testing.T) {
 
 	// Assert that there were no validation or component building errors
 	test.That(t, logs.FilterMessageSnippet(
-		"Modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
+		"Modular config validation error found in resource: generic1",
+	).Len(), test.ShouldEqual, 0)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 
 	// Swap in the v3 build. Version 3 requires `generic1` to have a `motor` in its
@@ -215,7 +218,8 @@ func TestVersionBumpWithNewImplicitDepsWithoutConfigChange(t *testing.T) {
 
 	// Assert that there were no validation or component building errors
 	test.That(t, logs.FilterMessageSnippet(
-		"Modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
+		"Modular config validation error found in resource: generic1",
+	).Len(), test.ShouldEqual, 0)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 }
 
@@ -259,7 +263,8 @@ func TestVersionBumpWithLessImplicitDepsWithoutConfigChange(t *testing.T) {
 
 	// Assert that there were no validation or component building errors
 	test.That(t, logs.FilterMessageSnippet(
-		"Modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
+		"Modular config validation error found in resource: generic1",
+	).Len(), test.ShouldEqual, 0)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 
 	// Swap in the v1 build and remove `motor1`. Version 1 does not require `generic1` to have a `motor` in its
@@ -277,6 +282,7 @@ func TestVersionBumpWithLessImplicitDepsWithoutConfigChange(t *testing.T) {
 
 	// Assert that there were no validation or component building errors
 	test.That(t, logs.FilterMessageSnippet(
-		"Modular config validation error found in resource: generic1").Len(), test.ShouldEqual, 0)
+		"Modular config validation error found in resource: generic1",
+	).Len(), test.ShouldEqual, 0)
 	test.That(t, logs.FilterMessageSnippet("error building component").Len(), test.ShouldEqual, 0)
 }

--- a/motionplan/armplanning/api.go
+++ b/motionplan/armplanning/api.go
@@ -132,7 +132,8 @@ func (req *PlanRequest) validatePlanRequest() error {
 		}
 
 		req.ObstaclesInWorldFrame = referenceframe.NewGeometriesInFrame(
-			req.ObstaclesInWorldFrame.Parent(), pcdGeometries)
+			req.ObstaclesInWorldFrame.Parent(), pcdGeometries,
+		)
 	}
 
 	// Validate the goals. Each goal with a pose must not also have a configuration specified. The parent frame of the pose must exist.

--- a/motionplan/armplanning/cBiRRT.go
+++ b/motionplan/armplanning/cBiRRT.go
@@ -234,9 +234,11 @@ func (mp *cBiRRTMotionPlanner) constrainedExtend(
 	for i := 0; i < maxExtendIter; i++ {
 		configDistMetric := mp.pc.ConfigurationDistanceFunc
 		dist := configDistMetric(
-			&motionplan.SegmentFS{StartConfiguration: near.inputs, EndConfiguration: target.inputs})
+			&motionplan.SegmentFS{StartConfiguration: near.inputs, EndConfiguration: target.inputs},
+		)
 		oldDist := configDistMetric(
-			&motionplan.SegmentFS{StartConfiguration: oldNear.inputs, EndConfiguration: target.inputs})
+			&motionplan.SegmentFS{StartConfiguration: oldNear.inputs, EndConfiguration: target.inputs},
+		)
 
 		switch {
 		case dist < mp.pc.planOpts.InputIdentDist:
@@ -256,7 +258,8 @@ func (mp *cBiRRTMotionPlanner) constrainedExtend(
 		}
 
 		nearDist := mp.pc.ConfigurationDistanceFunc(
-			&motionplan.SegmentFS{StartConfiguration: oldNear.inputs, EndConfiguration: newNear})
+			&motionplan.SegmentFS{StartConfiguration: oldNear.inputs, EndConfiguration: newNear},
+		)
 
 		if nearDist < math.Pow(mp.pc.planOpts.InputIdentDist, 3) {
 			if !doubled {

--- a/motionplan/armplanning/cmd-plan/cmd-plan.go
+++ b/motionplan/armplanning/cmd-plan/cmd-plan.go
@@ -398,7 +398,8 @@ func (r *runner) loadRequest(file string) (*armplanning.PlanRequest, motionplan.
 
 	if r.opts.pseudolinearLine > 0 || r.opts.pseudolinearOrientation > 0 {
 		req.Constraints.AddPseudolinearConstraint(
-			motionplan.PseudolinearConstraint{r.opts.pseudolinearLine, r.opts.pseudolinearOrientation})
+			motionplan.PseudolinearConstraint{r.opts.pseudolinearLine, r.opts.pseudolinearOrientation},
+		)
 	}
 
 	if r.opts.seed >= 0 {
@@ -848,7 +849,8 @@ func visualize(req *armplanning.PlanRequest, plan motionplan.Plan, mylog *log.Lo
 					StartConfiguration: plan.Trajectory()[idx-1].ToLinearInputs(),
 					EndConfiguration:   plan.Trajectory()[idx].ToLinearInputs(),
 					FS:                 req.FrameSystem,
-				}, 2)
+				}, 2,
+			)
 			if err != nil {
 				return err
 			}
@@ -896,7 +898,9 @@ func drawGoalPoses(req *armplanning.PlanRequest) error {
 			poseInWorldFrame := poseValue.Transform(
 				referenceframe.NewPoseInFrame(
 					req.FrameSystem.World().Name(),
-					spatialmath.NewZeroPose())).(*referenceframe.PoseInFrame)
+					spatialmath.NewZeroPose(),
+				),
+			).(*referenceframe.PoseInFrame)
 			goalPoses = append(goalPoses, poseInWorldFrame.Pose())
 		}
 	}
@@ -1037,7 +1041,9 @@ func doInteractive(req *armplanning.PlanRequest, plan motionplan.Plan, planErr e
 					poseInWorldFrame := poseValue.Transform(
 						referenceframe.NewPoseInFrame(
 							req.FrameSystem.World().Name(),
-							spatialmath.NewZeroPose())).(*referenceframe.PoseInFrame)
+							spatialmath.NewZeroPose(),
+						),
+					).(*referenceframe.PoseInFrame)
 					sphere, err := spatialmath.NewSphere(poseInWorldFrame.Pose(), 10, fmt.Sprintf("goal-%d-%v", gi, pi))
 					if err != nil {
 						return err

--- a/motionplan/armplanning/errors.go
+++ b/motionplan/armplanning/errors.go
@@ -30,7 +30,8 @@ func newImmovableGoalError(fs *referenceframe.FrameSystem, moveFrameName, goalFr
 		"cannot move frame %q relative to %q: no DoF moves %q, so planning cannot reposition it. %q is rigidly "+
 			"attached to the world frame through: %s. Check that the frame being moved is one which some DoF "+
 			"actually moves, such as an arm or a frame mounted on one",
-		moveFrameName, goalFrameName, moveFrameName, moveFrameName, chainToWorldDescription(fs, moveFrameName))
+		moveFrameName, goalFrameName, moveFrameName, moveFrameName, chainToWorldDescription(fs, moveFrameName),
+	)
 }
 
 // chainToWorldDescription renders a frame's parentage as "frame -> parent -> ... -> world".

--- a/motionplan/armplanning/functional_test.go
+++ b/motionplan/armplanning/functional_test.go
@@ -320,7 +320,8 @@ func testPlanner(t *testing.T, ctx context.Context, config planConfigConstructor
 				StartConfiguration: nodes[j],
 				EndConfiguration:   nodes[j+1],
 				FS:                 cfg.FS,
-			}, cfg.Options.Resolution, true)
+			}, cfg.Options.Resolution, true,
+		)
 		test.That(t, err, test.ShouldBeNil)
 	}
 }
@@ -626,7 +627,8 @@ func TestMultiArmSolve(t *testing.T) {
 	test.That(t,
 		spatialmath.PoseAlmostCoincidentEps(
 			solvedPose.(*frame.PoseInFrame).Pose(),
-			goals["xArmVgripper"].Pose(), 0.1),
+			goals["xArmVgripper"].Pose(), 0.1,
+		),
 		test.ShouldBeTrue)
 }
 

--- a/motionplan/armplanning/mpserver/server.go
+++ b/motionplan/armplanning/mpserver/server.go
@@ -1278,7 +1278,9 @@ func computeGoalPoseMap(req *armplanning.PlanRequest, goalIdx int) (map[string]p
 		poseInWorldFrame := poseValue.Transform(
 			referenceframe.NewPoseInFrame(
 				req.FrameSystem.World().Name(),
-				spatialmath.NewZeroPose())).(*referenceframe.PoseInFrame)
+				spatialmath.NewZeroPose(),
+			),
+		).(*referenceframe.PoseInFrame)
 		result[frameName] = poseInFrameToComponents(poseInWorldFrame)
 	}
 	return result, nil
@@ -1393,7 +1395,9 @@ func collectGoalPoses(req *armplanning.PlanRequest) ([]spatialmath.Pose, error) 
 			poseInWorldFrame := poseValue.Transform(
 				referenceframe.NewPoseInFrame(
 					req.FrameSystem.World().Name(),
-					spatialmath.NewZeroPose())).(*referenceframe.PoseInFrame)
+					spatialmath.NewZeroPose(),
+				),
+			).(*referenceframe.PoseInFrame)
 			goalPoses = append(goalPoses, poseInWorldFrame.Pose())
 		}
 	}
@@ -1519,7 +1523,8 @@ func visualizeLinearTrajectory(ctx context.Context, req *armplanning.PlanRequest
 					StartConfiguration: steps[idx-1],
 					EndConfiguration:   step,
 					FS:                 req.FrameSystem,
-				}, 2)
+				}, 2,
+			)
 			if err != nil {
 				return err
 			}

--- a/motionplan/armplanning/node.go
+++ b/motionplan/armplanning/node.go
@@ -684,7 +684,8 @@ solutionLoop:
 			if !ok {
 				logger.Debugf(
 					"Stopping because input channel is closed. Best score: %v With problem: %v",
-					solvingState.bestScoreNoProblem, solvingState.bestScoreWithProblem)
+					solvingState.bestScoreNoProblem, solvingState.bestScoreWithProblem,
+				)
 				// No longer using the generated solutions. Cancel the workers.
 				cancel()
 				break solutionLoop

--- a/motionplan/armplanning/nudge_test.go
+++ b/motionplan/armplanning/nudge_test.go
@@ -113,7 +113,8 @@ func nudgeBlockedScene(t *testing.T) (fs *referenceframe.FrameSystem, startJoint
 	// A thin post right where the end effector sweeps through mid-path: the
 	// straight line is blocked, but a small nudge goes around it.
 	obstacle, err := spatialmath.NewBox(
-		spatialmath.NewPoseFromPoint(midPose.Point()), r3.Vector{X: 20, Y: 20, Z: 150}, "post")
+		spatialmath.NewPoseFromPoint(midPose.Point()), r3.Vector{X: 20, Y: 20, Z: 150}, "post",
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	req = &PlanRequest{

--- a/motionplan/armplanning/plan_manager.go
+++ b/motionplan/armplanning/plan_manager.go
@@ -256,7 +256,8 @@ func (pm *planManager) planSingleGoal(
 		// the configured distance metric plus a neutral-pose bias, so it is
 		// not a joint angle and cannot back the threshold or the message.
 		reconfigL2 := math.Sqrt(flatL2Sq(
-			psc.start.GetLinearizedInputs(), planSeed.maps.optNode.inputs.GetLinearizedInputs()))
+			psc.start.GetLinearizedInputs(), planSeed.maps.optNode.inputs.GetLinearizedInputs(),
+		))
 		const reconfigWallRad = 1.5
 		if eeDelta >= 0 && eeDelta < 50 && lc <= 50 && reconfigL2 > reconfigWallRad {
 			pm.logger.Warnf("goal is %0.1fmm of end-effector motion but the nearest valid goal configuration is "+

--- a/motionplan/armplanning/posecloud_int_test.go
+++ b/motionplan/armplanning/posecloud_int_test.go
@@ -23,20 +23,23 @@ func TestPoseCloudPlanning(t *testing.T) {
 
 	fs := referenceframe.NewEmptyFrameSystem("huh")
 	lite6, err := referenceframe.ParseModelJSONFile(
-		utils.ResolveFile("components/arm/kinematics/lite6.json"), "lite6")
+		utils.ResolveFile("components/arm/kinematics/lite6.json"), "lite6",
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	err = fs.AddFrame(lite6, fs.World())
 	test.That(t, err, test.ShouldBeNil)
 
 	gripperOffset, err := referenceframe.NewStaticFrame(
-		"gripper_offset", spatialmath.NewPoseFromPoint(r3.Vector{Z: 40}))
+		"gripper_offset", spatialmath.NewPoseFromPoint(r3.Vector{Z: 40}),
+	)
 	test.That(t, err, test.ShouldBeNil)
 	err = fs.AddFrame(gripperOffset, lite6)
 	test.That(t, err, test.ShouldBeNil)
 
 	gripper, err := referenceframe.ParseModelJSONFile(
-		utils.ResolveFile("referenceframe/testfiles/test_gripper.json"), "gripper")
+		utils.ResolveFile("referenceframe/testfiles/test_gripper.json"), "gripper",
+	)
 	test.That(t, err, test.ShouldBeNil)
 	err = fs.AddFrame(gripper, gripperOffset)
 	test.That(t, err, test.ShouldBeNil)
@@ -45,14 +48,16 @@ func TestPoseCloudPlanning(t *testing.T) {
 		spatialmath.NewPose(
 			r3.Vector{X: 400, Y: -150, Z: 60},
 			&spatialmath.OrientationVectorDegrees{OX: -.2, OY: 0.3, OZ: 0.6},
-		), r3.Vector{X: 20, Y: 60, Z: 100}, "glass")
+		), r3.Vector{X: 20, Y: 60, Z: 100}, "glass",
+	)
 	test.That(t, err, test.ShouldBeNil)
 	glassFrame, err := referenceframe.NewStaticFrameWithGeometry(
 		"glass", spatialmath.NewPose(
 			r3.Vector{X: 400, Y: -150, Z: 60},
 			&spatialmath.OrientationVectorDegrees{OX: -.2, OY: 0.3, OZ: 0.6},
 		),
-		glassGeometry)
+		glassGeometry,
+	)
 	test.That(t, err, test.ShouldBeNil)
 	fs.AddFrame(glassFrame, fs.World())
 	test.That(t, err, test.ShouldBeNil)
@@ -79,7 +84,9 @@ func TestPoseCloudPlanning(t *testing.T) {
 			NewPlanState(referenceframe.FrameSystemPoses{
 				"gripper": referenceframe.NewPoseInFrame(
 					"glass", spatialmath.NewPoseFromOrientation(
-						&spatialmath.EulerAngles{Roll: math.Pi, Yaw: math.Pi / 2})),
+						&spatialmath.EulerAngles{Roll: math.Pi, Yaw: math.Pi / 2},
+					),
+				),
 			}, nil),
 		},
 		StartState: NewPlanState(nil, referenceframe.FrameSystemInputs{
@@ -104,7 +111,8 @@ func TestPoseCloudPlanning(t *testing.T) {
 			NewPlanState(referenceframe.FrameSystemPoses{
 				"gripper": referenceframe.NewPoseInFrameWithGoalCloud(
 					"glass", spatialmath.NewPoseFromOrientation(
-						&spatialmath.EulerAngles{Roll: math.Pi, Yaw: math.Pi / 2}),
+						&spatialmath.EulerAngles{Roll: math.Pi, Yaw: math.Pi / 2},
+					),
 					&referenceframe.PoseCloud{
 						X: 10, Y: 10, Z: 40, OX: 1.0, OY: 1.0, Theta: 45,
 					},

--- a/motionplan/armplanning/retreat.go
+++ b/motionplan/armplanning/retreat.go
@@ -66,7 +66,8 @@ func retreatChain(
 		curPt := curDQ.Point()
 		target := spatialmath.NewPose(
 			r3.Vector{X: curPt.X, Y: curPt.Y, Z: curPt.Z + goalRetreatStepMM},
-			curDQ.Orientation())
+			curDQ.Orientation(),
+		)
 
 		metric := psc.pc.planOpts.GetGoalMetricWithOrientationSlack(referenceframe.FrameSystemPoses{
 			frame: referenceframe.NewPoseInFrame(referenceframe.World, target),

--- a/motionplan/armplanning/smart_seed_test.go
+++ b/motionplan/armplanning/smart_seed_test.go
@@ -74,7 +74,8 @@ func TestSmartSeedCache1(t *testing.T) {
 			start.Get("ur5e"),
 			goal,
 			10,
-			logger)
+			logger,
+		)
 		logger.Infof("time to run findSeedsForFrame: %v", time.Since(startTime))
 		test.That(t, err, test.ShouldBeNil)
 		best := 100000.0

--- a/motionplan/armplanning/wallhop_test.go
+++ b/motionplan/armplanning/wallhop_test.go
@@ -47,7 +47,8 @@ func TestWallHopWithoutSearch(t *testing.T) {
 	wallCenter := midPose.Point()
 	wallCenter.Z -= 100
 	obstacle, err := spatialmath.NewBox(
-		spatialmath.NewPoseFromPoint(wallCenter), r3.Vector{X: 350, Y: 350, Z: 500}, "bigwall")
+		spatialmath.NewPoseFromPoint(wallCenter), r3.Vector{X: 350, Y: 350, Z: 500}, "bigwall",
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	plan, meta, err := PlanMotion(context.Background(), logger, &PlanRequest{

--- a/motionplan/collision_test.go
+++ b/motionplan/collision_test.go
@@ -123,7 +123,8 @@ func TestUniqueCollisions(t *testing.T) {
 
 	zeroGeoms := internalGeometries.Geometries()
 	zeroPositionCollisions, _, err := checkCollisionsHinted(
-		zeroGeoms, zeroGeoms, nil, nil, defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t))
+		zeroGeoms, zeroGeoms, nil, nil, defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t),
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	// case 1: no self collision - check no new collisions are returned
@@ -198,7 +199,8 @@ func TestCollisionMinDistance(t *testing.T) {
 	geom2.SetLabel("box2")
 
 	collisions, minDist, err := checkCollisionsHinted(
-		[]spatial.Geometry{geom1}, []spatial.Geometry{geom2}, nil, nil, defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t))
+		[]spatial.Geometry{geom1}, []spatial.Geometry{geom2}, nil, nil, defaultCollisionBufferMM, true, nil, logging.NewTestLogger(t),
+	)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(collisions), test.ShouldEqual, 0)
 	test.That(t, minDist, test.ShouldBeGreaterThan, 8.0)

--- a/motionplan/constraint_checker.go
+++ b/motionplan/constraint_checker.go
@@ -245,7 +245,8 @@ func checkLinearConstraint(frame string, linConstraint LinearConstraint, from, t
 	if orientTol > 0 {
 		dist := min(
 			OrientDist(from.Orientation(), currPose.Orientation()),
-			OrientDist(to.Orientation(), currPose.Orientation()))
+			OrientDist(to.Orientation(), currPose.Orientation()),
+		)
 		if dist > orientTol {
 			return orientationError(frame, from.Orientation(), to.Orientation(), currPose.Orientation(), dist, orientTol)
 		}
@@ -269,7 +270,8 @@ func checkPseudoLinearConstraint(frame string, plinConstraint PseudolinearConstr
 		orientTol *= OrientDist(from.Orientation(), to.Orientation())
 		dist := min(
 			OrientDist(from.Orientation(), currPose.Orientation()),
-			OrientDist(to.Orientation(), currPose.Orientation()))
+			OrientDist(to.Orientation(), currPose.Orientation()),
+		)
 		if dist > orientTol {
 			return orientationError(frame, from.Orientation(), to.Orientation(), currPose.Orientation(), dist, orientTol)
 		}
@@ -631,7 +633,8 @@ func NewCollisionConstraintFS(
 			return 0, err
 		}
 		collisions, minDist, err := checkCollisionsHinted(
-			geoms, static, staticPre, allowed, collisionBufferMM, false, pairHint, logger)
+			geoms, static, staticPre, allowed, collisionBufferMM, false, pairHint, logger,
+		)
 		return finish(collisions, math.Min(minDist, sdfMin), err)
 	}
 
@@ -691,7 +694,8 @@ func NewCollisionConstraintFS(
 			return 0, err
 		}
 		collisions, minDist, err := checkCollisionsHinted(
-			geoms, geoms, nil, allowed, collisionBufferMM, false, pairHint, logger)
+			geoms, geoms, nil, allowed, collisionBufferMM, false, pairHint, logger,
+		)
 		return finish(collisions, math.Min(minDist, selfMin), err)
 	}
 
@@ -764,7 +768,8 @@ func NewCollisionConstraintFS(
 			staticPreToUse = nil
 		}
 		collisions, minDist, err := checkCollisionsHinted(
-			internalGeoms, staticToCheck, staticPreToUse, allowed, collisionBufferMM, false, pairHint, logger)
+			internalGeoms, staticToCheck, staticPreToUse, allowed, collisionBufferMM, false, pairHint, logger,
+		)
 		minDist = math.Min(minDist, sdfMin)
 		if err != nil {
 			return minDist, err
@@ -790,7 +795,8 @@ func computeInitialCollisionsToIgnore(
 ) ([]Collision, error) {
 	// Geometries in collision at move start should thereafter be ignored
 	initialCollisions, _, err := checkCollisionsHinted(
-		group1, group2, nil, makeAllowedCollisionsLookup(collisionSpecifications), collisionBufferMM, true, nil, logger)
+		group1, group2, nil, makeAllowedCollisionsLookup(collisionSpecifications), collisionBufferMM, true, nil, logger,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/motionplan/constraint_test.go
+++ b/motionplan/constraint_test.go
@@ -516,7 +516,8 @@ func TestCollisionDistance(t *testing.T) {
 
 		collisions, minDist, err := checkCollisionsHinted(
 			[]spatial.Geometry{geom1}, []spatial.Geometry{geom2}, nil, nil,
-			defaultCollisionBufferMM, false, nil, logging.NewTestLogger(t))
+			defaultCollisionBufferMM, false, nil, logging.NewTestLogger(t),
+		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, collisions, test.ShouldBeEmpty)
 		test.That(t, minDist, test.ShouldBeGreaterThan, 0)
@@ -531,7 +532,8 @@ func TestCollisionDistance(t *testing.T) {
 		ignoreList := []Collision{{"box1", "box2"}}
 		collisions, minDist, err := checkCollisionsHinted(
 			[]spatial.Geometry{geom1}, []spatial.Geometry{geom2}, nil, makeAllowedCollisionsLookup(ignoreList),
-			defaultCollisionBufferMM, false, nil, logging.NewTestLogger(t))
+			defaultCollisionBufferMM, false, nil, logging.NewTestLogger(t),
+		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, collisions, test.ShouldBeEmpty)
 		test.That(t, minDist, test.ShouldBeGreaterThan, 0)
@@ -670,7 +672,8 @@ func BenchmarkCollisionConstraintsObstructedEdge(b *testing.B) {
 		fs, movingRobotGeometries,
 		map[string]bool{model.Name(): true},
 		staticRobotGeometries, worldGeometries.Geometries(),
-		nil, defaultCollisionBufferMM, nil, logging.NewTestLogger(b))
+		nil, defaultCollisionBufferMM, nil, logging.NewTestLogger(b),
+	)
 	test.That(b, err, test.ShouldBeNil)
 
 	// Walk a short trajectory that stays in collision throughout — simulates

--- a/pointcloud/las.go
+++ b/pointcloud/las.go
@@ -102,7 +102,7 @@ func writeToLASFile(cloud PointCloud, fn string) (err error) {
 			Y: pos.Y,
 			Z: pos.Z,
 			BitField: lidario.PointBitField{
-				Value: (1) | (1 << 3) | (0 << 6) | (0 << 7),
+				Value: 1 | (1 << 3) | (0 << 6) | (0 << 7),
 			},
 			ClassBitField: lidario.ClassificationBitField{
 				Value: 0,

--- a/protoutils/sensor.go
+++ b/protoutils/sensor.go
@@ -102,7 +102,8 @@ func goToProto(v interface{}) (*structpb.Value, error) {
 	// errors from here do not contain non-breaking spaces.
 	if err != nil {
 		ascii := strings.ReplaceAll(
-			err.Error(), " " /* non-breaking space */, " " /* normal space */)
+			err.Error(), " " /* non-breaking space */, " ", /* normal space */
+		)
 		err = errors.New(ascii)
 	}
 	return vv, err

--- a/referenceframe/frame.go
+++ b/referenceframe/frame.go
@@ -267,8 +267,9 @@ func RestrictedRandomFrameInputs(m Frame, rSeed *rand.Rand, restrictionPercent f
 		}
 
 		frameSpan := u - l
-		minVal := math.Max(l, reference[i]-restrictionPercent*frameSpan/2)
-		maxVal := math.Min(u, reference[i]+restrictionPercent*frameSpan/2)
+		// The DoF length check above bounds i against reference, which gosec does not follow.
+		minVal := math.Max(l, reference[i]-restrictionPercent*frameSpan/2) //nolint:gosec
+		maxVal := math.Min(u, reference[i]+restrictionPercent*frameSpan/2) //nolint:gosec
 		samplingSpan := maxVal - minVal
 		pos = append(pos, samplingSpan*rSeed.Float64()+minVal)
 	}

--- a/referenceframe/limits.go
+++ b/referenceframe/limits.go
@@ -9,7 +9,8 @@ import (
 
 // ErrURDFLimitsUnsupported is returned when limits are set on a URDF-backed kinematics document.
 var ErrURDFLimitsUnsupported = fmt.Errorf(
-	"cannot set joint limits on a URDF document; see RSDK-14232")
+	"cannot set joint limits on a URDF document; see RSDK-14232",
+)
 
 // JointLimits is a partial update to one joint's limits. A nil field leaves that limit as it is,
 // so a caller who knows only how fast a joint may move can say that without restating where it
@@ -96,7 +97,8 @@ func SetJointLimits(cfg *ModelConfigJSON, limits map[string]JointLimits) (*Model
 	if cfg.KinParamType == "DH" {
 		return nil, fmt.Errorf(
 			"cannot set joint limits on model %q: DH kinematics describe joints as parameters rather "+
-				"than as joints with limits", cfg.Name)
+				"than as joints with limits", cfg.Name,
+		)
 	}
 
 	// Joints is the only field we write, so it is the only one that needs its own copy. Clearing

--- a/referenceframe/model.go
+++ b/referenceframe/model.go
@@ -497,7 +497,6 @@ func (m *SimpleModel) Transform(inputs []Input) (spatialmath.Pose, error) {
 			var frameInputs []Input
 			if offset == -1 {
 				mm := m.mimicMappings[chainFrame.Name()]
-				//nolint: gosec
 				frameInputs = []Input{mm.valueMultiplier*inputs[mm.sourceInputIdx] + mm.valueOffset}
 			} else {
 				frameInputs = inputs[offset : offset+dof]
@@ -518,7 +517,6 @@ func (m *SimpleModel) Transform(inputs []Input) (spatialmath.Pose, error) {
 				pose, err = chainFrame.Transform(emptyInputs)
 			} else if offset == -1 {
 				mm := m.mimicMappings[chainFrame.Name()]
-				//nolint: gosec
 				pose, err = chainFrame.Transform([]Input{mm.valueMultiplier*inputs[mm.sourceInputIdx] + mm.valueOffset})
 			} else {
 				pose, err = chainFrame.Transform(inputs[offset : offset+dof])

--- a/referenceframe/model_json.go
+++ b/referenceframe/model_json.go
@@ -13,7 +13,8 @@ var ErrMimicSourceNotFound = errors.New("mimic joint references non-existent sou
 
 // ErrMimicWithLimits is returned when a mimic joint specifies its own limits.
 var ErrMimicWithLimits = errors.New(
-	"mimic joint must not specify min/max or velocity/acceleration limits; limits are determined by the source joint")
+	"mimic joint must not specify min/max or velocity/acceleration limits; limits are determined by the source joint",
+)
 
 // ErrCircularMimicReference is returned when mimic joint references form a cycle.
 var ErrCircularMimicReference = errors.New("circular mimic joint reference detected")

--- a/referenceframe/transformable.go
+++ b/referenceframe/transformable.go
@@ -83,7 +83,8 @@ func (pF *PoseInFrame) SetName(name string) {
 // The tf PoseInFrame represents the pose of the pF reference frame with respect to the destination reference frame.
 func (pF *PoseInFrame) Transform(tf *PoseInFrame) Transformable {
 	return NewPoseInFrameWithGoalCloud(
-		tf.parent, spatialmath.Compose(tf.pose, pF.pose), pF.GoalCloud)
+		tf.parent, spatialmath.Compose(tf.pose, pF.pose), pF.GoalCloud,
+	)
 }
 
 // TransformOpt transforms the `pF` as a DualQuaternion in place.

--- a/resource/config.go
+++ b/resource/config.go
@@ -133,7 +133,8 @@ func NativeConfig[T any](conf Config) (T, error) {
 	if err != nil {
 		err = fmt.Errorf(
 			"incorrect config type: NativeConfig %w. Make sure the config type registered to the "+
-				"resource matches the one passed into NativeConfig", err)
+				"resource matches the one passed into NativeConfig", err,
+		)
 	}
 	return val, err
 }
@@ -336,7 +337,8 @@ func (conf *Config) validate(path, defaultAPIType string) ([]string, []string, e
 	if conf.Name == DefaultServiceName && !IsDefaultService(conf.Name, conf.API) {
 		return nil, nil, NewConfigValidationError(path, errors.Errorf(
 			"name %q is reserved for built-in default services and cannot be used by a %q resource",
-			DefaultServiceName, conf.API))
+			DefaultServiceName, conf.API,
+		))
 	}
 	if conf.ConvertedAttributes != nil {
 		var err error

--- a/resource/name.go
+++ b/resource/name.go
@@ -82,7 +82,8 @@ func (n Name) PrependRemote(remoteName string) Name {
 	return newRemoteName(
 		remoteName,
 		n.API,
-		n.Name)
+		n.Name,
+	)
 }
 
 // PopRemote pop the first remote from a Name (if any) and returns the new Name.
@@ -94,7 +95,8 @@ func (n Name) PopRemote() Name {
 	return newRemoteName(
 		strings.Join(remotes[1:], ":"),
 		n.API,
-		n.Name)
+		n.Name,
+	)
 }
 
 // ContainsRemoteNames return true if the resource is a remote resource.

--- a/resource/resource_graph.go
+++ b/resource/resource_graph.go
@@ -1014,7 +1014,8 @@ func (g *Graph) ResolveDependencies(logger logging.Logger) error {
 					if errors.As(err, &multiErr) {
 						allErrs = multierr.Combine(
 							allErrs,
-							errors.Errorf("conflicting names for resource %q: %v", nodeName, NamesToStrings(multiErr.Matches)))
+							errors.Errorf("conflicting names for resource %q: %v", nodeName, NamesToStrings(multiErr.Matches)),
+						)
 						logger.Errorw(
 							"cannot resolve dependency for resource due to multiple matching names",
 							"name", nodeName,

--- a/rimage/compare_img.go
+++ b/rimage/compare_img.go
@@ -55,7 +55,8 @@ func CompareImages(img1, img2 image.Image) (int, image.Image, error) {
 				resultImg.Set(
 					bounds1.Min.X+x,
 					bounds1.Min.Y+y,
-					color.RGBA{R: 255, A: 255})
+					color.RGBA{R: 255, A: 255},
+				)
 			}
 		}
 	}

--- a/rimage/filters.go
+++ b/rimage/filters.go
@@ -289,7 +289,7 @@ func savitskyGolayKernel(radius, order int) ([][]float64, error) {
 	for i, y := range yRange {
 		for j, x := range xRange {
 			for k, exp := range exps {
-				A.Set(i*(windowSize)+j, k, math.Pow(float64(x), float64(exp.X))*math.Pow(float64(y), float64(exp.Y)))
+				A.Set(i*windowSize+j, k, math.Pow(float64(x), float64(exp.X))*math.Pow(float64(y), float64(exp.Y)))
 			}
 		}
 	}

--- a/rimage/transform/pinhole_camera_parameters_test.go
+++ b/rimage/transform/pinhole_camera_parameters_test.go
@@ -173,14 +173,16 @@ func TestUndistortDepthMap(t *testing.T) {
 
 	// wrong size error
 	dmWrong, err := rimage.NewDepthMapFromFile(
-		context.Background(), artifact.MustPath("transform/align-test-1615761793.png"))
+		context.Background(), artifact.MustPath("transform/align-test-1615761793.png"),
+	)
 	test.That(t, err, test.ShouldBeNil)
 	_, err = pinhole.UndistortDepthMap(dmWrong)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "img dimension and intrinsics don't match")
 
 	// correct undistortion
 	img, err := rimage.NewDepthMapFromFile(
-		context.Background(), artifact.MustPath("rimage/board2_gray.png"))
+		context.Background(), artifact.MustPath("rimage/board2_gray.png"),
+	)
 	test.That(t, err, test.ShouldBeNil)
 	corrected, err := pinhole.UndistortDepthMap(img)
 	test.That(t, err, test.ShouldBeNil)

--- a/rimage/warp_test.go
+++ b/rimage/warp_test.go
@@ -67,7 +67,8 @@ func TestWarp2(t *testing.T) {
 			{size, 0},
 			{0, size},
 			{size, size},
-		})
+		},
+	)
 
 	out := WarpImage(img, m, image.Point{size, size})
 
@@ -93,7 +94,8 @@ func BenchmarkWarp(b *testing.B) {
 			{size, 0},
 			{0, size},
 			{size, size},
-		})
+		},
+	)
 
 	b.ResetTimer()
 

--- a/robot/client/client_session_test.go
+++ b/robot/client/client_session_test.go
@@ -278,7 +278,8 @@ func TestClientSessionOptions(t *testing.T) {
 						}
 
 						test.That(t, svc.Close(ctx), test.ShouldBeNil)
-					})
+					},
+				)
 			}
 		}
 	}
@@ -492,7 +493,8 @@ func TestClientSessionExpiration(t *testing.T) {
 				test.That(t, err, test.ShouldBeNil)
 
 				test.That(t, svc.Close(ctx), test.ShouldBeNil)
-			})
+			},
+		)
 	}
 }
 
@@ -660,7 +662,8 @@ func TestClientSessionResume(t *testing.T) {
 				test.That(t, err, test.ShouldBeNil)
 
 				test.That(t, svc.Close(ctx), test.ShouldBeNil)
-			})
+			},
+		)
 	}
 }
 

--- a/robot/client/client_test.go
+++ b/robot/client/client_test.go
@@ -306,7 +306,8 @@ func TestUnimplementedRPCSubtypes(t *testing.T) {
 		ctx2,
 		&pb.RobotService_ServiceDesc,
 		&unimplementedService,
-		pb.RegisterRobotServiceHandlerFromEndpoint)
+		pb.RegisterRobotServiceHandlerFromEndpoint,
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	go func() {
@@ -504,7 +505,8 @@ func TestStatusClient(t *testing.T) {
 	gServer1.RegisterService(&inputcontrollerpb.InputControllerService_ServiceDesc, input.NewRPCServiceServer(inputControllerSvc1, logger))
 
 	inputControllerSvc2, err := resource.NewAPIResourceCollection(
-		input.API, map[resource.Name]input.Controller{input.Named("inputController1"): injectInputDev})
+		input.API, map[resource.Name]input.Controller{input.Named("inputController1"): injectInputDev},
+	)
 	test.That(t, err, test.ShouldBeNil)
 	gServer2.RegisterService(&inputcontrollerpb.InputControllerService_ServiceDesc, input.NewRPCServiceServer(inputControllerSvc2, logger))
 

--- a/robot/impl/jobmanager_test.go
+++ b/robot/impl/jobmanager_test.go
@@ -195,7 +195,8 @@ func TestJobManagerHistory(t *testing.T) {
 			logger logging.Logger,
 		) (sensor.Sensor, error) {
 			return injectSensor, nil
-		}})
+		}},
+	)
 	resource.RegisterComponent(
 		sensor.API,
 		fakeSensorModelPanic,
@@ -206,7 +207,8 @@ func TestJobManagerHistory(t *testing.T) {
 			logger logging.Logger,
 		) (sensor.Sensor, error) {
 			return injectSensorPanic, nil
-		}})
+		}},
+	)
 
 	// test GetReadings success, DoCommand fail
 	cfg := &config.Config{
@@ -504,7 +506,8 @@ func TestJobManagerConfigChanges(t *testing.T) {
 				return dummyArm2, nil
 			}
 			return dummyArm3, nil
-		}})
+		}},
+	)
 
 	defer func() {
 		resource.Deregister(arm.API, model)
@@ -632,7 +635,8 @@ func TestJobManagerRemote(t *testing.T) {
 			logger logging.Logger,
 		) (sensor.Sensor, error) {
 			return dummySensor, nil
-		}})
+		}},
+	)
 
 	defer func() {
 		resource.Deregister(sensor.API, model)
@@ -729,7 +733,8 @@ func TestJobManagerRemoteWithPrefix(t *testing.T) {
 			logger logging.Logger,
 		) (sensor.Sensor, error) {
 			return dummySensor, nil
-		}})
+		}},
+	)
 
 	defer func() {
 		resource.Deregister(sensor.API, model)
@@ -825,7 +830,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (arm.Arm, error) {
 			return dummyArm, nil
-		}})
+		}},
+	)
 
 	// audioin
 	dummyAudioIn := inject.NewAudioIn("audioin")
@@ -842,7 +848,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (audioin.AudioIn, error) {
 			return dummyAudioIn, nil
-		}})
+		}},
+	)
 
 	// audioout
 	dummyAudioOut := inject.NewAudioOut("audioout")
@@ -859,7 +866,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (audioout.AudioOut, error) {
 			return dummyAudioOut, nil
-		}})
+		}},
+	)
 
 	// base
 	dummyBase := inject.NewBase("base")
@@ -876,7 +884,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (base.Base, error) {
 			return dummyBase, nil
-		}})
+		}},
+	)
 
 	// board
 	dummyBoard := inject.NewBoard("board")
@@ -897,7 +906,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (board.Board, error) {
 			return dummyBoard, nil
-		}})
+		}},
+	)
 
 	// button
 	dummyButton := inject.NewButton("button")
@@ -917,7 +927,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (button.Button, error) {
 			return dummyButton, nil
-		}})
+		}},
+	)
 	// camera
 	dummyCamera := inject.NewCamera("camera")
 	dummyCamera.PropertiesFunc = func(ctx context.Context) (camera.Properties, error) {
@@ -933,7 +944,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (camera.Camera, error) {
 			return dummyCamera, nil
-		}})
+		}},
+	)
 	// encoder
 	dummyEncoder := inject.NewEncoder("encoder")
 	dummyEncoder.PropertiesFunc = func(ctx context.Context,
@@ -951,7 +963,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (encoder.Encoder, error) {
 			return dummyEncoder, nil
-		}})
+		}},
+	)
 	// gantry
 	dummyGantry := inject.NewGantry("gantry")
 	dummyGantry.HomeFunc = func(ctx context.Context, extra map[string]any) (bool, error) {
@@ -967,7 +980,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (gantry.Gantry, error) {
 			return dummyGantry, nil
-		}})
+		}},
+	)
 	// generic
 	genericCounter := 0
 	dummyGeneric := inject.NewGenericComponent("generic")
@@ -987,7 +1001,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (generic.Resource, error) {
 			return dummyGeneric, nil
-		}})
+		}},
+	)
 	// gripper
 	dummyGripper := inject.NewGripper("gripper")
 	dummyGripper.GrabFunc = func(ctx context.Context, extra map[string]any) (bool, error) {
@@ -1003,7 +1018,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (gripper.Gripper, error) {
 			return dummyGripper, nil
-		}})
+		}},
+	)
 	// inputcontroller
 	dummyInputController := inject.NewInputController("my_input")
 	dummyInputController.EventsFunc = func(ctx context.Context,
@@ -1023,7 +1039,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (input.Controller, error) {
 			return dummyInputController, nil
-		}})
+		}},
+	)
 	// motor
 	dummyMotor := inject.NewMotor("motor")
 	dummyMotor.SetPowerFunc = func(ctx context.Context, powerPct float64, extra map[string]any) error {
@@ -1039,7 +1056,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (motor.Motor, error) {
 			return dummyMotor, nil
-		}})
+		}},
+	)
 	// movementsensor
 	dummyMovementSensor := inject.NewMovementSensor("move_sensor")
 	dummyMovementSensor.OrientationFunc = func(ctx context.Context, extra map[string]any) (spatialmath.Orientation, error) {
@@ -1055,7 +1073,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (movementsensor.MovementSensor, error) {
 			return dummyMovementSensor, nil
-		}})
+		}},
+	)
 	// posetracker
 	dummyPoseTracker := inject.NewPoseTracker("pose")
 	dummyPoseTracker.PosesFunc = func(ctx context.Context,
@@ -1074,7 +1093,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (posetracker.PoseTracker, error) {
 			return dummyPoseTracker, nil
-		}})
+		}},
+	)
 	// powersensor
 	dummyPowerSensor := inject.NewPowerSensor("power_sensor")
 	dummyPowerSensor.VoltageFunc = func(ctx context.Context, extra map[string]any) (float64, bool, error) {
@@ -1090,7 +1110,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (powersensor.PowerSensor, error) {
 			return dummyPowerSensor, nil
-		}})
+		}},
+	)
 	// sensor
 	dummySensor := inject.NewSensor("sensor")
 	dummySensor.ReadingsFunc = func(ctx context.Context, extra map[string]any) (map[string]any, error) {
@@ -1108,7 +1129,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (sensor.Sensor, error) {
 			return dummySensor, nil
-		}})
+		}},
+	)
 	// servo
 	dummyServo := inject.NewServo("servo")
 	dummyServo.PositionFunc = func(ctx context.Context, extra map[string]any) (uint32, error) {
@@ -1124,7 +1146,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (servo.Servo, error) {
 			return dummyServo, nil
-		}})
+		}},
+	)
 	// switch
 	dummySwitch := inject.NewSwitch("switch")
 	dummySwitch.GetNumberOfPositionsFunc = func(ctx context.Context, extra map[string]interface{}) (uint32, []string, error) {
@@ -1143,7 +1166,8 @@ func TestJobManagerComponents(t *testing.T) {
 			logger logging.Logger,
 		) (sw.Switch, error) {
 			return dummySwitch, nil
-		}})
+		}},
+	)
 
 	// create the actual config and fill it
 	cfg := &config.Config{
@@ -1460,7 +1484,8 @@ func TestJobManagerServices(t *testing.T) {
 			logger logging.Logger,
 		) (datamanager.Service, error) {
 			return dummyDataManager, nil
-		}})
+		}},
+	)
 
 	// discovery
 	dummyDiscovery := inject.NewDiscoveryService("discovery")
@@ -1484,7 +1509,8 @@ func TestJobManagerServices(t *testing.T) {
 			logger logging.Logger,
 		) (discovery.Service, error) {
 			return dummyDiscovery, nil
-		}})
+		}},
+	)
 
 	// generic
 	var genericCounter int
@@ -1505,7 +1531,8 @@ func TestJobManagerServices(t *testing.T) {
 			logger logging.Logger,
 		) (genSvc.Service, error) {
 			return dummyGeneric, nil
-		}})
+		}},
+	)
 	// ml_model
 	dummyML := inject.NewMLModelService("ml_model")
 	dummyML.InferFunc = func(ctx context.Context, tensors ml.Tensors) (ml.Tensors, error) {
@@ -1521,7 +1548,8 @@ func TestJobManagerServices(t *testing.T) {
 			logger logging.Logger,
 		) (mlmodel.Service, error) {
 			return dummyML, nil
-		}})
+		}},
+	)
 	// motion
 	dummyMotion := injectmotion.NewMotionService("motion")
 	dummyMotion.ListPlanStatusesFunc = func(ctx context.Context, req motion.ListPlanStatusesReq) ([]motion.PlanStatusWithID, error) {
@@ -1537,7 +1565,8 @@ func TestJobManagerServices(t *testing.T) {
 			logger logging.Logger,
 		) (motion.Service, error) {
 			return dummyMotion, nil
-		}})
+		}},
+	)
 	// navigation
 	dummyNav := inject.NewNavigationService("navigation")
 	dummyNav.ModeFunc = func(ctx context.Context, extra map[string]any) (navigation.Mode, error) {
@@ -1553,7 +1582,8 @@ func TestJobManagerServices(t *testing.T) {
 			logger logging.Logger,
 		) (navigation.Service, error) {
 			return dummyNav, nil
-		}})
+		}},
+	)
 	// shell
 	var shellCounter int
 	dummyShell := inject.NewShellService("shell")
@@ -1573,7 +1603,8 @@ func TestJobManagerServices(t *testing.T) {
 			logger logging.Logger,
 		) (shell.Service, error) {
 			return dummyShell, nil
-		}})
+		}},
+	)
 	// slam
 	dummySlam := inject.NewSLAMService("slam")
 	dummySlam.PropertiesFunc = func(ctx context.Context) (slam.Properties, error) {
@@ -1591,7 +1622,8 @@ func TestJobManagerServices(t *testing.T) {
 			logger logging.Logger,
 		) (slam.Service, error) {
 			return dummySlam, nil
-		}})
+		}},
+	)
 	// vision
 	dummyVision := inject.NewVisionService("vision")
 	dummyVision.GetPropertiesFunc = func(ctx context.Context, extra map[string]any) (*vision.Properties, error) {
@@ -1611,7 +1643,8 @@ func TestJobManagerServices(t *testing.T) {
 			logger logging.Logger,
 		) (vision.Service, error) {
 			return dummyVision, nil
-		}})
+		}},
+	)
 	cfg := &config.Config{
 		Services: []resource.Config{
 			{
@@ -1848,7 +1881,8 @@ func TestJobManagerErrors(t *testing.T) {
 			logger logging.Logger,
 		) (arm.Arm, error) {
 			return dummyArm, nil
-		}})
+		}},
+	)
 
 	newConf := config.Config{
 		Components: []resource.Config{

--- a/robot/impl/local_robot.go
+++ b/robot/impl/local_robot.go
@@ -615,22 +615,26 @@ func newWithResources(
 	defer r.reconfigurationLock.Unlock()
 	if err := r.manager.resources.AddNode(
 		web.InternalServiceName,
-		resource.NewConfiguredGraphNode(resource.Config{}, r.webSvc, builtinModel)); err != nil {
+		resource.NewConfiguredGraphNode(resource.Config{}, r.webSvc, builtinModel),
+	); err != nil {
 		return nil, err
 	}
 	if err := r.manager.resources.AddNode(
 		framesystem.InternalServiceName,
-		resource.NewConfiguredGraphNode(resource.Config{}, r.frameSvc, builtinModel)); err != nil {
+		resource.NewConfiguredGraphNode(resource.Config{}, r.frameSvc, builtinModel),
+	); err != nil {
 		return nil, err
 	}
 	if err := r.manager.resources.AddNode(
 		r.packageManager.Name(),
-		resource.NewConfiguredGraphNode(resource.Config{}, r.packageManager, builtinModel)); err != nil {
+		resource.NewConfiguredGraphNode(resource.Config{}, r.packageManager, builtinModel),
+	); err != nil {
 		return nil, err
 	}
 	if err := r.manager.resources.AddNode(
 		r.cloudConnSvc.Name(),
-		resource.NewConfiguredGraphNode(resource.Config{}, r.cloudConnSvc, builtinModel)); err != nil {
+		resource.NewConfiguredGraphNode(resource.Config{}, r.cloudConnSvc, builtinModel),
+	); err != nil {
 		return nil, err
 	}
 
@@ -1473,7 +1477,8 @@ func (r *localRobot) getLocalFrameSystemParts(ctx context.Context) ([]*reference
 				default: // > 1
 					logger.Warnw(
 						"`Geometries` returned more than one geometry, but the LinkInFrame does not support that."+
-							"Keeping the first one.", "Size", len(resGeometries))
+							"Keeping the first one.", "Size", len(resGeometries),
+					)
 					fallthrough
 				case 1:
 					geom := resGeometries[0]

--- a/robot/impl/local_robot_test.go
+++ b/robot/impl/local_robot_test.go
@@ -781,7 +781,8 @@ func TestStopAll(t *testing.T) {
 				return dummyArm1, nil
 			}
 			return dummyArm2, nil
-		}})
+		}},
+	)
 
 	armConfig := fmt.Sprintf(`{
 		"components": [
@@ -883,7 +884,8 @@ func TestStopAllDoesNotCancelOwnContext(t *testing.T) {
 			logger logging.Logger,
 		) (arm.Arm, error) {
 			return dummyArm, nil
-		}})
+		}},
+	)
 	defer resource.Deregister(arm.API, model)
 
 	armConfig := fmt.Sprintf(`{
@@ -937,7 +939,8 @@ func TestNewTeardown(t *testing.T) {
 					return nil
 				},
 			}, nil
-		}})
+		}},
+	)
 	resource.RegisterComponent(
 		gripper.API,
 		model,
@@ -948,7 +951,8 @@ func TestNewTeardown(t *testing.T) {
 			logger logging.Logger,
 		) (gripper.Gripper, error) {
 			return nil, errors.New("whoops")
-		}})
+		}},
+	)
 
 	defer func() {
 		resource.Deregister(board.API, model)
@@ -5251,7 +5255,8 @@ func TestMaintenanceConfig(t *testing.T) {
 			logger logging.Logger,
 		) (sensor.Sensor, error) {
 			return newValidSensor(), nil
-		}})
+		}},
+	)
 	resource.RegisterComponent(
 		sensor.API,
 		modelErrorSensor,
@@ -5262,7 +5267,8 @@ func TestMaintenanceConfig(t *testing.T) {
 			logger logging.Logger,
 		) (sensor.Sensor, error) {
 			return newInvalidSensor(), nil
-		}})
+		}},
+	)
 	defer func() {
 		resource.Deregister(sensor.API, model)
 		resource.Deregister(sensor.API, modelErrorSensor)
@@ -5461,7 +5467,8 @@ func TestMaintenanceConfigLogs(t *testing.T) {
 			logger logging.Logger,
 		) (sensor.Sensor, error) {
 			return newValidSensor(), nil
-		}})
+		}},
+	)
 	resource.RegisterComponent(
 		sensor.API,
 		modelErrorSensor,
@@ -5472,7 +5479,8 @@ func TestMaintenanceConfigLogs(t *testing.T) {
 			logger logging.Logger,
 		) (sensor.Sensor, error) {
 			return newErrorSensor(), nil
-		}})
+		}},
+	)
 	defer func() {
 		resource.Deregister(sensor.API, model)
 		resource.Deregister(sensor.API, modelErrorSensor)
@@ -5682,7 +5690,8 @@ func TestRemovingOfflineRemotes(t *testing.T) {
 	node := resource.NewConfiguredGraphNode(
 		resource.Config{
 			ConvertedAttributes: &configRemote,
-		}, nil, builtinModel)
+		}, nil, builtinModel,
+	)
 	// Set node to [NodeStateUnhealthy]
 	node.LogAndSetLastError(errors.New("Its so bad plz help"))
 	localRobot.manager.resources.AddNode(remoteName, node)
@@ -5773,7 +5782,8 @@ func TestModuleNamePassing(t *testing.T) {
 		) (sensor.Sensor, error) {
 			// Be lazy -- just return an a singleton object.
 			return callbackSensor, nil
-		}})
+		}},
+	)
 
 	const moduleName = "fancy_module_name"
 	localRobot := setupLocalRobot(t, ctx, &config.Config{
@@ -5862,7 +5872,8 @@ func TestInternalPanicFromModuleDoesNotCrash(t *testing.T) {
 					panic("oh no")
 				},
 			}, nil
-		}})
+		}},
+	)
 
 	testPath := rtestutils.BuildTempModule(t, "module/testmodule")
 	helperModel := resource.NewModel("rdk", "test", "helper")

--- a/robot/impl/optional_dependencies_test.go
+++ b/robot/impl/optional_dependencies_test.go
@@ -184,7 +184,8 @@ func TestOptionalDependencies(t *testing.T) {
 		optionalChildModel,
 		resource.Registration[*optionalChild, *optionalChildConfig]{
 			Constructor: newOptionalChild,
-		})
+		},
+	)
 	defer resource.Deregister(generic.API, optionalChildModel)
 
 	// Reconfigure the robot to have an optional child component, its required motor, and no
@@ -702,7 +703,8 @@ func TestOptionalDependencyOnBuiltin(t *testing.T) {
 		optionalChildModel,
 		resource.Registration[*optionalChild, *optionalChildConfig]{
 			Constructor: newOptionalChild,
-		})
+		},
+	)
 	defer resource.Deregister(generic.API, optionalChildModel)
 
 	// Reconfigure the robot to have an optional child component with a required motor 'm' and an
@@ -1237,7 +1239,8 @@ func TestOptionalDependenciesCycles(t *testing.T) {
 		mutualOptionalChildModel,
 		resource.Registration[*mutualOptionalChild, *mutualOptionalChildConfig]{
 			Constructor: newMutualOptionalChild,
-		})
+		},
+	)
 	defer resource.Deregister(generic.API, mutualOptionalChildModel)
 
 	// Reconfigure the robot to have a mutual optional child component that is missing its
@@ -1584,7 +1587,8 @@ func TestOptionalDependencyRepeatedErrors(t *testing.T) {
 		optionalChildModel,
 		resource.Registration[*optionalChild, *optionalChildConfig]{
 			Constructor: newOptionalChild,
-		})
+		},
+	)
 	defer resource.Deregister(generic.API, optionalChildModel)
 
 	// Configure the robot with:
@@ -1845,7 +1849,8 @@ func TestOptionalDependencyUnrelatedResourceRemoval(t *testing.T) {
 		optionalChildModel,
 		resource.Registration[*optionalChild, *optionalChildConfig]{
 			Constructor: newOptionalChild,
-		})
+		},
+	)
 	defer resource.Deregister(generic.API, optionalChildModel)
 
 	// Configure the robot with:

--- a/robot/impl/resource_manager.go
+++ b/robot/impl/resource_manager.go
@@ -604,7 +604,8 @@ func (manager *resourceManager) mergeResourceRPCAPIsWithRemote(r robot.Robot, ty
 				manager.logger.Errorw(
 					"remote proto service name clashes with another of the same API",
 					"existing", svcName.GetFullyQualifiedName(),
-					"remote", remoteType.Desc.GetFullyQualifiedName())
+					"remote", remoteType.Desc.GetFullyQualifiedName(),
+				)
 			}
 			continue
 		}
@@ -814,7 +815,8 @@ func (manager *resourceManager) completeConfig(
 				defer timeoutCancel()
 
 				stopSlowLogger := rutils.SlowLogger(
-					ctx, "Waiting for resource to complete (re)configuration", "resource", resName.String(), manager.logger)
+					ctx, "Waiting for resource to complete (re)configuration", "resource", resName.String(), manager.logger,
+				)
 
 				lr.reconfigureWorkers.Add(1)
 				goutils.PanicCapturingGo(func() {
@@ -848,7 +850,8 @@ func (manager *resourceManager) completeConfig(
 						gNode.LogAndSetLastError(
 							fmt.Errorf("resource config validation error: %w", err),
 							"resource", conf.ResourceName(),
-							"model", conf.Model)
+							"model", conf.Model,
+						)
 						return
 					}
 					if manager.moduleManager.Provides(conf) {
@@ -857,7 +860,8 @@ func (manager *resourceManager) completeConfig(
 							gNode.LogAndSetLastError(
 								fmt.Errorf("modular resource config validation error: %w", err),
 								"resource", conf.ResourceName(),
-								"model", conf.Model)
+								"model", conf.Model,
+							)
 							return
 						}
 
@@ -905,7 +909,8 @@ func (manager *resourceManager) completeConfig(
 							gNode.LogAndSetLastError(
 								fmt.Errorf("resource build error: %v", err.Error()),
 								"resource", conf.ResourceName(),
-								"model", conf.Model)
+								"model", conf.Model,
+							)
 							buildDuration := time.Since(activityStarted)
 							manager.logger.Activity(activityType, "fail",
 								"resource", resName.String(),
@@ -923,7 +928,8 @@ func (manager *resourceManager) completeConfig(
 						// updating the graph to be safe.
 						if errors.Is(ctxWithTimeout.Err(), context.DeadlineExceeded) {
 							manager.logger.CErrorw(
-								ctx, "error building resource", "resource", conf.ResourceName(), "model", conf.Model, "error", ctxWithTimeout.Err())
+								ctx, "error building resource", "resource", conf.ResourceName(), "model", conf.Model, "error", ctxWithTimeout.Err(),
+							)
 							buildDuration := time.Since(activityStarted)
 							manager.logger.Activity(activityType, "fail",
 								"resource", resName.String(), "model", conf.Model.String(), "revision", activityRevision,
@@ -1022,13 +1028,15 @@ func (manager *resourceManager) completeConfigForRemotes(ctx context.Context, lr
 				// Validate the remote config
 				if _, _, err := remConf.Validate(""); err != nil {
 					gNode.LogAndSetLastError(
-						fmt.Errorf("remote config validation error: %w", err), "remote", remConf.Name)
+						fmt.Errorf("remote config validation error: %w", err), "remote", remConf.Name,
+					)
 					return
 				}
 				rr, err := manager.processRemote(ctx, *remConf, gNode)
 				if err != nil {
 					gNode.LogAndSetLastError(
-						fmt.Errorf("error connecting to remote: %w", err), "remote", remConf.Name)
+						fmt.Errorf("error connecting to remote: %w", err), "remote", remConf.Name,
+					)
 					return
 				}
 				manager.addRemote(ctx, rr, gNode, *remConf)
@@ -1532,7 +1540,8 @@ func (manager *resourceManager) markRemoved(
 	// resource is served by a different module, this allows the chain of dependencies to be rebuilt.
 	resourcesToCloseBeforeComplete = append(
 		resourcesToCloseBeforeComplete,
-		manager.markResourcesRemoved(closedModularResourceNames, addNames, false)...)
+		manager.markResourcesRemoved(closedModularResourceNames, addNames, false)...,
+	)
 
 	// Only rebuild modular resources that are not marked for removal.
 	var resourcesToRebuild []resource.Name

--- a/robot/impl/resource_manager_test.go
+++ b/robot/impl/resource_manager_test.go
@@ -1509,7 +1509,8 @@ func TestManagerResourceRPCAPIs(t *testing.T) {
 	// one of these will be true due to a clash
 	test.That(t,
 		cmp.Equal(
-			apisM[api2].AsProto(), cameraDesc.AsProto(), protocmp.Transform()) ||
+			apisM[api2].AsProto(), cameraDesc.AsProto(), protocmp.Transform(),
+		) ||
 			cmp.Equal(apisM[api2].AsProto(), gripperDesc.AsProto(), protocmp.Transform()),
 		test.ShouldBeTrue)
 }

--- a/robot/impl/robot_reconfigure_test.go
+++ b/robot/impl/robot_reconfigure_test.go
@@ -100,7 +100,8 @@ func TestRobotReconfigure(t *testing.T) {
 					childValues: make(map[string]int),
 				}, nil
 			},
-		})
+		},
+	)
 
 	resetComponentFailureState := func() {
 		reconfigurableTrue = true
@@ -122,7 +123,8 @@ func TestRobotReconfigure(t *testing.T) {
 				}
 				return &mockFake2{Named: conf.ResourceName().AsNamed()}, nil
 			},
-		})
+		},
+	)
 
 	mockWithDepModel := registerMockComponent(t, resource.Registration[resource.Resource, *mockWithDepConfig]{
 		Constructor: func(
@@ -729,10 +731,12 @@ func TestRobotReconfigure(t *testing.T) {
 				rdktestutils.ConcatResourceNames(
 					motorNames,
 					resource.DefaultServices(),
-					[]resource.Name{mockNamed("mock1")}),
+					[]resource.Name{mockNamed("mock1")},
+				),
 				rdktestutils.ConcatResourceNames(
 					armNames,
-					[]resource.Name{mockNamed("mock2"), mockNamed("mock3")}),
+					[]resource.Name{mockNamed("mock2"), mockNamed("mock3")},
+				),
 				baseNames,
 				boardNames,
 			},
@@ -975,7 +979,8 @@ func TestRobotReconfigure(t *testing.T) {
 			[][]resource.Name{
 				rdktestutils.ConcatResourceNames(
 					motorNames,
-					resource.DefaultServices()),
+					resource.DefaultServices(),
+				),
 				armNames,
 				baseNames,
 				boardNames,
@@ -3543,7 +3548,8 @@ func TestResourceConstructCtxCancel(t *testing.T) {
 					<-ctx.Done()
 					return &mockFake{Named: conf.ResourceName().AsNamed()}, nil
 				},
-			})
+			},
+		)
 
 		th.cfg = &config.Config{
 			Components: []resource.Config{
@@ -3621,7 +3627,8 @@ func TestResourceConstructCtxDone(t *testing.T) {
 					}
 					return th.mf, nil
 				},
-			})
+			},
+		)
 		mock1Cfg := resource.Config{
 			Name:  "one",
 			Model: model1,

--- a/robot/impl/robot_reconfigure_weak_dependencies_test.go
+++ b/robot/impl/robot_reconfigure_weak_dependencies_test.go
@@ -74,7 +74,8 @@ func TestUpdateWeakDependents(t *testing.T) {
 				}, nil
 			},
 			WeakDependencies: []resource.Matcher{resource.TypeMatcher{Type: resource.APITypeComponentName}},
-		})
+		},
+	)
 	defer resource.Deregister(weakAPI, weakModel)
 
 	// Create a configuration with a single component that has an explicit, unresolved
@@ -311,7 +312,8 @@ func TestWeakDependentsExplicitDependency(t *testing.T) {
 				}, nil
 			},
 			WeakDependencies: []resource.Matcher{resource.TypeMatcher{Type: resource.APITypeComponentName}},
-		})
+		},
+	)
 	defer resource.Deregister(weakAPI, weakModel)
 
 	// Start robot with two components and one resource with weak dependencies
@@ -495,7 +497,8 @@ func TestWeakDependentsDependedOn(t *testing.T) {
 				}, nil
 			},
 			WeakDependencies: []resource.Matcher{resource.TypeMatcher{Type: resource.APITypeComponentName}},
-		})
+		},
+	)
 	defer resource.Deregister(weakAPI, weakModel)
 
 	// Start robot with two components (one of which has an explicit dependency on weak dependents)

--- a/robot/jobmanager/jobmanager.go
+++ b/robot/jobmanager/jobmanager.go
@@ -261,7 +261,8 @@ func (jm *JobManager) createJobFunction(jc config.JobConfig, continuous bool) fu
 			grpcurl.Format("json"),
 			descSource,
 			bytes.NewBuffer(argumentBytes),
-			options)
+			options,
+		)
 		if err != nil {
 			jobLogger.CWarnw(jm.ctx, "could not create parser and formatter for grpc requests", "error", err.Error())
 			return err

--- a/robot/session_test.go
+++ b/robot/session_test.go
@@ -46,7 +46,8 @@ func TestSessionsMixedClients(t *testing.T) {
 			) (motor.Motor, error) {
 				return &dummyMotor1, nil
 			},
-		})
+		},
+	)
 
 	roboConfig := fmt.Sprintf(`{
 		"components": [
@@ -139,7 +140,8 @@ func TestSessionsMixedOwnersNoAuth(t *testing.T) {
 			) (motor.Motor, error) {
 				return &dummyMotor1, nil
 			},
-		})
+		},
+	)
 
 	roboConfig := fmt.Sprintf(`{
 		"components": [
@@ -246,7 +248,8 @@ func TestSessionsMixedOwnersImplicitAuth(t *testing.T) {
 			) (motor.Motor, error) {
 				return &dummyMotor1, nil
 			},
-		})
+		},
+	)
 
 	roboConfig := fmt.Sprintf(`{
 		"components": [
@@ -374,7 +377,8 @@ func TestSessionsWithRemote(t *testing.T) {
 					) (motor.Motor, error) {
 						return &dummyMotor1, nil
 					},
-				})
+				},
+			)
 
 			ctx := context.Background()
 

--- a/robot/web/authorization.go
+++ b/robot/web/authorization.go
@@ -100,7 +100,8 @@ func newUserPermsAuthorizer(userPerms []config.UserPermission, logger logging.Lo
 		case config.UserTypeDefault:
 			if ra.defaultPerms != nil {
 				ra.logger.Error(
-					"multiple user_permissions entries for default user; fully restricting default user until collision is fixed")
+					"multiple user_permissions entries for default user; fully restricting default user until collision is fixed",
+				)
 				// An empty permSet fully restricts.
 				ra.defaultPerms = permSet{}
 				continue
@@ -115,7 +116,8 @@ func newUserPermsAuthorizer(userPerms []config.UserPermission, logger logging.Lo
 		if _, seen := ra.identityPerms[key]; seen {
 			ra.logger.Errorw(
 				"multiple user_permissions entries for user; fully restricting user until collision is fixed",
-				"type", user.Type, "id", user.ID)
+				"type", user.Type, "id", user.ID,
+			)
 			// An empty permSet fully restricts.
 			ra.identityPerms[key] = permSet{}
 			continue

--- a/robot/web/request_counter.go
+++ b/robot/web/request_counter.go
@@ -42,7 +42,8 @@ func (e RequestLimitExceededError) Error() string {
 		"exceeded the shared concurrent-request limit of %v on resource %v. This limit is shared "+
 			"across all clients/modules (your client has %v in-flight requests). Check the viam-server "+
 			`logs for 'Request limit exceeded' to find the offending client. See %v for troubleshooting steps`,
-		e.limit, e.resource, e.numInFlightRequestsForClient, ReqLimitExceededURL)
+		e.limit, e.resource, e.numInFlightRequestsForClient, ReqLimitExceededURL,
+	)
 }
 
 // GRPCStatus allows this error to be converted to a [status.Status].
@@ -460,7 +461,8 @@ func (rc *RequestCounter) UnaryInterceptor(
 				requestCounterKey,
 				time.Since(start),
 				respSize,
-				err != nil)
+				err != nil,
+			)
 		}()
 	}
 
@@ -512,7 +514,8 @@ func (rc *RequestCounter) ensureCounterForResourceForPC(
 			&inFlightAndRejectedRequests{
 				&atomic.Int64{},
 				&atomic.Int64{},
-			})
+			},
+		)
 	}
 
 	switch cn {

--- a/robot/web/stream/remove_unauthorized_streams_test.go
+++ b/robot/web/stream/remove_unauthorized_streams_test.go
@@ -26,7 +26,8 @@ func TestRemoveUnauthorizedStreams(t *testing.T) {
 	// we can later assert whether the track was detached.
 	addTrack := func(streamID string) *webrtc.RTPSender {
 		track, err := webrtc.NewTrackLocalStaticSample(
-			webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeH264}, "video", streamID)
+			webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeH264}, "video", streamID,
+		)
 		test.That(t, err, test.ShouldBeNil)
 		sender, err := pc.AddTrack(track)
 		test.That(t, err, test.ShouldBeNil)

--- a/robot/web/web.go
+++ b/robot/web/web.go
@@ -410,14 +410,16 @@ func (svc *webService) startProtocolModuleParentServer(ctx context.Context, tcpM
 				"panic", fmt.Sprintf("%v", p),
 				"stack", debug.Stack())
 			return status.Errorf(codes.Internal, "%v", p)
-		}))))
+		}),
+	)))
 	streamInterceptors = append(streamInterceptors, grpc_recovery.StreamServerInterceptor(grpc_recovery.WithRecoveryHandler(
 		grpc_recovery.RecoveryHandlerFunc(func(p interface{}) error {
 			svc.logger.Errorw("panicked while calling stream server method for module request",
 				"panic", fmt.Sprintf("%v", p),
 				"stack", debug.Stack())
 			return status.Errorf(codes.Internal, "%v", p)
-		}))))
+		}),
+	)))
 
 	opManager := svc.r.OperationManager()
 	unaryInterceptors = append(unaryInterceptors,
@@ -1131,7 +1133,8 @@ func (svc *webService) foreignServiceHandler(srv interface{}, stream googlegrpc.
 		if err := stream.RecvMsg(secondMsg); err == nil {
 			return errors.Errorf(
 				"method %q is a server-streaming RPC, but request data contained more than 1 message",
-				methodDesc.GetFullyQualifiedName())
+				methodDesc.GetFullyQualifiedName(),
+			)
 		} else if !errors.Is(err, io.EOF) {
 			return err
 		}

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -2106,7 +2106,7 @@ func TestHandleRestartStatus(t *testing.T) {
 
 	t.Run("allows localhost requests", func(t *testing.T) {
 		restartAllowedCalls = 0
-		req := httptest.NewRequest(http.MethodGet, "/restart_status", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/restart_status", nil)
 		req.RemoteAddr = "127.0.0.1:56789"
 		rec := httptest.NewRecorder()
 
@@ -2126,7 +2126,7 @@ func TestHandleRestartStatus(t *testing.T) {
 
 	t.Run("rejects non-local requests", func(t *testing.T) {
 		restartAllowedCalls = 0
-		req := httptest.NewRequest(http.MethodGet, "/restart_status", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/restart_status", nil)
 		req.RemoteAddr = "203.0.113.5:45678"
 		rec := httptest.NewRecorder()
 

--- a/robot/web/web_test.go
+++ b/robot/web/web_test.go
@@ -1826,7 +1826,8 @@ func TestPerResourceLimitsAndFTDC(t *testing.T) {
 				close(callBlocking)
 				<-blockCall
 				return pos, nil
-			}))
+			}),
+		)
 		defer injectRobot.Close(ctx)
 		svc := New(injectRobot, logger)
 		defer svc.Stop()
@@ -1934,7 +1935,8 @@ func TestPerResourceLimitsAndFTDC(t *testing.T) {
 				close(callBlocking)
 				<-blockCall
 				return pos, nil
-			}))
+			}),
+		)
 		defer injectRobot.Close(ctx)
 		svc := New(injectRobot, logger)
 		defer svc.Stop()

--- a/services/datamanager/builtin/builtin.go
+++ b/services/datamanager/builtin/builtin.go
@@ -87,7 +87,8 @@ func init() {
 				resource.SubtypeMatcher{Subtype: slam.SubtypeName},
 				resource.SubtypeMatcher{Subtype: vision.SubtypeName},
 			},
-		})
+		},
+	)
 }
 
 // builtIn initializes and orchestrates data capture and data sync based on the config.
@@ -431,7 +432,8 @@ func captureControlSensorFromDeps(cfg *CaptureControlSensorConfig, deps resource
 	if err != nil {
 		logger.Errorw(
 			"unable to initialize capture control sensor; controls will not apply until fixed or removed from config",
-			"error", err.Error())
+			"error", err.Error(),
+		)
 		return nil, ""
 	}
 	if cfg.Key == "" {
@@ -507,7 +509,8 @@ func syncSensorFromDeps(name string, deps resource.Dependencies, logger logging.
 	if err != nil {
 		// see sync.Config for how this affects whether or not scheduled sync will run
 		logger.Errorw(
-			"unable to initialize selective syncer; will not schedule sync at all until fixed or removed from config", "error", err.Error())
+			"unable to initialize selective syncer; will not schedule sync at all until fixed or removed from config", "error", err.Error(),
+		)
 		return nil, true
 	}
 	return syncSensor, true

--- a/services/datamanager/builtin/builtin_sync_test.go
+++ b/services/datamanager/builtin/builtin_sync_test.go
@@ -625,7 +625,7 @@ func TestArbitraryFileUpload(t *testing.T) {
 							}
 							closeFn()
 							uploadCount.Add(1)
-							return &v1.FileUploadResponse{FileId: "some file id"}, nil
+							return &v1.FileUploadResponse{BinaryDataId: "some binary data id"}, nil
 						},
 					}, nil
 				},

--- a/services/datamanager/builtin/builtin_test.go
+++ b/services/datamanager/builtin/builtin_test.go
@@ -190,7 +190,8 @@ func TestNew(t *testing.T) {
 		_, err := New(
 			ctx,
 			resource.Dependencies{},
-			resource.Config{ConvertedAttributes: &Config{}}, datasync.NoOpCloudClientConstructor, logger)
+			resource.Config{ConvertedAttributes: &Config{}}, datasync.NoOpCloudClientConstructor, logger,
+		)
 		errExp := errors.New("Resource missing from dependencies. " +
 			"Resource: " + cloud.InternalServiceName.String())
 		test.That(t, err, test.ShouldBeError, errExp)

--- a/services/datamanager/builtin/capture/capture.go
+++ b/services/datamanager/builtin/capture/capture.go
@@ -428,7 +428,8 @@ func collectorConfigDescription(
 func targetDir(captureDir string, collectorConfig datamanager.DataCaptureConfig) string {
 	return data.CaptureFilePathWithReplacedReservedChars(
 		filepath.Join(captureDir, collectorConfig.Name.API.String(),
-			collectorConfig.Name.ShortName(), collectorConfig.Method))
+			collectorConfig.Name.ShortName(), collectorConfig.Method),
+	)
 }
 
 // closeCollectors closes collectors.
@@ -453,7 +454,8 @@ func (c *Capture) closeCollectors() {
 				c.logger.Debugf("closing collector %s", md)
 				tmp.Close()
 				c.logger.Debugf("collector closed %s", md)
-			}, wg.Done)
+			}, wg.Done,
+		)
 	}
 	wg.Wait()
 }

--- a/services/datamanager/builtin/capture/collector_metadata.go
+++ b/services/datamanager/builtin/capture/collector_metadata.go
@@ -17,7 +17,8 @@ type collectorMetadata struct {
 func (r collectorMetadata) String() string {
 	return fmt.Sprintf(
 		"[Resource Name: %s, API: %s, Method Name: %s, Method Params: %s]",
-		r.ResourceName, r.MethodMetadata.API, r.MethodMetadata.MethodName, r.MethodParams)
+		r.ResourceName, r.MethodMetadata.API, r.MethodMetadata.MethodName, r.MethodParams,
+	)
 }
 
 func newCollectorMetadata(c datamanager.DataCaptureConfig) collectorMetadata {

--- a/services/datamanager/builtin/sync/file_deletion.go
+++ b/services/datamanager/builtin/sync/file_deletion.go
@@ -81,7 +81,8 @@ func maybeDeleteExcessFiles(
 		deleteEveryNth,
 		diskUsageThreshold,
 		captureDirThreshold,
-		logger)
+		logger,
+	)
 	duration := clock.Since(start)
 	syncStats.filesDeletedToFreeSpace.Add(int64(count))
 
@@ -110,7 +111,8 @@ func deleteExcessFiles(
 		captureDir,
 		diskUsageThreshold,
 		captureDirToFSThreshold,
-		logger)
+		logger,
+	)
 	if err != nil {
 		return 0, errors.Wrap(err, "error checking file system stats")
 	}

--- a/services/discovery/fake/fake.go
+++ b/services/discovery/fake/fake.go
@@ -23,7 +23,8 @@ func init() {
 			logger logging.Logger,
 		) (discovery.Service, error) {
 			return newDiscovery(conf.ResourceName(), logger), nil
-		}})
+		}},
+	)
 }
 
 func newDiscovery(name resource.Name, logger logging.Logger) discovery.Service {

--- a/services/generic/fake/generic.go
+++ b/services/generic/fake/generic.go
@@ -20,7 +20,8 @@ func init() {
 			logger logging.Logger,
 		) (resource.Resource, error) {
 			return newGeneric(conf.ResourceName(), logger), nil
-		}})
+		}},
+	)
 }
 
 func newGeneric(name resource.Name, logger logging.Logger) resource.Resource {

--- a/services/motion/builtin/builtin_test.go
+++ b/services/motion/builtin/builtin_test.go
@@ -631,7 +631,8 @@ func TestWritePlanRequest(t *testing.T) {
 		"",
 		// No planTag here.
 		"",
-		nil)
+		nil,
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	planDirEntries, err = os.ReadDir(planDir)
@@ -666,7 +667,8 @@ func TestWritePlanRequest(t *testing.T) {
 		"1234-abc-56-no-78",
 		// No planTag here.
 		"",
-		nil)
+		nil,
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	planDirEntries, err = os.ReadDir(planDir)
@@ -703,7 +705,8 @@ func TestWritePlanRequest(t *testing.T) {
 		time.Now(),
 		"",
 		"custom-test-tag", // Custom plan tag
-		nil)
+		nil,
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	planDirEntries, err = os.ReadDir(planDir)
@@ -732,7 +735,8 @@ func TestWritePlanRequest(t *testing.T) {
 		time.Now(),
 		"1234-abc-56-no-78",
 		"",
-		errors.New("planning failed"))
+		errors.New("planning failed"),
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	planDirEntries, err = os.ReadDir(planDir)
@@ -767,7 +771,8 @@ func TestWritePlanRequest(t *testing.T) {
 		time.Now(),
 		"",
 		"",
-		errors.New("planning failed"))
+		errors.New("planning failed"),
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	planDirEntries, err = os.ReadDir(planDir)

--- a/services/motion/client_test.go
+++ b/services/motion/client_test.go
@@ -113,7 +113,8 @@ func TestClient(t *testing.T) {
 				receivedTransforms[tf.Name()] = tf
 			}
 			return referenceframe.NewPoseInFrame(
-				destinationFrame+componentName, spatialmath.NewPoseFromPoint(r3.Vector{X: 1, Y: 2, Z: 3})), nil
+				destinationFrame+componentName, spatialmath.NewPoseFromPoint(r3.Vector{X: 1, Y: 2, Z: 3}),
+			), nil
 		}
 
 		// Move

--- a/services/motion/localizer_test.go
+++ b/services/motion/localizer_test.go
@@ -61,7 +61,8 @@ func TestLocalizerOrientation(t *testing.T) {
 	// A compass heading of 0 means we are pointing north.
 	test.That(t, spatialmath.OrientationAlmostEqual(
 		pif.Pose().Orientation(),
-		&spatialmath.OrientationVectorDegrees{OZ: 1, Theta: 0}),
+		&spatialmath.OrientationVectorDegrees{OZ: 1, Theta: 0},
+	),
 		test.ShouldBeTrue,
 	)
 
@@ -75,7 +76,8 @@ func TestLocalizerOrientation(t *testing.T) {
 	// A compass heading of 315 means we are pointing northwest.
 	test.That(t, spatialmath.OrientationAlmostEqual(
 		pif.Pose().Orientation(),
-		&spatialmath.OrientationVectorDegrees{OZ: 1, Theta: 45}),
+		&spatialmath.OrientationVectorDegrees{OZ: 1, Theta: 45},
+	),
 		test.ShouldBeTrue,
 	)
 
@@ -89,7 +91,8 @@ func TestLocalizerOrientation(t *testing.T) {
 	// A compass heading of 90 means we are pointing east.
 	test.That(t, spatialmath.OrientationAlmostEqual(
 		pif.Pose().Orientation(),
-		&spatialmath.OrientationVectorDegrees{OZ: 1, Theta: -90}),
+		&spatialmath.OrientationVectorDegrees{OZ: 1, Theta: -90},
+	),
 		test.ShouldBeTrue,
 	)
 }

--- a/services/motion/motion.go
+++ b/services/motion/motion.go
@@ -114,7 +114,8 @@ func (r MoveOnMapReq) String() string {
 		r.Destination,
 		r.MotionCfg,
 		r.Obstacles,
-		r.Extra)
+		r.Extra,
+	)
 }
 
 // StopPlanReq describes the request to StopPlan().

--- a/services/motion/motion_test.go
+++ b/services/motion/motion_test.go
@@ -1115,7 +1115,8 @@ func TestMoveOnMapReq(t *testing.T) {
 			validMoveOnMapReq.Destination,
 			validMoveOnMapReq.MotionCfg,
 			validMoveOnMapReq.Obstacles,
-			validMoveOnMapReq.Extra)
+			validMoveOnMapReq.Extra,
+		)
 		test.That(t, validMoveOnMapReq.String(), test.ShouldEqual, s)
 	})
 

--- a/services/motion/server_test.go
+++ b/services/motion/server_test.go
@@ -188,13 +188,15 @@ func TestServerMoveOnGlobe(t *testing.T) {
 		geometries1, err := spatialmath.NewBox(
 			spatialmath.NewPoseFromPoint(r3.Vector{X: 50, Y: 0, Z: 0}),
 			boxDims,
-			"wall")
+			"wall",
+		)
 		test.That(t, err, test.ShouldBeNil)
 
 		geometries2, err := spatialmath.NewBox(
 			spatialmath.NewPoseFromPoint(r3.Vector{X: 0, Y: 70, Z: 0}),
 			boxDims,
-			"other wall")
+			"other wall",
+		)
 		test.That(t, err, test.ShouldBeNil)
 
 		geometries3, err := spatialmath.NewSphere(spatialmath.NewZeroPose(), 1, "sphere")

--- a/services/navigation/builtin/builtin_test.go
+++ b/services/navigation/builtin/builtin_test.go
@@ -1420,7 +1420,7 @@ func TestStartWaypoint(t *testing.T) {
 			if err := ctx.Err(); err != nil {
 				return uuid.Nil, err
 			}
-			executionID := executionIDs[(counter.Inc())]
+			executionID := executionIDs[counter.Inc()]
 			s.Lock()
 			defer s.Unlock()
 			if s.mogrs == nil {
@@ -1556,7 +1556,7 @@ func TestStartWaypoint(t *testing.T) {
 			if err := ctx.Err(); err != nil {
 				return uuid.Nil, err
 			}
-			executionID := executionIDs[(counter.Inc())]
+			executionID := executionIDs[counter.Inc()]
 			s.Lock()
 			defer s.Unlock()
 			if s.mogrs == nil {

--- a/services/shell/server.go
+++ b/services/shell/server.go
@@ -147,7 +147,8 @@ func (server *serviceServer) CopyFilesToMachine(srv pb.ShellService_CopyFilesToM
 		CopyFilesSourceTypeFromProto(md.Metadata.SourceType),
 		md.Metadata.Destination,
 		md.Metadata.Preserve,
-		md.Metadata.Extra.AsMap())
+		md.Metadata.Extra.AsMap(),
+	)
 	if err != nil {
 		var pathErr *fs.PathError
 		var errno syscall.Errno
@@ -195,7 +196,8 @@ func (server *serviceServer) CopyFilesFromMachine(srv pb.ShellService_CopyFilesF
 		md.Metadata.AllowRecursion,
 		md.Metadata.Preserve,
 		newCopyFileFromMachineFactory(srv, md.Metadata.Preserve),
-		md.Metadata.Extra.AsMap())
+		md.Metadata.Extra.AsMap(),
+	)
 }
 
 // DoCommand receives arbitrary commands.

--- a/services/slam/fake/slam_test.go
+++ b/services/slam/fake/slam_test.go
@@ -31,7 +31,8 @@ func TestFakeSLAMPosition(t *testing.T) {
 	// were causing tests to pass on M1 mac but fail on ci.
 	expectedPose := spatialmath.NewPose(
 		r3.Vector{X: 5.921536787524187, Y: 13.296696037491639, Z: 0.0000000000000},
-		&spatialmath.Quaternion{Real: 0.9999997195238413, Imag: 0, Jmag: 0, Kmag: 0.0007489674483818071})
+		&spatialmath.Quaternion{Real: 0.9999997195238413, Imag: 0, Jmag: 0, Kmag: 0.0007489674483818071},
+	)
 	test.That(t, spatialmath.PoseAlmostEqual(p, expectedPose), test.ShouldBeTrue)
 
 	p2, err := slamSvc.Position(context.Background())

--- a/services/video/client_test.go
+++ b/services/video/client_test.go
@@ -35,7 +35,8 @@ func setupVideoService(t *testing.T, injectVideo *inject.Video) (net.Listener, f
 	test.That(t, err, test.ShouldBeNil)
 
 	videoSvc, err := resource.NewAPIResourceCollection(
-		video.API, map[resource.Name]video.Service{video.Named(testVideoName): injectVideo})
+		video.API, map[resource.Name]video.Service{video.Named(testVideoName): injectVideo},
+	)
 	test.That(t, err, test.ShouldBeNil)
 	resourceAPI, ok, err := resource.LookupAPIRegistration[video.Service](video.API)
 	test.That(t, err, test.ShouldBeNil)

--- a/services/vision/vision_service_builder.go
+++ b/services/vision/vision_service_builder.go
@@ -44,7 +44,8 @@ func NewService(
 ) (Service, error) {
 	if cf == nil && df == nil && s3f == nil {
 		return nil, errors.Errorf(
-			"model %q does not fulfill any method of the vision service. It is neither a detector, nor classifier, nor 3D segmenter", name)
+			"model %q does not fulfill any method of the vision service. It is neither a detector, nor classifier, nor 3D segmenter", name,
+		)
 	}
 
 	p := Properties{false, false, false, nil}
@@ -91,7 +92,8 @@ func DeprecatedNewService(
 ) (Service, error) {
 	if cf == nil && df == nil && s3f == nil {
 		return nil, errors.Errorf(
-			"model %q does not fulfill any method of the vision service. It is neither a detector, nor classifier, nor 3D segmenter", name)
+			"model %q does not fulfill any method of the vision service. It is neither a detector, nor classifier, nor 3D segmenter", name,
+		)
 	}
 
 	p := Properties{false, false, false, nil}

--- a/services/worldstatestore/fake/fake.go
+++ b/services/worldstatestore/fake/fake.go
@@ -73,7 +73,8 @@ func init() {
 			}
 			logger.Infof("new fake world state store with name: %s", newConf.WorldName)
 			return newFakeWorldStateStore(conf.ResourceName(), newConf, logger), nil
-		}})
+		}},
+	)
 }
 
 // ListUUIDs returns all transform UUIDs currently in the store.

--- a/spatialmath/bvh.go
+++ b/spatialmath/bvh.go
@@ -616,15 +616,17 @@ func triangleLeafCollide(
 
 // triAABB returns the 3-point AABB of a triangle in whatever space its points are in.
 func triAABB(t *Triangle) (r3.Vector, r3.Vector) {
-	return r3.Vector{
+	lo := r3.Vector{
 		X: min(min(t.p0.X, t.p1.X), t.p2.X),
 		Y: min(min(t.p0.Y, t.p1.Y), t.p2.Y),
 		Z: min(min(t.p0.Z, t.p1.Z), t.p2.Z),
-	}, r3.Vector{
+	}
+	hi := r3.Vector{
 		X: max(max(t.p0.X, t.p1.X), t.p2.X),
 		Y: max(max(t.p0.Y, t.p1.Y), t.p2.Y),
 		Z: max(max(t.p0.Z, t.p1.Z), t.p2.Z),
 	}
+	return lo, hi
 }
 
 // bvhDistanceFromBVH computes the minimum distance between two BVH trees.

--- a/spatialmath/bvh.go
+++ b/spatialmath/bvh.go
@@ -617,14 +617,14 @@ func triangleLeafCollide(
 // triAABB returns the 3-point AABB of a triangle in whatever space its points are in.
 func triAABB(t *Triangle) (r3.Vector, r3.Vector) {
 	return r3.Vector{
-			X: min(min(t.p0.X, t.p1.X), t.p2.X),
-			Y: min(min(t.p0.Y, t.p1.Y), t.p2.Y),
-			Z: min(min(t.p0.Z, t.p1.Z), t.p2.Z),
-		}, r3.Vector{
-			X: max(max(t.p0.X, t.p1.X), t.p2.X),
-			Y: max(max(t.p0.Y, t.p1.Y), t.p2.Y),
-			Z: max(max(t.p0.Z, t.p1.Z), t.p2.Z),
-		}
+		X: min(min(t.p0.X, t.p1.X), t.p2.X),
+		Y: min(min(t.p0.Y, t.p1.Y), t.p2.Y),
+		Z: min(min(t.p0.Z, t.p1.Z), t.p2.Z),
+	}, r3.Vector{
+		X: max(max(t.p0.X, t.p1.X), t.p2.X),
+		Y: max(max(t.p0.Y, t.p1.Y), t.p2.Y),
+		Z: max(max(t.p0.Z, t.p1.Z), t.p2.Z),
+	}
 }
 
 // bvhDistanceFromBVH computes the minimum distance between two BVH trees.

--- a/spatialmath/bvh_test.go
+++ b/spatialmath/bvh_test.go
@@ -560,7 +560,8 @@ func TestLeafCollidesWithLeaf(t *testing.T) {
 		)
 
 		collides, _, err := leafCollidesWithLeaf(
-			trianglesToGeometries(tri1), trianglesToGeometries(tri2), zeroPose, zeroPose, 0, nil, math.Inf(1))
+			trianglesToGeometries(tri1), trianglesToGeometries(tri2), zeroPose, zeroPose, 0, nil, math.Inf(1),
+		)
 		test.That(t, collides, test.ShouldBeTrue)
 		test.That(t, err, test.ShouldBeNil)
 	})
@@ -578,7 +579,8 @@ func TestLeafCollidesWithLeaf(t *testing.T) {
 		)
 
 		collides, dist, err := leafCollidesWithLeaf(
-			trianglesToGeometries(tri1), trianglesToGeometries(tri2), zeroPose, zeroPose, 0, nil, math.Inf(1))
+			trianglesToGeometries(tri1), trianglesToGeometries(tri2), zeroPose, zeroPose, 0, nil, math.Inf(1),
+		)
 		test.That(t, collides, test.ShouldBeFalse)
 		test.That(t, dist, test.ShouldAlmostEqual, 5, 1e-9)
 		test.That(t, err, test.ShouldBeNil)
@@ -598,7 +600,8 @@ func TestLeafCollidesWithLeaf(t *testing.T) {
 
 		// No collision without buffer
 		collides, _, err := leafCollidesWithLeaf(
-			trianglesToGeometries(tri1), trianglesToGeometries(tri2), zeroPose, zeroPose, 0, nil, math.Inf(1))
+			trianglesToGeometries(tri1), trianglesToGeometries(tri2), zeroPose, zeroPose, 0, nil, math.Inf(1),
+		)
 		test.That(t, collides, test.ShouldBeFalse)
 		test.That(t, err, test.ShouldBeNil)
 

--- a/spatialmath/geometry_test.go
+++ b/spatialmath/geometry_test.go
@@ -131,7 +131,7 @@ func TestBoxVsBoxCollision(t *testing.T) {
 		{
 			"coincident edges near contact",
 			[2]Geometry{
-				makeTestBox((NewZeroOrientation()), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}),
+				makeTestBox(NewZeroOrientation(), r3.Vector{0, 0, 0}, r3.Vector{2, 2, 2}),
 				makeTestBox(NewZeroOrientation(), r3.Vector{2, 4.01, 0}, r3.Vector{2, 6, 2}),
 			},
 			0.01,

--- a/spatialmath/geometry_utils.go
+++ b/spatialmath/geometry_utils.go
@@ -29,7 +29,7 @@ func DistToLineSegment(pt1, pt2, query r3.Vector) float64 {
 	if bv.Dot(ab) >= 0.0 { // Point is advanced past the end of the segment, so perpendicular distance is not viable.
 		return bv.Norm()
 	}
-	return (ab.Cross(av)).Norm() / ab.Norm()
+	return ab.Cross(av).Norm() / ab.Norm()
 }
 
 // ClosestPointSegmentPoint takes a line segment defined by pt1 and pt2, plus some query point, and returns the point on the line segment

--- a/spatialmath/mesh.go
+++ b/spatialmath/mesh.go
@@ -865,7 +865,8 @@ func (m *Mesh) collidesWithMesh(other *Mesh, collisionBufferMM float64) (bool, f
 	}
 
 	collides, dist, witness, err := bvhCollidesWithBVHTracked(
-		m.ensureBVH(), other.ensureBVH(), m.ensurePoseCache(), other.ensurePoseCache(), collisionBufferMM)
+		m.ensureBVH(), other.ensureBVH(), m.ensurePoseCache(), other.ensurePoseCache(), collisionBufferMM,
+	)
 	if err != nil {
 		return false, 0, err
 	}

--- a/testutils/vcamera/vcamera.go
+++ b/testutils/vcamera/vcamera.go
@@ -143,7 +143,8 @@ func startStream(config *Config, dev device) (<-chan struct{}, error) {
 			"! videoscale "+
 			"! video/x-raw,format=YUY2,width=%d,height=%d "+
 			"! v4l2sink device=/dev/video%s",
-		dev.resolution.Width, dev.resolution.Height, dev.key))
+		dev.resolution.Width, dev.resolution.Height, dev.key,
+	))
 
 	// capture output from stdout
 	stdout, err := cmd.StdoutPipe()

--- a/utils/diskusage/disk_usage_windows.go
+++ b/utils/diskusage/disk_usage_windows.go
@@ -44,7 +44,8 @@ func newWindowsDiskUsage(volumePath string) (*windowsDiskUsage, error) {
 		uintptr(unsafe.Pointer(utf16Ptr)),
 		uintptr(unsafe.Pointer(&du.freeBytes)),
 		uintptr(unsafe.Pointer(&du.totalBytes)),
-		uintptr(unsafe.Pointer(&du.availBytes)))
+		uintptr(unsafe.Pointer(&du.availBytes)),
+	)
 	if r1 == 0 {
 		return nil, fmt.Errorf("GetDiskFreeSpaceExW failed for %q: %w", volumePath, callErr)
 	}

--- a/utils/math.go
+++ b/utils/math.go
@@ -53,7 +53,7 @@ func AntiCWDeg(deg float64) float64 {
 // ModAngDeg returns the given angle modulus 360 and resolves
 // any negativity.
 func ModAngDeg(ang float64) float64 {
-	return math.Mod(math.Mod((ang), 360)+360, 360)
+	return math.Mod(math.Mod(ang, 360)+360, 360)
 }
 
 // Median returns the median value of the given values. If there

--- a/vision/segmentation/plane_segmentation_test.go
+++ b/vision/segmentation/plane_segmentation_test.go
@@ -62,7 +62,8 @@ func TestSegmentPlaneWRTGround(t *testing.T) {
 	// get depth map
 	d, err := rimage.NewDepthMapFromFile(
 		context.Background(),
-		artifact.MustPath("vision/segmentation/pointcloudsegmentation/align-test-1615172036.png"))
+		artifact.MustPath("vision/segmentation/pointcloudsegmentation/align-test-1615172036.png"),
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	// Pixel to Meter
@@ -115,7 +116,8 @@ func TestSegmentPlane(t *testing.T) {
 	// get depth map
 	d, err := rimage.NewDepthMapFromFile(
 		context.Background(),
-		artifact.MustPath("vision/segmentation/pointcloudsegmentation/align-test-1615172036.png"))
+		artifact.MustPath("vision/segmentation/pointcloudsegmentation/align-test-1615172036.png"),
+	)
 	test.That(t, err, test.ShouldBeNil)
 
 	// Pixel to Meter
@@ -151,7 +153,8 @@ func TestDepthMapToPointCloud(t *testing.T) {
 
 	d, err := rimage.NewDepthMapFromFile(
 		context.Background(),
-		artifact.MustPath("vision/segmentation/pointcloudsegmentation/align-test-1615172036.png"))
+		artifact.MustPath("vision/segmentation/pointcloudsegmentation/align-test-1615172036.png"),
+	)
 	test.That(t, err, test.ShouldBeNil)
 	sensorParams, err := transform.NewDepthColorIntrinsicsExtrinsicsFromJSONFile(intel515ParamsPath)
 	test.That(t, err, test.ShouldBeNil)
@@ -172,7 +175,8 @@ func TestProjectPlane3dPointsToRGBPlane(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	d, err := rimage.NewDepthMapFromFile(
 		context.Background(),
-		artifact.MustPath("vision/segmentation/pointcloudsegmentation/align-test-1615172036.png"))
+		artifact.MustPath("vision/segmentation/pointcloudsegmentation/align-test-1615172036.png"),
+	)
 	test.That(t, err, test.ShouldBeNil)
 	h, w := rgb.Height(), rgb.Width()
 
@@ -215,7 +219,8 @@ func BenchmarkPlaneSegmentPointCloud(b *testing.B) {
 
 	d, err := rimage.NewDepthMapFromFile(
 		context.Background(),
-		artifact.MustPath("vision/segmentation/pointcloudsegmentation/align-test-1615172036.png"))
+		artifact.MustPath("vision/segmentation/pointcloudsegmentation/align-test-1615172036.png"),
+	)
 	test.That(b, err, test.ShouldBeNil)
 
 	// Pixel to Meter

--- a/web/server/entrypoint.go
+++ b/web/server/entrypoint.go
@@ -250,7 +250,8 @@ func RunServer(ctx context.Context, args []string, _ logging.Logger) (err error)
 		if cloud.SignalingAddress != "" && cloud.SignalingAddress != cloud.AppAddress {
 			signalingConnLogger := networkingLogger.Sublogger("signaling_connection")
 			signalingConn, err = grpc.NewAppConn(
-				ctx, cloud.SignalingAddress, cloud.ID, cloudCreds, signalingConnLogger)
+				ctx, cloud.SignalingAddress, cloud.ID, cloudCreds, signalingConnLogger,
+			)
 			if err != nil {
 				return err
 			}
@@ -528,7 +529,8 @@ func (s *robotServer) serveWeb(ctx context.Context, cfg *config.Config) (err err
 	// viam-server stack traces by default on app.viam.com.
 	stackTraceLogger := s.rootLogger.Sublogger("stack_traces")
 	slowWatcher, slowWatcherCancel := utils.SlowGoroutineWatcherAfterContext(
-		ctx, hungShutdownDeadline, "server is taking a while to shutdown", stackTraceLogger)
+		ctx, hungShutdownDeadline, "server is taking a while to shutdown", stackTraceLogger,
+	)
 
 	doneServing := make(chan struct{})
 


### PR DESCRIPTION
rdk's CI restores a golangci-lint cache built from another tree on every lint job. A recent run's logs show a prefix-key fallback on restore and a save failing with "token has no writable scopes", so it is only ever read. Before 2.13.0 that was unsafe. A cache entry holds only the facts a package produced about its own objects; those inherited from dependencies were never stored, and nothing rebuilt them on a hit. golangci/golangci-lint#6683 adds that rebuild.

The failure is silent. `exhaustive` learns about an enum declared in another package through such a fact, so when one goes missing it treats the type as a non-enum and skips the switch. `nolintlint` then calls the covering `//nolint:exhaustive` unused, and `--fix` deletes it. In app that blocked four PRs and rewrote three files their authors never touched.

Draft because the bump is not free. `golangci-lint run` reports 113 issues: gofumpt 50, gosec 27, govet 18, staticcheck 11, nolintlint 2, noctx 2, gci 2. An explicit enable list stops new linters turning themselves on; `govet: enable-all` does not, and all 18 govet hits are its new `inline` analyzer. `gofumpt.extra-rules` and `gomodguard` need migrating too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
