### PR TITLE
RSDK-13659 - run shell service tests on windows CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -416,6 +416,9 @@ jobs:
           go.viam.com/rdk/module
           go.viam.com/rdk/logging
           go.viam.com/rdk/cli
+          go.viam.com/rdk/services/shell
+          go.viam.com/rdk/services/shell/builtin
+          go.viam.com/rdk/services/shell/testutils
         )
         WINDOWS_PATTERN=$(IFS='|'; echo "${WORKING_WINDOWS_TESTS[*]}")
         TEST_TARGET=$(echo "$TEST_TARGET" | grep -E "^(${WINDOWS_PATTERN})$")

--- a/services/shell/copy_local.go
+++ b/services/shell/copy_local.go
@@ -300,41 +300,57 @@ func NewLocalFileReadCopier(
 	allowRecursive bool,
 	relativeToHome bool,
 	copyFactory FileCopyFactory,
-) (FileReadCopier, error) {
+) (_ FileReadCopier, err error) {
 	var filesToCopy []*os.File
 
-	for _, p := range paths {
-		p, err := fixPeerPath(p, false, relativeToHome)
+	// An error return hands the caller no copier to Close, so release whatever we
+	// opened here. A lingering handle blocks deletes and renames of that path on
+	// Windows long after the failed copy.
+	defer func() {
 		if err != nil {
+			for _, f := range filesToCopy {
+				utils.UncheckedError(f.Close())
+			}
+		}
+	}()
+
+	for _, p := range paths {
+		var fixedPath string
+		if fixedPath, err = fixPeerPath(p, false, relativeToHome); err != nil {
 			return nil, err
 		}
 
+		var fileToCopy *os.File
 		//nolint:gosec // this is from an authenticated/authorized connection
-		fileToCopy, err := os.Open(p)
-		if err != nil {
+		if fileToCopy, err = os.Open(fixedPath); err != nil {
 			return nil, err
 		}
+		// track before validating so the cleanup above covers every error path below
+		filesToCopy = append(filesToCopy, fileToCopy)
+
 		if !allowRecursive {
-			fileInfo, err := fileToCopy.Stat()
-			if err != nil {
+			var fileInfo fs.FileInfo
+			if fileInfo, err = fileToCopy.Stat(); err != nil {
 				return nil, err
 			}
 			if fileInfo.IsDir() {
 				details := &errdetails.BadRequest_FieldViolation{
 					Field:       "paths",
-					Description: fmt.Sprintf("local %q is a directory but copy recursion not used", p),
+					Description: fmt.Sprintf("local %q is a directory but copy recursion not used", fixedPath),
 				}
-				s, err := status.New(codes.InvalidArgument, ErrMsgDirectoryCopyRequestNoRecursion).WithDetails(details)
+				var s *status.Status
+				s, err = status.New(codes.InvalidArgument, ErrMsgDirectoryCopyRequestNoRecursion).WithDetails(details)
 				if err != nil {
 					return nil, err
 				}
-				return nil, s.Err()
+				err = s.Err()
+				return nil, err
 			}
 		}
-		filesToCopy = append(filesToCopy, fileToCopy)
 	}
 	if len(filesToCopy) == 0 {
-		return nil, errors.New("no files provided to copy")
+		err = errors.New("no files provided to copy")
+		return nil, err
 	}
 	return &localFileReadCopier{filesToCopy: filesToCopy, copyFactory: copyFactory}, nil
 }
@@ -472,7 +488,8 @@ func fixPeerPath(path string, allowEmpty, relativeToHome bool) (string, error) {
 		case path == ViamHomePrefix || strings.HasPrefix(path, ViamHomePrefix+"/"):
 			path = filepath.Join(rutils.ViamDotDir, strings.TrimPrefix(path, ViamHomePrefix))
 		case strings.HasPrefix(path, "~/"):
-			path = strings.Replace(path, "~", homeDir, 1)
+			// Join rather than a raw substitution so the result keeps native separators
+			path = filepath.Join(homeDir, strings.TrimPrefix(path, "~/"))
 		case path == "":
 			if !allowEmpty {
 				return "", errUnexpectedEmptyPath

--- a/services/shell/copy_local_test.go
+++ b/services/shell/copy_local_test.go
@@ -32,12 +32,36 @@ func TestFixPeerPath(t *testing.T) {
 	realTempDir, err := os.Getwd()
 	test.That(t, err, test.ShouldBeNil)
 
-	fixed, err := fixPeerPath("/one/two/three", false, true)
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, fixed, test.ShouldEqual, "/one/two/three")
-
 	homeDir, err := os.UserHomeDir()
 	test.That(t, err, test.ShouldBeNil)
+
+	// a unix-style absolute path has no volume, so Windows treats it as relative and
+	// resolves it under HOME rather than leaving it alone
+	wantUnixAbs := "/one/two/three"
+	if runtime.GOOS == "windows" {
+		wantUnixAbs = filepath.Join(homeDir, "one/two/three")
+	}
+	fixed, err := fixPeerPath("/one/two/three", false, true)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fixed, test.ShouldEqual, wantUnixAbs)
+
+	if runtime.GOOS == "windows" {
+		// a drive-qualified path is already absolute, so a caller can always name a
+		// drive explicitly rather than relying on the resolution above
+		fixed, err = fixPeerPath(`C:\one\two\three`, false, true)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, fixed, test.ShouldEqual, `C:\one\two\three`)
+
+		// as is a UNC path
+		fixed, err = fixPeerPath(`\\server\share\one`, false, true)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, fixed, test.ShouldEqual, `\\server\share\one`)
+
+		// the backslash form of a volume-less path resolves like the slash form
+		fixed, err = fixPeerPath(`\one\two\three`, false, true)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, fixed, test.ShouldEqual, wantUnixAbs)
+	}
 
 	fixed, err = fixPeerPath("one/two/three", false, true)
 	test.That(t, err, test.ShouldBeNil)

--- a/services/shell/testutils/utils.go
+++ b/services/shell/testutils/utils.go
@@ -5,14 +5,12 @@ package shelltestutils
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"go.viam.com/test"
-	"go.viam.com/utils"
 )
 
 // DirectoryContentsEqual checks if the directory contents on the left and right are equal,
