### PR TITLE
Fix data client cache never persisting in QueryTabularDataForResource

### DIFF
--- a/module/data_consumer.go
+++ b/module/data_consumer.go
@@ -3,6 +3,7 @@ package module
 import (
 	"context"
 	"os"
+	"sync"
 	"time"
 
 	"go.viam.com/rdk/app"
@@ -23,10 +24,14 @@ type queryBackend interface {
 
 // ResourceDataConsumer can be added as an anonymous struct member to a resource to enable historical module data queries.
 type ResourceDataConsumer struct {
+	mu         sync.Mutex
 	dataClient queryBackend
 }
 
 func (r *ResourceDataConsumer) setDataClient(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if r.dataClient != nil {
 		return nil
 	}
@@ -40,7 +45,7 @@ func (r *ResourceDataConsumer) setDataClient(ctx context.Context) error {
 }
 
 // QueryTabularDataForResource will return historical data for a resource.
-func (r ResourceDataConsumer) QueryTabularDataForResource(
+func (r *ResourceDataConsumer) QueryTabularDataForResource(
 	ctx context.Context, resourceName string, opts *QueryTabularDataOptions,
 ) ([]map[string]any, error) {
 	err := r.setDataClient(ctx)

--- a/module/data_consumer.go
+++ b/module/data_consumer.go
@@ -24,6 +24,9 @@ type queryBackend interface {
 
 // ResourceDataConsumer can be added as an anonymous struct member to a resource to enable historical module data queries.
 type ResourceDataConsumer struct {
+	// mu guards the lazy initialization of dataClient. This is embedded in
+	// resources, whose methods the RDK may call concurrently, so the nil check
+	// and the assignment in setDataClient have to happen under one lock.
 	mu         sync.Mutex
 	dataClient queryBackend
 }


### PR DESCRIPTION
## Summary

`ResourceDataConsumer` never actually caches its data client, so every call to `QueryTabularDataForResource` dials a fresh `ViamClient` that is never closed. `QueryTabularDataForResource` has a value receiver while `setDataClient` has a pointer receiver, so the assignment lands on a copy that is discarded when the method returns. A module querying on a timer leaks a gRPC connection per call.

## Note

This does not close the client. With caching fixed the `ViamClient` is created once and held for the life of the resource, but `ResourceDataConsumer` has no teardown hook, so nothing ever calls `Close()`. Fixing that means adding a `Close()` here and getting every embedding resource to call it from its own — worth a separate issue rather than widening this one.