@@ -20,8 +18,10 @@ import (
 //
 //nolint:gosec // for testing
 func DirectoryContentsEqual(leftRoot, rightRoot string) error {
-	traverseAndGather := func(root string) (map[string]*os.File, error) {
-		files := map[string]*os.File{}
+	// Gather paths, not open handles: nothing stays open past this call, which matters
+	// on Windows where an open handle blocks the caller's t.TempDir cleanup.
+	traverseAndGather := func(root string) (map[string]string, error) {
+		files := map[string]string{}
 
 		var traverseAndGatherInner func(relDir, currentDir string) error
 		traverseAndGatherInner = func(relDir, currentDir string) error {
@@ -33,11 +33,8 @@ func DirectoryContentsEqual(leftRoot, rightRoot string) error {
 			for _, entry := range entries {
 				entryPath := filepath.Join(currentDir, entry.Name())
 				relPath := filepath.Join(relDir, entry.Name())
-				file, err := os.Open(entryPath)
-				if err != nil {
-					return err
-				}
-				info, err := file.Stat()
+				// Stat, not Lstat, so a symlinked directory is traversed like a real one.
+				info, err := os.Stat(entryPath)
 				if err != nil {
 					return err
 				}
@@ -46,7 +43,7 @@ func DirectoryContentsEqual(leftRoot, rightRoot string) error {
 						return err
 					}
 				}
-				files[relPath] = file
+				files[relPath] = entryPath
 			}
 			return nil
 		}
@@ -55,23 +52,15 @@ func DirectoryContentsEqual(leftRoot, rightRoot string) error {
 		}
 		return files, nil
 	}
-	closeFiles := func(files map[string]*os.File) {
-		for _, file := range files {
-			utils.UncheckedError(file.Close())
-		}
-	}
 
 	leftFiles, err := traverseAndGather(leftRoot)
 	if err != nil {
 		return err
 	}
-	defer closeFiles(leftFiles)
-
 	rightFiles, err := traverseAndGather(rightRoot)
 	if err != nil {
 		return err
 	}
-	defer closeFiles(rightFiles)
 
 	if len(leftFiles) != len(rightFiles) {
 		return fmt.Errorf(
@@ -80,40 +69,40 @@ func DirectoryContentsEqual(leftRoot, rightRoot string) error {
 			rightRoot, len(rightFiles),
 		)
 	}
-	for leftFilePath, leftFile := range leftFiles {
-		rightFile, ok := rightFiles[leftFilePath]
+	for relPath, leftPath := range leftFiles {
+		rightPath, ok := rightFiles[relPath]
 		if !ok {
-			return fmt.Errorf("right does not have %q", leftFilePath)
+			return fmt.Errorf("right does not have %q", relPath)
 		}
-		delete(rightFiles, leftFilePath)
+		delete(rightFiles, relPath)
 
-		if filepath.Base(leftFile.Name()) != filepath.Base(rightFile.Name()) {
-			panic(fmt.Errorf("unexpected mismatched name %q, %q", leftFile.Name(), rightFile.Name()))
+		if filepath.Base(leftPath) != filepath.Base(rightPath) {
+			panic(fmt.Errorf("unexpected mismatched name %q, %q", leftPath, rightPath))
 		}
-		leftInfo, err := leftFile.Stat()
+		leftInfo, err := os.Stat(leftPath)
 		if err != nil {
 			return err
 		}
-		rightInfo, err := rightFile.Stat()
+		rightInfo, err := os.Stat(rightPath)
 		if err != nil {
 			return err
 		}
 		if leftInfo.IsDir() != rightInfo.IsDir() {
-			return fmt.Errorf("%q directory/file mismatch", leftFilePath)
+			return fmt.Errorf("%q directory/file mismatch", relPath)
 		}
 		if leftInfo.IsDir() {
 			continue
 		}
-		leftRd, err := io.ReadAll(leftFile)
+		leftRd, err := os.ReadFile(leftPath)
 		if err != nil {
 			return err
 		}
-		rightRd, err := io.ReadAll(rightFile)
+		rightRd, err := os.ReadFile(rightPath)
 		if err != nil {
 			return err
 		}
 		if !bytes.Equal(leftRd, rightRd) {
-			return fmt.Errorf("%q contents not equal", leftFilePath)
+			return fmt.Errorf("%q contents not equal", relPath)
 		}
 	}
 	if len(rightFiles) != 0 {

--- a/services/shell/testutils/utils_test.go
+++ b/services/shell/testutils/utils_test.go
@@ -1,6 +1,8 @@
 package shelltestutils
 
 import (
+	"errors"
+	"io/fs"
 	"testing"
 
 	"go.viam.com/test"
@@ -11,7 +13,10 @@ func TestDirectoryContentsEqual(t *testing.T) {
 
 	err := DirectoryContentsEqual(tfs.Root, tfs.SingleFileNested)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "not a directory")
+	// the errno differs by platform (ENOTDIR on unix, ERROR_PATH_NOT_FOUND on Windows)
+	var pathErr *fs.PathError
+	test.That(t, errors.As(err, &pathErr), test.ShouldBeTrue)
+	test.That(t, pathErr.Path, test.ShouldEqual, tfs.SingleFileNested)
 
 	err = DirectoryContentsEqual(tfs.Root, tfs.InnerDir)
 	test.That(t, err, test.ShouldNotBeNil)


### PR DESCRIPTION
Adds `services/shell` and its `builtin`/`testutils` packages to `WORKING_WINDOWS_TESTS` in `test.yml`.

Turning the job on surfaced two production bugs that unix hides, since unix permits unlinking an open file:

- **`NewLocalFileReadCopier` leaked a handle on every error return.** It opens each source path, then returns early on validation failure without closing it — and with no copier for the caller to `Close`. On Windows a failed `viam machine part cp machine:<dir> .` (no `-r`) left viam-server holding that directory open, blocking later renames and deletes. Same failure mode as RSDK-13682. Fixed with a named error return plus deferred release, tracking files immediately after `os.Open` so future error paths are covered by construction.
- **`fixPeerPath` expanded `~/` with a raw string substitution**, producing `C:\Users\x/one/two/three`. The other three branches already used `filepath.Join`. Resolves to the identical file on every platform and is byte-identical on unix — it canonicalizes the string, it does not reinterpret the path.

The rest is test-side:

- `DirectoryContentsEqual` opened every entry (directories included) into a map, then `delete`d each matched entry before the deferred `closeFiles` ran — so on a successful compare **none** of the right-side handles closed, wedging the caller's `t.TempDir` cleanup. Rewritten to gather paths instead of handles.
- Two assertions encoded unix-only semantics: an `ENOTDIR` message string, and `/one/two/three` being absolute (`filepath.IsAbs` is false on Windows — no volume).

`services/shell/register` is omitted from the allowlist; it has no test files.

## Verification

Green Windows run: https://github.com/viamrobotics/rdk/actions/runs/34646096751/job/103417135424

That run used a scratch `test.yml` invoking `./services/shell/...` directly, so it validates the packages on Windows rather than the allowlist wiring itself — the allowlist edit here is the mechanical equivalent, and I confirmed the filter selects exactly these three packages.

Both handle leaks were confirmed by fd-counting before and after the fix (20 calls leaked 20 fds pre-fix, 0 post-fix), not just by reasoning.

Locally: `gofmt` clean, `golangci-lint 2.9.0` 0 issues, `GOOS=windows go vet` compiles, `services/shell/...` and `cli` pass (548 tests). `actionlint` on `test.yml` reports the same 23 pre-existing findings before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)